### PR TITLE
A whole load of Compulsory stuff and moving stuff to Mech Library (Re…

### DIFF
--- a/2022 - Horus Heresy.gst
+++ b/2022 - Horus Heresy.gst
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<gameSystem id="28d4-bd2e-4858-ece6" name="(HH V2) Horus Heresy (2022)" revision="12" battleScribeVersion="2.03" xmlns="http://www.battlescribe.net/schema/gameSystemSchema">
+<gameSystem id="28d4-bd2e-4858-ece6" name="(HH V2) Horus Heresy (2022)" revision="13" battleScribeVersion="2.03" xmlns="http://www.battlescribe.net/schema/gameSystemSchema">
   <publications>
     <publication id="e77a-823a-da94-16b9" name="Warhammer: The Horus Heresy - Age of Darkness Rulebook" shortName="Main Rules" publicationDate="June 18th, 2022"/>
     <publication id="817a-6288-e016-7469" name="Liber Astartes – Loyalist Legiones Astartes Army Book" shortName="LA - Loyalist" publicationDate="June 18th, 2022"/>
@@ -506,6 +506,17 @@ In addition, when a Fast Vehicle moves, it may choose to move at Flat-out:</desc
             <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1c0d-0ff5-e468-703c" type="max"/>
           </constraints>
         </categoryLink>
+        <categoryLink id="b095-12d9-ff21-c90b" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false">
+          <constraints>
+            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9073-7fc5-88a9-209e" type="min"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="8737-255b-9d36-2f15" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false">
+          <constraints>
+            <constraint field="selections" scope="force" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8810-8109-85db-93e4" type="min"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="4240-0870-e7ec-839e" name="Rite of War:" hidden="false" targetId="d494-e450-d4aa-579a" primary="false"/>
       </categoryLinks>
     </forceEntry>
     <forceEntry id="d4f2-6da5-b6de-06ec" name="Allied Detachment" hidden="false">
@@ -543,6 +554,17 @@ In addition, when a Fast Vehicle moves, it may choose to move at Flat-out:</desc
             <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0bc1-40ca-638b-3578" type="max"/>
           </constraints>
         </categoryLink>
+        <categoryLink id="4df4-9c0d-3f28-4dd3" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false">
+          <constraints>
+            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="efa5-391f-c0d5-86f2" type="min"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="bec3-b01f-58f1-ef8a" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false">
+          <constraints>
+            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3965-7b5b-1e0b-d284" type="min"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="b5a1-9980-4945-e1aa" name="Rite of War:" hidden="false" targetId="d494-e450-d4aa-579a" primary="false"/>
       </categoryLinks>
     </forceEntry>
   </forceEntries>
@@ -4997,31 +5019,6 @@ Thaumaturge’s Cleansing (Psychic Weapon)</description>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="c1d2-77e3-5d1c-5297" name="Arioch Power Claw" publicationId="bde1-6db1-163b-3b76" page="122" hidden="false" collective="false" import="true" type="upgrade">
-      <profiles>
-        <profile id="86f8-ab1b-6868-15bc" name="Arioch Power Claw" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
-          <characteristics>
-            <characteristic name="Range" typeId="95ba-cda7-b831-6066">-</characteristic>
-            <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">15</characteristic>
-            <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">1</characteristic>
-            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Melee, Shred, Destructor, Instant Death, Armourbane (Melee)</characteristic>
-          </characteristics>
-        </profile>
-      </profiles>
-      <infoLinks>
-        <infoLink id="9639-9f60-1ec1-2fdf" name="Shred" hidden="false" targetId="5e7e-1628-8174-6f2c" type="rule"/>
-        <infoLink id="e471-c4b0-fb6e-7637" name="Destructor" hidden="false" targetId="1f93-c765-f7b2-a025" type="rule"/>
-        <infoLink id="6c62-c1df-00e5-10cf" name="Instant Death" hidden="false" targetId="9e96-fff1-b916-d9a3" type="rule"/>
-        <infoLink id="71c8-9f03-b6e1-3c46" name="Armourbane (X)" hidden="false" targetId="cb59-f920-f071-7cd4" type="rule">
-          <modifiers>
-            <modifier type="set" field="name" value="Armourbane (Melee)"/>
-          </modifiers>
-        </infoLink>
-      </infoLinks>
-      <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
-      </costs>
-    </selectionEntry>
     <selectionEntry id="454e-eb44-05fc-0471" name="Belicosa Volcano Cannon" publicationId="bde1-6db1-163b-3b76" page="117" hidden="false" collective="false" import="true" type="upgrade">
       <profiles>
         <profile id="ff92-564d-36b8-a808" name="Belicosa Volcano Cannon" publicationId="bde1-6db1-163b-3b76" page="117" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
@@ -5040,367 +5037,6 @@ Thaumaturge’s Cleansing (Psychic Weapon)</description>
       </infoLinks>
       <costs>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="537f-846d-90e3-2526" name="Castellax Battle-Automata Maniple " publicationId="bde1-6db1-163b-3b76" page="37" hidden="false" collective="false" import="true" type="unit">
-      <categoryLinks>
-        <categoryLink id="c983-0d60-1e45-d450" name="Automata Unit-type:" hidden="false" targetId="d8ab-8e21-e193-63ba" primary="false"/>
-        <categoryLink id="efaf-7a32-0d19-5370" name="Cybernetica Sub-type:" hidden="false" targetId="2440-b64e-cb24-87f0" primary="false"/>
-      </categoryLinks>
-      <selectionEntries>
-        <selectionEntry id="ab78-91e2-bb5c-9da3" name="Castellax" publicationId="bde1-6db1-163b-3b76" page="37" hidden="false" collective="false" import="true" type="model">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e15e-beff-e63f-0b56" type="min"/>
-            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1c4c-58d1-59b2-df0a" type="max"/>
-          </constraints>
-          <profiles>
-            <profile id="2b2b-6a5d-8e25-8dfa" name="Castellax" publicationId="bde1-6db1-163b-3b76" page="37" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName="Unit">
-              <modifiers>
-                <modifier type="increment" field="f111-2ce5-dd12-d6b0" value="1">
-                  <conditions>
-                    <condition field="selections" scope="ab78-91e2-bb5c-9da3" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2121-ee7c-8ac9-5133" type="equalTo"/>
-                  </conditions>
-                </modifier>
-              </modifiers>
-              <characteristics>
-                <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Automata (Cybernetica)</characteristic>
-                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7</characteristic>
-                <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">3</characteristic>
-                <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
-                <characteristic name="S" typeId="e478-41d4-a092-48a8">7</characteristic>
-                <characteristic name="T" typeId="c32b-5fdd-3fbe-9b1f">6</characteristic>
-                <characteristic name="W" typeId="57ee-1126-32a9-5672">4</characteristic>
-                <characteristic name="I" typeId="62d3-22d7-2d49-52dc">3</characteristic>
-                <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">2</characteristic>
-                <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">7</characteristic>
-                <characteristic name="Save" typeId="e593-6b3c-f169-04f0">3+</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
-          <infoLinks>
-            <infoLink id="c3fb-9ffb-5a52-e31d" name="Hammer of Wrath (X)" hidden="false" targetId="aec0-c3aa-1e4e-1779" type="rule">
-              <modifiers>
-                <modifier type="set" field="name" value="Hammer of Wrath (1)"/>
-              </modifiers>
-            </infoLink>
-          </infoLinks>
-          <selectionEntryGroups>
-            <selectionEntryGroup id="e983-48d4-cde7-040e" name="A) May Exchange Main Weapon for:" hidden="false" collective="false" import="true">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5a40-0fc1-b193-81ac" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4709-d97c-fb4d-6a82" type="max"/>
-              </constraints>
-              <entryLinks>
-                <entryLink id="b927-430f-d60e-e4c7" name="Mauler Bolt Cannon" hidden="false" collective="false" import="true" targetId="7478-2c29-dfc4-f4cf" type="selectionEntry"/>
-                <entryLink id="b87c-b6d7-106d-b5e4" name="Multi-Melta" hidden="false" collective="false" import="true" targetId="9332-3834-cf3a-56b4" type="selectionEntry">
-                  <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0"/>
-                  </costs>
-                </entryLink>
-                <entryLink id="75ef-82ba-98ba-4821" name="Darkfire Cannon" hidden="false" collective="false" import="true" targetId="6f3d-9a42-da1d-2c2e" type="selectionEntry">
-                  <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0"/>
-                  </costs>
-                </entryLink>
-              </entryLinks>
-            </selectionEntryGroup>
-            <selectionEntryGroup id="11c0-d3c0-d632-ba9c" name="B) May Exchange both Melee Weapons for:" hidden="false" collective="false" import="true">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b1d6-8a8c-191d-fe8c" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7eee-d4d6-6660-04c2" type="min"/>
-              </constraints>
-              <entryLinks>
-                <entryLink id="59ea-b328-a16f-3a4b" name="Shock Charger" hidden="false" collective="false" import="true" targetId="3234-492f-9ebf-f23c" type="selectionEntry">
-                  <modifiers>
-                    <modifier type="set" field="name" value="Two Shock Charger"/>
-                  </modifiers>
-                </entryLink>
-                <entryLink id="11be-ab2c-90d2-a096" name="Siege Wrecker" hidden="false" collective="false" import="true" targetId="178d-8a3a-bfda-7443" type="selectionEntry"/>
-                <entryLink id="0fc0-fe96-a918-6761" name="Power Blade Array" hidden="false" collective="false" import="true" targetId="2121-ee7c-8ac9-5133" type="selectionEntry">
-                  <modifiers>
-                    <modifier type="set" field="name" value="Two Power Blade Array"/>
-                  </modifiers>
-                </entryLink>
-              </entryLinks>
-            </selectionEntryGroup>
-            <selectionEntryGroup id="a0b3-b91e-9efd-32da" name="C) Shock Charger / Power Blades may Exchange In-Built Bolter for:" hidden="false" collective="false" import="true">
-              <modifiers>
-                <modifier type="increment" field="2acc-367e-880f-a688" value="2.0">
-                  <repeats>
-                    <repeat field="selections" scope="ab78-91e2-bb5c-9da3" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2121-ee7c-8ac9-5133" repeats="1" roundUp="false"/>
-                    <repeat field="selections" scope="ab78-91e2-bb5c-9da3" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3234-492f-9ebf-f23c" repeats="1" roundUp="false"/>
-                  </repeats>
-                </modifier>
-                <modifier type="increment" field="9629-ad8d-df33-e930" value="2.0">
-                  <repeats>
-                    <repeat field="selections" scope="ab78-91e2-bb5c-9da3" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3234-492f-9ebf-f23c" repeats="1" roundUp="false"/>
-                    <repeat field="selections" scope="ab78-91e2-bb5c-9da3" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2121-ee7c-8ac9-5133" repeats="1" roundUp="false"/>
-                  </repeats>
-                </modifier>
-              </modifiers>
-              <constraints>
-                <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9629-ad8d-df33-e930" type="min"/>
-                <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2acc-367e-880f-a688" type="max"/>
-              </constraints>
-              <entryLinks>
-                <entryLink id="263e-f3ca-ea00-171e" name="Bolter" hidden="false" collective="false" import="true" targetId="1ade-0c02-5612-252b" type="selectionEntry">
-                  <modifiers>
-                    <modifier type="set" field="name" value="In-Built Bolter"/>
-                  </modifiers>
-                </entryLink>
-                <entryLink id="cfb0-3d95-e727-23b1" name="Maxima Bolter" hidden="false" collective="false" import="true" targetId="1d3e-1b60-d133-ea0d" type="selectionEntry">
-                  <modifiers>
-                    <modifier type="set" field="name" value="In-Built Maxima Bolter"/>
-                  </modifiers>
-                </entryLink>
-                <entryLink id="8256-19fd-7b72-660e" name="Flamer" hidden="false" collective="false" import="true" targetId="9f41-82e2-90f6-973a" type="selectionEntry">
-                  <modifiers>
-                    <modifier type="set" field="name" value="In-Built Flamer"/>
-                  </modifiers>
-                  <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
-                  </costs>
-                </entryLink>
-              </entryLinks>
-            </selectionEntryGroup>
-          </selectionEntryGroups>
-          <entryLinks>
-            <entryLink id="b191-e6a3-ec6b-f986" name="Paragon of Metal" hidden="false" collective="false" import="true" targetId="cc2a-46fe-bbf3-6ba2" type="selectionEntry">
-              <modifiers>
-                <modifier type="set" field="hidden" value="true">
-                  <conditions>
-                    <condition field="selections" scope="537f-846d-90e3-2526" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ab78-91e2-bb5c-9da3" type="greaterThan"/>
-                  </conditions>
-                </modifier>
-              </modifiers>
-              <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="35.0"/>
-              </costs>
-            </entryLink>
-          </entryLinks>
-          <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="85.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
-      <entryLinks>
-        <entryLink id="f5d5-dc3a-7642-c6e0" name="Searchlights" hidden="false" collective="false" import="true" targetId="4ae3-79b4-6051-505e" type="selectionEntry">
-          <modifiers>
-            <modifier type="set" field="d2ee-04cb-5f8a-2642" value="1.0">
-              <repeats>
-                <repeat field="selections" scope="537f-846d-90e3-2526" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ab78-91e2-bb5c-9da3" repeats="1" roundUp="false"/>
-              </repeats>
-            </modifier>
-          </modifiers>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c33d-1bca-1121-a3bf" type="max"/>
-          </constraints>
-        </entryLink>
-      </entryLinks>
-      <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="6f3d-9a42-da1d-2c2e" name="Darkfire Cannon" publicationId="bde1-6db1-163b-3b76" page="117" hidden="false" collective="false" import="true" type="upgrade">
-      <profiles>
-        <profile id="f9b1-869e-9b30-6413" name="Darkfire Cannon" publicationId="bde1-6db1-163b-3b76" page="117" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
-          <characteristics>
-            <characteristic name="Range" typeId="95ba-cda7-b831-6066">36&quot;</characteristic>
-            <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">7</characteristic>
-            <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">2</characteristic>
-            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Heavy 2, Blind, Lance, Gets Hot</characteristic>
-          </characteristics>
-        </profile>
-      </profiles>
-      <infoLinks>
-        <infoLink id="2016-0c2e-d948-14d5" name="Blind" hidden="false" targetId="d836-747d-07d6-2b63" type="rule"/>
-        <infoLink id="d91d-7508-71f5-25be" name="Lance" hidden="false" targetId="3d6b-9e0b-56f0-8a1e" type="rule"/>
-        <infoLink id="d6bb-d9c3-2b9a-076c" name="Gets Hot" hidden="false" targetId="679f-9d97-5ace-a652" type="rule"/>
-      </infoLinks>
-      <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="55e4-0853-3720-c068" name="Defensor Autocannon Battery" publicationId="bde1-6db1-163b-3b76" page="114" hidden="false" collective="false" import="true" type="upgrade">
-      <profiles>
-        <profile id="4ddd-1d39-8f02-1e99" name="Defensor Autocannon Battery" publicationId="bde1-6db1-163b-3b76" page="114" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
-          <characteristics>
-            <characteristic name="Range" typeId="95ba-cda7-b831-6066">72&quot;</characteristic>
-            <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">7</characteristic>
-            <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">4</characteristic>
-            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Heavy 4, Rending (6+), Twin-linked, Sunder, Skyfire</characteristic>
-          </characteristics>
-        </profile>
-      </profiles>
-      <infoLinks>
-        <infoLink id="2d12-cf79-2991-a694" name="Rending (X)" hidden="false" targetId="0ac9-fab7-aef3-de1d" type="rule">
-          <modifiers>
-            <modifier type="set" field="name" value="Rending (6+)"/>
-          </modifiers>
-        </infoLink>
-        <infoLink id="707d-4700-a7b0-1da0" name="Twin-linked" hidden="false" targetId="8542-ee9d-e2fa-52fe" type="rule"/>
-        <infoLink id="faf9-82b1-cc68-83b8" name="Sunder" hidden="false" targetId="20e2-75cf-bc16-cd8f" type="rule"/>
-        <infoLink id="998e-cd8d-7e3e-93cb" name="Skyfire" hidden="false" targetId="f2bf-5daa-9f93-0b01" type="rule"/>
-      </infoLinks>
-      <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="fee2-949c-6d55-2a2f" name="Defensor Bolt Cannon" publicationId="bde1-6db1-163b-3b76" page="114" hidden="false" collective="false" import="true" type="upgrade">
-      <profiles>
-        <profile id="6590-8653-7d8f-78c6" name="Defensor Bolt Cannon" publicationId="bde1-6db1-163b-3b76" page="114" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
-          <characteristics>
-            <characteristic name="Range" typeId="95ba-cda7-b831-6066">24&quot;</characteristic>
-            <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">6</characteristic>
-            <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">4</characteristic>
-            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Heavy 6, Ardex-defensor</characteristic>
-          </characteristics>
-        </profile>
-      </profiles>
-      <infoLinks>
-        <infoLink id="dac5-8a5f-a367-1d93" name="Ardex-Defensor" hidden="false" targetId="d242-cb71-bc7f-eadd" type="rule"/>
-      </infoLinks>
-      <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="2a03-11f0-739e-01a7" name="Defensor Lascannon" publicationId="bde1-6db1-163b-3b76" page="114" hidden="false" collective="false" import="true" type="upgrade">
-      <profiles>
-        <profile id="6151-332a-2039-4716" name="Defensor Lascannon" publicationId="bde1-6db1-163b-3b76" page="114" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
-          <characteristics>
-            <characteristic name="Range" typeId="95ba-cda7-b831-6066">48&quot;</characteristic>
-            <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">9</characteristic>
-            <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">2</characteristic>
-            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Heavy 1, Ardex-defensor, Sunder, Twin-linked</characteristic>
-          </characteristics>
-        </profile>
-      </profiles>
-      <infoLinks>
-        <infoLink id="d6b0-83a6-a9a9-d4ee" name="Ardex-Defensor" hidden="false" targetId="d242-cb71-bc7f-eadd" type="rule"/>
-        <infoLink id="560a-b8d1-c9f3-4abd" name="Sunder" hidden="false" targetId="20e2-75cf-bc16-cd8f" type="rule"/>
-        <infoLink id="a3be-17ad-5153-5017" name="Twin-linked" hidden="false" targetId="8542-ee9d-e2fa-52fe" type="rule"/>
-      </infoLinks>
-      <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="1a1b-fa35-a6a2-ca78" name="Domitar Battle-Automata Maniple" publicationId="bde1-6db1-163b-3b76" page="31" hidden="false" collective="false" import="true" type="unit">
-      <categoryLinks>
-        <categoryLink id="f34b-917f-4dc5-41a0" name="Automata Unit-type:" hidden="false" targetId="d8ab-8e21-e193-63ba" primary="false"/>
-        <categoryLink id="ba42-793b-aee7-2b65" name="Cybernetica Sub-type:" hidden="false" targetId="2440-b64e-cb24-87f0" primary="false"/>
-      </categoryLinks>
-      <selectionEntries>
-        <selectionEntry id="200f-3379-95a3-c3a4" name="Domitar" hidden="false" collective="false" import="true" type="model">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7684-c5d0-888e-0668" type="min"/>
-            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6560-36ea-b5d0-b855" type="max"/>
-          </constraints>
-          <profiles>
-            <profile id="27b6-ab96-5544-b612" name="Domitar" publicationId="bde1-6db1-163b-3b76" page="31" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName="Unit">
-              <characteristics>
-                <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Automata (Cybernetica)</characteristic>
-                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">8</characteristic>
-                <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
-                <characteristic name="BS" typeId="74ae-c840-0036-d244">3</characteristic>
-                <characteristic name="S" typeId="e478-41d4-a092-48a8">7</characteristic>
-                <characteristic name="T" typeId="c32b-5fdd-3fbe-9b1f">7</characteristic>
-                <characteristic name="W" typeId="57ee-1126-32a9-5672">5</characteristic>
-                <characteristic name="I" typeId="62d3-22d7-2d49-52dc">3</characteristic>
-                <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">3</characteristic>
-                <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">7</characteristic>
-                <characteristic name="Save" typeId="e593-6b3c-f169-04f0">3+</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
-          <infoLinks>
-            <infoLink id="573c-7dd2-5f44-2aae" name="Hammer of Wrath (X)" hidden="false" targetId="aec0-c3aa-1e4e-1779" type="rule">
-              <modifiers>
-                <modifier type="set" field="name" value="Hammer of Wrath (1)"/>
-              </modifiers>
-            </infoLink>
-            <infoLink id="930b-7c31-044a-40f8" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule"/>
-          </infoLinks>
-          <selectionEntries>
-            <selectionEntry id="b871-734b-b876-f794" name="Missile Launcher with Frag, Krak and Ignis Missiles" publicationId="bde1-6db1-163b-3b76" hidden="false" collective="false" import="true" type="upgrade">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b107-efec-e9cb-b6fb" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5fc6-1f16-aa7c-977e" type="max"/>
-              </constraints>
-              <profiles>
-                <profile id="fa47-f0be-b1c4-5a4d" name="Missile Launcher - Frag" publicationId="a716-c1c4-7b26-8424" page="133" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
-                  <characteristics>
-                    <characteristic name="Range" typeId="95ba-cda7-b831-6066">48&quot;</characteristic>
-                    <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">4</characteristic>
-                    <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">6</characteristic>
-                    <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Heavy 1, Blast (3&quot;), Pinning</characteristic>
-                  </characteristics>
-                </profile>
-                <profile id="ee3b-1cc3-4a97-6fdd" name="Missile Launcher - Ignis" publicationId="bde1-6db1-163b-3b76" page="118" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
-                  <characteristics>
-                    <characteristic name="Range" typeId="95ba-cda7-b831-6066">48&quot;</characteristic>
-                    <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">5</characteristic>
-                    <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">6</characteristic>
-                    <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Heavy 1, Blast (3&quot;), Ignores Cover</characteristic>
-                  </characteristics>
-                </profile>
-                <profile id="2783-8001-8e0d-0f7f" name="Missile Launcher - Krak" publicationId="a716-c1c4-7b26-8424" page="133" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
-                  <characteristics>
-                    <characteristic name="Range" typeId="95ba-cda7-b831-6066">48&quot;</characteristic>
-                    <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">8</characteristic>
-                    <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">3</characteristic>
-                    <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Heavy 1</characteristic>
-                  </characteristics>
-                </profile>
-              </profiles>
-              <infoLinks>
-                <infoLink id="19b7-4553-d94e-4746" name="Pinning" hidden="false" targetId="1c96-205c-59a0-3cf2" type="rule"/>
-                <infoLink id="a034-61f7-5d44-6466" name="Blast" hidden="false" targetId="1d9a-73ef-5f4f-8bd8" type="rule"/>
-                <infoLink id="ec38-2e57-c47c-94a2" name="Ignores Cover" hidden="false" targetId="fdb5-59e2-c446-1cbc" type="rule"/>
-              </infoLinks>
-              <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-          <entryLinks>
-            <entryLink id="7549-b055-00a9-7fbe" name="Graviton Hammer" hidden="false" collective="false" import="true" targetId="ceaa-178d-3995-c2c8" type="selectionEntry">
-              <constraints>
-                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6f4e-6276-589c-4e89" type="min"/>
-                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3817-88a0-382c-01f0" type="max"/>
-              </constraints>
-            </entryLink>
-            <entryLink id="9d03-1f50-3111-a224" name="Atomantic Deflector" hidden="false" collective="false" import="true" targetId="38fb-9a0b-edef-a497" type="selectionEntry">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="be33-1192-2508-125a" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b895-152b-024d-c335" type="max"/>
-              </constraints>
-            </entryLink>
-            <entryLink id="8045-8709-9262-02f8" name="Searchlights" hidden="false" collective="false" import="true" targetId="4ae3-79b4-6051-505e" type="selectionEntry">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6282-1ce5-0c03-d93a" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="46f5-b818-cac3-aa5d" type="max"/>
-              </constraints>
-            </entryLink>
-            <entryLink id="d4dc-190d-5cc9-e7b1" name="Paragon of Metal" hidden="false" collective="false" import="true" targetId="cc2a-46fe-bbf3-6ba2" type="selectionEntry">
-              <modifiers>
-                <modifier type="set" field="hidden" value="true">
-                  <conditions>
-                    <condition field="selections" scope="1a1b-fa35-a6a2-ca78" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="200f-3379-95a3-c3a4" type="greaterThan"/>
-                  </conditions>
-                </modifier>
-              </modifiers>
-              <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="35.0"/>
-              </costs>
-            </entryLink>
-          </entryLinks>
-          <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="130.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
-      <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="12c4-10db-40e2-04c4" name="Gatling Blaster" publicationId="bde1-6db1-163b-3b76" page="114" hidden="false" collective="false" import="true" type="upgrade">
@@ -5423,49 +5059,6 @@ Thaumaturge’s Cleansing (Psychic Weapon)</description>
           </modifiers>
         </infoLink>
         <infoLink id="12a9-123a-1516-c633" name="Blast" hidden="false" targetId="1d9a-73ef-5f4f-8bd8" type="rule"/>
-      </infoLinks>
-      <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="ceaa-178d-3995-c2c8" name="Graviton Hammer" publicationId="bde1-6db1-163b-3b76" page="116" hidden="false" collective="false" import="true" type="upgrade">
-      <profiles>
-        <profile id="3135-eb29-2a63-329d" name="Graviton Hammer (Melee)" publicationId="bde1-6db1-163b-3b76" page="116" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
-          <characteristics>
-            <characteristic name="Range" typeId="95ba-cda7-b831-6066">-</characteristic>
-            <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">10</characteristic>
-            <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">2</characteristic>
-            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Melee, Armourbane (Melee), Concussive (2)</characteristic>
-          </characteristics>
-        </profile>
-        <profile id="d867-d7b0-ce2b-dc88" name="Graviton Hammer (Ranged)" publicationId="bde1-6db1-163b-3b76" page="116" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
-          <characteristics>
-            <characteristic name="Range" typeId="95ba-cda7-b831-6066">Template</characteristic>
-            <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">*</characteristic>
-            <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">6</characteristic>
-            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Heavy 1, Concussive (1), Graviton Pulse*, Grav Wave, Haywire</characteristic>
-          </characteristics>
-        </profile>
-      </profiles>
-      <infoLinks>
-        <infoLink id="88f3-0cb5-d310-74fc" name="Armourbane (X)" hidden="false" targetId="cb59-f920-f071-7cd4" type="rule">
-          <modifiers>
-            <modifier type="set" field="name" value="Armourbane (Melee)"/>
-          </modifiers>
-        </infoLink>
-        <infoLink id="0d30-dbad-b929-3bd5" name="Concussive (X)" hidden="false" targetId="7ce5-1bfb-64e6-f826" type="rule">
-          <modifiers>
-            <modifier type="set" field="name" value="Concussive (2)"/>
-          </modifiers>
-        </infoLink>
-        <infoLink id="3a2b-4675-ded5-a6f0" name="Concussive (X)" hidden="false" targetId="7ce5-1bfb-64e6-f826" type="rule">
-          <modifiers>
-            <modifier type="set" field="name" value="Concussive (1)"/>
-          </modifiers>
-        </infoLink>
-        <infoLink id="1d35-d0fa-0e25-3fff" name="Grav Wave" hidden="false" targetId="1cc2-eaee-8bcf-96d3" type="rule"/>
-        <infoLink id="9561-cc6f-740e-7fe9" name="Graviton Pulse" hidden="false" targetId="5b9c-2738-616c-abdf" type="rule"/>
-        <infoLink id="72a9-4787-6458-78e4" name="Haywire" hidden="false" targetId="1dd4-7a75-5c59-8425" type="rule"/>
       </infoLinks>
       <costs>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
@@ -5590,70 +5183,6 @@ Thaumaturge’s Cleansing (Psychic Weapon)</description>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="f65c-633a-5865-7f6b" name="Lightning Gun" publicationId="bde1-6db1-163b-3b76" page="113" hidden="false" collective="false" import="true" type="upgrade">
-      <profiles>
-        <profile id="7aca-056b-f2c7-e744" name="Lightning Gun (Arc)" publicationId="bde1-6db1-163b-3b76" page="113" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
-          <characteristics>
-            <characteristic name="Range" typeId="95ba-cda7-b831-6066">18&quot;</characteristic>
-            <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">4</characteristic>
-            <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">-</characteristic>
-            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Heavy 3, Shred</characteristic>
-          </characteristics>
-        </profile>
-        <profile id="530a-de1b-b3cd-989f" name="Lightning Gun (Strike)" publicationId="bde1-6db1-163b-3b76" page="113" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
-          <characteristics>
-            <characteristic name="Range" typeId="95ba-cda7-b831-6066">18&quot;</characteristic>
-            <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">7</characteristic>
-            <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">5</characteristic>
-            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Heavy 1, Rending (4+), Shred</characteristic>
-          </characteristics>
-        </profile>
-      </profiles>
-      <infoLinks>
-        <infoLink id="9621-1a87-9bbe-8c8e" name="Rending (X)" hidden="false" targetId="0ac9-fab7-aef3-de1d" type="rule">
-          <modifiers>
-            <modifier type="set" field="name" value="Rending (4+)"/>
-          </modifiers>
-        </infoLink>
-        <infoLink id="75d2-fa45-545b-b466" name="Shred" hidden="false" targetId="5e7e-1628-8174-6f2c" type="rule"/>
-      </infoLinks>
-      <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="7478-2c29-dfc4-f4cf" name="Mauler Bolt Cannon" publicationId="bde1-6db1-163b-3b76" page="114" hidden="false" collective="false" import="true" type="upgrade">
-      <profiles>
-        <profile id="0d73-2c3e-acc4-6043" name="Mauler Bolt Cannon" publicationId="bde1-6db1-163b-3b76" page="114" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
-          <characteristics>
-            <characteristic name="Range" typeId="95ba-cda7-b831-6066">24&quot;</characteristic>
-            <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">6</characteristic>
-            <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">4</characteristic>
-            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Heavy 4, Pinning</characteristic>
-          </characteristics>
-        </profile>
-      </profiles>
-      <infoLinks>
-        <infoLink id="c266-d515-6109-7c39" name="Pinning" hidden="false" targetId="1c96-205c-59a0-3cf2" type="rule"/>
-      </infoLinks>
-      <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="1d3e-1b60-d133-ea0d" name="Maxima Bolter" publicationId="bde1-6db1-163b-3b76" page="114" hidden="false" collective="false" import="true" type="upgrade">
-      <profiles>
-        <profile id="54b0-1838-c2c5-1191" name="Maxima Bolter" publicationId="bde1-6db1-163b-3b76" page="114" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
-          <characteristics>
-            <characteristic name="Range" typeId="95ba-cda7-b831-6066">12&quot;</characteristic>
-            <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">4</characteristic>
-            <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">5</characteristic>
-            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Assault 3</characteristic>
-          </characteristics>
-        </profile>
-      </profiles>
-      <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
-      </costs>
-    </selectionEntry>
     <selectionEntry id="7a16-0e23-c633-c668" name="Melta Cannon" publicationId="bde1-6db1-163b-3b76" page="117" hidden="false" collective="false" import="true" type="upgrade">
       <profiles>
         <profile id="ace6-d246-d221-6912" name="Melta Cannon" publicationId="bde1-6db1-163b-3b76" page="117" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
@@ -5672,32 +5201,6 @@ Thaumaturge’s Cleansing (Psychic Weapon)</description>
             <modifier type="set" field="name" value="Armourbane (Melta)"/>
           </modifiers>
         </infoLink>
-      </infoLinks>
-      <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="eab1-7776-c8da-da00" name="Mori Quake Cannon" publicationId="bde1-6db1-163b-3b76" page="113" hidden="false" collective="false" import="true" type="upgrade">
-      <profiles>
-        <profile id="a101-d643-7adf-a419" name="Mori Quake Cannon" publicationId="bde1-6db1-163b-3b76" page="113" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
-          <characteristics>
-            <characteristic name="Range" typeId="95ba-cda7-b831-6066">24&quot;-360&quot;</characteristic>
-            <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">10/8/6</characteristic>
-            <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">3</characteristic>
-            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Destroyer 1, Apocalyptic Mega-blast, Barrage, Seismic Shock, Concussive (1)</characteristic>
-          </characteristics>
-        </profile>
-      </profiles>
-      <infoLinks>
-        <infoLink id="968b-72b9-94b1-2949" name="Destroyer" hidden="false" targetId="44d6-09b2-3bd3-b2d6" type="rule"/>
-        <infoLink id="47bf-488c-00ab-3694" name="Blast" hidden="false" targetId="1d9a-73ef-5f4f-8bd8" type="rule"/>
-        <infoLink id="e478-7a02-f953-f109" name="Barrage" hidden="false" targetId="7255-b5ee-c3f4-3037" type="rule"/>
-        <infoLink id="3e74-94bd-676c-20ea" name="Concussive (X)" hidden="false" targetId="7ce5-1bfb-64e6-f826" type="rule">
-          <modifiers>
-            <modifier type="set" field="name" value="Concussive (1)"/>
-          </modifiers>
-        </infoLink>
-        <infoLink id="26b7-8408-49e0-48bb" name="Seismic Shock" hidden="false" targetId="5e0d-b2af-e7b4-a8cd" type="rule"/>
       </infoLinks>
       <costs>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
@@ -5810,31 +5313,6 @@ In addition, a model with the Paragon of Metal special rule may not be targeted 
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="226a-8196-f0af-f8a8" name="Plasma Mortar" publicationId="bde1-6db1-163b-3b76" page="118" hidden="false" collective="false" import="true" type="upgrade">
-      <profiles>
-        <profile id="b024-fd99-74bd-a470" name="Plasma Mortar" publicationId="bde1-6db1-163b-3b76" page="118" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
-          <characteristics>
-            <characteristic name="Range" typeId="95ba-cda7-b831-6066">36&quot;</characteristic>
-            <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">8</characteristic>
-            <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">4</characteristic>
-            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Ordnance 1, Large Blast (5&quot;), Breaching (4+), Ignores Cover, Reactor Overload</characteristic>
-          </characteristics>
-        </profile>
-      </profiles>
-      <infoLinks>
-        <infoLink id="b1a0-5946-ac80-f88e" name="Blast" hidden="false" targetId="1d9a-73ef-5f4f-8bd8" type="rule"/>
-        <infoLink id="477b-d136-c36a-e2d5" name="Breaching (X)" hidden="false" targetId="a760-f736-1bf3-fa3c" type="rule">
-          <modifiers>
-            <modifier type="set" field="name" value="Breaching (4+)"/>
-          </modifiers>
-        </infoLink>
-        <infoLink id="9311-8b5a-f831-8f6c" name="Ignores Cover" hidden="false" targetId="fdb5-59e2-c446-1cbc" type="rule"/>
-        <infoLink id="3ce5-eddf-7453-a879" name="Reactor Overload" hidden="false" targetId="a073-b86c-7bc1-d3f9" type="rule"/>
-      </infoLinks>
-      <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
-      </costs>
-    </selectionEntry>
     <selectionEntry id="2121-ee7c-8ac9-5133" name="Power Blade Array" publicationId="bde1-6db1-163b-3b76" page="122" hidden="false" collective="false" import="true" type="upgrade">
       <profiles>
         <profile id="3a2b-2c15-46b8-f8f8" name="Power Blade Array" publicationId="bde1-6db1-163b-3b76" page="122" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
@@ -5897,29 +5375,6 @@ In addition, a model with the Paragon of Metal special rule may not be targeted 
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="24d6-7dc1-0dde-9504" name="Sollex Heavy-Las" publicationId="bde1-6db1-163b-3b76" page="117" hidden="false" collective="false" import="true" type="upgrade">
-      <profiles>
-        <profile id="63ed-87d1-30f3-100d" name="Sollex Heavy-Las" publicationId="bde1-6db1-163b-3b76" page="117" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
-          <characteristics>
-            <characteristic name="Range" typeId="95ba-cda7-b831-6066">48&quot;</characteristic>
-            <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">10</characteristic>
-            <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">2</characteristic>
-            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Heavy 3, Armourbane (Ranged), Shock Pulse</characteristic>
-          </characteristics>
-        </profile>
-      </profiles>
-      <infoLinks>
-        <infoLink id="494e-b266-33dc-5871" name="Armourbane (X)" hidden="false" targetId="cb59-f920-f071-7cd4" type="rule">
-          <modifiers>
-            <modifier type="set" field="name" value="Armourbane (Ranged)"/>
-          </modifiers>
-        </infoLink>
-        <infoLink id="e656-46c8-1175-7673" name="Shock Pulse" hidden="false" targetId="9222-f6c5-dc19-905a" type="rule"/>
-      </infoLinks>
-      <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
-      </costs>
-    </selectionEntry>
     <selectionEntry id="f4dc-88a0-0ad9-4c61" name="Sunfury Plasma Annihilator" publicationId="bde1-6db1-163b-3b76" page="118" hidden="false" collective="false" import="true" type="upgrade">
       <profiles>
         <profile id="bc66-cc98-7577-e716" name="Sunfury Plasma Annihilator" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
@@ -5936,220 +5391,6 @@ In addition, a model with the Paragon of Metal special rule may not be targeted 
         <infoLink id="e712-a41d-76b9-dfde" name="Blast" hidden="false" targetId="1d9a-73ef-5f4f-8bd8" type="rule"/>
         <infoLink id="1e2c-84c3-5b0e-0a40" name="Ignores Cover" hidden="false" targetId="fdb5-59e2-c446-1cbc" type="rule"/>
         <infoLink id="c764-ef6c-259c-84bc" name="Reactor Overload" hidden="false" targetId="a073-b86c-7bc1-d3f9" type="rule"/>
-      </infoLinks>
-      <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="2903-fef6-e839-368b" name="Thanatar Siege-automata Maniple" publicationId="bde1-6db1-163b-3b76" page="46" hidden="false" collective="false" import="true" type="unit">
-      <rules>
-        <rule id="5b8f-4c94-7cc1-90f2" name="Thanatar Maniple" publicationId="bde1-6db1-163b-3b76" page="110" hidden="false">
-          <description>When deployed onto the battlefield (either at the start of the battle or when arriving from Reserves) all models in the unit must be placed within unit coherency, but afterwards operate independently and are not treated asa single unit.</description>
-        </rule>
-      </rules>
-      <categoryLinks>
-        <categoryLink id="ce97-d8a6-5bef-c2aa" name="Automata Unit-type:" hidden="false" targetId="d8ab-8e21-e193-63ba" primary="false"/>
-        <categoryLink id="12f3-e9d8-79be-f918" name="Cybernetica Sub-type:" hidden="false" targetId="2440-b64e-cb24-87f0" primary="false"/>
-        <categoryLink id="c841-2f37-df8e-f4f8" name="Light Sub-type:" hidden="false" targetId="bff2-ae16-74a8-8712" primary="false"/>
-        <categoryLink id="c452-b818-fc00-c8d0" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
-      </categoryLinks>
-      <selectionEntries>
-        <selectionEntry id="c48e-f9ea-9d9d-46aa" name="Thanatar" publicationId="bde1-6db1-163b-3b76" page="46" hidden="false" collective="false" import="true" type="model">
-          <modifiers>
-            <modifier type="set" field="name" value="Thanatar Calix">
-              <conditions>
-                <condition field="selections" scope="c48e-f9ea-9d9d-46aa" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4c16-20c7-f928-2aa6" type="equalTo"/>
-              </conditions>
-            </modifier>
-            <modifier type="set" field="name" value="Thanatar Cavas">
-              <conditions>
-                <condition field="selections" scope="c48e-f9ea-9d9d-46aa" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5331-31f3-87ed-5ebe" type="equalTo"/>
-              </conditions>
-            </modifier>
-          </modifiers>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4f1c-057b-1a09-e4bb" type="min"/>
-            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5056-7e9f-20b9-96eb" type="max"/>
-          </constraints>
-          <selectionEntryGroups>
-            <selectionEntryGroup id="15b5-1ed0-a48c-a9b8" name="A single Thanatar-Cavas in the Maniple may be replaced with a Thanatar Calix" hidden="false" collective="false" import="true">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e0f0-a2f0-5ed0-84e4" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="aefd-3258-c13f-7078" type="max"/>
-              </constraints>
-              <selectionEntries>
-                <selectionEntry id="5331-31f3-87ed-5ebe" name="Thanatar Cavas" hidden="false" collective="false" import="true" type="upgrade">
-                  <profiles>
-                    <profile id="891f-90ee-c496-ce0d" name="Thanatar Cavas" publicationId="bde1-6db1-163b-3b76" page="46" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName="Unit">
-                      <characteristics>
-                        <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Automata (Cybernetica, Light)</characteristic>
-                        <characteristic name="Move" typeId="893e-2d76-8f04-44e5">8</characteristic>
-                        <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
-                        <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
-                        <characteristic name="S" typeId="e478-41d4-a092-48a8">6</characteristic>
-                        <characteristic name="T" typeId="c32b-5fdd-3fbe-9b1f">5</characteristic>
-                        <characteristic name="W" typeId="57ee-1126-32a9-5672">4</characteristic>
-                        <characteristic name="I" typeId="62d3-22d7-2d49-52dc">4</characteristic>
-                        <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">3</characteristic>
-                        <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">7</characteristic>
-                        <characteristic name="Save" typeId="e593-6b3c-f169-04f0">3+</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                  <infoLinks>
-                    <infoLink id="cf31-6e0c-68b4-2bb4" name="Hammer of Wrath (X)" hidden="false" targetId="aec0-c3aa-1e4e-1779" type="rule">
-                      <modifiers>
-                        <modifier type="set" field="name" value="Hammer of Wrath (1)"/>
-                      </modifiers>
-                    </infoLink>
-                  </infoLinks>
-                  <entryLinks>
-                    <entryLink id="f896-a67c-5732-74e6" name="Plasma Mortar" hidden="false" collective="false" import="true" targetId="226a-8196-f0af-f8a8" type="selectionEntry">
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f470-9498-1a5a-595d" type="min"/>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="62a2-4026-8135-684c" type="max"/>
-                      </constraints>
-                    </entryLink>
-                    <entryLink id="5504-f040-14db-6982" name="Shock Charger" hidden="false" collective="false" import="true" targetId="3234-492f-9ebf-f23c" type="selectionEntry">
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="09ba-e021-c071-a9c7" type="min"/>
-                        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6e3c-216c-30ac-0a04" type="max"/>
-                      </constraints>
-                    </entryLink>
-                    <entryLink id="6920-5af8-8152-d756" name="Atomantic Deflector" hidden="false" collective="false" import="true" targetId="38fb-9a0b-edef-a497" type="selectionEntry">
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8361-6260-e133-6fdb" type="min"/>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b414-b34e-2d24-b68b" type="max"/>
-                      </constraints>
-                    </entryLink>
-                    <entryLink id="7524-1194-0bcd-024e" name="Twin-linked Mauler Bolt Cannon" hidden="false" collective="false" import="true" targetId="ac88-bcf4-d7b4-5c56" type="selectionEntry">
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e16b-86f7-2db9-9778" type="min"/>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fdc8-c39c-127a-89b6" type="max"/>
-                      </constraints>
-                    </entryLink>
-                  </entryLinks>
-                  <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
-                  </costs>
-                </selectionEntry>
-                <selectionEntry id="4c16-20c7-f928-2aa6" name="Thanatar Calix" hidden="false" collective="false" import="true" type="upgrade">
-                  <constraints>
-                    <constraint field="selections" scope="2903-fef6-e839-368b" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="83fc-f27c-08a9-0907" type="max"/>
-                  </constraints>
-                  <profiles>
-                    <profile id="df17-9de2-31bf-f684" name="Thanatar Calix" publicationId="bde1-6db1-163b-3b76" page="46" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName="Unit">
-                      <characteristics>
-                        <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Automata (Cybernetica, Light)</characteristic>
-                        <characteristic name="Move" typeId="893e-2d76-8f04-44e5">8</characteristic>
-                        <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
-                        <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
-                        <characteristic name="S" typeId="e478-41d4-a092-48a8">6</characteristic>
-                        <characteristic name="T" typeId="c32b-5fdd-3fbe-9b1f">5</characteristic>
-                        <characteristic name="W" typeId="57ee-1126-32a9-5672">4</characteristic>
-                        <characteristic name="I" typeId="62d3-22d7-2d49-52dc">4</characteristic>
-                        <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">3</characteristic>
-                        <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">7</characteristic>
-                        <characteristic name="Save" typeId="e593-6b3c-f169-04f0">3+</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                  <infoLinks>
-                    <infoLink id="5769-8876-abc8-6b62" name="Hammer of Wrath (X)" hidden="false" targetId="aec0-c3aa-1e4e-1779" type="rule">
-                      <modifiers>
-                        <modifier type="set" field="name" value="Hammer of Wrath (1)"/>
-                      </modifiers>
-                    </infoLink>
-                  </infoLinks>
-                  <entryLinks>
-                    <entryLink id="0fc7-4df7-8728-f720" name="Graviton Ram" hidden="false" collective="false" import="true" targetId="f610-008f-5046-ea99" type="selectionEntry">
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b35e-74a6-848b-3971" type="min"/>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="869a-0615-e77d-8a4b" type="max"/>
-                      </constraints>
-                    </entryLink>
-                    <entryLink id="5528-2ffc-88ff-9c57" name="Sollex Heavy-Las" hidden="false" collective="false" import="true" targetId="24d6-7dc1-0dde-9504" type="selectionEntry">
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eac4-7aa1-ed74-2107" type="min"/>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ccf9-9967-b2f0-0e65" type="max"/>
-                      </constraints>
-                    </entryLink>
-                    <entryLink id="b455-6e04-25d8-2eb6" name="Atomantic Deflector" hidden="false" collective="false" import="true" targetId="38fb-9a0b-edef-a497" type="selectionEntry">
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f171-d842-4134-3bf0" type="min"/>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1bcb-8717-3150-e809" type="max"/>
-                      </constraints>
-                    </entryLink>
-                    <entryLink id="072c-045d-c5cc-c0e2" name="Twin-linked Mauler Bolt Cannon" hidden="false" collective="false" import="true" targetId="ac88-bcf4-d7b4-5c56" type="selectionEntry">
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="456b-366e-bb16-2a1a" type="min"/>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3ee1-2b23-b60f-a203" type="max"/>
-                      </constraints>
-                    </entryLink>
-                  </entryLinks>
-                  <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0"/>
-                  </costs>
-                </selectionEntry>
-              </selectionEntries>
-            </selectionEntryGroup>
-          </selectionEntryGroups>
-          <entryLinks>
-            <entryLink id="d184-0a35-7e08-07f1" name="Paragon of Metal" hidden="false" collective="false" import="true" targetId="cc2a-46fe-bbf3-6ba2" type="selectionEntry">
-              <modifiers>
-                <modifier type="set" field="hidden" value="true">
-                  <conditions>
-                    <condition field="selections" scope="2903-fef6-e839-368b" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c48e-f9ea-9d9d-46aa" type="greaterThan"/>
-                  </conditions>
-                </modifier>
-              </modifiers>
-              <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="35.0"/>
-              </costs>
-            </entryLink>
-          </entryLinks>
-          <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="235.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
-      <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="2952-52d9-49e2-cbfd" name="Titan Power Fist" publicationId="bde1-6db1-163b-3b76" page="122" hidden="false" collective="false" import="true" type="upgrade">
-      <profiles>
-        <profile id="1198-69f8-54f2-7a5d" name="Titan Power Fist" publicationId="bde1-6db1-163b-3b76" page="122" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
-          <characteristics>
-            <characteristic name="Range" typeId="95ba-cda7-b831-6066">-</characteristic>
-            <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">14</characteristic>
-            <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">1</characteristic>
-            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Melee, Sunder, Destructor</characteristic>
-          </characteristics>
-        </profile>
-      </profiles>
-      <infoLinks>
-        <infoLink id="86c1-3c47-751e-9c64" name="Sunder" hidden="false" targetId="20e2-75cf-bc16-cd8f" type="rule"/>
-        <infoLink id="d31c-ac5b-aafc-3f5c" name="Destructor" hidden="false" targetId="1f93-c765-f7b2-a025" type="rule"/>
-      </infoLinks>
-      <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="ac88-bcf4-d7b4-5c56" name="Twin-linked Mauler Bolt Cannon" publicationId="bde1-6db1-163b-3b76" page="114" hidden="false" collective="false" import="true" type="upgrade">
-      <profiles>
-        <profile id="8398-d59e-6c60-9c3d" name="Twin-linked Mauler Bolt Cannon" publicationId="bde1-6db1-163b-3b76" page="114" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
-          <characteristics>
-            <characteristic name="Range" typeId="95ba-cda7-b831-6066">24&quot;</characteristic>
-            <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">6</characteristic>
-            <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">4</characteristic>
-            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Heavy 4, Pinning, Twin-linked</characteristic>
-          </characteristics>
-        </profile>
-      </profiles>
-      <infoLinks>
-        <infoLink id="7003-efbe-2388-6776" name="Pinning" hidden="false" targetId="1c96-205c-59a0-3cf2" type="rule"/>
-        <infoLink id="509e-4e52-b5d5-f867" name="Twin-linked" hidden="false" targetId="8542-ee9d-e2fa-52fe" type="rule"/>
       </infoLinks>
       <costs>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
@@ -6172,132 +5413,6 @@ In addition, a model with the Paragon of Metal special rule may not be targeted 
         <infoLink id="c702-a2c4-ac1f-2d72" name="Twin-linked" hidden="false" targetId="8542-ee9d-e2fa-52fe" type="rule"/>
         <infoLink id="45ab-52e4-d6d4-1bf3" name="**Turbo-Laser issue" hidden="false" targetId="2ac7-9784-9b0f-182b" type="rule"/>
       </infoLinks>
-      <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="f144-1079-11ff-019d" name="Vorax Battle-automata Maniple" publicationId="bde1-6db1-163b-3b76" page="42" hidden="false" collective="false" import="true" type="unit">
-      <categoryLinks>
-        <categoryLink id="75eb-2b97-8b36-a501" name="Automata Unit-type:" hidden="false" targetId="d8ab-8e21-e193-63ba" primary="false"/>
-        <categoryLink id="4a9a-7fa9-75bb-1914" name="Cybernetica Sub-type:" hidden="false" targetId="2440-b64e-cb24-87f0" primary="false"/>
-        <categoryLink id="f6a5-5001-3a55-c7f9" name="Light Sub-type:" hidden="false" targetId="bff2-ae16-74a8-8712" primary="false"/>
-      </categoryLinks>
-      <selectionEntries>
-        <selectionEntry id="59fd-998f-8190-baec" name="Vorax" publicationId="bde1-6db1-163b-3b76" page="42" hidden="false" collective="false" import="true" type="model">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f64e-d371-c8bc-2142" type="min"/>
-            <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="263e-aaf5-8054-419e" type="max"/>
-          </constraints>
-          <profiles>
-            <profile id="244c-1e6b-3768-3c13" name="Vorax" publicationId="bde1-6db1-163b-3b76" page="42" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName="Unit">
-              <characteristics>
-                <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Automata (Cybernetica, Light)</characteristic>
-                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">8</characteristic>
-                <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
-                <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
-                <characteristic name="S" typeId="e478-41d4-a092-48a8">6</characteristic>
-                <characteristic name="T" typeId="c32b-5fdd-3fbe-9b1f">5</characteristic>
-                <characteristic name="W" typeId="57ee-1126-32a9-5672">4</characteristic>
-                <characteristic name="I" typeId="62d3-22d7-2d49-52dc">4</characteristic>
-                <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">3</characteristic>
-                <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">7</characteristic>
-                <characteristic name="Save" typeId="e593-6b3c-f169-04f0">3+</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
-          <infoLinks>
-            <infoLink id="569f-ee61-f33a-e599" name="Fleet (X)" hidden="false" targetId="ddc9-0b4b-78da-bbd2" type="rule">
-              <modifiers>
-                <modifier type="set" field="name" value="Fleet (2)"/>
-              </modifiers>
-            </infoLink>
-            <infoLink id="3c21-bfee-eb7c-b5d2" name="Scout" hidden="false" targetId="aacf-9a7e-982d-b793" type="rule"/>
-            <infoLink id="e32e-91b4-6fa0-b57c" name="Hammer of Wrath (X)" hidden="false" targetId="aec0-c3aa-1e4e-1779" type="rule">
-              <modifiers>
-                <modifier type="set" field="name" value="Hammer of Wrath (1)"/>
-              </modifiers>
-            </infoLink>
-          </infoLinks>
-          <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="65.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="ee45-7759-1541-af8c" name="Power Blade Array with In-Built Rotar Cannon" hidden="false" collective="false" import="true" type="upgrade">
-          <constraints>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="68f5-f681-5d6f-9474" type="min"/>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="13c8-0f3a-2331-f6db" type="max"/>
-          </constraints>
-          <entryLinks>
-            <entryLink id="b70c-2074-fc15-ed1c" name="Power Blade Array" hidden="false" collective="false" import="true" targetId="2121-ee7c-8ac9-5133" type="selectionEntry">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b4ee-e1ee-76bf-98e5" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3ee8-7743-087c-2c41" type="max"/>
-              </constraints>
-            </entryLink>
-            <entryLink id="094e-d74f-b609-f0ab" name="Rotor Cannon" hidden="false" collective="false" import="true" targetId="5ce3-3aa5-3f5e-9ead" type="selectionEntry">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="55d0-41a9-76c9-b974" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9c3a-e0d2-89d7-47f1" type="max"/>
-              </constraints>
-            </entryLink>
-          </entryLinks>
-          <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
-      <selectionEntryGroups>
-        <selectionEntryGroup id="4d5d-73fe-9e1d-34f5" name="One in Three Vorax in the unit, may exchange its Lightning Gun" hidden="false" collective="false" import="true">
-          <modifiers>
-            <modifier type="increment" field="618c-0761-5152-1969" value="1.0">
-              <repeats>
-                <repeat field="selections" scope="f144-1079-11ff-019d" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="59fd-998f-8190-baec" repeats="1" roundUp="false"/>
-              </repeats>
-            </modifier>
-            <modifier type="increment" field="c07c-ccfe-108a-cbca" value="1.0">
-              <repeats>
-                <repeat field="selections" scope="f144-1079-11ff-019d" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="59fd-998f-8190-baec" repeats="1" roundUp="false"/>
-              </repeats>
-            </modifier>
-          </modifiers>
-          <constraints>
-            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c07c-ccfe-108a-cbca" type="min"/>
-            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="618c-0761-5152-1969" type="max"/>
-          </constraints>
-          <entryLinks>
-            <entryLink id="c0fe-3ade-f089-a298" name="Irad-Cleanser" hidden="false" collective="false" import="true" targetId="b3c5-237f-e1d2-d9f8" type="selectionEntry">
-              <modifiers>
-                <modifier type="increment" field="0296-5f17-31bc-b1db" value="1.0">
-                  <repeats>
-                    <repeat field="selections" scope="f144-1079-11ff-019d" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="59fd-998f-8190-baec" repeats="1" roundUp="false"/>
-                  </repeats>
-                </modifier>
-              </modifiers>
-              <constraints>
-                <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0296-5f17-31bc-b1db" type="max"/>
-              </constraints>
-              <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
-              </costs>
-            </entryLink>
-            <entryLink id="c288-f2f9-d72d-e2b2" name="Lightning Gun" hidden="false" collective="false" import="true" targetId="f65c-633a-5865-7f6b" type="selectionEntry"/>
-          </entryLinks>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
-      <entryLinks>
-        <entryLink id="9503-d92e-8e8c-771a" name="Paragon of Metal" hidden="false" collective="false" import="true" targetId="cc2a-46fe-bbf3-6ba2" type="selectionEntry">
-          <modifiers>
-            <modifier type="set" field="hidden" value="true">
-              <conditions>
-                <condition field="selections" scope="f144-1079-11ff-019d" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="59fd-998f-8190-baec" type="greaterThan"/>
-              </conditions>
-            </modifier>
-          </modifiers>
-          <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="35.0"/>
-          </costs>
-        </entryLink>
-      </entryLinks>
       <costs>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
       </costs>
@@ -6460,6 +5575,9 @@ In addition, a model with the Paragon of Metal special rule may not be targeted 
           </modifiers>
         </infoLink>
       </infoLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="cc2e-df5f-1778-29d8" name="Earthshaker cannon" publicationId="d0df-7166-5cd3-89fd" page="25" hidden="false" collective="false" import="true" type="upgrade">
       <profiles>
@@ -6482,6 +5600,9 @@ In addition, a model with the Paragon of Metal special rule may not be targeted 
         <infoLink id="23ca-c48c-ae3b-073a" name="Pinning" hidden="false" targetId="1c96-205c-59a0-3cf2" type="rule"/>
         <infoLink id="8f76-4b67-7105-c838" name="Shred" hidden="false" targetId="5e7e-1628-8174-6f2c" type="rule"/>
       </infoLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="1a31-37ac-618e-4135" name="Whirlwind missile launcher" hidden="false" collective="false" import="true" type="upgrade">
       <entryLinks>
@@ -6504,6 +5625,9 @@ In addition, a model with the Paragon of Metal special rule may not be targeted 
           </constraints>
         </entryLink>
       </entryLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="0885-325b-5583-2942" name="Talonis HE missile" publicationId="d0df-7166-5cd3-89fd" page="27" hidden="false" collective="false" import="true" type="upgrade">
       <profiles>
@@ -6524,6 +5648,9 @@ In addition, a model with the Paragon of Metal special rule may not be targeted 
           </modifiers>
         </infoLink>
       </infoLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="215a-8348-38fc-553d" name="Thermios AP missile" publicationId="d0df-7166-5cd3-89fd" page="27" hidden="false" collective="false" import="true" type="upgrade">
       <profiles>
@@ -6549,6 +5676,9 @@ In addition, a model with the Paragon of Metal special rule may not be targeted 
           </modifiers>
         </infoLink>
       </infoLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="77c7-6225-dd22-59df" name="Icarios AA missile" hidden="false" collective="false" import="true" type="upgrade">
       <profiles>
@@ -6565,6 +5695,9 @@ In addition, a model with the Paragon of Metal special rule may not be targeted 
         <infoLink id="7951-2feb-9dd2-5166" name="Skyfire" hidden="false" targetId="f2bf-5daa-9f93-0b01" type="rule"/>
         <infoLink id="fe25-d0cc-e8f0-80fd" name="Twin-linked" hidden="false" targetId="8542-ee9d-e2fa-52fe" type="rule"/>
       </infoLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
     </selectionEntry>
   </sharedSelectionEntries>
   <sharedSelectionEntryGroups>
@@ -8953,9 +8086,6 @@ Warhammer: The Horus Heresy – Age of Darkness Rulebook).</description>
     <rule id="2ac7-9784-9b0f-182b" name="**Turbo-Laser issue" hidden="false">
       <description>The UK digital and Physcal versions of the Mech book had the wrong stats printed (lowering the S to 10 and AP to 3, as well as removing Ignores Cover). The correct value was in other versions of the book such as the German version which are the same as the stats presented in the Legion books.</description>
     </rule>
-    <rule id="d242-cb71-bc7f-eadd" name="Ardex-Defensor" publicationId="bde1-6db1-163b-3b76" page="102" hidden="false">
-      <description>A model with the Knight or Titan Unit Sub-types that has weapons with this special rule may make the Overwatch Reaction when it is triggered by models that do not have the Knight, Titan, Super-heavy, or Lumbering Flyer Unit Sub-types, or that have fewer than 8 Wounds. When making Shooting Attacks as part of the Overwatch Reaction, the Reacting model may only make Shooting Attacks with weapons with this special rule.</description>
-    </rule>
     <rule id="c41f-6ac9-6909-44c4" name="Catastrophic Destruction" publicationId="bde1-6db1-163b-3b76" page="103" hidden="false">
       <description>When destroyed, a model with this special rule resolves Catastrophic Damage at AP 1.</description>
     </rule>
@@ -8967,9 +8097,6 @@ Warhammer: The Horus Heresy – Age of Darkness Rulebook).</description>
     </rule>
     <rule id="4eb9-9e5e-bb27-3644" name="Disruption (X)" publicationId="bde1-6db1-163b-3b76" page="103" hidden="false">
       <description>To Hit rolls of the value X indicated made by a weapon with this rule cause an automatic Glancing Hit against models with the Vehicle Unit Type instead of rolling for Armour Penetration, and an automatic Wound against models with the Dreadnought or Automata Unit Types, instead of rolling To Wound.</description>
-    </rule>
-    <rule id="66b8-7232-1ed3-3f70" name="God-Engine" publicationId="bde1-6db1-163b-3b76" page="104" hidden="false">
-      <description>A model with this special rule ignores all Psychic Powers and Cybertheurgic Rites and Attacks made by Psychic and Cybertheurgic Weapons. In addition, a model with this special rule ignores the effects of the Haywire and Disruption (X) special rules. In all cases, weapons which benefit from these special rules must attempt to damage a model with this special rule normally using the attack’s Strength value. In addition, all friendly Mechanicum units with at least one model within 24&quot; of a model with this special rule gain the Fearless special rule.</description>
     </rule>
     <rule id="1cc2-eaee-8bcf-96d3" name="Grav Wave" publicationId="bde1-6db1-163b-3b76" page="104" hidden="false">
       <description>Any successful Charge that targets a unit containing a model with a weapon with this special rule is always counted as a Disordered Charge.</description>

--- a/2022 - LA - Blood Angels.cat
+++ b/2022 - LA - Blood Angels.cat
@@ -1,16 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="cd4d-8765-5387-8409" name="LA -  IX: Blood Angels" revision="7" battleScribeVersion="2.03" authorName="Jon K &quot;Alphalas&quot;" authorContact="Twitter: Alphalas_ Discord: Alphalas#8789" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="12" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="cd4d-8765-5387-8409" name="LA -  IX: Blood Angels" revision="8" battleScribeVersion="2.03" authorName="Jon K &quot;Alphalas&quot;" authorContact="Twitter: Alphalas_ Discord: Alphalas#8789" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="13" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entryLinks>
     <entryLink id="1900-3f09-f47b-bed2" name="Praetor" hidden="false" collective="false" import="false" targetId="03be-5d55-d05a-771d" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="41ff-7a92-f8e9-0631" type="equalTo"/>
-          </conditions>
-        </modifier>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="7e95-886f-ed9d-3000" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="4180-caf6-d0dc-7347" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
       </categoryLinks>
       <entryLinks>
         <entryLink id="0493-4e5d-281f-d4f2" name="Retinue" hidden="false" collective="false" import="true" targetId="6307-ed53-0ac4-0212" type="selectionEntryGroup"/>
@@ -20,46 +14,26 @@
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="41ff-7a92-f8e9-0631" type="equalTo"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
         <categoryLink id="9ebe-3513-9ab7-69db" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="3357-5e6d-c437-5295" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="201c-1876-1343-82bd" name="Contemptor-Incaendius Dreadnought" hidden="false" collective="false" import="false" targetId="090c-5656-0180-16c8" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="41ff-7a92-f8e9-0631" type="equalTo"/>
-          </conditions>
-        </modifier>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="f0c3-dea6-a3b3-8814" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="c1af-e2cc-99eb-9c5b" name="Crimson Paladins" hidden="false" collective="false" import="false" targetId="33fe-9683-bde5-95ca" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="41ff-7a92-f8e9-0631" type="equalTo"/>
-          </conditions>
-        </modifier>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="b2fb-57e6-76d1-b70e" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="f425-f617-0a7a-ce2b" name="Dawnbreaker Cohort" hidden="false" collective="false" import="false" targetId="3c67-35da-d64a-f22b" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="41ff-7a92-f8e9-0631" type="equalTo"/>
-          </conditions>
-        </modifier>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="2138-4038-c520-9323" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
       </categoryLinks>
@@ -68,31 +42,38 @@
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="41ff-7a92-f8e9-0631" type="equalTo"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
         <categoryLink id="66b1-54b1-9b38-8d89" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="805e-3ba0-5df2-fb4d" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="8a1e-4de2-5a75-956f" name="Judicar Aster Crohne" hidden="false" collective="false" import="false" targetId="8dba-83cd-4922-bc63" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="41ff-7a92-f8e9-0631" type="equalTo"/>
-          </conditions>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
         <categoryLink id="fc0b-2d5b-6e2b-a661" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="18df-f052-5edd-948c" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="6c34-54c1-2c55-e6dc" name="Sanguinius" hidden="false" collective="false" import="false" targetId="2c54-82c1-c1e4-3aee" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="41ff-7a92-f8e9-0631" type="equalTo"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
           </conditions>
         </modifier>
       </modifiers>
@@ -101,13 +82,6 @@
       </categoryLinks>
     </entryLink>
     <entryLink id="d781-5311-119f-a8e2" name="The Angel&apos;s Tears" hidden="false" collective="false" import="false" targetId="dda1-0fcf-0245-6c10" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="41ff-7a92-f8e9-0631" type="equalTo"/>
-          </conditions>
-        </modifier>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="bd40-3a9c-fc64-acc2" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
       </categoryLinks>

--- a/2022 - LA - Dark Angels.cat
+++ b/2022 - LA - Dark Angels.cat
@@ -1,32 +1,20 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="ee5e-198e-1b19-4b9f" name="LA -   I: Dark Angels" revision="4" battleScribeVersion="2.03" authorName="revivedtitan" authorContact="BSData Developers Discord" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="10" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="ee5e-198e-1b19-4b9f" name="LA -   I: Dark Angels" revision="5" battleScribeVersion="2.03" authorName="revivedtitan" authorContact="BSData Developers Discord" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="13" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entryLinks>
     <entryLink id="7653-8041-8d1c-c872" name="Dreadwing Interemptor Squad" hidden="false" collective="false" import="false" targetId="3008-e8ed-9e97-71c9" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditionGroups>
-            <conditionGroup type="or">
-              <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b2b4-2198-0b90-dd9f" type="equalTo"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="b375-4d79-dba1-0791" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="73f2-8df7-0fa9-dd37" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="7089-ea3d-51ac-2dc2" name="Corswain" hidden="false" collective="false" import="false" targetId="4097-b2b4-d9da-da99" type="selectionEntry">
+    <entryLink id="7089-ea3d-51ac-2dc2" name="Corswain" hidden="true" collective="false" import="false" targetId="4097-b2b4-d9da-da99" type="selectionEntry">
       <modifiers>
-        <modifier type="set" field="hidden" value="true">
+        <modifier type="set" field="hidden" value="false">
           <conditionGroups>
-            <conditionGroup type="or">
+            <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b2b4-2198-0b90-dd9f" type="equalTo"/>
-                <condition field="selections" scope="e90d-e5a8-f42d-da84" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="equalTo"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
@@ -35,19 +23,15 @@
       <categoryLinks>
         <categoryLink id="a4a2-0795-10b3-814b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="7b72-0a2d-ea5f-e088" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="e12a-8c05-d094-5857" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="f659-7581-5953-ae59" name="Excindio Battle-automata" hidden="false" collective="false" import="false" targetId="cf23-fd3a-15a0-7347" type="selectionEntry">
+    <entryLink id="f659-7581-5953-ae59" name="Excindio Battle-automata" hidden="true" collective="false" import="false" targetId="cf23-fd3a-15a0-7347" type="selectionEntry">
       <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditionGroups>
-            <conditionGroup type="or">
-              <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b2b4-2198-0b90-dd9f" type="equalTo"/>
-                <condition field="selections" scope="e90d-e5a8-f42d-da84" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="equalTo"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
+        <modifier type="set" field="hidden" value="false">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="equalTo"/>
+          </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
@@ -56,33 +40,17 @@
       </categoryLinks>
     </entryLink>
     <entryLink id="c177-60f6-4324-8398" name="Inner Circle Knights Cenobium" hidden="false" collective="false" import="false" targetId="9946-61c0-3656-36dd" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditionGroups>
-            <conditionGroup type="or">
-              <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b2b4-2198-0b90-dd9f" type="equalTo"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="694a-cf77-3824-c33c" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="f12a-bca3-dacd-dafe" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="f4cc-eb88-0035-2e1b" name="Inner Circle Knights Cenobium - Order of the Broken Claws" hidden="false" collective="false" import="false" targetId="b9ad-ab3e-437e-c373" type="selectionEntry">
+    <entryLink id="f4cc-eb88-0035-2e1b" name="Inner Circle Knights Cenobium - Order of the Broken Claws" hidden="true" collective="false" import="false" targetId="b9ad-ab3e-437e-c373" type="selectionEntry">
       <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditionGroups>
-            <conditionGroup type="or">
-              <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b2b4-2198-0b90-dd9f" type="equalTo"/>
-                <condition field="selections" scope="e90d-e5a8-f42d-da84" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8d56-d960-0687-7fee" type="equalTo"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
+        <modifier type="set" field="hidden" value="false">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8d56-d960-0687-7fee" type="equalTo"/>
+          </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
@@ -90,17 +58,12 @@
         <categoryLink id="bc8b-eb32-5fdd-202b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="9607-feb8-a864-9192" name="Lion El&apos;Jonson " hidden="false" collective="false" import="false" targetId="0689-b550-0b0e-63d6" type="selectionEntry">
+    <entryLink id="9607-feb8-a864-9192" name="Lion El&apos;Jonson " hidden="true" collective="false" import="false" targetId="0689-b550-0b0e-63d6" type="selectionEntry">
       <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditionGroups>
-            <conditionGroup type="or">
-              <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b2b4-2198-0b90-dd9f" type="equalTo"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
+        <modifier type="set" field="hidden" value="false">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
+          </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
@@ -108,33 +71,28 @@
         <categoryLink id="ab33-7225-f48a-340c" name="New CategoryLink" hidden="false" targetId="ad5f-31db-8bc7-5c46" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="5233-1cc8-f2d5-9023" name="Marduk Sedras" hidden="false" collective="false" import="false" targetId="9136-b5e8-13f9-0c0f" type="selectionEntry">
+    <entryLink id="5233-1cc8-f2d5-9023" name="Marduk Sedras" hidden="true" collective="false" import="false" targetId="9136-b5e8-13f9-0c0f" type="selectionEntry">
       <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditionGroups>
-            <conditionGroup type="or">
-              <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b2b4-2198-0b90-dd9f" type="equalTo"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
+        <modifier type="set" field="hidden" value="false">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
+          </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
         <categoryLink id="e67b-8c05-a2d9-646e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="65f5-a164-400b-1ccb" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="c8ff-1043-75af-8a7d" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="7995-b170-5ac4-af2b" name="Farith Redloss" hidden="false" collective="false" import="false" targetId="28ab-ad48-d8b3-0d5d" type="selectionEntry">
+    <entryLink id="7995-b170-5ac4-af2b" name="Farith Redloss" hidden="true" collective="false" import="false" targetId="28ab-ad48-d8b3-0d5d" type="selectionEntry">
       <modifiers>
-        <modifier type="set" field="hidden" value="true">
+        <modifier type="set" field="hidden" value="false">
           <conditionGroups>
-            <conditionGroup type="or">
+            <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b2b4-2198-0b90-dd9f" type="equalTo"/>
-                <condition field="selections" scope="e90d-e5a8-f42d-da84" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="equalTo"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
@@ -143,17 +101,17 @@
       <categoryLinks>
         <categoryLink id="8bf4-9640-3056-cb98" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="f522-bc46-1dcc-5c12" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="dbda-9f35-26f3-f2bf" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="b977-4bae-f84a-1cba" name="Holguin" hidden="false" collective="false" import="false" targetId="902d-5951-9b95-19fb" type="selectionEntry">
+    <entryLink id="b977-4bae-f84a-1cba" name="Holguin" hidden="true" collective="false" import="false" targetId="902d-5951-9b95-19fb" type="selectionEntry">
       <modifiers>
-        <modifier type="set" field="hidden" value="true">
+        <modifier type="set" field="hidden" value="false">
           <conditionGroups>
-            <conditionGroup type="or">
+            <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b2b4-2198-0b90-dd9f" type="equalTo"/>
-                <condition field="selections" scope="e90d-e5a8-f42d-da84" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="equalTo"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
@@ -162,19 +120,15 @@
       <categoryLinks>
         <categoryLink id="bebe-9b3c-7ba0-ed35" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="75ff-379c-b33c-2438" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="7e2b-77a4-fe27-c674" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="3a8f-2121-9fa4-6d74" name="Firewing Enigmatus Cabal" hidden="false" collective="false" import="false" targetId="3731-e0df-bd0c-a33e" type="selectionEntry">
+    <entryLink id="3a8f-2121-9fa4-6d74" name="Firewing Enigmatus Cabal" hidden="true" collective="false" import="false" targetId="3731-e0df-bd0c-a33e" type="selectionEntry">
       <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditionGroups>
-            <conditionGroup type="or">
-              <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b2b4-2198-0b90-dd9f" type="equalTo"/>
-                <condition field="selections" scope="e90d-e5a8-f42d-da84" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="equalTo"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
+        <modifier type="set" field="hidden" value="false">
+          <conditions>
+            <condition field="selections" scope="e90d-e5a8-f42d-da84" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="equalTo"/>
+          </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
@@ -820,13 +774,6 @@
       </costs>
     </selectionEntry>
     <selectionEntry id="28ab-ad48-d8b3-0d5d" name="Farith Redloss" publicationId="d0df-7166-5cd3-89fd" page="45" hidden="false" collective="false" import="true" type="unit">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo"/>
-          </conditions>
-        </modifier>
-      </modifiers>
       <constraints>
         <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7c0a-d13c-972b-eebb" type="max"/>
       </constraints>
@@ -1107,13 +1054,6 @@ Selenite Shard-bolt Pistol</description>
       </costs>
     </selectionEntry>
     <selectionEntry id="3731-e0df-bd0c-a33e" name="Firewing Enigmatus Cabal" publicationId="d0df-7166-5cd3-89fd" page="52" hidden="false" collective="false" import="true" type="unit">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b2b4-2198-0b90-dd9f" type="equalTo"/>
-          </conditions>
-        </modifier>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="3a4b-b4f9-aeeb-da68" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="8c89-c8a4-6609-6878" name="Jump Infantry:" hidden="false" targetId="eee8-3c7c-2762-e33e" primary="false"/>
@@ -1284,13 +1224,6 @@ Selenite Shard-bolt Pistol</description>
       </costs>
     </selectionEntry>
     <selectionEntry id="902d-5951-9b95-19fb" name="Holguin" publicationId="d0df-7166-5cd3-89fd" page="47" hidden="false" collective="false" import="true" type="unit">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo"/>
-          </conditions>
-        </modifier>
-      </modifiers>
       <constraints>
         <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0af1-a178-7ad3-c6af" type="max"/>
       </constraints>
@@ -1844,13 +1777,6 @@ part of a close combat attack.</description>
     </selectionEntry>
     <selectionEntry id="0689-b550-0b0e-63d6" name="Lion El&apos;Jonson " hidden="false" collective="false" import="true" type="unit">
       <comment>Hexagrammaton</comment>
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo"/>
-          </conditions>
-        </modifier>
-      </modifiers>
       <constraints>
         <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="fe1f-71bf-448a-cb04" type="max"/>
       </constraints>

--- a/2022 - LA - Death Guard.cat
+++ b/2022 - LA - Death Guard.cat
@@ -1,17 +1,12 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="d228-55e8-b58c-1b77" name="LA -  XIV: Death Guard" revision="4" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="10" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="d228-55e8-b58c-1b77" name="LA -  XIV: Death Guard" revision="5" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="13" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entryLinks>
     <entryLink id="fb89-32c1-bdc5-2e3d" name="Mortarion" hidden="false" collective="false" import="false" targetId="7427-bdfa-c359-ebb8" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
-          <conditionGroups>
-            <conditionGroup type="or">
-              <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dd1f-1c51-706c-e5f7" type="equalTo"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
+          <conditions>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo"/>
+          </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
@@ -23,32 +18,23 @@
     <entryLink id="72f2-159d-02fd-662b" name="Calas Typhon" hidden="false" collective="false" import="false" targetId="e830-3788-1a0d-0c02" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
-          <conditionGroups>
-            <conditionGroup type="or">
-              <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dd1f-1c51-706c-e5f7" type="equalTo"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
+          <conditions>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo"/>
+          </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
         <categoryLink id="004e-da45-354f-882d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="0fd1-c287-ea0a-743e" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="763f-933b-5168-70a4" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="ecb3-9b17-ac05-a9e0" name="Mortus Poisoner Squad" hidden="false" collective="false" import="false" targetId="dd7b-fe21-cf53-0ebc" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
-          <conditionGroups>
-            <conditionGroup type="or">
-              <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8d56-d960-0687-7fee" type="equalTo"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dd1f-1c51-706c-e5f7" type="equalTo"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
+          <conditions>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8d56-d960-0687-7fee" type="equalTo"/>
+          </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
@@ -57,17 +43,6 @@
       </categoryLinks>
     </entryLink>
     <entryLink id="dc48-119e-d8cc-26e9" name="Grave Warden Terminator Squad" hidden="false" collective="false" import="false" targetId="be32-77c9-fe55-7dc0" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditionGroups>
-            <conditionGroup type="or">
-              <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dd1f-1c51-706c-e5f7" type="equalTo"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="85f0-1143-bf32-04ad" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="214a-b147-8867-83e7" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
@@ -80,7 +55,6 @@
             <conditionGroup type="or">
               <conditions>
                 <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dd1f-1c51-706c-e5f7" type="equalTo"/>
                 <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="equalTo"/>
               </conditions>
             </conditionGroup>
@@ -90,6 +64,7 @@
       <categoryLinks>
         <categoryLink id="7cec-7e9a-41cf-e2cb" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="84cb-a551-d3fd-4401" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="8bc4-d33a-bea2-a8f0" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="781d-4c08-a032-b54e" name="Marshal Durak Rask" hidden="false" collective="false" import="false" targetId="bd75-611c-23bb-7064" type="selectionEntry">
@@ -98,7 +73,6 @@
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dd1f-1c51-706c-e5f7" type="equalTo"/>
                 <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo"/>
                 <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="equalTo"/>
               </conditions>
@@ -109,6 +83,7 @@
       <categoryLinks>
         <categoryLink id="6535-1408-9914-1567" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="952c-b3c9-50e1-b074" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="bd34-12ec-2df1-8239" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="47ce-73d3-f6bf-7f54" name="  XIV: Death Guard" hidden="false" collective="false" import="false" targetId="dd1f-1c51-706c-e5f7" type="selectionEntry">

--- a/2022 - LA - Emperor's Children.cat
+++ b/2022 - LA - Emperor's Children.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="72ba-61c2-37ad-c785" name="LA -   III: Emperor&apos;s Children" revision="4" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="11" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="72ba-61c2-37ad-c785" name="LA -   III: Emperor&apos;s Children" revision="5" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="13" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entryLinks>
     <entryLink id="b36e-8c73-fe83-f087" name="   III: Emperor&apos;s Children" hidden="false" collective="false" import="false" targetId="3edc-a1b9-6dc6-b1ea" type="selectionEntry">
       <constraints>
@@ -10,29 +10,67 @@
         <categoryLink id="81e6-96ee-9e60-32fa" name="New CategoryLink" hidden="false" targetId="e90d-e5a8-f42d-da84" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="a119-3943-4b8b-b651" name="Captain Lucius" hidden="false" collective="false" import="false" targetId="0707-1e4b-27da-9cd4" type="selectionEntry">
+    <entryLink id="a119-3943-4b8b-b651" name="Captain Lucius" hidden="true" collective="false" import="false" targetId="0707-1e4b-27da-9cd4" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="8198-4bd3-2445-7a2b" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="9304-b442-49fe-fa71" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="31b0-fad0-cbb6-491d" name="Captain Saul Tarvitz" hidden="false" collective="false" import="false" targetId="a91c-719f-4abf-1598" type="selectionEntry">
+    <entryLink id="31b0-fad0-cbb6-491d" name="Captain Saul Tarvitz" hidden="true" collective="false" import="false" targetId="a91c-719f-4abf-1598" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="ae2e-66fe-3c38-c0c2" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="c295-161b-a153-5e23" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="d159-e0c0-f0a4-c8c9" name="Fulgrim" hidden="false" collective="false" import="false" targetId="0de5-8b3c-74a0-858e" type="selectionEntry">
+    <entryLink id="d159-e0c0-f0a4-c8c9" name="Fulgrim" hidden="true" collective="false" import="false" targetId="0de5-8b3c-74a0-858e" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="d1b1-8747-b31c-93ba" name="New CategoryLink" hidden="false" targetId="ad5f-31db-8bc7-5c46" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="3e78-22f5-fc51-3a6e" name="Kakophoni Squad" hidden="false" collective="false" import="false" targetId="8359-c463-9cde-4f21" type="selectionEntry">
+    <entryLink id="3e78-22f5-fc51-3a6e" name="Kakophoni Squad" hidden="true" collective="false" import="false" targetId="8359-c463-9cde-4f21" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="76ab-3f7a-43b7-7b98" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="ec64-4532-a15d-ad6b" name="Lord Commander Eidolon" hidden="false" collective="false" import="false" targetId="ac90-d090-9a21-60c4" type="selectionEntry">
+    <entryLink id="ec64-4532-a15d-ad6b" name="Lord Commander Eidolon" hidden="true" collective="false" import="false" targetId="ac90-d090-9a21-60c4" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="d7b4-0c11-69c4-0790" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="dafb-5fbd-1def-b788" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="b704-91be-c88e-763e" name="Palatine Blade Squad" hidden="false" collective="false" import="false" targetId="fa86-f7a5-0062-a205" type="selectionEntry">
@@ -45,31 +83,38 @@
         <categoryLink id="0f06-08b1-9de3-dac5" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="9e33-b30a-861d-c0f8" name="Rylanor the Unyielding" hidden="false" collective="false" import="false" targetId="281b-1950-5c15-de68" type="selectionEntry">
+    <entryLink id="9e33-b30a-861d-c0f8" name="Rylanor the Unyielding" hidden="true" collective="false" import="false" targetId="281b-1950-5c15-de68" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="f813-02a8-90f1-a6fe" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="abb4-2af9-15c8-2c3d" name="Sun Killer Squad" hidden="false" collective="false" import="false" targetId="cce2-fd03-ac17-88e4" type="selectionEntry">
+    <entryLink id="abb4-2af9-15c8-2c3d" name="Sun Killer Squad" hidden="true" collective="false" import="false" targetId="cce2-fd03-ac17-88e4" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8d56-d960-0687-7fee" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="2a6f-aeba-536a-ffb8" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
       </categoryLinks>
     </entryLink>
   </entryLinks>
   <sharedSelectionEntries>
-    <selectionEntry id="0de5-8b3c-74a0-858e" name="Fulgrim" hidden="true" collective="false" import="true" type="unit">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditionGroups>
-            <conditionGroup type="and">
-              <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3edc-a1b9-6dc6-b1ea" type="equalTo"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-      </modifiers>
+    <selectionEntry id="0de5-8b3c-74a0-858e" name="Fulgrim" hidden="false" collective="false" import="true" type="unit">
       <constraints>
         <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b7bb-0fb5-04bc-feb5" type="max"/>
       </constraints>
@@ -261,13 +306,6 @@ Sire of the Emperor’s Children - All friendly models with the Legiones Astarte
       </costs>
     </selectionEntry>
     <selectionEntry id="5b08-65c1-cc45-1b91" name="Phoenix Terminator Squad" publicationId="09c5-eeae-f398-b653" page="158" hidden="false" collective="false" import="true" type="unit">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3edc-a1b9-6dc6-b1ea" type="equalTo"/>
-          </conditions>
-        </modifier>
-      </modifiers>
       <rules>
         <rule id="c8a9-354d-f168-5a37" name="Phoenix Retinue" hidden="false">
           <description>A Phoenix Terminator Squad may be selected as a Retinue Squad in a Detachment that includes at least one model  with both the Master of the Legion and the Legiones Astartes (Emperor&apos;s Children) special rules, instead of as an Elites choice. A unit selected as a &apos;Retinue Squad&apos; must have one model with both the Master of the Legion and Legiones Astartes (Emperor&apos;s Children) special rules from the same Detachment selected by the controlling player as the Phoenix Terminator Squad&apos;s Leader for the purposes of this special rule. A Phoenix Terminator Squad selected as a Retinue Squad does not use up a Force Organisation slot and is considered part of the same unit as the model selected as the model selected as its Leader. A Phoenix Terminator Squad selected as a Retinue Squad must be deployed with the model selected as its Leader deployed as part of the unit and the Leader may not voluntarily leave the Retinue Squad during play. One Phoenix Terminator in a Phoenix Terminator Squad selected as a Retinue may exchange their Phoenix power spear for a Legion standard and a Phoenix rapier for +15 points.</description>
@@ -463,13 +501,6 @@ Sire of the Emperor’s Children - All friendly models with the Legiones Astarte
       </costs>
     </selectionEntry>
     <selectionEntry id="fa86-f7a5-0062-a205" name="Palatine Blade Squad" hidden="false" collective="false" import="true" type="unit">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3edc-a1b9-6dc6-b1ea" type="equalTo"/>
-          </conditions>
-        </modifier>
-      </modifiers>
       <infoLinks>
         <infoLink id="0fc4-9034-cfce-a4ab" name="Legiones Astartes (Emperor&apos;s Children) " hidden="false" targetId="4a36-8b9d-6b6c-51e1" type="rule"/>
         <infoLink id="17b2-6634-186d-8d31" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule"/>
@@ -675,19 +706,7 @@ Sire of the Emperor’s Children - All friendly models with the Legiones Astarte
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="8359-c463-9cde-4f21" name="Kakophoni Squad" hidden="true" collective="false" import="true" type="unit">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditionGroups>
-            <conditionGroup type="and">
-              <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3edc-a1b9-6dc6-b1ea" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-      </modifiers>
+    <selectionEntry id="8359-c463-9cde-4f21" name="Kakophoni Squad" hidden="false" collective="false" import="true" type="unit">
       <infoLinks>
         <infoLink id="1114-cab4-4a62-2cc3" name="Legiones Astartes (Emperor&apos;s Children) " hidden="false" targetId="4a36-8b9d-6b6c-51e1" type="rule"/>
         <infoLink id="0435-1879-2846-3361" name="Fearless" hidden="false" targetId="b48c-d7e1-2a83-2f5b" type="rule"/>
@@ -853,19 +872,7 @@ Sire of the Emperor’s Children - All friendly models with the Legiones Astarte
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="ac90-d090-9a21-60c4" name="Lord Commander Eidolon" hidden="true" collective="false" import="true" type="unit">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditionGroups>
-            <conditionGroup type="and">
-              <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3edc-a1b9-6dc6-b1ea" type="equalTo"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-      </modifiers>
+    <selectionEntry id="ac90-d090-9a21-60c4" name="Lord Commander Eidolon" hidden="false" collective="false" import="true" type="unit">
       <constraints>
         <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="77cf-98c8-12f6-e491" type="max"/>
       </constraints>
@@ -1025,19 +1032,7 @@ Sire of the Emperor’s Children - All friendly models with the Legiones Astarte
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="215.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="a91c-719f-4abf-1598" name="Captain Saul Tarvitz" hidden="true" collective="false" import="true" type="unit">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditionGroups>
-            <conditionGroup type="and">
-              <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3edc-a1b9-6dc6-b1ea" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-      </modifiers>
+    <selectionEntry id="a91c-719f-4abf-1598" name="Captain Saul Tarvitz" hidden="false" collective="false" import="true" type="unit">
       <constraints>
         <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e781-7860-b7ab-ca6f" type="max"/>
       </constraints>
@@ -1200,19 +1195,7 @@ If any of these are true then Captain Saul Tarvitz and any friendly units with a
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="155.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="0707-1e4b-27da-9cd4" name="Captain Lucius" hidden="true" collective="false" import="true" type="upgrade">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditionGroups>
-            <conditionGroup type="and">
-              <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3edc-a1b9-6dc6-b1ea" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-      </modifiers>
+    <selectionEntry id="0707-1e4b-27da-9cd4" name="Captain Lucius" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
         <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9326-cd69-c6f1-949b" type="max"/>
       </constraints>
@@ -1421,19 +1404,7 @@ Captain Lucius is engaged in a Challenge all friendly models in the same combat 
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="175.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="281b-1950-5c15-de68" name="Rylanor the Unyielding" hidden="true" collective="false" import="true" type="model">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditionGroups>
-            <conditionGroup type="and">
-              <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3edc-a1b9-6dc6-b1ea" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-      </modifiers>
+    <selectionEntry id="281b-1950-5c15-de68" name="Rylanor the Unyielding" hidden="false" collective="false" import="true" type="model">
       <constraints>
         <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ea33-bd2e-4b08-59c6" type="max"/>
       </constraints>
@@ -1501,14 +1472,7 @@ Captain Lucius is engaged in a Challenge all friendly models in the same combat 
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="250.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="cce2-fd03-ac17-88e4" name="Sun Killer Squad" hidden="true" collective="false" import="true" type="unit">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3edc-a1b9-6dc6-b1ea" type="equalTo"/>
-          </conditions>
-        </modifier>
-      </modifiers>
+    <selectionEntry id="cce2-fd03-ac17-88e4" name="Sun Killer Squad" hidden="false" collective="false" import="true" type="unit">
       <constraints>
         <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ef7e-6bfd-8a32-f184" type="max"/>
       </constraints>

--- a/2022 - LA - Imperial Fists.cat
+++ b/2022 - LA - Imperial Fists.cat
@@ -1,17 +1,12 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="8866-00ec-715f-f21a" name="LA -   VII: Imperial Fists" revision="4" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="10" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="8866-00ec-715f-f21a" name="LA -   VII: Imperial Fists" revision="5" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="13" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entryLinks>
     <entryLink id="b3e4-1487-4ab7-7515" name="Alexis Polux " hidden="false" collective="false" import="false" targetId="9229-b4f9-2213-9672" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
-          <conditionGroups>
-            <conditionGroup type="or">
-              <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a0e1-f2c4-8bcd-0723" type="equalTo"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
+          <conditions>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
+          </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
@@ -22,14 +17,9 @@
     <entryLink id="f3a4-1d62-0904-18c5" name="Fafnir Rann" hidden="false" collective="false" import="false" targetId="d483-8c34-3bcb-f1d5" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
-          <conditionGroups>
-            <conditionGroup type="or">
-              <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a0e1-f2c4-8bcd-0723" type="equalTo"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
+          <conditions>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
+          </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
@@ -38,17 +28,6 @@
       </categoryLinks>
     </entryLink>
     <entryLink id="a7ed-633f-9b24-83bb" name="Phalanx Warder Squad" hidden="false" collective="false" import="false" targetId="19ce-b8dc-dd40-fee9" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditionGroups>
-            <conditionGroup type="or">
-              <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a0e1-f2c4-8bcd-0723" type="equalTo"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="5d82-2938-d6b0-d460" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="0a15-f02d-76e8-3f43" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
@@ -57,14 +36,9 @@
     <entryLink id="eb84-0ca9-ee5b-9d94" name="Sigismund" hidden="false" collective="false" import="false" targetId="f323-a02c-fa4e-b1ef" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
-          <conditionGroups>
-            <conditionGroup type="or">
-              <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a0e1-f2c4-8bcd-0723" type="equalTo"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
+          <conditions>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
+          </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
@@ -73,17 +47,6 @@
       </categoryLinks>
     </entryLink>
     <entryLink id="c1a0-4e23-bb48-8b6b" name="Templar Brethren" hidden="false" collective="false" import="false" targetId="6f69-665c-3199-77aa" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditionGroups>
-            <conditionGroup type="or">
-              <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a0e1-f2c4-8bcd-0723" type="equalTo"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="b5a2-d4b6-25b7-29df" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="796e-07e7-3709-4854" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
@@ -92,14 +55,9 @@
     <entryLink id="6de5-a6a9-bf25-76c8" name="Rogal Dorn" hidden="false" collective="false" import="false" targetId="6910-f5e3-01df-f3d5" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
-          <conditionGroups>
-            <conditionGroup type="or">
-              <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a0e1-f2c4-8bcd-0723" type="equalTo"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
+          <conditions>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
+          </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
@@ -110,14 +68,9 @@
     <entryLink id="bf53-51f2-5ab5-fecc" name="Huscarl Squad" hidden="false" collective="false" import="false" targetId="4420-5ce0-beb7-cb5e" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
-          <conditionGroups>
-            <conditionGroup type="or">
-              <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a0e1-f2c4-8bcd-0723" type="equalTo"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8d56-d960-0687-7fee" type="equalTo"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
+          <conditions>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8d56-d960-0687-7fee" type="equalTo"/>
+          </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
@@ -131,7 +84,6 @@
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a0e1-f2c4-8bcd-0723" type="equalTo"/>
                 <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6910-f5e3-01df-f3d5" type="equalTo"/>
                 <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="equalTo"/>
               </conditions>

--- a/2022 - LA - Iron Hands.cat
+++ b/2022 - LA - Iron Hands.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="b73e-125f-db29-17f2" name="LA -  X: Iron Hands" revision="4" battleScribeVersion="2.03" authorName="Figjam Bohica" authorContact="BSData Developers Discord" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="10" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="b73e-125f-db29-17f2" name="LA -  X: Iron Hands" revision="5" battleScribeVersion="2.03" authorName="Figjam Bohica" authorContact="BSData Developers Discord" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="13" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entryLinks>
     <entryLink id="6107-168e-198e-2e94" name="  X: Iron Hands" hidden="false" collective="false" import="false" targetId="bfc9-c99c-bf8a-3917" type="selectionEntry">
       <constraints>
@@ -13,14 +13,9 @@
     <entryLink id="2fdc-7a7e-ae85-ad77" name="Iron Father Autek Mor" hidden="false" collective="false" import="false" targetId="0283-efdd-6ee3-6741" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
-          <conditionGroups>
-            <conditionGroup type="or">
-              <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bfc9-c99c-bf8a-3917" type="equalTo"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
+          <conditions>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
+          </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
@@ -35,7 +30,7 @@
             <conditionGroup type="or">
               <conditions>
                 <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bfc9-c99c-bf8a-3917" type="equalTo"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="equalTo"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
@@ -48,17 +43,6 @@
       </categoryLinks>
     </entryLink>
     <entryLink id="e1ce-d9b7-2ea1-760b" name="Medusan Immortal Squad" hidden="false" collective="false" import="false" targetId="f9e4-0da2-5049-df81" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditionGroups>
-            <conditionGroup type="or">
-              <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bfc9-c99c-bf8a-3917" type="equalTo"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="028c-19b9-ccdf-9229" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="3f2e-25c7-b685-51db" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
@@ -66,17 +50,6 @@
       </categoryLinks>
     </entryLink>
     <entryLink id="de83-37e7-9228-0b81" name="Gorgon Terminator Squad" hidden="false" collective="false" import="false" targetId="ea50-6315-7a52-f560" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditionGroups>
-            <conditionGroup type="or">
-              <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bfc9-c99c-bf8a-3917" type="equalTo"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="26b1-401b-c49d-a163" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="0ac3-4093-1c72-a6c2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
@@ -86,14 +59,9 @@
     <entryLink id="acbb-d53d-6be7-eef8" name="Ferrus Manus" hidden="false" collective="false" import="false" targetId="554b-1024-a345-0d14" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
-          <conditionGroups>
-            <conditionGroup type="or">
-              <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bfc9-c99c-bf8a-3917" type="equalTo"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
+          <conditions>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
+          </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>

--- a/2022 - LA - Iron Warriors.cat
+++ b/2022 - LA - Iron Warriors.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="2ee4-57ed-db44-8a63" name="LA -   IV: Iron Warriors" revision="4" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="10" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="2ee4-57ed-db44-8a63" name="LA -   IV: Iron Warriors" revision="5" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="13" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entryLinks>
     <entryLink id="fe10-3104-0252-96de" name="Nârik Dreygur" hidden="false" collective="false" import="false" targetId="ac97-c8ce-16ba-9c49" type="selectionEntry">
       <modifiers>
@@ -8,8 +8,7 @@
             <conditionGroup type="or">
               <conditions>
                 <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="equalTo"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5f54-457a-fbb9-6730" type="equalTo"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
@@ -18,19 +17,15 @@
       <categoryLinks>
         <categoryLink id="daf2-90f2-060e-054f" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="a63e-60c5-2db0-676a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="684c-a721-6593-9e2a" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="7fe3-8433-2dfa-2166" name="Perturabo" hidden="false" collective="false" import="false" targetId="f944-6641-a714-2fe8" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
-          <conditionGroups>
-            <conditionGroup type="or">
-              <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5f54-457a-fbb9-6730" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
+          <conditions>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo"/>
+          </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
@@ -42,14 +37,9 @@
     <entryLink id="ede1-9c07-8401-67f9" name="Iron Havocs" hidden="false" collective="false" import="false" targetId="d355-5488-1277-fabf" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
-          <conditionGroups>
-            <conditionGroup type="or">
-              <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="equalTo"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5f54-457a-fbb9-6730" type="equalTo"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
+          <conditions>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="equalTo"/>
+          </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
@@ -58,34 +48,12 @@
       </categoryLinks>
     </entryLink>
     <entryLink id="9dc3-f518-9d31-3973" name="Iron Circle Maniple" hidden="false" collective="false" import="false" targetId="a6e3-baab-45b9-7fea" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditionGroups>
-            <conditionGroup type="or">
-              <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5f54-457a-fbb9-6730" type="equalTo"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="9203-b759-34d2-9552" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="eb77-1b03-c09f-6681" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="6d85-0a41-fc02-2844" name="Tyrant Siege Terminator Squad" hidden="false" collective="false" import="false" targetId="795a-5698-a1bc-6ec6" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditionGroups>
-            <conditionGroup type="or">
-              <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5f54-457a-fbb9-6730" type="equalTo"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="002f-dc9a-b983-d44c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="7da6-dade-1275-d75a" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
@@ -97,8 +65,8 @@
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f944-6641-a714-2fe8" type="equalTo"/>
                 <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="equalTo"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5f54-457a-fbb9-6730" type="equalTo"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
@@ -116,8 +84,7 @@
             <conditionGroup type="or">
               <conditions>
                 <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="equalTo"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5f54-457a-fbb9-6730" type="equalTo"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
@@ -126,37 +93,29 @@
       <categoryLinks>
         <categoryLink id="3cb3-e3bb-c0cf-9678" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="df59-0d00-2be6-f275" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="fbaf-2b4b-5a38-6925" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="7471-1a1e-4285-65cb" name="Erasmus Golg" hidden="false" collective="false" import="false" targetId="3feb-3ea1-97c2-9861" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
-          <conditionGroups>
-            <conditionGroup type="or">
-              <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="equalTo"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5f54-457a-fbb9-6730" type="equalTo"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
+          <conditions>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="equalTo"/>
+          </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
         <categoryLink id="a813-57fa-9782-da6f" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="621a-4766-c501-14df" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="f5c8-d1da-2871-3ba5" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="7cd1-2f14-2775-c1b2" name="Dominator Cohort" hidden="false" collective="false" import="false" targetId="1bfa-2413-beb9-5f32" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
-          <conditionGroups>
-            <conditionGroup type="or">
-              <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8d56-d960-0687-7fee" type="equalTo"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5f54-457a-fbb9-6730" type="equalTo"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
+          <conditions>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8d56-d960-0687-7fee" type="equalTo"/>
+          </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>

--- a/2022 - LA - Night Lords.cat
+++ b/2022 - LA - Night Lords.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="36dc-14fc-8872-476b" name="LA -   VIII: Night Lords" revision="4" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="10" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="36dc-14fc-8872-476b" name="LA -   VIII: Night Lords" revision="5" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="13" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entryLinks>
     <entryLink id="f491-c7fa-f6d3-917d" name="Contekar Terminator Squad" hidden="false" collective="false" import="false" targetId="837e-c3ca-437e-dfbf" type="selectionEntry">
       <modifiers>
@@ -17,19 +17,15 @@
       <categoryLinks>
         <categoryLink id="037c-77b8-6f60-cefc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="9908-6951-cb40-369c" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="1132-38e8-0e5f-6d62" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="77a5-7cca-d050-de27" name="Konrad Curze" hidden="false" collective="false" import="false" targetId="1636-d8d9-2428-f166" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
-          <conditionGroups>
-            <conditionGroup type="or">
-              <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo"/>
-                <condition field="selections" scope="e90d-e5a8-f42d-da84" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a836-6c63-1be4-a8a5" type="equalTo"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
+          <conditions>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo"/>
+          </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
@@ -38,17 +34,6 @@
       </categoryLinks>
     </entryLink>
     <entryLink id="44dc-815a-7895-cfa0" name="Night Raptor Squad" hidden="false" collective="false" import="false" targetId="9bb8-8fe4-11c1-9e50" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditionGroups>
-            <conditionGroup type="or">
-              <conditions>
-                <condition field="selections" scope="e90d-e5a8-f42d-da84" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a836-6c63-1be4-a8a5" type="equalTo"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="0de9-ad2e-c5af-664a" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="cb4b-49f7-d796-a3b1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
@@ -57,33 +42,18 @@
     <entryLink id="fb5a-4a13-3b2d-aeda" name="Sevatar" hidden="false" collective="false" import="false" targetId="d2ce-94c1-242d-2a7f" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
-          <conditionGroups>
-            <conditionGroup type="or">
-              <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo"/>
-                <condition field="selections" scope="e90d-e5a8-f42d-da84" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a836-6c63-1be4-a8a5" type="equalTo"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
+          <conditions>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo"/>
+          </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
         <categoryLink id="57a9-a024-e7a3-e8bf" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="5356-33e7-612f-b258" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="2f21-d05c-f877-7bf7" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="ecad-ff3f-4ef3-d8ae" name="Terror Squad" hidden="false" collective="false" import="false" targetId="53ce-6dc9-aa69-fbaa" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditionGroups>
-            <conditionGroup type="or">
-              <conditions>
-                <condition field="selections" scope="e90d-e5a8-f42d-da84" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a836-6c63-1be4-a8a5" type="equalTo"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="4edc-3e13-084e-ba81" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="8ce1-4ddc-5784-6fda" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
@@ -92,14 +62,9 @@
     <entryLink id="6ee2-037b-e211-5d0c" name="Atramentar Squad" hidden="false" collective="false" import="false" targetId="12d3-9df0-4118-997f" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
-          <conditionGroups>
-            <conditionGroup type="or">
-              <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8d56-d960-0687-7fee" type="equalTo"/>
-                <condition field="selections" scope="e90d-e5a8-f42d-da84" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a836-6c63-1be4-a8a5" type="equalTo"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
+          <conditions>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8d56-d960-0687-7fee" type="equalTo"/>
+          </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
@@ -117,17 +82,6 @@
       </categoryLinks>
     </entryLink>
     <entryLink id="32c0-440e-bcd3-31d0" name="Contekar Terminator Squad" hidden="false" collective="false" import="false" targetId="837e-c3ca-437e-dfbf" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditionGroups>
-            <conditionGroup type="and">
-              <conditions>
-                <condition field="selections" scope="e90d-e5a8-f42d-da84" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a836-6c63-1be4-a8a5" type="equalTo"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="90fa-b324-1d69-b9f7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="8a66-cd15-98b3-053b" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
@@ -141,7 +95,6 @@
               <conditions>
                 <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="equalTo"/>
                 <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo"/>
-                <condition field="selections" scope="e90d-e5a8-f42d-da84" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a836-6c63-1be4-a8a5" type="equalTo"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
@@ -150,6 +103,7 @@
       <categoryLinks>
         <categoryLink id="3ff4-9877-8cff-4bc3" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="c809-7da7-7cef-0b91" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="9495-3e27-bd74-804a" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="693a-aaca-0c13-ab35" name="Kheron Ophion of the Kyroptera" hidden="false" collective="false" import="false" targetId="021c-6d75-36ca-fe7a" type="selectionEntry">
@@ -160,7 +114,6 @@
               <conditions>
                 <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="equalTo"/>
                 <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo"/>
-                <condition field="selections" scope="e90d-e5a8-f42d-da84" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a836-6c63-1be4-a8a5" type="equalTo"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
@@ -169,6 +122,7 @@
       <categoryLinks>
         <categoryLink id="6383-da25-4d31-9d0f" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="fd32-a0de-1d51-721e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="88e9-963c-1da4-2970" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="0102-9a6f-effb-52f3" name="Nakrid Thole" hidden="false" collective="false" import="false" targetId="4e5b-9710-67f5-478c" type="selectionEntry">
@@ -179,7 +133,6 @@
               <conditions>
                 <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="equalTo"/>
                 <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo"/>
-                <condition field="selections" scope="e90d-e5a8-f42d-da84" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a836-6c63-1be4-a8a5" type="equalTo"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
@@ -188,6 +141,7 @@
       <categoryLinks>
         <categoryLink id="d220-725f-227a-8331" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="de2e-45e1-c96a-f8dd" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="e1a5-7428-ea5b-f5c1" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
       </categoryLinks>
     </entryLink>
   </entryLinks>

--- a/2022 - LA - Raven Guard.cat
+++ b/2022 - LA - Raven Guard.cat
@@ -1,14 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="d21e-9c80-a7f8-728c" name="LA - XIX: Raven Guard" revision="3" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="10" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="d21e-9c80-a7f8-728c" name="LA - XIX: Raven Guard" revision="4" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="13" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entryLinks>
     <entryLink id="84cc-e59c-174e-fb25" name="Mor Deythan Squad" hidden="false" collective="false" import="false" targetId="c268-08ac-5b90-d034" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditions>
-            <condition field="selections" scope="e90d-e5a8-f42d-da84" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="dc34-fe08-dd44-fb99" type="equalTo"/>
-          </conditions>
-        </modifier>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="2e94-0345-48a1-212d" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="b955-7a72-615e-214c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
@@ -17,14 +10,9 @@
     <entryLink id="495b-4009-800a-2446" name="Moritat-Prime Kaedes Nex" hidden="false" collective="false" import="false" targetId="5be0-17a1-bb08-670f" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
-          <conditionGroups>
-            <conditionGroup type="or">
-              <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="equalTo"/>
-                <condition field="selections" scope="e90d-e5a8-f42d-da84" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="dc34-fe08-dd44-fb99" type="equalTo"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
+          <conditions>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="equalTo"/>
+          </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
@@ -33,13 +21,6 @@
       </categoryLinks>
     </entryLink>
     <entryLink id="4d01-e777-0fc3-5af0" name="Dark Furies" hidden="false" collective="false" import="false" targetId="58f4-3d8d-f243-6e5d" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditions>
-            <condition field="selections" scope="e90d-e5a8-f42d-da84" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="dc34-fe08-dd44-fb99" type="equalTo"/>
-          </conditions>
-        </modifier>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="b3bf-9ad9-9085-e594" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
         <categoryLink id="c981-a1a9-1e0e-a0c6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
@@ -48,32 +29,23 @@
     <entryLink id="b259-41d9-dd0b-6e71" name="Strike Captain Alvarex Maun" hidden="false" collective="false" import="false" targetId="0e66-8311-405c-1e49" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
-          <conditionGroups>
-            <conditionGroup type="or">
-              <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="equalTo"/>
-                <condition field="selections" scope="e90d-e5a8-f42d-da84" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="dc34-fe08-dd44-fb99" type="equalTo"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
+          <conditions>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="equalTo"/>
+          </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
         <categoryLink id="09fb-5221-1260-a028" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="35aa-395e-a852-77e8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="ca61-d4be-80ed-be27" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="7e7b-c3d0-0f16-ffbf" name="Corvus Corax" hidden="false" collective="false" import="false" targetId="8ff5-cece-0fc2-100d" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
-          <conditionGroups>
-            <conditionGroup type="or">
-              <conditions>
-                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
-                <condition field="selections" scope="e90d-e5a8-f42d-da84" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="dc34-fe08-dd44-fb99" type="equalTo"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
+          <conditions>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
+          </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
@@ -93,14 +65,9 @@
     <entryLink id="eaff-3c75-ef08-341e" name="Deliverers Squad" hidden="false" collective="false" import="false" targetId="5d1d-8348-ed95-d366" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
-          <conditionGroups>
-            <conditionGroup type="or">
-              <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8d56-d960-0687-7fee" type="equalTo"/>
-                <condition field="selections" scope="e90d-e5a8-f42d-da84" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="dc34-fe08-dd44-fb99" type="equalTo"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
+          <conditions>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8d56-d960-0687-7fee" type="equalTo"/>
+          </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>

--- a/2022 - LA - Salamanders.cat
+++ b/2022 - LA - Salamanders.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="3547-84d8-d789-bab7" name="LA -  XVIII: Salamanders" revision="3" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="10" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="3547-84d8-d789-bab7" name="LA -  XVIII: Salamanders" revision="4" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="13" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entryLinks>
     <entryLink id="93d2-b1cb-b684-a9b3" name="  XVIII: Salamanders" hidden="false" collective="false" import="false" targetId="c805-ca3a-ff93-5e2f" type="selectionEntry">
       <constraints>
@@ -10,9 +10,22 @@
         <categoryLink id="e7bb-068e-33b8-7e33" name="New CategoryLink" hidden="false" targetId="e90d-e5a8-f42d-da84" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="a4b6-92c9-7e8b-bfcd" name="Cassian Dracos Reborn" hidden="false" collective="false" import="false" targetId="fb8a-ab72-52ce-38f3" type="selectionEntry">
+    <entryLink id="a4b6-92c9-7e8b-bfcd" name="Cassian Dracos Reborn" hidden="true" collective="false" import="false" targetId="fb8a-ab72-52ce-38f3" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="2de5-e3bc-f6bc-5558" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="b475-cb4a-5a9b-cf9b" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="34f6-2994-6de1-98cc" name="Firedrake Terminator Squad" hidden="false" collective="false" import="false" targetId="6775-8379-8d6b-9614" type="selectionEntry">
@@ -20,9 +33,22 @@
         <categoryLink id="26b1-529c-841e-80c6" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="13d2-61df-c76d-7b32" name="Lord Chaplain Nomus Rhy&apos;Tan" hidden="false" collective="false" import="false" targetId="74f6-96f4-ee55-9c78" type="selectionEntry">
+    <entryLink id="13d2-61df-c76d-7b32" name="Lord Chaplain Nomus Rhy&apos;Tan" hidden="true" collective="false" import="false" targetId="74f6-96f4-ee55-9c78" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="ac1a-5683-b0a6-a1f5" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="2ac4-69c5-3a1e-7314" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="5e51-de9f-0a93-825b" name="Pyroclast Squad" hidden="false" collective="false" import="false" targetId="71fe-d3bc-b7f9-75ca" type="selectionEntry">
@@ -30,31 +56,39 @@
         <categoryLink id="eaf6-1e7a-32ab-b017" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="4c5f-15e0-0de3-af6a" name="Vulkan" hidden="false" collective="false" import="false" targetId="8c74-40b1-5019-f4d4" type="selectionEntry">
+    <entryLink id="4c5f-15e0-0de3-af6a" name="Vulkan" hidden="true" collective="false" import="false" targetId="8c74-40b1-5019-f4d4" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="64a8-ba7d-4c9b-3f3e" name="New CategoryLink" hidden="false" targetId="ad5f-31db-8bc7-5c46" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="2607-05cd-6852-2f52" name="Xiaphas Jurr" hidden="false" collective="false" import="false" targetId="30b8-05a5-fef7-fe66" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="61c9-1410-be7e-6c64" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-      </categoryLinks>
-    </entryLink>
-  </entryLinks>
-  <sharedSelectionEntries>
-    <selectionEntry id="8c74-40b1-5019-f4d4" name="Vulkan" hidden="true" collective="false" import="true" type="upgrade">
+    <entryLink id="2607-05cd-6852-2f52" name="Xiaphas Jurr" hidden="true" collective="false" import="false" targetId="30b8-05a5-fef7-fe66" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c805-ca3a-ff93-5e2f" type="equalTo"/>
                 <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="equalTo"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
+      <categoryLinks>
+        <categoryLink id="61c9-1410-be7e-6c64" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="28d1-eb1c-4e2e-0ce6" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
+      </categoryLinks>
+    </entryLink>
+  </entryLinks>
+  <sharedSelectionEntries>
+    <selectionEntry id="8c74-40b1-5019-f4d4" name="Vulkan" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
         <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="65d8-0392-0de1-6820" type="max"/>
       </constraints>
@@ -180,13 +214,6 @@
       </costs>
     </selectionEntry>
     <selectionEntry id="71fe-d3bc-b7f9-75ca" name="Pyroclast Squad" hidden="false" collective="false" import="true" type="unit">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c805-ca3a-ff93-5e2f" type="equalTo"/>
-          </conditions>
-        </modifier>
-      </modifiers>
       <rules>
         <rule id="135c-a0b8-c4d6-93ee" name="Mantle of Ash" hidden="false">
           <description>Models with this special rule gain an Invulnerable Save of 5+ against all Flame, Plasma, Melta and Volkite weapons.</description>
@@ -387,14 +414,7 @@
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="6775-8379-8d6b-9614" name="Firedrake Terminator Squad" hidden="true" collective="false" import="true" type="unit">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c805-ca3a-ff93-5e2f" type="equalTo"/>
-          </conditions>
-        </modifier>
-      </modifiers>
+    <selectionEntry id="6775-8379-8d6b-9614" name="Firedrake Terminator Squad" hidden="false" collective="false" import="true" type="unit">
       <rules>
         <rule id="5643-e6a1-a722-b0c6" name="Favoured of Vulkan " hidden="true">
           <description>A Firedrake Squad may be selected as a Retinue Squad in a Detachment that includes at least one model with both the Master of the Legion and Legiones Astartes (Salamanders) special rules, instead of as an Elites choice. A unit selected as a ‘Retinue Squad’ must have one model with both the Master of the Legion and Legiones Astartes (Salamanders) special rules from the same Detachment selected by the controlling player as the Firedrake Squad’s Leader for the purposes of this special rule. A Firedrake Squad selected as a Retinue Squad does not use up a Force Organisation slot and is considered part of the same unit as the model selected as its Leader. A Firedrake Squad selected as a Retinue Squad must be deployed with the model selected as its Leader deployed as part of the unit and the Leader may not voluntarily leave the Retinue Squad during play</description>
@@ -632,19 +652,7 @@
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="fb8a-ab72-52ce-38f3" name="Cassian Dracos Reborn" hidden="true" collective="false" import="true" type="model">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditionGroups>
-            <conditionGroup type="and">
-              <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c805-ca3a-ff93-5e2f" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8cf7-d353-bf83-2ae6" type="equalTo"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-      </modifiers>
+    <selectionEntry id="fb8a-ab72-52ce-38f3" name="Cassian Dracos Reborn" hidden="false" collective="false" import="true" type="model">
       <constraints>
         <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="05bb-a7ee-45fa-877a" type="max"/>
       </constraints>
@@ -742,19 +750,7 @@
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="310.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="74f6-96f4-ee55-9c78" name="Lord Chaplain Nomus Rhy&apos;Tan" hidden="true" collective="false" import="true" type="model">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditionGroups>
-            <conditionGroup type="and">
-              <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8cf7-d353-bf83-2ae6" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c805-ca3a-ff93-5e2f" type="equalTo"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-      </modifiers>
+    <selectionEntry id="74f6-96f4-ee55-9c78" name="Lord Chaplain Nomus Rhy&apos;Tan" hidden="false" collective="false" import="true" type="model">
       <constraints>
         <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="918e-d896-4cbf-4b53" type="max"/>
       </constraints>
@@ -872,19 +868,7 @@
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="215.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="30b8-05a5-fef7-fe66" name="Xiaphas Jurr" hidden="true" collective="false" import="true" type="model">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditionGroups>
-            <conditionGroup type="and">
-              <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8cf7-d353-bf83-2ae6" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c805-ca3a-ff93-5e2f" type="equalTo"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-      </modifiers>
+    <selectionEntry id="30b8-05a5-fef7-fe66" name="Xiaphas Jurr" hidden="false" collective="false" import="true" type="model">
       <constraints>
         <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ad8d-9fdb-7550-1d9d" type="max"/>
       </constraints>

--- a/2022 - LA - Sons of Horus.cat
+++ b/2022 - LA - Sons of Horus.cat
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="62c7-42f4-5523-af1b" name="LA -  XVI: Sons of Horus" revision="2" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="12" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="62c7-42f4-5523-af1b" name="LA -  XVI: Sons of Horus" revision="3" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="13" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entryLinks>
-    <entryLink id="c2a2-9b6d-b384-3f43" name="  XVI: Sons of Horus" hidden="false" collective="false" import="true" targetId="01b4-57c7-bf61-2abf" type="selectionEntry">
+    <entryLink id="c2a2-9b6d-b384-3f43" name="  XVI: Sons of Horus" hidden="false" collective="false" import="false" targetId="01b4-57c7-bf61-2abf" type="selectionEntry">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="57a1-d021-4da4-093e" type="min"/>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="17ce-5398-8e0c-9aa7" type="max"/>
@@ -13,38 +13,28 @@
     <entryLink id="e2c3-2fb9-ad2e-c424" name="Chieftain Squad" hidden="false" collective="false" import="false" targetId="0c73-9141-d1b4-6a40" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
-          <conditionGroups>
-            <conditionGroup type="or">
-              <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="01b4-57c7-bf61-2abf" type="equalTo"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8d56-d960-0687-7fee" type="equalTo"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
+          <conditions>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8d56-d960-0687-7fee" type="equalTo"/>
+          </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="8e6e-e267-9c12-5680" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="3c43-e8dc-f4f3-4010" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="false"/>
         <categoryLink id="114d-f93f-d7a5-80d7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="f195-05cd-45e6-70af" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="7742-6ac2-9a35-df68" name="Maloghurst the Twisted" hidden="false" collective="false" import="false" targetId="0b37-0420-b06a-fcc5" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
-          <conditionGroups>
-            <conditionGroup type="or">
-              <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="01b4-57c7-bf61-2abf" type="equalTo"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
+          <conditions>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo"/>
+          </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
         <categoryLink id="b32e-3835-5d7e-6f91" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="bd61-dd1a-5314-ed85" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="126c-a234-df65-26be" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="bb45-67fc-bc65-c082" name="Tybalt Marr" hidden="false" collective="false" import="false" targetId="c3db-b014-dfaa-d189" type="selectionEntry">
@@ -55,7 +45,6 @@
               <conditions>
                 <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="equalTo"/>
                 <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo"/>
-                <condition field="selections" scope="e90d-e5a8-f42d-da84" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c2a2-9b6d-b384-3f43" type="equalTo"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
@@ -64,6 +53,7 @@
       <categoryLinks>
         <categoryLink id="aa5f-6290-d3fb-abdc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="0929-6baa-85a0-1f92" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="c2bd-dc92-2e11-b309" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
       </categoryLinks>
       <costs>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="175.0"/>
@@ -72,14 +62,9 @@
     <entryLink id="79f4-181d-3ce9-f37b" name="Reaver Aggressor Squad" hidden="false" collective="false" import="false" targetId="af3a-334f-152f-d55f" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
-          <conditionGroups>
-            <conditionGroup type="or">
-              <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="equalTo"/>
-                <condition field="selections" scope="e90d-e5a8-f42d-da84" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c2a2-9b6d-b384-3f43" type="equalTo"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
+          <conditions>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="equalTo"/>
+          </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
@@ -88,17 +73,6 @@
       </categoryLinks>
     </entryLink>
     <entryLink id="24ed-4463-3ad8-4da7" name="Reaver Attack Squad" hidden="false" collective="false" import="false" targetId="8b29-bf2a-a814-5642" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditionGroups>
-            <conditionGroup type="or">
-              <conditions>
-                <condition field="selections" scope="e90d-e5a8-f42d-da84" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c2a2-9b6d-b384-3f43" type="equalTo"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="0789-bb51-f100-dd5e" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="77a5-bc2d-91c4-f76e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
@@ -107,32 +81,23 @@
     <entryLink id="bcf7-3f90-c06a-5208" name="Ezekyle Abaddon" hidden="false" collective="false" import="false" targetId="09df-6357-0a00-80a6" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
-          <conditionGroups>
-            <conditionGroup type="or">
-              <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="01b4-57c7-bf61-2abf" type="equalTo"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
+          <conditions>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo"/>
+          </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
         <categoryLink id="f3d1-a002-2b03-4847" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="020a-df9f-429e-a84a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="6e66-b81f-4d44-a873" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="97be-411c-8c15-dfd2" name="Horus Lupercal" hidden="false" collective="false" import="false" targetId="f0a3-4ae4-e07a-91b8" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
-          <conditionGroups>
-            <conditionGroup type="or">
-              <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="01b4-57c7-bf61-2abf" type="equalTo"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
+          <conditions>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo"/>
+          </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
@@ -143,33 +108,18 @@
     <entryLink id="f092-385d-cb95-de74" name="Garviel Loken" hidden="false" collective="false" import="false" targetId="44bf-8a69-f21a-dfba" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
-          <conditionGroups>
-            <conditionGroup type="or">
-              <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="01b4-57c7-bf61-2abf" type="equalTo"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
+          <conditions>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
+          </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
         <categoryLink id="8cab-2c82-02c7-7545" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="faf8-056b-cd6a-94e6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="1272-35e1-e6fe-f231" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="c121-2d4a-e85e-14c7" name="Justaerin Terminator Squad" hidden="false" collective="false" import="false" targetId="c45d-ade3-6b28-68a2" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditionGroups>
-            <conditionGroup type="or">
-              <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="01b4-57c7-bf61-2abf" type="equalTo"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="1d7a-0e25-aa2d-ac68" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="d429-527d-c73b-bddc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
@@ -364,6 +314,9 @@
               </characteristics>
             </profile>
           </profiles>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+          </costs>
         </selectionEntry>
         <selectionEntry id="bc32-bea3-06d2-338d" name="The Warmaster&apos;s Talon" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
@@ -393,6 +346,9 @@
             <infoLink id="52e3-c93b-1b55-76a1" name="Deflagrate" hidden="false" targetId="60bc-f79a-67ae-be4f" type="rule"/>
             <infoLink id="9696-333a-f9bb-535d" name="Twin-linked" hidden="false" targetId="8542-ee9d-e2fa-52fe" type="rule"/>
           </infoLinks>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+          </costs>
         </selectionEntry>
         <selectionEntry id="ae00-4cb3-fc75-80de" name="Worldbreaker" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
@@ -419,6 +375,9 @@
             <infoLink id="0b04-e9fc-242c-694b" name="Sunder" hidden="false" targetId="20e2-75cf-bc16-cd8f" type="rule"/>
             <infoLink id="6db7-9837-a7f0-466b" name="Unwieldy" hidden="false" targetId="1570-c21a-881f-8b8a" type="rule"/>
           </infoLinks>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+          </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
@@ -618,6 +577,9 @@ All models of the Infantry Unit Type in the same army as Horus Lupercal, regardl
               </characteristics>
             </profile>
           </profiles>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+          </costs>
         </selectionEntry>
         <selectionEntry id="e222-7677-b70e-f1be" name="Reaver" hidden="false" collective="false" import="true" type="model">
           <constraints>
@@ -1497,6 +1459,9 @@ remains in play and regains 1D3 Wounds.</description>
               </modifiers>
             </infoLink>
           </infoLinks>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+          </costs>
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
@@ -1607,6 +1572,9 @@ remains in play and regains 1D3 Wounds.</description>
               </characteristics>
             </profile>
           </profiles>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+          </costs>
         </selectionEntry>
         <selectionEntry id="35fc-92c4-ecd6-b80a" name="Reaver Aggressor" hidden="false" collective="false" import="true" type="model">
           <constraints>

--- a/2022 - LA - Space Wolves.cat
+++ b/2022 - LA - Space Wolves.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="ca15-13de-89cb-bbb2" name="LA -   VI: Space Wolves" revision="3" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="12" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="ca15-13de-89cb-bbb2" name="LA -   VI: Space Wolves" revision="4" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="13" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entryLinks>
     <entryLink id="ff53-69d9-ec0b-9caa" name="   VI: Space Wolves" hidden="false" collective="false" import="false" targetId="4916-965e-8339-44f6" type="selectionEntry">
       <constraints>
@@ -16,44 +16,94 @@
         <categoryLink id="90f3-333e-c096-a39d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="8eb8-d620-5aae-d5ff" name="Fenrisian Wolf Pack" hidden="false" collective="false" import="false" targetId="f47e-c270-b62a-4205" type="selectionEntry"/>
+    <entryLink id="8eb8-d620-5aae-d5ff" name="Fenrisian Wolf Pack" hidden="false" collective="false" import="false" targetId="f47e-c270-b62a-4205" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditions>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="ecf9-012f-8171-c36a" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true"/>
+      </categoryLinks>
+    </entryLink>
     <entryLink id="145a-e620-0394-c8e6" name="Geigor Fell-Hand" hidden="false" collective="false" import="false" targetId="b4c7-4f96-122b-7ade" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditions>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="6535-c9ec-ed83-7d89" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="1147-77ac-040c-ff0f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="e2f9-db44-a72b-c576" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="7a57-b5be-d2e5-93f1" name="Grey Slayer Pack" hidden="false" collective="false" import="false" targetId="4bbf-f3df-7b18-4a49" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="37a5-e559-aa6f-a23d" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="9fab-f8f9-82e9-e115" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="a657-599b-10e2-1ae1" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="2e36-c0e4-643d-7f4e" name="Grey Stalker Pack" hidden="false" collective="false" import="false" targetId="4dbc-6266-853a-5114" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="c550-0f2f-8b47-f6ed" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="cc44-9321-b02a-11a5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="9dee-400e-17b5-10cf" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="ff22-4cd4-671e-7ec0" name="Hvarl Red-Blade" hidden="false" collective="false" import="false" targetId="31b6-168b-3c08-14b0" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditions>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="76e8-88e7-36d9-7a91" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="f177-b333-d0fd-981c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="f78b-4136-ea01-903f" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="7313-b16a-cb0c-47a4" name="Jorlund Hunter Pack" hidden="false" collective="false" import="false" targetId="fcc8-bc3c-e443-eb3f" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditions>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8d56-d960-0687-7fee" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="2b8c-b008-2f79-76cb" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="6596-a629-9cda-0b3b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="912f-464e-f011-8a3c" name="Leman Russ" hidden="false" collective="false" import="false" targetId="c028-dc90-e4b6-8b43" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditions>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="02d9-6d81-e872-d7b7" name="New CategoryLink" hidden="false" targetId="ad5f-31db-8bc7-5c46" primary="true"/>
         <categoryLink id="1b8f-f807-3d22-80df" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="89e7-9749-8180-3d09" name="The Wolf-kin of Russ" hidden="false" collective="false" import="false" targetId="3bb9-4637-e963-b36f" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditions>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="1194-4568-72cb-9521" name="New CategoryLink" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="true"/>
         <categoryLink id="a879-10d5-44fa-e515" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
@@ -68,18 +118,6 @@
   </entryLinks>
   <sharedSelectionEntries>
     <selectionEntry id="c028-dc90-e4b6-8b43" name="Leman Russ" hidden="false" collective="false" import="true" type="unit">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditionGroups>
-            <conditionGroup type="or">
-              <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
-                <condition field="selections" scope="e90d-e5a8-f42d-da84" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4916-965e-8339-44f6" type="equalTo"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-      </modifiers>
       <rules>
         <rule id="00ed-3f49-ad36-075e" name="Howl of the Death Wolf" hidden="false">
           <description>Once per battle, Leman Russ&apos; controlling plaer may declare the use of this special rule at the start of their turn. For the duration of that player turn only, all friendly models with the Legiones Astartes (Space Wolves) special rule gain a bonus of +1 to their Movement Characteristic and any enemy units that include one or more models with the Legiones Astartes (Space Wolves) special rule must take an an immediate Pinning test.</description>
@@ -261,18 +299,6 @@
       </costs>
     </selectionEntry>
     <selectionEntry id="3bb9-4637-e963-b36f" name="The Wolf-kin of Russ" hidden="false" collective="false" import="true" type="unit">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditionGroups>
-            <conditionGroup type="or">
-              <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
-                <condition field="selections" scope="e90d-e5a8-f42d-da84" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4916-965e-8339-44f6" type="equalTo"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-      </modifiers>
       <constraints>
         <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7d1c-d50c-bc98-97a5" type="max"/>
       </constraints>
@@ -447,13 +473,6 @@
       </costs>
     </selectionEntry>
     <selectionEntry id="3fa0-d6ed-981b-e361" name="Deathsworn Pack" hidden="false" collective="false" import="true" type="unit">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditions>
-            <condition field="selections" scope="e90d-e5a8-f42d-da84" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4916-965e-8339-44f6" type="equalTo"/>
-          </conditions>
-        </modifier>
-      </modifiers>
       <rules>
         <rule id="a62c-dfcc-3413-f919" name="Cult of Morkai" hidden="false">
           <description>Deathsworn Pack may not be joined by models with the Independent Character special rule other than the models with the Speaker of the Dead or Caster of Runes Consul upgrades. In addition, a Deathsworn Pack may be selected as a Retinue Squad in a Detachment that includes at least one model with the Speaker of the Dead or Caster of Runes Consul upgrades, instead of as an Elite choice. A unit selected as a Retinue squad must have one model with the speak with the Speaker of the Dead or Caster of Runes Consul upgrades from the same Detachment selected by the controlling player as the Deathswon Pack&apos;s Leader for the Purposes of this special rule. A Deathsworn Pack selected as a Retinue Squad does not use up a Force Organisation slot and is considered part of the same unit as the model selected as its Leader. A Deathsworn Pack selected as a Retinue Squad must be deployed with the model selected as its Leader deployed as part of the unit and the Leader may not voluntarily leave the Retinue Squad during play.</description>
@@ -621,17 +640,6 @@
       </costs>
     </selectionEntry>
     <selectionEntry id="9359-61a5-fcdb-c28e" name="Varagyr Wolf Guard Terminator Squad" hidden="false" collective="false" import="true" type="unit">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditionGroups>
-            <conditionGroup type="or">
-              <conditions>
-                <condition field="selections" scope="e90d-e5a8-f42d-da84" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4916-965e-8339-44f6" type="equalTo"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-      </modifiers>
       <rules>
         <rule id="26bf-0536-40d0-ba84" name="Lordsbane" hidden="false">
           <description>Models with this special rule may issue and accept Challenges as if they had the Character Sub-type in combat, and in addittion, when fighting in a Challenge, if the enemy challenger is removed as a casualty then then they may add an additional +1 to the number of successful Wounds cause for the purposes of resolving which side has won a combat.</description>
@@ -909,13 +917,6 @@
       </costs>
     </selectionEntry>
     <selectionEntry id="4bbf-f3df-7b18-4a49" name="Grey Slayer Pack" publicationId="a716-c1c4-7b26-8424" hidden="false" collective="false" import="true" type="unit">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditions>
-            <condition field="selections" scope="e90d-e5a8-f42d-da84" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4916-965e-8339-44f6" type="equalTo"/>
-          </conditions>
-        </modifier>
-      </modifiers>
       <infoLinks>
         <infoLink id="93fd-8b85-2340-ab02" name="Heart of the Legion" hidden="false" targetId="c0dd-9002-2ebd-f96d" type="rule"/>
         <infoLink id="d615-5cfc-48ae-91e1" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule"/>
@@ -1310,13 +1311,6 @@
       </costs>
     </selectionEntry>
     <selectionEntry id="4dbc-6266-853a-5114" name="Grey Stalker Pack" publicationId="a716-c1c4-7b26-8424" hidden="false" collective="false" import="true" type="unit">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditions>
-            <condition field="selections" scope="e90d-e5a8-f42d-da84" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4916-965e-8339-44f6" type="equalTo"/>
-          </conditions>
-        </modifier>
-      </modifiers>
       <infoLinks>
         <infoLink id="32a3-4015-d07a-3db1" name="Heart of the Legion" hidden="false" targetId="c0dd-9002-2ebd-f96d" type="rule"/>
         <infoLink id="cb15-1672-0494-dfde" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule"/>
@@ -1783,18 +1777,6 @@
       </costs>
     </selectionEntry>
     <selectionEntry id="b4c7-4f96-122b-7ade" name="Geigor Fell-Hand" hidden="false" collective="false" import="true" type="unit">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditionGroups>
-            <conditionGroup type="or">
-              <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
-                <condition field="selections" scope="e90d-e5a8-f42d-da84" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4916-965e-8339-44f6" type="equalTo"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-      </modifiers>
       <constraints>
         <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="855f-f43d-fd08-ea00" type="max"/>
       </constraints>
@@ -1929,18 +1911,6 @@
       </costs>
     </selectionEntry>
     <selectionEntry id="31b6-168b-3c08-14b0" name="Hvarl Red-Blade" hidden="false" collective="false" import="true" type="unit">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditionGroups>
-            <conditionGroup type="or">
-              <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
-                <condition field="selections" scope="e90d-e5a8-f42d-da84" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4916-965e-8339-44f6" type="equalTo"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-      </modifiers>
       <constraints>
         <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c89d-e03f-7b36-7045" type="max"/>
       </constraints>
@@ -2067,18 +2037,6 @@
       </costs>
     </selectionEntry>
     <selectionEntry id="fcc8-bc3c-e443-eb3f" name="Jorlund Hunter Pack" hidden="false" collective="false" import="true" type="unit">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditionGroups>
-            <conditionGroup type="or">
-              <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8d56-d960-0687-7fee" type="equalTo"/>
-                <condition field="selections" scope="e90d-e5a8-f42d-da84" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="4916-965e-8339-44f6" type="equalTo"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-      </modifiers>
       <rules>
         <rule id="2daf-4203-d5a5-9e8a" name="Scouring Tempest" hidden="false">
           <description>Once per battle, during the Shooting phase of one of their turns as the Active player, the controlling player of a unit made up entirely of models with this special rule may choose to activate Scouring Tempest before the unit is selected to make a Shooting Attack. Until the end of the Phase, all Flame weapons in the unit gain the Pinning and Torrent (3&quot;) special rules.</description>
@@ -2306,18 +2264,6 @@
       </costs>
     </selectionEntry>
     <selectionEntry id="f47e-c270-b62a-4205" name="Fenrisian Wolf Pack" publicationId="d0df-7166-5cd3-89fd" hidden="false" collective="false" import="true" type="upgrade">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditionGroups>
-            <conditionGroup type="or">
-              <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="equalTo"/>
-                <condition field="selections" scope="e90d-e5a8-f42d-da84" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="4916-965e-8339-44f6" type="equalTo"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-      </modifiers>
       <rules>
         <rule id="f58a-d1de-185f-b203" name="Pack Retinue" hidden="false">
           <description>A Fenrisian Wolf Pack may only be chosen as a Retinue for a model with both the Legiones Astartes (Space Wolves) and Master of the Legion special rules. This Model is referred to as the Fenrisian Wolf Pack’s Leader for the purposes of this special rule. The Fenrisian Wolf Pack does not use up a Force Organisation slot and is considered part of the same unit as the model taken as its Leader. The Fenrisian Wolf Pack must be deployed with the model selected as its Leader deployed as part of the unit and the Leader may not voluntarily leave the Fenrisian Wolf Pack during play. A Fenrisian Wolf Pack may not be selected as part of an army without a Leader.</description>

--- a/2022 - LA - Thousand Sons.cat
+++ b/2022 - LA - Thousand Sons.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="abac-8dd1-df65-e253" name="LA -  XV: Thousand Sons" revision="4" battleScribeVersion="2.03" authorName="Arkangelmark5" authorContact="BSData Developers Discord" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="12" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="abac-8dd1-df65-e253" name="LA -  XV: Thousand Sons" revision="5" battleScribeVersion="2.03" authorName="Arkangelmark5" authorContact="BSData Developers Discord" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="13" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entryLinks>
     <entryLink id="5900-484e-9f23-c753" name="  XV: Thousand Sons" hidden="false" collective="false" import="false" targetId="21c3-2f28-7820-e51a" type="selectionEntry">
       <constraints>
@@ -13,32 +13,23 @@
     <entryLink id="4ca2-991b-8a05-495b" name="Ahzek Ahriman" hidden="false" collective="false" import="false" targetId="f1d9-5c86-f496-61f0" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
-          <conditionGroups>
-            <conditionGroup type="or">
-              <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="21c3-2f28-7820-e51a" type="equalTo"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
+          <conditions>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo"/>
+          </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
         <categoryLink id="a860-2386-adfb-9190" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="0195-28e3-c5c1-05d4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="920c-4841-9359-1c16" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="ef34-0fc0-70a1-9511" name="Ammitara Occult Intercession Cabal" hidden="false" collective="false" import="false" targetId="d3ad-275c-e22b-a28f" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
-          <conditionGroups>
-            <conditionGroup type="or">
-              <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="21c3-2f28-7820-e51a" type="equalTo"/>
-                <condition field="selections" scope="e90d-e5a8-f42d-da84" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="equalTo"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
+          <conditions>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="equalTo"/>
+          </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
@@ -47,17 +38,6 @@
       </categoryLinks>
     </entryLink>
     <entryLink id="eccd-7e17-7359-665c" name="Castellax-Achea Automata" hidden="false" collective="false" import="false" targetId="95cb-9366-295e-f10d" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditionGroups>
-            <conditionGroup type="or">
-              <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="21c3-2f28-7820-e51a" type="equalTo"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="96c0-503c-eb35-b5c3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="dc90-d478-5300-3dd9" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
@@ -66,32 +46,23 @@
     <entryLink id="803c-bb4e-a743-cfe2" name="Magistus Amon" hidden="false" collective="false" import="false" targetId="161b-2f2a-8616-9d4f" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
-          <conditionGroups>
-            <conditionGroup type="or">
-              <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="21c3-2f28-7820-e51a" type="equalTo"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
+          <conditions>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo"/>
+          </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
         <categoryLink id="4f1c-f718-fd3a-7b34" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="f9a9-61a7-3163-99e5" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="dca3-8510-af4c-2eba" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="2f6f-dd0e-e3b7-262e" name="Magnus the Red" hidden="false" collective="false" import="false" targetId="8baf-c9b9-b622-0272" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
-          <conditionGroups>
-            <conditionGroup type="or">
-              <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="21c3-2f28-7820-e51a" type="equalTo"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
+          <conditions>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo"/>
+          </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
@@ -100,47 +71,18 @@
       </categoryLinks>
     </entryLink>
     <entryLink id="cefc-c45c-128a-fbce" name="Sekhmet Terminator Cabal" hidden="false" collective="false" import="false" targetId="dda2-bdd0-3ced-b427" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditionGroups>
-            <conditionGroup type="or">
-              <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="21c3-2f28-7820-e51a" type="equalTo"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="ac58-0cd7-c143-5583" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="993d-e85b-bfeb-8a0e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="b132-3f20-976c-ff1c" name="Khenetai Occult Cabal" hidden="false" collective="false" import="false" targetId="faa7-27d5-2ee2-5d58" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditionGroups>
-            <conditionGroup type="or">
-              <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="21c3-2f28-7820-e51a" type="equalTo"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="a55f-2ae6-b17c-e872" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="7bfb-d732-cefe-f207" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="396f-5ab5-e4c1-89c4" name="Contemptor-Osiron Dreadnought Talon" hidden="false" collective="false" import="true" targetId="eef1-0f91-a59f-b3e2" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="21c3-2f28-7820-e51a" type="equalTo"/>
-          </conditions>
-        </modifier>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="8ada-aa38-fcb3-d993" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="497d-849e-d9b4-be08" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>

--- a/2022 - LA - Ultramarines.cat
+++ b/2022 - LA - Ultramarines.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="68ae-9855-b56a-95e6" name="LA -  XIII: Ultramarines" revision="4" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="12" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="68ae-9855-b56a-95e6" name="LA -  XIII: Ultramarines" revision="5" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="12" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entryLinks>
     <entryLink id="76b3-52d9-a195-2b31" name="  XIII: Ultramarines" hidden="false" collective="false" import="false" targetId="8e0f-3552-8842-f281" type="selectionEntry">
       <constraints>
@@ -13,14 +13,9 @@
     <entryLink id="ec0b-803f-6220-45e0" name="Fulmentarus Terminator Squad" hidden="false" collective="false" import="false" targetId="7fb0-6302-d46f-029d" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
-          <conditionGroups>
-            <conditionGroup type="or">
-              <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="76b3-52d9-a195-2b31" type="equalTo"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="equalTo"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
+          <conditions>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="equalTo"/>
+          </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
@@ -31,14 +26,9 @@
     <entryLink id="b4d9-c808-7d7a-bf39" name="Locutarus Storm Squad" hidden="false" collective="false" import="false" targetId="314d-f363-fb52-743a" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
-          <conditionGroups>
-            <conditionGroup type="or">
-              <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="76b3-52d9-a195-2b31" type="equalTo"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="equalTo"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
+          <conditions>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="equalTo"/>
+          </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
@@ -51,7 +41,6 @@
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="76b3-52d9-a195-2b31" type="equalTo"/>
                 <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
                 <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="equalTo"/>
               </conditions>
@@ -65,33 +54,11 @@
       </categoryLinks>
     </entryLink>
     <entryLink id="0601-875a-65a7-9702" name="Invictarus Suzerain Squad" hidden="false" collective="false" import="false" targetId="ed63-e872-9410-a4b5" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditionGroups>
-            <conditionGroup type="or">
-              <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="76b3-52d9-a195-2b31" type="equalTo"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="a64a-afb1-07f6-2e1c" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="a0ee-1e5c-eefb-cbe8" name="Praetorian Breacher Squad" hidden="false" collective="false" import="false" targetId="7587-35cc-01f6-b5d2" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditionGroups>
-            <conditionGroup type="or">
-              <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="76b3-52d9-a195-2b31" type="equalTo"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="c367-a4e7-916c-f376" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="85bf-5fad-fade-3696" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
@@ -100,32 +67,23 @@
     <entryLink id="7b2b-7eec-41c8-ac72" name="Remus Ventanus" hidden="false" collective="false" import="false" targetId="e055-f9d2-33d9-739f" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
-          <conditionGroups>
-            <conditionGroup type="or">
-              <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="76b3-52d9-a195-2b31" type="equalTo"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
+          <conditions>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
+          </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
         <categoryLink id="0da5-c661-19f7-a22b" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="72db-c9b1-2570-cf99" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="19b5-180b-0b78-cc2f" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="f0af-547d-1b9d-2530" name="Robute Gulliman" hidden="false" collective="false" import="false" targetId="a35d-8563-eb47-e985" type="selectionEntry">
+    <entryLink id="f0af-547d-1b9d-2530" name="Roboute Guilliman" hidden="false" collective="false" import="false" targetId="a35d-8563-eb47-e985" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
-          <conditionGroups>
-            <conditionGroup type="or">
-              <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="76b3-52d9-a195-2b31" type="equalTo"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
+          <conditions>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
+          </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
@@ -133,17 +91,12 @@
         <categoryLink id="9f58-9b7f-011e-d79c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="ea1b-3176-6e4b-8a4d" name="Nemisis Destroyer Squad" hidden="false" collective="false" import="false" targetId="32d1-29a6-9023-142c" type="selectionEntry">
+    <entryLink id="ea1b-3176-6e4b-8a4d" name="Nemesis Destroyer Squad" hidden="false" collective="false" import="false" targetId="32d1-29a6-9023-142c" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
-          <conditionGroups>
-            <conditionGroup type="or">
-              <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="76b3-52d9-a195-2b31" type="equalTo"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8d56-d960-0687-7fee" type="equalTo"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
+          <conditions>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8d56-d960-0687-7fee" type="equalTo"/>
+          </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>

--- a/2022 - LA - White Scars.cat
+++ b/2022 - LA - White Scars.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="caa9-c50e-8eed-2259" name="LA -   V: White Scars" revision="3" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="11" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="caa9-c50e-8eed-2259" name="LA -   V: White Scars" revision="4" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="13" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entryLinks>
     <entryLink id="a738-6a11-dfe7-286c" name="   V: White Scars" hidden="false" collective="false" import="false" targetId="e01e-5cdd-e512-8353" type="selectionEntry">
       <constraints>
@@ -13,14 +13,9 @@
     <entryLink id="2053-c79e-817a-32cb" name="Dark Sons of Death " hidden="false" collective="false" import="false" targetId="4372-ad51-04a6-97ce" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
-          <conditionGroups>
-            <conditionGroup type="or">
-              <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8d56-d960-0687-7fee" type="equalTo"/>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
+          <conditions>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8d56-d960-0687-7fee" type="equalTo"/>
+          </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
@@ -29,13 +24,6 @@
       </categoryLinks>
     </entryLink>
     <entryLink id="ef8a-7d90-01fc-4eb4" name="Ebon Keshig Cohort" hidden="false" collective="false" import="false" targetId="eb44-e977-2ce5-b239" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
-          </conditions>
-        </modifier>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="2046-6c03-bfac-0631" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="981c-8d75-2230-8fc6" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
@@ -44,14 +32,9 @@
     <entryLink id="f531-b3bf-a683-bbe1" name="Falcon&apos;s Claws" hidden="false" collective="false" import="false" targetId="c598-7fda-13d0-7523" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
-          <conditionGroups>
-            <conditionGroup type="or">
-              <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="equalTo"/>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
+          <conditions>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="equalTo"/>
+          </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
@@ -60,26 +43,12 @@
       </categoryLinks>
     </entryLink>
     <entryLink id="6d08-1a34-76e4-2256" name="Golden Keshig Squadron" hidden="false" collective="false" import="false" targetId="1d55-faa7-caa5-a132" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
-          </conditions>
-        </modifier>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="98eb-50a0-d89c-664a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="90d1-acd8-eff5-467f" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="866d-e6ce-71a2-0476" name="Kyzagan Assualt Speeder Squadron" hidden="false" collective="false" import="false" targetId="e37e-09ea-50c6-2daa" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
-          </conditions>
-        </modifier>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="395e-8bb9-faa9-afd6" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
         <categoryLink id="bfe2-c28e-eb07-add1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
@@ -88,32 +57,23 @@
     <entryLink id="23a4-cb25-4fc5-5c3c" name="Qin Xa" hidden="false" collective="false" import="false" targetId="5ac0-277f-15da-5f29" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
-          <conditionGroups>
-            <conditionGroup type="and">
-              <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
+          <conditions>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
+          </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
         <categoryLink id="3282-02f6-67ab-9faf" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="f73e-34e5-fa25-642e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="9189-508b-565b-fd20" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="2159-2614-e411-5aa2" name="Jaghatai Khan" hidden="false" collective="false" import="false" targetId="4b3a-8550-a3aa-1b91" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
-          <conditionGroups>
-            <conditionGroup type="and">
-              <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
+          <conditions>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
+          </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
@@ -127,8 +87,7 @@
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
                 <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="equalTo"/>
               </conditions>
             </conditionGroup>
@@ -138,6 +97,7 @@
       <categoryLinks>
         <categoryLink id="a7da-28a9-5f15-d931" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="a7ae-0458-9ffb-c783" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="a9bd-8e73-b3dc-7062" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
       </categoryLinks>
     </entryLink>
   </entryLinks>

--- a/2022 - LA - Word Bearers.cat
+++ b/2022 - LA - Word Bearers.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="1df7-bbbc-b70e-6a3f" name="LA -  XVII: Word Bearers" revision="3" battleScribeVersion="2.03" authorName="UrsinePatriarch" authorContact="BSData Developers Discord" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="10" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="1df7-bbbc-b70e-6a3f" name="LA -  XVII: Word Bearers" revision="4" battleScribeVersion="2.03" authorName="UrsinePatriarch" authorContact="BSData Developers Discord" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="13" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entryLinks>
     <entryLink id="70a7-c1ee-bf88-94ab" name="  XVII: Word Bearers" hidden="false" collective="false" import="false" targetId="9dbf-0760-d7ae-f125" type="selectionEntry">
       <constraints>
@@ -13,32 +13,23 @@
     <entryLink id="6414-8db6-98c1-1319" name="Zardu Layak" hidden="false" collective="false" import="false" targetId="4cf8-1bf9-5193-4c9c" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
-          <conditionGroups>
-            <conditionGroup type="or">
-              <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9dbf-0760-d7ae-f125" type="equalTo"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
+          <conditions>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo"/>
+          </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
         <categoryLink id="a725-f9c9-3ca4-1df3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="3854-9b1c-75be-f251" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="7c61-d840-15bb-ea6a" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="3b20-7c83-a696-2ba4" name="Gal Vorbak Squad" hidden="false" collective="false" import="false" targetId="be3a-5acc-b4bd-8621" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
-          <conditionGroups>
-            <conditionGroup type="or">
-              <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9dbf-0760-d7ae-f125" type="equalTo"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
+          <conditions>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo"/>
+          </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
@@ -49,14 +40,9 @@
     <entryLink id="929e-1f4c-fdb0-60f9" name="Lorgar " hidden="false" collective="false" import="false" targetId="9289-65f7-e452-51a5" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
-          <conditionGroups>
-            <conditionGroup type="or">
-              <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9dbf-0760-d7ae-f125" type="equalTo"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
+          <conditions>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo"/>
+          </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
@@ -67,33 +53,18 @@
     <entryLink id="b296-2ad3-1158-0110" name="High Chaplain Erebus" hidden="false" collective="false" import="false" targetId="b958-a335-40b2-dc55" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
-          <conditionGroups>
-            <conditionGroup type="or">
-              <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9dbf-0760-d7ae-f125" type="equalTo"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
+          <conditions>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo"/>
+          </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
         <categoryLink id="2fef-2b84-70db-e88a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="dc7f-c1ed-8d5f-37b1" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="3d0d-10b5-3bbb-912b" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="60bb-a1e2-77b8-fe35" name="Ashen Circle" hidden="false" collective="false" import="false" targetId="f4e7-a798-a322-dc10" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditionGroups>
-            <conditionGroup type="or">
-              <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9dbf-0760-d7ae-f125" type="equalTo"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="f650-e375-34c8-f203" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="3c53-062a-658c-c195" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
@@ -102,32 +73,23 @@
     <entryLink id="4c0b-a7fa-7fed-aed2" name="Kor Phaeron" hidden="false" collective="false" import="false" targetId="6301-3135-aafa-2cbf" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
-          <conditionGroups>
-            <conditionGroup type="or">
-              <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9dbf-0760-d7ae-f125" type="equalTo"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
+          <conditions>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo"/>
+          </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
         <categoryLink id="82bc-9ae6-b57c-75d7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="1486-4d78-4dea-482d" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="d622-620e-8c28-3450" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="b76f-2807-520c-e6d4" name="Mhara Gal Dreadnought" hidden="false" collective="false" import="false" targetId="5254-5c76-10d4-c909" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
-          <conditionGroups>
-            <conditionGroup type="or">
-              <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9dbf-0760-d7ae-f125" type="equalTo"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
+          <conditions>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo"/>
+          </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
@@ -138,19 +100,15 @@
     <entryLink id="eb38-8626-fa8a-1c9d" name="Argel Tal" hidden="false" collective="false" import="false" targetId="a752-bb63-f1ba-13a6" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
-          <conditionGroups>
-            <conditionGroup type="or">
-              <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9dbf-0760-d7ae-f125" type="equalTo"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
+          <conditions>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo"/>
+          </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
         <categoryLink id="5c45-7a13-99ff-7ae8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="3c39-038c-1967-b7d8" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="6d34-d904-7880-c2c1" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
       </categoryLinks>
     </entryLink>
   </entryLinks>

--- a/2022 - LA - World Eaters.cat
+++ b/2022 - LA - World Eaters.cat
@@ -1,17 +1,12 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="d901-0eca-48b5-304a" name="LA -  XII: World Eaters" revision="4" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="10" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="d901-0eca-48b5-304a" name="LA -  XII: World Eaters" revision="5" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="13" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entryLinks>
     <entryLink id="d647-fd99-73e0-bd57" name="Angron" hidden="false" collective="false" import="false" targetId="71b3-6007-e056-fbea" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
-          <conditionGroups>
-            <conditionGroup type="or">
-              <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="90ee-77dd-1b7f-ddfe" type="equalTo"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
+          <conditions>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo"/>
+          </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
@@ -25,14 +20,9 @@
     <entryLink id="eae7-92b5-7fb5-0667" name="Khârn the Bloody" hidden="false" collective="false" import="false" targetId="4e05-c812-187e-095f" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
-          <conditionGroups>
-            <conditionGroup type="or">
-              <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="90ee-77dd-1b7f-ddfe" type="equalTo"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
+          <conditions>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo"/>
+          </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
@@ -40,6 +30,7 @@
         <categoryLink id="3cd1-2a33-5ca2-8154" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="9220-f305-3d8e-5388" name="Independant Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
         <categoryLink id="b5b5-a986-cf0b-f8fa" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
+        <categoryLink id="8fbf-5446-8439-7d5b" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="e38a-7bdf-7ddc-7084" name="Shabran Darr" hidden="false" collective="false" import="false" targetId="aa6d-c70a-199f-1db5" type="selectionEntry">
@@ -49,7 +40,6 @@
             <conditionGroup type="or">
               <conditions>
                 <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="90ee-77dd-1b7f-ddfe" type="equalTo"/>
                 <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="equalTo"/>
               </conditions>
             </conditionGroup>
@@ -61,19 +51,15 @@
         <categoryLink id="7196-76e9-d9ce-2f13" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="04f7-f1e9-d144-5f4c" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
         <categoryLink id="5c3e-5676-a666-e485" name="Independant Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
+        <categoryLink id="eaeb-08e5-5cda-7c6a" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="2d0a-125c-d539-b7cc" name="Red Hand Destroyer Assault Squad" hidden="false" collective="false" import="false" targetId="7a04-bc44-70bb-cb98" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
-          <conditionGroups>
-            <conditionGroup type="or">
-              <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="90ee-77dd-1b7f-ddfe" type="equalTo"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8d56-d960-0687-7fee" type="equalTo"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
+          <conditions>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8d56-d960-0687-7fee" type="equalTo"/>
+          </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
@@ -82,17 +68,6 @@
       </categoryLinks>
     </entryLink>
     <entryLink id="6fa2-aa20-9b69-1d6b" name="Rampager Squad" hidden="false" collective="false" import="false" targetId="2fb9-74a8-43b0-dd00" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditionGroups>
-            <conditionGroup type="or">
-              <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="90ee-77dd-1b7f-ddfe" type="equalTo"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="8586-4da8-8d15-4d96" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="4ed9-df3c-d9cc-b1f2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
@@ -105,7 +80,6 @@
             <conditionGroup type="or">
               <conditions>
                 <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="90ee-77dd-1b7f-ddfe" type="equalTo"/>
                 <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="equalTo"/>
               </conditions>
             </conditionGroup>
@@ -117,20 +91,10 @@
         <categoryLink id="8ba5-d6d8-3c2a-cf09" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="da90-6f7c-a866-ed37" name="Independant Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
         <categoryLink id="8325-a1d8-1787-4316" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
+        <categoryLink id="b9d3-c817-7e77-1c90" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="85a9-21ca-dcf0-beb4" name="Red Butchers" hidden="false" collective="false" import="false" targetId="1987-2aa5-929b-979e" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditionGroups>
-            <conditionGroup type="or">
-              <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="90ee-77dd-1b7f-ddfe" type="equalTo"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="6809-da13-d863-b286" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="63b2-2890-7ed2-7b00" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>

--- a/2022 - Legiones Astartes.cat
+++ b/2022 - Legiones Astartes.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="6393-649c-7213-a327" name="(HH V2) Legions Astartes" revision="34" battleScribeVersion="2.03" authorName="Various" authorUrl="https://github.com/BSData/horus-heresy" library="true" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="12" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="6393-649c-7213-a327" name="(HH V2) Legions Astartes" revision="35" battleScribeVersion="2.03" authorName="Various" authorUrl="https://github.com/BSData/horus-heresy" library="true" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="12" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <profileTypes>
     <profileType id="7002-2f9a-59c4-2742" name="Prosperine Arcana">
       <characteristicTypes>
@@ -190,6 +190,7 @@
       <categoryLinks>
         <categoryLink id="783b-26bc-fea7-cf01" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="a46d-5d6e-000a-5d66" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="750b-c107-f16a-22c1" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="6a0e-18ff-e970-9d33" name="Tactical Support Squad" hidden="false" collective="false" import="true" targetId="50ed-5869-643d-1ac5" type="selectionEntry">
@@ -256,28 +257,32 @@
         <categoryLink id="2d2f-d471-f236-4a26" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="3d91-5381-7d3b-12b8" name="Cataphractii Praetor" hidden="false" collective="false" import="true" targetId="1b79-1951-5a63-4b9e" type="selectionEntry">
+    <entryLink id="3d91-5381-7d3b-12b8" name="Praetor, Cataphractii" hidden="false" collective="false" import="true" targetId="1b79-1951-5a63-4b9e" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="5800-1474-acf6-eaa4" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="a39f-97c6-bd27-6c45" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="9a35-9771-5bdb-628d" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="4d02-2e0f-f548-23e9" name="Praetor" hidden="false" collective="false" import="true" targetId="03be-5d55-d05a-771d" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="d9bf-cd35-923c-3207" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="597a-992e-0dee-68b2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="fc30-5449-a5e1-4578" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="a564-0857-9118-4d61" name="Tartaros Praetor" hidden="false" collective="false" import="true" targetId="3760-204e-444c-1044" type="selectionEntry">
+    <entryLink id="a564-0857-9118-4d61" name="Praetor, Tartaros" hidden="false" collective="false" import="true" targetId="3760-204e-444c-1044" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="eff7-ac73-8de0-8151" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="2fca-89ca-9bbe-1233" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="11c7-6299-a96e-c840" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="d5ee-bae6-98b1-0b68" name="Centurion" hidden="false" collective="false" import="true" targetId="25a2-7a52-632a-6b2c" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="2cb4-308b-c7b1-98a2" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="3281-a38d-9db8-ddbd" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="f912-30d5-5b1c-6b1f" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="f62b-3d2a-f993-53cc" name="Terminator Tartaros Squad" hidden="false" collective="false" import="true" targetId="1a8e-0ded-a4dc-2b4e" type="selectionEntry">
@@ -291,12 +296,14 @@
       <categoryLinks>
         <categoryLink id="f378-4a79-15fa-81ca" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="693b-515a-4819-55c6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="e992-f385-d0a9-3db7" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="5aec-1a12-76e3-c199" name="Despoiler Squad" hidden="false" collective="false" import="true" targetId="4357-930e-165a-a6e3" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="0eeb-6b16-f452-5827" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="4c76-7464-7688-fa83" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="8506-ef11-7744-3c5f" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="c3b8-4eb1-012c-e665" name="Terminator Cataphractii Squad" hidden="false" collective="false" import="true" targetId="d91a-a3c7-d7be-4293" type="selectionEntry">
@@ -315,6 +322,7 @@
       <categoryLinks>
         <categoryLink id="eb7c-c2d1-e7c3-8647" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="4c64-8f55-a7cd-a47d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="35e9-5e62-ec02-4c95" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="80a6-9e7a-8f51-f86a" name="Storm Eagle Gunship" hidden="false" collective="false" import="true" targetId="8aa5-ff31-7de7-19d4" type="selectionEntry">
@@ -335,7 +343,7 @@
         <categoryLink id="dca2-5356-23b4-8101" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="5645-f091-4c36-43a8" name="*Cataphractii Centurion (Placeholder Points)" hidden="false" collective="false" import="true" targetId="3766-ea98-0aa7-62d0" type="selectionEntry">
+    <entryLink id="5645-f091-4c36-43a8" name="Centurion, Cataphractii " hidden="false" collective="false" import="true" targetId="3766-ea98-0aa7-62d0" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="355b-9512-6222-4261" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="0e13-5e67-ed4e-d272" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
@@ -559,10 +567,11 @@
         <categoryLink id="3cf3-6ea6-f1e7-2170" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="3870-4373-1d58-f961" name="**Terminator Indomitus Squad" hidden="false" collective="false" import="true" targetId="aa7f-bd4c-5231-d459" type="selectionEntry">
+    <entryLink id="3870-4373-1d58-f961" name="Terminator Indomitus Squad" hidden="false" collective="false" import="true" targetId="aa7f-bd4c-5231-d459" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="6aa7-1cbd-8158-ec09" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="0a59-1af0-8703-cdc6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="008a-2b38-471b-dc0a" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="ff7d-5072-81f6-2d65" name="**Nullificator Squad" hidden="false" collective="false" import="true" targetId="954d-cf8e-eefd-27a6" type="selectionEntry">

--- a/2022 - Mech Library.cat
+++ b/2022 - Mech Library.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="3129-da35-55e0-642d" name="2022 - Mech Library" revision="3" battleScribeVersion="2.03" library="true" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="12" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="3129-da35-55e0-642d" name="2022 - Mech Library" revision="4" battleScribeVersion="2.03" library="true" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="12" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <categoryEntries>
     <categoryEntry id="4086-0589-f010-e688" name="Titan Legion Min Troop/LoW" hidden="false"/>
   </categoryEntries>
@@ -636,7 +636,7 @@ Invulnerable Saves granted by a mag-inverter shield do not stack with other Invu
             <categoryLink id="8f20-9c8d-f873-27e3" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
-            <selectionEntryGroup id="4bd0-7503-e4af-d39d" name="Left Arm Weapon" hidden="false" collective="false" import="true">
+            <selectionEntryGroup id="4bd0-7503-e4af-d39d" name="Left Arm Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="a056-17b7-f14b-85e8">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3329-6406-79c5-8005" type="min"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c925-fb84-27ad-b780" type="max"/>
@@ -649,7 +649,7 @@ Invulnerable Saves granted by a mag-inverter shield do not stack with other Invu
                 <entryLink id="d68d-d638-d1b2-1fbe" name="Titan Power Fist" hidden="false" collective="false" import="true" targetId="2952-52d9-49e2-cbfd" type="selectionEntry"/>
               </entryLinks>
             </selectionEntryGroup>
-            <selectionEntryGroup id="c539-4121-4c2e-54a3" name="Right Arm Weapon" hidden="false" collective="false" import="true">
+            <selectionEntryGroup id="c539-4121-4c2e-54a3" name="Right Arm Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="aadc-7e82-152f-2670">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fa50-8bc0-6455-c0ce" type="min"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="98e6-0cac-610d-5b62" type="max"/>
@@ -662,7 +662,7 @@ Invulnerable Saves granted by a mag-inverter shield do not stack with other Invu
                 <entryLink id="1cd4-605e-636f-88d0" name="Volcano Cannon" hidden="false" collective="false" import="true" targetId="c65f-0423-6564-a622" type="selectionEntry"/>
               </entryLinks>
             </selectionEntryGroup>
-            <selectionEntryGroup id="31e7-9f08-d614-a3d6" name="Carapace Mounted Weapon" hidden="false" collective="false" import="true">
+            <selectionEntryGroup id="31e7-9f08-d614-a3d6" name="Carapace Mounted Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="e134-8a55-0bb8-c02f">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="50f1-c5f2-900d-aa63" type="min"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9b48-0daa-8549-a156" type="max"/>
@@ -730,7 +730,7 @@ Invulnerable Saves granted by a mag-inverter shield do not stack with other Invu
             <categoryLink id="f66b-4dee-d200-9691" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
-            <selectionEntryGroup id="9fdb-9757-b9d8-f13f" name="Left Arm Weapon" hidden="false" collective="false" import="true">
+            <selectionEntryGroup id="9fdb-9757-b9d8-f13f" name="Left Arm Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="12a0-894b-9d31-af12">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ac7b-296e-7e03-d05a" type="min"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="67d0-f67c-bec0-9b3b" type="max"/>
@@ -742,7 +742,7 @@ Invulnerable Saves granted by a mag-inverter shield do not stack with other Invu
                 <entryLink id="e68e-a2e2-59a2-9299" name="Melta Cannon" hidden="false" collective="false" import="true" targetId="7a16-0e23-c633-c668" type="selectionEntry"/>
               </entryLinks>
             </selectionEntryGroup>
-            <selectionEntryGroup id="46bd-4f52-34c2-7e6c" name="Right Arm Weapon" hidden="false" collective="false" import="true">
+            <selectionEntryGroup id="46bd-4f52-34c2-7e6c" name="Right Arm Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="eedf-dba9-2033-d661">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="835b-3a0c-498b-ca4b" type="min"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1f01-9c36-0490-7c05" type="max"/>
@@ -754,7 +754,7 @@ Invulnerable Saves granted by a mag-inverter shield do not stack with other Invu
                 <entryLink id="1bf5-3fce-c99e-d4c8" name="Melta Cannon" hidden="false" collective="false" import="true" targetId="7a16-0e23-c633-c668" type="selectionEntry"/>
               </entryLinks>
             </selectionEntryGroup>
-            <selectionEntryGroup id="2388-1fbf-d680-56a0" name="Right Shoulder Carapace Mounted Weapon" hidden="false" collective="false" import="true">
+            <selectionEntryGroup id="2388-1fbf-d680-56a0" name="Right Shoulder Carapace Mounted Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="84d0-9c52-debf-a987">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="938a-ad56-22f2-6193" type="min"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7f8c-f05d-7274-ee71" type="max"/>
@@ -763,7 +763,7 @@ Invulnerable Saves granted by a mag-inverter shield do not stack with other Invu
                 <entryLink id="84d0-9c52-debf-a987" name="Defensor Autocannon Battery" hidden="false" collective="false" import="true" targetId="55e4-0853-3720-c068" type="selectionEntry"/>
               </entryLinks>
             </selectionEntryGroup>
-            <selectionEntryGroup id="d6a6-3559-1836-0314" name="Left Shoulder Carapace Mounted Weapon" hidden="false" collective="false" import="true">
+            <selectionEntryGroup id="d6a6-3559-1836-0314" name="Left Shoulder Carapace Mounted Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="67ba-a3d6-e903-a091">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1a27-1095-1dce-59fa" type="min"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3731-a82c-4beb-1916" type="max"/>
@@ -772,7 +772,7 @@ Invulnerable Saves granted by a mag-inverter shield do not stack with other Invu
                 <entryLink id="67ba-a3d6-e903-a091" name="Defensor Autocannon Battery" hidden="false" collective="false" import="true" targetId="55e4-0853-3720-c068" type="selectionEntry"/>
               </entryLinks>
             </selectionEntryGroup>
-            <selectionEntryGroup id="9e6c-16f9-30c9-9771" name="Two Hull (Front) Weapons" hidden="false" collective="false" import="true">
+            <selectionEntryGroup id="9e6c-16f9-30c9-9771" name="Two Hull (Front) Weapons" hidden="false" collective="false" import="true" defaultSelectionEntryId="f39a-4da7-687b-bd50">
               <constraints>
                 <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2283-53ed-5e34-3b65" type="min"/>
                 <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="133c-3829-46bd-4ed3" type="max"/>
@@ -781,7 +781,7 @@ Invulnerable Saves granted by a mag-inverter shield do not stack with other Invu
                 <entryLink id="f39a-4da7-687b-bd50" name="Defensor Bolt Cannon" hidden="false" collective="false" import="true" targetId="fee2-949c-6d55-2a2f" type="selectionEntry"/>
               </entryLinks>
             </selectionEntryGroup>
-            <selectionEntryGroup id="6965-4ba4-7168-2ad2" name="One Hull (Rear) Weapon" hidden="false" collective="false" import="true">
+            <selectionEntryGroup id="6965-4ba4-7168-2ad2" name="One Hull (Rear) Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="f17b-3901-4ba9-2227">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="254b-630f-8548-f4b1" type="min"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c906-dcff-4e64-07fc" type="max"/>
@@ -790,7 +790,7 @@ Invulnerable Saves granted by a mag-inverter shield do not stack with other Invu
                 <entryLink id="f17b-3901-4ba9-2227" name="Defensor Bolt Cannon" hidden="false" collective="false" import="true" targetId="fee2-949c-6d55-2a2f" type="selectionEntry"/>
               </entryLinks>
             </selectionEntryGroup>
-            <selectionEntryGroup id="f206-6212-23e8-07e6" name="Main Carapace Mounted Weapon" hidden="false" collective="false" import="true">
+            <selectionEntryGroup id="f206-6212-23e8-07e6" name="Main Carapace Mounted Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="572b-c858-8765-1e15">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4b55-fd5f-e766-1418" type="min"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7e70-8d0d-1836-8b8d" type="max"/>
@@ -903,7 +903,7 @@ Invulnerable Saves granted by a mag-inverter shield do not stack with other Invu
             <categoryLink id="e91e-b235-f4d0-bc52" name="Fast Vehicles" hidden="false" targetId="0ea2-efb5-b7af-226e" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
-            <selectionEntryGroup id="9421-2b5c-e5f4-6029" name="Left Arm Weapon" hidden="false" collective="false" import="true">
+            <selectionEntryGroup id="9421-2b5c-e5f4-6029" name="Left Arm Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="d7e1-874e-679e-bb26">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1353-9f50-6ddf-f09a" type="min"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4818-85f0-f870-8523" type="max"/>
@@ -915,7 +915,7 @@ Invulnerable Saves granted by a mag-inverter shield do not stack with other Invu
                 <entryLink id="bff0-1ef8-6b6f-e6a7" name="Inferno Gun" hidden="false" collective="false" import="true" targetId="aa57-fc73-86fe-217c" type="selectionEntry"/>
               </entryLinks>
             </selectionEntryGroup>
-            <selectionEntryGroup id="2b18-4de0-85f9-e89b" name="Right Arm Weapon" hidden="false" collective="false" import="true">
+            <selectionEntryGroup id="2b18-4de0-85f9-e89b" name="Right Arm Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="10b6-946d-d13e-c214">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ba5e-0d6f-27d1-94fd" type="min"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0a9f-7623-0860-35fc" type="max"/>
@@ -986,7 +986,7 @@ Invulnerable Saves granted by a mag-inverter shield do not stack with other Invu
             <categoryLink id="baca-62ce-c351-565d" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
-            <selectionEntryGroup id="4eb8-020c-c441-cfe5" name="Left Arm Weapon" hidden="false" collective="false" import="true">
+            <selectionEntryGroup id="4eb8-020c-c441-cfe5" name="Left Arm Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="baf6-5b24-9ff5-36fc">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5c36-a943-2039-c846" type="min"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b32b-f147-24f0-96a1" type="max"/>
@@ -1009,7 +1009,7 @@ Invulnerable Saves granted by a mag-inverter shield do not stack with other Invu
                 <entryLink id="7112-7a32-7bae-2825" name="Sunfury Plasma Annihilator" hidden="false" collective="false" import="true" targetId="f4dc-88a0-0ad9-4c61" type="selectionEntry"/>
               </entryLinks>
             </selectionEntryGroup>
-            <selectionEntryGroup id="e9e0-2bc5-255b-0bd4" name="Right Arm Weapon" hidden="false" collective="false" import="true">
+            <selectionEntryGroup id="e9e0-2bc5-255b-0bd4" name="Right Arm Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="ecb9-a680-093f-de7d">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="491f-311e-ba82-cb1f" type="min"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f6b0-a68b-f5ff-662e" type="max"/>
@@ -1032,7 +1032,7 @@ Invulnerable Saves granted by a mag-inverter shield do not stack with other Invu
                 <entryLink id="ec5f-4499-6365-b9c0" name="Sunfury Plasma Annihilator" hidden="false" collective="false" import="true" targetId="f4dc-88a0-0ad9-4c61" type="selectionEntry"/>
               </entryLinks>
             </selectionEntryGroup>
-            <selectionEntryGroup id="2728-c1f9-389d-196b" name="Two Carapace Mounted Weapons" hidden="false" collective="false" import="true">
+            <selectionEntryGroup id="2728-c1f9-389d-196b" name="Two Carapace Mounted Weapons" hidden="false" collective="false" import="true" defaultSelectionEntryId="223a-0c19-9a43-5488">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b0ab-6650-1cc4-c146" type="min"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0a4e-9b49-7652-09e7" type="max"/>
@@ -1050,7 +1050,7 @@ Invulnerable Saves granted by a mag-inverter shield do not stack with other Invu
                 </entryLink>
               </entryLinks>
             </selectionEntryGroup>
-            <selectionEntryGroup id="290c-99b7-0623-0a4e" name="Two Hull (Front) Weapons" hidden="false" collective="false" import="true">
+            <selectionEntryGroup id="290c-99b7-0623-0a4e" name="Two Hull (Front) Weapons" hidden="false" collective="false" import="true" defaultSelectionEntryId="0ee9-6ce4-f233-7f7e">
               <constraints>
                 <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f914-1d82-d36a-0445" type="min"/>
                 <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4055-83f9-c9e0-13f8" type="max"/>
@@ -1059,7 +1059,7 @@ Invulnerable Saves granted by a mag-inverter shield do not stack with other Invu
                 <entryLink id="0ee9-6ce4-f233-7f7e" name="Defensor Bolt Cannon" hidden="false" collective="false" import="true" targetId="fee2-949c-6d55-2a2f" type="selectionEntry"/>
               </entryLinks>
             </selectionEntryGroup>
-            <selectionEntryGroup id="1350-f866-cff7-e072" name="Two Hull (Rear) Weapons" hidden="false" collective="false" import="true">
+            <selectionEntryGroup id="1350-f866-cff7-e072" name="Two Hull (Rear) Weapons" hidden="false" collective="false" import="true" defaultSelectionEntryId="c0f6-4906-8480-4734">
               <constraints>
                 <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e37a-32d4-61e9-0995" type="min"/>
                 <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8454-9a23-3727-026d" type="max"/>
@@ -1197,7 +1197,7 @@ Invulnerable Saves granted by a mag-inverter shield do not stack with other Invu
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
-        <selectionEntryGroup id="bf3f-1515-4ef9-7132" name="May exchange its Hull (Front) Mounted Ironstorm missile pod for:" hidden="false" collective="false" import="true">
+        <selectionEntryGroup id="bf3f-1515-4ef9-7132" name="May exchange its Hull (Front) Mounted Ironstorm missile pod for:" hidden="false" collective="false" import="true" defaultSelectionEntryId="7f85-9078-da63-2ad1">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9533-c039-43e0-0a49" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="302d-06f5-8246-e26b" type="max"/>
@@ -1227,7 +1227,7 @@ Invulnerable Saves granted by a mag-inverter shield do not stack with other Invu
             <entryLink id="7f85-9078-da63-2ad1" name="Ironstorm Missile Pod" hidden="false" collective="false" import="true" targetId="82e0-160b-28f5-f01e" type="selectionEntry"/>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="e5d0-fd09-329c-e0a0" name="May exchange either or both of its Hull (Front) Mounted Autocannon to one of the following:" hidden="false" collective="false" import="true">
+        <selectionEntryGroup id="e5d0-fd09-329c-e0a0" name="May exchange either or both of its Hull (Front) Mounted Autocannon to one of the following:" hidden="false" collective="false" import="true" defaultSelectionEntryId="920d-0e70-a210-32e0">
           <constraints>
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="de53-6863-2f1a-7ec0" type="min"/>
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="45b1-5372-9656-c729" type="max"/>
@@ -1334,7 +1334,7 @@ Invulnerable Saves granted by a mag-inverter shield do not stack with other Invu
             </selectionEntry>
           </selectionEntries>
           <selectionEntryGroups>
-            <selectionEntryGroup id="88d3-7193-f0f5-0c05" name="May Exchange its Heavy Stubber for:" hidden="false" collective="false" import="true">
+            <selectionEntryGroup id="88d3-7193-f0f5-0c05" name="May Exchange its Heavy Stubber for:" hidden="false" collective="false" import="true" defaultSelectionEntryId="772d-7881-f4c3-7d37">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ed7b-c1cd-1951-9426" type="min"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="23a7-567f-83e8-99ba" type="max"/>
@@ -1457,7 +1457,7 @@ Invulnerable Saves granted by a mag-inverter shield do not stack with other Invu
             </selectionEntry>
           </selectionEntries>
           <selectionEntryGroups>
-            <selectionEntryGroup id="6472-dba6-bfc8-4315" name="May Exchange its Heavy Stubber for:" hidden="false" collective="false" import="true">
+            <selectionEntryGroup id="6472-dba6-bfc8-4315" name="May Exchange its Heavy Stubber for:" hidden="false" collective="false" import="true" defaultSelectionEntryId="c29c-1d53-acc6-1aee">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6134-9221-6602-31b9" type="min"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="32d1-1830-2d71-3f5d" type="max"/>
@@ -2156,163 +2156,47 @@ Invulnerable Saves granted by a mag-inverter shield do not stack with other Invu
         </infoLink>
       </infoLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="50b4-a35e-137d-20a8" name="May exchange its Arm Mounted Reaper Chainsword for:" hidden="false" collective="false" import="true">
+        <selectionEntryGroup id="50b4-a35e-137d-20a8" name="May exchange its Arm Mounted Reaper Chainsword for:" hidden="false" collective="false" import="true" defaultSelectionEntryId="0696-eba7-6d52-40ce">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d5b3-9991-171e-6f89" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5c78-ad94-6633-d88f" type="max"/>
           </constraints>
-          <selectionEntries>
-            <selectionEntry id="219b-0272-0a20-8057" name="Avenger Gatling Cannon with In-Built Heavy Flamer" hidden="false" collective="false" import="true" type="upgrade">
-              <profiles>
-                <profile id="6bdb-5731-3d62-8777" name="Avenger Gatling Cannon" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
-                  <characteristics>
-                    <characteristic name="Range" typeId="95ba-cda7-b831-6066">36&quot;</characteristic>
-                    <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">6</characteristic>
-                    <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">4</characteristic>
-                    <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Heavy 12, Rending (6+)</characteristic>
-                  </characteristics>
-                </profile>
-              </profiles>
-              <infoLinks>
-                <infoLink id="0ec0-2509-792a-2129" name="Rending (X)" hidden="false" targetId="0ac9-fab7-aef3-de1d" type="rule">
-                  <modifiers>
-                    <modifier type="set" field="name" value="Rending (6+)"/>
-                  </modifiers>
-                </infoLink>
-                <infoLink id="4f7d-1c7d-1ef5-6bfb" name="Template Weapons" hidden="false" targetId="5e0e-88e6-db81-5a70" type="rule"/>
-                <infoLink id="6c24-d2d3-4a75-8fc2" name="Heavy Flamer" hidden="false" targetId="a6e9-e2e1-150f-b023" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="bc22-a0ac-cecd-d6b5" name="Thunderstrike Gauntlet" publicationId="bde1-6db1-163b-3b76" page="122" hidden="false" collective="false" import="true" type="upgrade">
-              <profiles>
-                <profile id="e862-b785-a568-3f39" name="Thunderstrike Gauntlet" publicationId="bde1-6db1-163b-3b76" page="122" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
-                  <characteristics>
-                    <characteristic name="Range" typeId="95ba-cda7-b831-6066">-</characteristic>
-                    <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">12</characteristic>
-                    <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">2</characteristic>
-                    <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Melee, Sunder</characteristic>
-                  </characteristics>
-                </profile>
-              </profiles>
-              <infoLinks>
-                <infoLink id="9323-ff61-070c-3fb8" name="Sunder" hidden="false" targetId="20e2-75cf-bc16-cd8f" type="rule"/>
-              </infoLinks>
+          <entryLinks>
+            <entryLink id="0696-eba7-6d52-40ce" name="Reaper Chainsword" hidden="false" collective="false" import="true" targetId="2164-1725-d032-ed49" type="selectionEntry"/>
+            <entryLink id="e73c-d4d2-93ca-a357" name="Avenger Gatling Cannon with In-Built Heavy Flamer" hidden="false" collective="false" import="true" targetId="1d6f-970d-3b89-7886" type="selectionEntry">
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
               </costs>
-            </selectionEntry>
-          </selectionEntries>
-          <entryLinks>
-            <entryLink id="0696-eba7-6d52-40ce" name="Reaper Chainsword" hidden="false" collective="false" import="true" targetId="2164-1725-d032-ed49" type="selectionEntry"/>
+            </entryLink>
+            <entryLink id="94eb-1c20-03e1-869b" name="Thunderstrike Gauntlet" hidden="false" collective="false" import="true" targetId="923a-c8cb-bcf8-b530" type="selectionEntry">
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+              </costs>
+            </entryLink>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="4a49-023e-5ab7-7085" name="May exchange its Arm Mounted Rapid-Fire Battle Cannon with In-Built Heavy Stubber for:" hidden="false" collective="false" import="true">
+        <selectionEntryGroup id="4a49-023e-5ab7-7085" name="May exchange its Arm Mounted Rapid-Fire Battle Cannon with In-Built Heavy Stubber for:" hidden="false" collective="false" import="true" defaultSelectionEntryId="d937-e0ce-7e8a-1d6e">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5880-a723-06d0-f71e" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fb15-c258-5d87-50ea" type="max"/>
           </constraints>
-          <selectionEntries>
-            <selectionEntry id="acce-533b-0e57-1921" name="Rapid-Fire Battle Cannon with In-Built Heavy Stubber" publicationId="bde1-6db1-163b-3b76" page="113" hidden="false" collective="false" import="true" type="upgrade">
-              <profiles>
-                <profile id="75ac-285a-4d20-464a" name="Rapid-Fire Battle Cannon" publicationId="bde1-6db1-163b-3b76" page="113" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
-                  <characteristics>
-                    <characteristic name="Range" typeId="95ba-cda7-b831-6066">48&quot;</characteristic>
-                    <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">8</characteristic>
-                    <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">4</characteristic>
-                    <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Ordnance 2, Large Blast (5&quot;)</characteristic>
-                  </characteristics>
-                </profile>
-              </profiles>
-              <infoLinks>
-                <infoLink id="fce8-e36b-275b-8194" name="Heavy Stubber" hidden="false" targetId="129d-1b6c-7ba2-29ec" type="profile"/>
-                <infoLink id="fd54-184b-215f-d176" name="Blast" hidden="false" targetId="1d9a-73ef-5f4f-8bd8" type="rule"/>
-                <infoLink id="ba11-1a13-6e49-6f97" name="Ordnance" hidden="false" targetId="6c55-22c8-1b01-2105" type="rule"/>
-              </infoLinks>
-              <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="c658-4be2-46e3-d0d2" name="Avenger Gatling Cannon with In-Built Heavy Flamer" hidden="false" collective="false" import="true" type="upgrade">
-              <infoLinks>
-                <infoLink id="00e6-e517-86af-d1fa" name="Rending (X)" hidden="false" targetId="0ac9-fab7-aef3-de1d" type="rule">
-                  <modifiers>
-                    <modifier type="set" field="name" value="Rending (6+)"/>
-                  </modifiers>
-                </infoLink>
-                <infoLink id="d6b2-d3b9-d698-cb4c" name="Template Weapons" hidden="false" targetId="5e0e-88e6-db81-5a70" type="rule"/>
-                <infoLink id="0021-e83e-c634-9f5c" name="Avenger Gatling Cannon" hidden="false" targetId="691d-aafb-9299-a873" type="profile"/>
-                <infoLink id="1834-90b8-912d-2275" name="Heavy Flamer" hidden="false" targetId="a6e9-e2e1-150f-b023" type="profile"/>
-              </infoLinks>
+          <entryLinks>
+            <entryLink id="e8d4-85bf-0041-ff2b" name="Reaper Chainsword" hidden="false" collective="false" import="true" targetId="2164-1725-d032-ed49" type="selectionEntry"/>
+            <entryLink id="0dfe-4f99-9af3-2f7e" name="Avenger Gatling Cannon with In-Built Heavy Flamer" hidden="false" collective="false" import="true" targetId="1d6f-970d-3b89-7886" type="selectionEntry">
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
               </costs>
-            </selectionEntry>
-            <selectionEntry id="97f8-be91-387f-7abc" name="Las-Impulsor" publicationId="bde1-6db1-163b-3b76" page="115 &amp; 121" hidden="false" collective="false" import="true" type="upgrade">
-              <profiles>
-                <profile id="ca99-0187-bfe4-ff22" name="Las-Impulsor (Ranged)" publicationId="bde1-6db1-163b-3b76" page="115" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
-                  <characteristics>
-                    <characteristic name="Range" typeId="95ba-cda7-b831-6066">12&quot;</characteristic>
-                    <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">10</characteristic>
-                    <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">2</characteristic>
-                    <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Heavy 2, Sunder, Instant Death</characteristic>
-                  </characteristics>
-                </profile>
-                <profile id="87ca-5697-36b0-1abc" name="Las-Impulsor (Melee)" publicationId="bde1-6db1-163b-3b76" page="121" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
-                  <characteristics>
-                    <characteristic name="Range" typeId="95ba-cda7-b831-6066">-</characteristic>
-                    <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">10</characteristic>
-                    <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">1</characteristic>
-                    <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Melee, Unwieldy, Cumbersome, Armourbane (Melee), Instant Death</characteristic>
-                  </characteristics>
-                </profile>
-              </profiles>
-              <infoLinks>
-                <infoLink id="af55-6d49-be84-1d1c" name="Sunder" hidden="false" targetId="20e2-75cf-bc16-cd8f" type="rule"/>
-                <infoLink id="5bfd-71ba-5299-429e" name="Unwieldy" hidden="false" targetId="1570-c21a-881f-8b8a" type="rule"/>
-                <infoLink id="123c-d02e-d894-27a4" name="Cumbersome" hidden="false" targetId="d89a-c10e-8a7a-92c3" type="rule"/>
-                <infoLink id="a3df-55b1-27c7-b3af" name="Armourbane (X)" hidden="false" targetId="cb59-f920-f071-7cd4" type="rule">
-                  <modifiers>
-                    <modifier type="set" field="name" value="Armourbane (Melee)"/>
-                  </modifiers>
-                </infoLink>
-                <infoLink id="dc7b-ed42-4768-305c" name="Instant Death" hidden="false" targetId="9e96-fff1-b916-d9a3" type="rule"/>
-              </infoLinks>
+            </entryLink>
+            <entryLink id="ca22-a0fb-784b-9380" name="Las-Impulsor" hidden="false" collective="false" import="true" targetId="8e68-00af-7bea-571a" type="selectionEntry">
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
               </costs>
-            </selectionEntry>
-            <selectionEntry id="f607-e566-8954-085b" name="Thermal Cannon" publicationId="bde1-6db1-163b-3b76" page="117" hidden="false" collective="false" import="true" type="upgrade">
-              <profiles>
-                <profile id="750b-ff9a-7290-ae83" name="Thermal Cannon" publicationId="bde1-6db1-163b-3b76" page="117" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
-                  <characteristics>
-                    <characteristic name="Range" typeId="95ba-cda7-b831-6066">36&quot;</characteristic>
-                    <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">8</characteristic>
-                    <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">1</characteristic>
-                    <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Heavy 1, Large Blast (5&quot;), Armourbane (Melta)</characteristic>
-                  </characteristics>
-                </profile>
-              </profiles>
-              <infoLinks>
-                <infoLink id="9f89-114a-bfe6-6c3f" name="Blast" hidden="false" targetId="1d9a-73ef-5f4f-8bd8" type="rule"/>
-                <infoLink id="237b-726b-26b8-1181" name="Armourbane (X)" hidden="false" targetId="cb59-f920-f071-7cd4" type="rule">
-                  <modifiers>
-                    <modifier type="set" field="name" value="Armourbane (Melta)"/>
-                  </modifiers>
-                </infoLink>
-              </infoLinks>
-              <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-          <entryLinks>
-            <entryLink id="e8d4-85bf-0041-ff2b" name="Reaper Chainsword" hidden="false" collective="false" import="true" targetId="2164-1725-d032-ed49" type="selectionEntry"/>
+            </entryLink>
+            <entryLink id="d937-e0ce-7e8a-1d6e" name="Rapid-Fire Battle Cannon with In-Built Heavy Stubber" hidden="false" collective="false" import="true" targetId="a0e4-12d7-ff85-51c4" type="selectionEntry"/>
+            <entryLink id="9d5b-eda4-cdee-0062" name="Thermal Cannon" hidden="false" collective="false" import="true" targetId="0aee-ef5a-9636-1740" type="selectionEntry"/>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="cbde-85d9-9a78-1e8f" name="May exchange its Hull (Front) Mounted Heavy Stubber with:" hidden="false" collective="false" import="true">
+        <selectionEntryGroup id="cbde-85d9-9a78-1e8f" name="May exchange its Hull (Front) Mounted Heavy Stubber with:" hidden="false" collective="false" import="true" defaultSelectionEntryId="aaaf-0640-640a-b248">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5132-24c7-348d-e87b" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a998-0ea4-c07f-a39d" type="max"/>
@@ -2481,7 +2365,7 @@ Invulnerable Saves granted by a mag-inverter shield do not stack with other Invu
         <infoLink id="8583-d986-6594-f390" name="Night Vision" hidden="false" targetId="683e-b4f2-f032-d31b" type="rule"/>
       </infoLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="fda6-d2ec-6c49-f60d" name="Arm Mounted Twin-Linked Heavy Conversion Beam Cannon" hidden="false" collective="false" import="true">
+        <selectionEntryGroup id="fda6-d2ec-6c49-f60d" name="Arm Mounted Twin-Linked Heavy Conversion Beam Cannon" hidden="false" collective="false" import="true" defaultSelectionEntryId="6784-8899-6af2-8432">
           <constraints>
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f1d9-d7ec-3c9a-c506" type="min"/>
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ed1b-d84c-4799-0472" type="max"/>
@@ -2490,7 +2374,7 @@ Invulnerable Saves granted by a mag-inverter shield do not stack with other Invu
             <entryLink id="6784-8899-6af2-8432" name="Heavy Conversion Beam Cannon" hidden="false" collective="false" import="true" targetId="7c47-e2e9-dc42-e838" type="selectionEntry"/>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="c21a-be92-c6c2-5931" name="Hull (Front) Mounted Karacnos Mortar Battery" hidden="false" collective="false" import="true">
+        <selectionEntryGroup id="c21a-be92-c6c2-5931" name="Hull (Front) Mounted Karacnos Mortar Battery" hidden="false" collective="false" import="true" defaultSelectionEntryId="ac3f-09f6-b607-867e">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="94b3-a011-6ddb-e43d" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0101-c016-8f7f-6ddf" type="max"/>
@@ -2499,7 +2383,7 @@ Invulnerable Saves granted by a mag-inverter shield do not stack with other Invu
             <entryLink id="ac3f-09f6-b607-867e" name="Karacnos Mortar Battery" hidden="false" collective="false" import="true" targetId="2b9f-41fb-a0a8-285e" type="selectionEntry"/>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="7074-0e84-ac6c-ee14" name="Hull (Front) Mounted Volkite Culverin" hidden="false" collective="false" import="true">
+        <selectionEntryGroup id="7074-0e84-ac6c-ee14" name="Hull (Front) Mounted Volkite Culverin" hidden="false" collective="false" import="true" defaultSelectionEntryId="426b-0f9f-7cc2-a3c7">
           <constraints>
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f993-cfc4-a930-ed87" type="min"/>
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6fe3-7e91-206e-80dc" type="max"/>
@@ -2885,36 +2769,21 @@ Invulnerable Saves granted by a mag-inverter shield do not stack with other Invu
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
-        <selectionEntryGroup id="36dc-7ab3-6da1-e782" name="May exchange its Arm Mounted Reaper Chainsword for:" hidden="false" collective="false" import="true">
+        <selectionEntryGroup id="36dc-7ab3-6da1-e782" name="May exchange its Arm Mounted Reaper Chainsword for:" hidden="false" collective="false" import="true" defaultSelectionEntryId="9a0c-42b5-1454-bfd6">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e359-6e6e-aceb-71e4" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="98e1-353c-3e8b-e7aa" type="max"/>
           </constraints>
-          <selectionEntries>
-            <selectionEntry id="4822-e8ba-3479-c8eb" name="Siege Claw with In-Built Irad-Cleanser" publicationId="bde1-6db1-163b-3b76" page="123" hidden="false" collective="false" import="true" type="upgrade">
-              <infoLinks>
-                <infoLink id="fa17-7a1a-ab61-e8ad" name="Irad-Cleanser" hidden="false" targetId="484b-1446-7bac-46d9" type="profile"/>
-                <infoLink id="bc06-b7a9-1571-0ee3" name="Fleshbane" hidden="false" targetId="40cd-9505-253c-e76f" type="rule"/>
-                <infoLink id="7d3b-a504-9a9f-403e" name="Rad-Phage" hidden="false" targetId="8189-e963-d2e5-5d3d" type="rule"/>
-                <infoLink id="93ee-a36c-537d-3a5d" name="Brutal (X)" hidden="false" targetId="5079-1fec-d32b-8b84" type="rule">
-                  <modifiers>
-                    <modifier type="set" field="name" value="Brutal (2)"/>
-                  </modifiers>
-                </infoLink>
-                <infoLink id="ef3b-01f7-bc81-10a5" name="Sunder" hidden="false" targetId="20e2-75cf-bc16-cd8f" type="rule"/>
-                <infoLink id="1f55-af11-25c7-b18a" name="Wrecker" hidden="false" targetId="ba77-a802-55df-da67" type="rule"/>
-                <infoLink id="592f-17c5-26f5-e0b8" name="Siege Claw" hidden="false" targetId="f417-99e0-bb03-dfa7" type="profile"/>
-              </infoLinks>
+          <entryLinks>
+            <entryLink id="9a0c-42b5-1454-bfd6" name="Reaper Chainsword" hidden="false" collective="false" import="true" targetId="2164-1725-d032-ed49" type="selectionEntry"/>
+            <entryLink id="bb9c-a5eb-ea69-f482" name="Siege Claw with In-Built Irad-Cleanser" hidden="false" collective="false" import="true" targetId="6a06-cbf5-fbbf-85fe" type="selectionEntry">
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0"/>
               </costs>
-            </selectionEntry>
-          </selectionEntries>
-          <entryLinks>
-            <entryLink id="9a0c-42b5-1454-bfd6" name="Reaper Chainsword" hidden="false" collective="false" import="true" targetId="2164-1725-d032-ed49" type="selectionEntry"/>
+            </entryLink>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="a009-f54b-f17a-e86e" name="Hull (Front) Mounted Phased Plasma-Fusil" hidden="false" collective="false" import="true">
+        <selectionEntryGroup id="a009-f54b-f17a-e86e" name="Hull (Front) Mounted Phased Plasma-Fusil" hidden="false" collective="false" import="true" defaultSelectionEntryId="bce2-b7ba-7c5e-af6a">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c0f7-179e-83c5-e562" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d702-8f2e-92d4-4466" type="max"/>
@@ -3077,36 +2946,21 @@ Invulnerable Saves granted by a mag-inverter shield do not stack with other Invu
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
-        <selectionEntryGroup id="8a6c-17e2-0478-ef0e" name="May exchange its Arm Mounted Reaper Chainsword for:" hidden="false" collective="false" import="true">
+        <selectionEntryGroup id="8a6c-17e2-0478-ef0e" name="May exchange its Arm Mounted Reaper Chainsword for:" hidden="false" collective="false" import="true" defaultSelectionEntryId="1774-049e-bc38-d8dc">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8e23-4648-8ba1-d2a7" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="de13-aeaa-e547-e7bf" type="max"/>
           </constraints>
-          <selectionEntries>
-            <selectionEntry id="52a1-de87-3c08-fc08" name="Siege Claw with In-Built Irad-Cleanser" hidden="false" collective="false" import="true" type="upgrade">
-              <infoLinks>
-                <infoLink id="9821-4421-eb01-7431" name="Irad-Cleanser" hidden="false" targetId="484b-1446-7bac-46d9" type="profile"/>
-                <infoLink id="d998-4165-5526-3889" name="Fleshbane" hidden="false" targetId="40cd-9505-253c-e76f" type="rule"/>
-                <infoLink id="318c-4932-2040-e36b" name="Rad-Phage" hidden="false" targetId="8189-e963-d2e5-5d3d" type="rule"/>
-                <infoLink id="b30f-2873-85b8-2981" name="Brutal (X)" hidden="false" targetId="5079-1fec-d32b-8b84" type="rule">
-                  <modifiers>
-                    <modifier type="set" field="name" value="Brutal (2)"/>
-                  </modifiers>
-                </infoLink>
-                <infoLink id="e1ff-2a45-660f-24ae" name="Sunder" hidden="false" targetId="20e2-75cf-bc16-cd8f" type="rule"/>
-                <infoLink id="205d-e6fe-c30b-5c24" name="Wrecker" hidden="false" targetId="ba77-a802-55df-da67" type="rule"/>
-                <infoLink id="64d2-1a8c-3801-b217" name="Siege Claw" hidden="false" targetId="f417-99e0-bb03-dfa7" type="profile"/>
-              </infoLinks>
+          <entryLinks>
+            <entryLink id="1774-049e-bc38-d8dc" name="Reaper Chainsword" hidden="false" collective="false" import="true" targetId="2164-1725-d032-ed49" type="selectionEntry"/>
+            <entryLink id="37d1-aa8e-c3b2-a90e" name="Siege Claw with In-Built Irad-Cleanser" hidden="false" collective="false" import="true" targetId="6a06-cbf5-fbbf-85fe" type="selectionEntry">
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0"/>
               </costs>
-            </selectionEntry>
-          </selectionEntries>
-          <entryLinks>
-            <entryLink id="1774-049e-bc38-d8dc" name="Reaper Chainsword" hidden="false" collective="false" import="true" targetId="2164-1725-d032-ed49" type="selectionEntry"/>
+            </entryLink>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="32a0-55a7-387a-5960" name="Hull (Front) Mounted Graviton Gun" hidden="false" collective="false" import="true">
+        <selectionEntryGroup id="32a0-55a7-387a-5960" name="Hull (Front) Mounted Graviton Gun" hidden="false" collective="false" import="true" defaultSelectionEntryId="8121-31d5-379b-3419">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="61bb-1c22-4bb3-42cf" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="53f3-2efa-9282-3aad" type="max"/>
@@ -3121,6 +2975,1041 @@ Invulnerable Saves granted by a mag-inverter shield do not stack with other Invu
       </entryLinks>
       <costs>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="380.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="c1d2-77e3-5d1c-5297" name="Arioch Power Claw" publicationId="bde1-6db1-163b-3b76" page="122" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="86f8-ab1b-6868-15bc" name="Arioch Power Claw" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="95ba-cda7-b831-6066">-</characteristic>
+            <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">15</characteristic>
+            <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">1</characteristic>
+            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Melee, Shred, Destructor, Instant Death, Armourbane (Melee)</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="da86-8838-15f0-aadb" name="Shred" hidden="false" targetId="5e7e-1628-8174-6f2c" type="rule"/>
+        <infoLink id="1fef-5c92-9e5c-cb8c" name="Destructor" hidden="false" targetId="1f93-c765-f7b2-a025" type="rule"/>
+        <infoLink id="ad27-cd61-1f42-8735" name="Instant Death" hidden="false" targetId="9e96-fff1-b916-d9a3" type="rule"/>
+        <infoLink id="f4af-f68d-2d53-3c5c" name="Armourbane (X)" hidden="false" targetId="cb59-f920-f071-7cd4" type="rule">
+          <modifiers>
+            <modifier type="set" field="name" value="Armourbane (Melee)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="537f-846d-90e3-2526" name="Castellax Battle-Automata Maniple " publicationId="bde1-6db1-163b-3b76" page="37" hidden="false" collective="false" import="true" type="unit">
+      <categoryLinks>
+        <categoryLink id="5cd5-6009-fe69-4b41" name="Automata Unit-type:" hidden="false" targetId="d8ab-8e21-e193-63ba" primary="false"/>
+        <categoryLink id="df13-6b0d-fd20-dd68" name="Cybernetica Sub-type:" hidden="false" targetId="2440-b64e-cb24-87f0" primary="false"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="ab78-91e2-bb5c-9da3" name="Castellax" publicationId="bde1-6db1-163b-3b76" page="37" hidden="false" collective="false" import="true" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1d43-7c11-b7e5-7ae9" type="min"/>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2238-1122-27bd-f08e" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="2b2b-6a5d-8e25-8dfa" name="Castellax" publicationId="bde1-6db1-163b-3b76" page="37" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName="Unit">
+              <modifiers>
+                <modifier type="increment" field="f111-2ce5-dd12-d6b0" value="1">
+                  <conditions>
+                    <condition field="selections" scope="ab78-91e2-bb5c-9da3" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2121-ee7c-8ac9-5133" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <characteristics>
+                <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Automata (Cybernetica)</characteristic>
+                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7</characteristic>
+                <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">3</characteristic>
+                <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
+                <characteristic name="S" typeId="e478-41d4-a092-48a8">7</characteristic>
+                <characteristic name="T" typeId="c32b-5fdd-3fbe-9b1f">6</characteristic>
+                <characteristic name="W" typeId="57ee-1126-32a9-5672">4</characteristic>
+                <characteristic name="I" typeId="62d3-22d7-2d49-52dc">3</characteristic>
+                <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">2</characteristic>
+                <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">7</characteristic>
+                <characteristic name="Save" typeId="e593-6b3c-f169-04f0">3+</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <infoLinks>
+            <infoLink id="d764-5dc5-59ca-0121" name="Hammer of Wrath (X)" hidden="false" targetId="aec0-c3aa-1e4e-1779" type="rule">
+              <modifiers>
+                <modifier type="set" field="name" value="Hammer of Wrath (1)"/>
+              </modifiers>
+            </infoLink>
+          </infoLinks>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="75c2-1212-5c68-59cf" name="A) May Exchange Main Weapon for:" hidden="false" collective="false" import="true" defaultSelectionEntryId="ba99-35d3-89d1-626b">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6a21-a96f-f00f-e28b" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e8b2-da34-7269-ed20" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="ba99-35d3-89d1-626b" name="Mauler Bolt Cannon" hidden="false" collective="false" import="true" targetId="7478-2c29-dfc4-f4cf" type="selectionEntry"/>
+                <entryLink id="ab91-981d-f2bd-5624" name="Multi-Melta" hidden="false" collective="false" import="true" targetId="9332-3834-cf3a-56b4" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="da56-d4fc-92fe-fabe" name="Darkfire Cannon" hidden="false" collective="false" import="true" targetId="6f3d-9a42-da1d-2c2e" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0"/>
+                  </costs>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="ef5c-5de1-f9e9-cee9" name="B) May Exchange both Melee Weapons for:" hidden="false" collective="false" import="true" defaultSelectionEntryId="4489-7b65-efb9-4aa8">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5fd7-68b0-a7d5-b8b5" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2475-8aae-97e6-b889" type="min"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="4489-7b65-efb9-4aa8" name="Shock Charger" hidden="false" collective="false" import="true" targetId="3234-492f-9ebf-f23c" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="name" value="Two Shock Charger"/>
+                  </modifiers>
+                </entryLink>
+                <entryLink id="3534-5161-38c0-2e9d" name="Siege Wrecker" hidden="false" collective="false" import="true" targetId="178d-8a3a-bfda-7443" type="selectionEntry"/>
+                <entryLink id="d14d-8ddf-a1c7-8391" name="Power Blade Array" hidden="false" collective="false" import="true" targetId="2121-ee7c-8ac9-5133" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="name" value="Two Power Blade Array"/>
+                  </modifiers>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="f012-80da-f40b-3cbd" name="C) Shock Charger / Power Blades may Exchange In-Built Bolter for:" hidden="false" collective="false" import="true" defaultSelectionEntryId="8081-f97c-b25c-affd">
+              <modifiers>
+                <modifier type="increment" field="c6d4-44b8-d12d-4ca7" value="2.0">
+                  <repeats>
+                    <repeat field="selections" scope="ab78-91e2-bb5c-9da3" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2121-ee7c-8ac9-5133" repeats="1" roundUp="false"/>
+                    <repeat field="selections" scope="ab78-91e2-bb5c-9da3" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3234-492f-9ebf-f23c" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+                <modifier type="increment" field="0a49-dc8a-95be-56d5" value="2.0">
+                  <repeats>
+                    <repeat field="selections" scope="ab78-91e2-bb5c-9da3" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3234-492f-9ebf-f23c" repeats="1" roundUp="false"/>
+                    <repeat field="selections" scope="ab78-91e2-bb5c-9da3" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2121-ee7c-8ac9-5133" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c6d4-44b8-d12d-4ca7" type="min"/>
+                <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0a49-dc8a-95be-56d5" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="8081-f97c-b25c-affd" name="Bolter" hidden="false" collective="false" import="true" targetId="1ade-0c02-5612-252b" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="name" value="In-Built Bolter"/>
+                  </modifiers>
+                </entryLink>
+                <entryLink id="893b-efe7-3a3e-4b39" name="Maxima Bolter" hidden="false" collective="false" import="true" targetId="1d3e-1b60-d133-ea0d" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="name" value="In-Built Maxima Bolter"/>
+                  </modifiers>
+                </entryLink>
+                <entryLink id="498e-5313-c591-6149" name="Flamer" hidden="false" collective="false" import="true" targetId="9f41-82e2-90f6-973a" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="name" value="In-Built Flamer"/>
+                  </modifiers>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                  </costs>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks>
+            <entryLink id="2e0f-2bb6-069f-03d6" name="Paragon of Metal" hidden="false" collective="false" import="true" targetId="cc2a-46fe-bbf3-6ba2" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="537f-846d-90e3-2526" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ab78-91e2-bb5c-9da3" type="greaterThan"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="35.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="85.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <entryLinks>
+        <entryLink id="7db0-719f-b641-ec3c" name="Searchlights" hidden="false" collective="false" import="true" targetId="4ae3-79b4-6051-505e" type="selectionEntry">
+          <modifiers>
+            <modifier type="set" field="d2ee-04cb-5f8a-2642" value="1.0">
+              <repeats>
+                <repeat field="selections" scope="537f-846d-90e3-2526" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ab78-91e2-bb5c-9da3" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b442-486a-dd6e-11f0" type="max"/>
+          </constraints>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="6f3d-9a42-da1d-2c2e" name="Darkfire Cannon" publicationId="bde1-6db1-163b-3b76" page="117" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="f9b1-869e-9b30-6413" name="Darkfire Cannon" publicationId="bde1-6db1-163b-3b76" page="117" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="95ba-cda7-b831-6066">36&quot;</characteristic>
+            <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">7</characteristic>
+            <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">2</characteristic>
+            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Heavy 2, Blind, Lance, Gets Hot</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="7ffc-4609-703e-f1a1" name="Blind" hidden="false" targetId="d836-747d-07d6-2b63" type="rule"/>
+        <infoLink id="e76d-d5eb-af95-8d34" name="Lance" hidden="false" targetId="3d6b-9e0b-56f0-8a1e" type="rule"/>
+        <infoLink id="8d14-fceb-5258-1213" name="Gets Hot" hidden="false" targetId="679f-9d97-5ace-a652" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="55e4-0853-3720-c068" name="Defensor Autocannon Battery" publicationId="bde1-6db1-163b-3b76" page="114" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="4ddd-1d39-8f02-1e99" name="Defensor Autocannon Battery" publicationId="bde1-6db1-163b-3b76" page="114" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="95ba-cda7-b831-6066">72&quot;</characteristic>
+            <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">7</characteristic>
+            <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">4</characteristic>
+            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Heavy 4, Rending (6+), Twin-linked, Sunder, Skyfire</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="ea72-0a06-6015-d1bf" name="Rending (X)" hidden="false" targetId="0ac9-fab7-aef3-de1d" type="rule">
+          <modifiers>
+            <modifier type="set" field="name" value="Rending (6+)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="1cbb-dc75-6866-d764" name="Twin-linked" hidden="false" targetId="8542-ee9d-e2fa-52fe" type="rule"/>
+        <infoLink id="f100-5889-9c00-70eb" name="Sunder" hidden="false" targetId="20e2-75cf-bc16-cd8f" type="rule"/>
+        <infoLink id="c1df-38bc-19b9-302f" name="Skyfire" hidden="false" targetId="f2bf-5daa-9f93-0b01" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="fee2-949c-6d55-2a2f" name="Defensor Bolt Cannon" publicationId="bde1-6db1-163b-3b76" page="114" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="6590-8653-7d8f-78c6" name="Defensor Bolt Cannon" publicationId="bde1-6db1-163b-3b76" page="114" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="95ba-cda7-b831-6066">24&quot;</characteristic>
+            <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">6</characteristic>
+            <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">4</characteristic>
+            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Heavy 6, Ardex-defensor</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="3ac3-3733-ba79-1765" name="Ardex-Defensor" hidden="false" targetId="d242-cb71-bc7f-eadd" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="2a03-11f0-739e-01a7" name="Defensor Lascannon" publicationId="bde1-6db1-163b-3b76" page="114" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="6151-332a-2039-4716" name="Defensor Lascannon" publicationId="bde1-6db1-163b-3b76" page="114" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="95ba-cda7-b831-6066">48&quot;</characteristic>
+            <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">9</characteristic>
+            <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">2</characteristic>
+            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Heavy 1, Ardex-defensor, Sunder, Twin-linked</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="cca8-12a1-7ce7-a382" name="Ardex-Defensor" hidden="false" targetId="d242-cb71-bc7f-eadd" type="rule"/>
+        <infoLink id="a254-b557-2b66-5a70" name="Sunder" hidden="false" targetId="20e2-75cf-bc16-cd8f" type="rule"/>
+        <infoLink id="0499-a24d-0ad8-693a" name="Twin-linked" hidden="false" targetId="8542-ee9d-e2fa-52fe" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="1a1b-fa35-a6a2-ca78" name="Domitar Battle-Automata Maniple" publicationId="bde1-6db1-163b-3b76" page="31" hidden="false" collective="false" import="true" type="unit">
+      <categoryLinks>
+        <categoryLink id="80b1-ecda-9fbc-d9bd" name="Automata Unit-type:" hidden="false" targetId="d8ab-8e21-e193-63ba" primary="false"/>
+        <categoryLink id="abca-590e-bde7-fa3a" name="Cybernetica Sub-type:" hidden="false" targetId="2440-b64e-cb24-87f0" primary="false"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="200f-3379-95a3-c3a4" name="Domitar" hidden="false" collective="false" import="true" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2116-a161-c40f-7ec0" type="min"/>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9c2f-e528-8697-48b5" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="c21f-a007-c5e0-83ea" name="Domitar" publicationId="bde1-6db1-163b-3b76" page="31" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName="Unit">
+              <characteristics>
+                <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Automata (Cybernetica)</characteristic>
+                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">8</characteristic>
+                <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
+                <characteristic name="BS" typeId="74ae-c840-0036-d244">3</characteristic>
+                <characteristic name="S" typeId="e478-41d4-a092-48a8">7</characteristic>
+                <characteristic name="T" typeId="c32b-5fdd-3fbe-9b1f">7</characteristic>
+                <characteristic name="W" typeId="57ee-1126-32a9-5672">5</characteristic>
+                <characteristic name="I" typeId="62d3-22d7-2d49-52dc">3</characteristic>
+                <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">3</characteristic>
+                <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">7</characteristic>
+                <characteristic name="Save" typeId="e593-6b3c-f169-04f0">3+</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <infoLinks>
+            <infoLink id="9447-bc9c-22db-c17e" name="Hammer of Wrath (X)" hidden="false" targetId="aec0-c3aa-1e4e-1779" type="rule">
+              <modifiers>
+                <modifier type="set" field="name" value="Hammer of Wrath (1)"/>
+              </modifiers>
+            </infoLink>
+            <infoLink id="2d31-8d08-3b95-7e7b" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule"/>
+          </infoLinks>
+          <selectionEntries>
+            <selectionEntry id="6c5e-befd-dbd7-7a16" name="Missile Launcher with Frag, Krak and Ignis Missiles" publicationId="bde1-6db1-163b-3b76" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="55fd-92d9-dd55-55cc" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c81a-f569-5593-0b5e" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="321f-2002-037a-41bd" name="Missile Launcher - Frag" publicationId="a716-c1c4-7b26-8424" page="133" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+                  <characteristics>
+                    <characteristic name="Range" typeId="95ba-cda7-b831-6066">48&quot;</characteristic>
+                    <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">4</characteristic>
+                    <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">6</characteristic>
+                    <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Heavy 1, Blast (3&quot;), Pinning</characteristic>
+                  </characteristics>
+                </profile>
+                <profile id="6de4-420b-51dd-3806" name="Missile Launcher - Ignis" publicationId="bde1-6db1-163b-3b76" page="118" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+                  <characteristics>
+                    <characteristic name="Range" typeId="95ba-cda7-b831-6066">48&quot;</characteristic>
+                    <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">5</characteristic>
+                    <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">6</characteristic>
+                    <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Heavy 1, Blast (3&quot;), Ignores Cover</characteristic>
+                  </characteristics>
+                </profile>
+                <profile id="9028-266b-f57c-4b27" name="Missile Launcher - Krak" publicationId="a716-c1c4-7b26-8424" page="133" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+                  <characteristics>
+                    <characteristic name="Range" typeId="95ba-cda7-b831-6066">48&quot;</characteristic>
+                    <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">8</characteristic>
+                    <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">3</characteristic>
+                    <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Heavy 1</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <infoLinks>
+                <infoLink id="f293-7e82-209d-1a02" name="Pinning" hidden="false" targetId="1c96-205c-59a0-3cf2" type="rule"/>
+                <infoLink id="207f-77f4-6258-f2bf" name="Blast" hidden="false" targetId="1d9a-73ef-5f4f-8bd8" type="rule"/>
+                <infoLink id="0aec-0289-a832-9d51" name="Ignores Cover" hidden="false" targetId="fdb5-59e2-c446-1cbc" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <entryLinks>
+            <entryLink id="a470-f451-0c7c-40af" name="Graviton Hammer" hidden="false" collective="false" import="true" targetId="ceaa-178d-3995-c2c8" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0520-53f3-6692-2c6a" type="min"/>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8d42-0858-2a72-c572" type="max"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="5592-1149-7714-dd0c" name="Atomantic Deflector" hidden="false" collective="false" import="true" targetId="38fb-9a0b-edef-a497" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="123d-1338-1cec-e2a1" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="738a-40a2-7c06-de3a" type="max"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="e9df-a245-e1e7-08ca" name="Searchlights" hidden="false" collective="false" import="true" targetId="4ae3-79b4-6051-505e" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7ba9-0c84-4683-628e" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5fb5-184f-1bfb-7580" type="max"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="2f3f-a0de-3a2d-c44c" name="Paragon of Metal" hidden="false" collective="false" import="true" targetId="cc2a-46fe-bbf3-6ba2" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="1a1b-fa35-a6a2-ca78" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="200f-3379-95a3-c3a4" type="greaterThan"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="35.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="130.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="ceaa-178d-3995-c2c8" name="Graviton Hammer" publicationId="bde1-6db1-163b-3b76" page="116" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="3135-eb29-2a63-329d" name="Graviton Hammer (Melee)" publicationId="bde1-6db1-163b-3b76" page="116" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="95ba-cda7-b831-6066">-</characteristic>
+            <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">10</characteristic>
+            <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">2</characteristic>
+            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Melee, Armourbane (Melee), Concussive (2)</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="d867-d7b0-ce2b-dc88" name="Graviton Hammer (Ranged)" publicationId="bde1-6db1-163b-3b76" page="116" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="95ba-cda7-b831-6066">Template</characteristic>
+            <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">*</characteristic>
+            <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">6</characteristic>
+            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Heavy 1, Concussive (1), Graviton Pulse*, Grav Wave, Haywire</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="4f78-333d-3c6e-8b26" name="Armourbane (X)" hidden="false" targetId="cb59-f920-f071-7cd4" type="rule">
+          <modifiers>
+            <modifier type="set" field="name" value="Armourbane (Melee)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="54f8-0974-394d-4b14" name="Concussive (X)" hidden="false" targetId="7ce5-1bfb-64e6-f826" type="rule">
+          <modifiers>
+            <modifier type="set" field="name" value="Concussive (2)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="8be2-16ab-b817-782e" name="Concussive (X)" hidden="false" targetId="7ce5-1bfb-64e6-f826" type="rule">
+          <modifiers>
+            <modifier type="set" field="name" value="Concussive (1)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="389a-51fb-e3a9-d06c" name="Grav Wave" hidden="false" targetId="1cc2-eaee-8bcf-96d3" type="rule"/>
+        <infoLink id="4326-10b6-edee-d84b" name="Graviton Pulse" hidden="false" targetId="5b9c-2738-616c-abdf" type="rule"/>
+        <infoLink id="7c04-163f-016a-0ca3" name="Haywire" hidden="false" targetId="1dd4-7a75-5c59-8425" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="f65c-633a-5865-7f6b" name="Lightning Gun" publicationId="bde1-6db1-163b-3b76" page="113" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="7aca-056b-f2c7-e744" name="Lightning Gun (Arc)" publicationId="bde1-6db1-163b-3b76" page="113" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="95ba-cda7-b831-6066">18&quot;</characteristic>
+            <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">4</characteristic>
+            <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">-</characteristic>
+            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Heavy 3, Shred</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="530a-de1b-b3cd-989f" name="Lightning Gun (Strike)" publicationId="bde1-6db1-163b-3b76" page="113" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="95ba-cda7-b831-6066">18&quot;</characteristic>
+            <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">7</characteristic>
+            <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">5</characteristic>
+            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Heavy 1, Rending (4+), Shred</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="5901-12d5-cf0a-eda9" name="Rending (X)" hidden="false" targetId="0ac9-fab7-aef3-de1d" type="rule">
+          <modifiers>
+            <modifier type="set" field="name" value="Rending (4+)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="fef9-4e89-547a-fe34" name="Shred" hidden="false" targetId="5e7e-1628-8174-6f2c" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="7478-2c29-dfc4-f4cf" name="Mauler Bolt Cannon" publicationId="bde1-6db1-163b-3b76" page="114" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="0d73-2c3e-acc4-6043" name="Mauler Bolt Cannon" publicationId="bde1-6db1-163b-3b76" page="114" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="95ba-cda7-b831-6066">24&quot;</characteristic>
+            <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">6</characteristic>
+            <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">4</characteristic>
+            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Heavy 4, Pinning</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="6bed-b535-3fab-408b" name="Pinning" hidden="false" targetId="1c96-205c-59a0-3cf2" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="1d3e-1b60-d133-ea0d" name="Maxima Bolter" publicationId="bde1-6db1-163b-3b76" page="114" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="54b0-1838-c2c5-1191" name="Maxima Bolter" publicationId="bde1-6db1-163b-3b76" page="114" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="95ba-cda7-b831-6066">12&quot;</characteristic>
+            <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">4</characteristic>
+            <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">5</characteristic>
+            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Assault 3</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="eab1-7776-c8da-da00" name="Mori Quake Cannon" publicationId="bde1-6db1-163b-3b76" page="113" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="a101-d643-7adf-a419" name="Mori Quake Cannon" publicationId="bde1-6db1-163b-3b76" page="113" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="95ba-cda7-b831-6066">24&quot;-360&quot;</characteristic>
+            <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">10/8/6</characteristic>
+            <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">3</characteristic>
+            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Destroyer 1, Apocalyptic Mega-blast, Barrage, Seismic Shock, Concussive (1)</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="eb83-d586-fd1f-41a5" name="Destroyer" hidden="false" targetId="44d6-09b2-3bd3-b2d6" type="rule"/>
+        <infoLink id="9300-02a9-17a8-e10f" name="Blast" hidden="false" targetId="1d9a-73ef-5f4f-8bd8" type="rule"/>
+        <infoLink id="fd52-e4d3-1c2e-3b01" name="Barrage" hidden="false" targetId="7255-b5ee-c3f4-3037" type="rule"/>
+        <infoLink id="3d79-d68e-7c0f-8882" name="Concussive (X)" hidden="false" targetId="7ce5-1bfb-64e6-f826" type="rule">
+          <modifiers>
+            <modifier type="set" field="name" value="Concussive (1)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="c3d7-2781-7667-c0a7" name="Seismic Shock" hidden="false" targetId="5e0d-b2af-e7b4-a8cd" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="226a-8196-f0af-f8a8" name="Plasma Mortar" publicationId="bde1-6db1-163b-3b76" page="118" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="b024-fd99-74bd-a470" name="Plasma Mortar" publicationId="bde1-6db1-163b-3b76" page="118" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="95ba-cda7-b831-6066">36&quot;</characteristic>
+            <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">8</characteristic>
+            <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">4</characteristic>
+            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Ordnance 1, Large Blast (5&quot;), Breaching (4+), Ignores Cover, Reactor Overload</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="e459-1b73-3002-3466" name="Blast" hidden="false" targetId="1d9a-73ef-5f4f-8bd8" type="rule"/>
+        <infoLink id="ad5e-31f9-6e0f-d0eb" name="Breaching (X)" hidden="false" targetId="a760-f736-1bf3-fa3c" type="rule">
+          <modifiers>
+            <modifier type="set" field="name" value="Breaching (4+)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="65ca-5e3f-ca45-1e72" name="Ignores Cover" hidden="false" targetId="fdb5-59e2-c446-1cbc" type="rule"/>
+        <infoLink id="2756-8d94-fba0-cf75" name="Reactor Overload" hidden="false" targetId="a073-b86c-7bc1-d3f9" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="24d6-7dc1-0dde-9504" name="Sollex Heavy-Las" publicationId="bde1-6db1-163b-3b76" page="117" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="63ed-87d1-30f3-100d" name="Sollex Heavy-Las" publicationId="bde1-6db1-163b-3b76" page="117" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="95ba-cda7-b831-6066">48&quot;</characteristic>
+            <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">10</characteristic>
+            <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">2</characteristic>
+            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Heavy 3, Armourbane (Ranged), Shock Pulse</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="49b2-83c7-84a4-9b87" name="Armourbane (X)" hidden="false" targetId="cb59-f920-f071-7cd4" type="rule">
+          <modifiers>
+            <modifier type="set" field="name" value="Armourbane (Ranged)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="3309-7bef-4adc-c408" name="Shock Pulse" hidden="false" targetId="9222-f6c5-dc19-905a" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="2903-fef6-e839-368b" name="Thanatar Siege-automata Maniple" publicationId="bde1-6db1-163b-3b76" page="46" hidden="false" collective="false" import="true" type="unit">
+      <rules>
+        <rule id="eccf-b13c-2b8f-6939" name="Thanatar Maniple" publicationId="bde1-6db1-163b-3b76" page="110" hidden="false">
+          <description>When deployed onto the battlefield (either at the start of the battle or when arriving from Reserves) all models in the unit must be placed within unit coherency, but afterwards operate independently and are not treated asa single unit.</description>
+        </rule>
+      </rules>
+      <categoryLinks>
+        <categoryLink id="d13c-fa11-113a-6b4b" name="Automata Unit-type:" hidden="false" targetId="d8ab-8e21-e193-63ba" primary="false"/>
+        <categoryLink id="ae51-75de-b9f6-61c2" name="Cybernetica Sub-type:" hidden="false" targetId="2440-b64e-cb24-87f0" primary="false"/>
+        <categoryLink id="140c-e71f-33aa-62da" name="Light Sub-type:" hidden="false" targetId="bff2-ae16-74a8-8712" primary="false"/>
+        <categoryLink id="0f64-8711-75d2-ad9b" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="c48e-f9ea-9d9d-46aa" name="Thanatar" publicationId="bde1-6db1-163b-3b76" page="46" hidden="false" collective="false" import="true" type="model">
+          <modifiers>
+            <modifier type="set" field="name" value="Thanatar Calix">
+              <conditions>
+                <condition field="selections" scope="c48e-f9ea-9d9d-46aa" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4c16-20c7-f928-2aa6" type="equalTo"/>
+              </conditions>
+            </modifier>
+            <modifier type="set" field="name" value="Thanatar Cavas">
+              <conditions>
+                <condition field="selections" scope="c48e-f9ea-9d9d-46aa" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5331-31f3-87ed-5ebe" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ce6c-c4a0-3622-b76b" type="min"/>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="15c6-ecce-8258-7e00" type="max"/>
+          </constraints>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="3a98-3aba-8cca-3ce8" name="A single Thanatar-Cavas in the Maniple may be replaced with a Thanatar Calix" hidden="false" collective="false" import="true">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ff2e-8bb8-49ba-0128" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5c70-688d-3d16-152b" type="max"/>
+              </constraints>
+              <selectionEntries>
+                <selectionEntry id="5331-31f3-87ed-5ebe" name="Thanatar Cavas" hidden="false" collective="false" import="true" type="upgrade">
+                  <profiles>
+                    <profile id="891f-90ee-c496-ce0d" name="Thanatar Cavas" publicationId="bde1-6db1-163b-3b76" page="46" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName="Unit">
+                      <characteristics>
+                        <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Automata (Cybernetica, Light)</characteristic>
+                        <characteristic name="Move" typeId="893e-2d76-8f04-44e5">8</characteristic>
+                        <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
+                        <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
+                        <characteristic name="S" typeId="e478-41d4-a092-48a8">6</characteristic>
+                        <characteristic name="T" typeId="c32b-5fdd-3fbe-9b1f">5</characteristic>
+                        <characteristic name="W" typeId="57ee-1126-32a9-5672">4</characteristic>
+                        <characteristic name="I" typeId="62d3-22d7-2d49-52dc">4</characteristic>
+                        <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">3</characteristic>
+                        <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">7</characteristic>
+                        <characteristic name="Save" typeId="e593-6b3c-f169-04f0">3+</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <infoLinks>
+                    <infoLink id="467a-4d09-3317-b057" name="Hammer of Wrath (X)" hidden="false" targetId="aec0-c3aa-1e4e-1779" type="rule">
+                      <modifiers>
+                        <modifier type="set" field="name" value="Hammer of Wrath (1)"/>
+                      </modifiers>
+                    </infoLink>
+                  </infoLinks>
+                  <entryLinks>
+                    <entryLink id="4d60-b322-e415-8fb3" name="Plasma Mortar" hidden="false" collective="false" import="true" targetId="226a-8196-f0af-f8a8" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3a63-4a40-1ed2-7e7b" type="min"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c116-1405-637e-12e0" type="max"/>
+                      </constraints>
+                    </entryLink>
+                    <entryLink id="8b0e-a547-c6e7-c92d" name="Shock Charger" hidden="false" collective="false" import="true" targetId="3234-492f-9ebf-f23c" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c009-b44c-eae9-d23e" type="min"/>
+                        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="63b3-1672-08f3-2354" type="max"/>
+                      </constraints>
+                    </entryLink>
+                    <entryLink id="48b8-3982-5332-1179" name="Atomantic Deflector" hidden="false" collective="false" import="true" targetId="38fb-9a0b-edef-a497" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6bf7-c459-e03a-0d0b" type="min"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7dc0-d3f9-bfcb-c080" type="max"/>
+                      </constraints>
+                    </entryLink>
+                    <entryLink id="1686-59c9-4551-fd61" name="Twin-linked Mauler Bolt Cannon" hidden="false" collective="false" import="true" targetId="ac88-bcf4-d7b4-5c56" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8a59-15e8-c0a4-bef1" type="min"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cf9a-e97f-f71e-b89c" type="max"/>
+                      </constraints>
+                    </entryLink>
+                  </entryLinks>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="4c16-20c7-f928-2aa6" name="Thanatar Calix" hidden="false" collective="false" import="true" type="upgrade">
+                  <constraints>
+                    <constraint field="selections" scope="2903-fef6-e839-368b" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e22a-28db-8399-2c86" type="max"/>
+                  </constraints>
+                  <profiles>
+                    <profile id="df17-9de2-31bf-f684" name="Thanatar Calix" publicationId="bde1-6db1-163b-3b76" page="46" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName="Unit">
+                      <characteristics>
+                        <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Automata (Cybernetica, Light)</characteristic>
+                        <characteristic name="Move" typeId="893e-2d76-8f04-44e5">8</characteristic>
+                        <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
+                        <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
+                        <characteristic name="S" typeId="e478-41d4-a092-48a8">6</characteristic>
+                        <characteristic name="T" typeId="c32b-5fdd-3fbe-9b1f">5</characteristic>
+                        <characteristic name="W" typeId="57ee-1126-32a9-5672">4</characteristic>
+                        <characteristic name="I" typeId="62d3-22d7-2d49-52dc">4</characteristic>
+                        <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">3</characteristic>
+                        <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">7</characteristic>
+                        <characteristic name="Save" typeId="e593-6b3c-f169-04f0">3+</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <infoLinks>
+                    <infoLink id="47a6-bf07-a5c0-fa73" name="Hammer of Wrath (X)" hidden="false" targetId="aec0-c3aa-1e4e-1779" type="rule">
+                      <modifiers>
+                        <modifier type="set" field="name" value="Hammer of Wrath (1)"/>
+                      </modifiers>
+                    </infoLink>
+                  </infoLinks>
+                  <entryLinks>
+                    <entryLink id="1476-9dd5-0b18-0c13" name="Graviton Ram" hidden="false" collective="false" import="true" targetId="f610-008f-5046-ea99" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5b9b-e235-7599-4d14" type="min"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="db3c-d274-561a-7340" type="max"/>
+                      </constraints>
+                    </entryLink>
+                    <entryLink id="999b-40fc-f640-9654" name="Sollex Heavy-Las" hidden="false" collective="false" import="true" targetId="24d6-7dc1-0dde-9504" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="86d9-55b2-bae3-2edf" type="min"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2134-41ec-4550-57ba" type="max"/>
+                      </constraints>
+                    </entryLink>
+                    <entryLink id="899c-cf56-334a-96fd" name="Atomantic Deflector" hidden="false" collective="false" import="true" targetId="38fb-9a0b-edef-a497" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b8ea-f7e1-0e38-261d" type="min"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5c52-c067-1a01-0b6b" type="max"/>
+                      </constraints>
+                    </entryLink>
+                    <entryLink id="6e71-c5ba-eb31-afa3" name="Twin-linked Mauler Bolt Cannon" hidden="false" collective="false" import="true" targetId="ac88-bcf4-d7b4-5c56" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2384-2c19-f54c-6a9f" type="min"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bf9e-906b-0cfb-a953" type="max"/>
+                      </constraints>
+                    </entryLink>
+                  </entryLinks>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks>
+            <entryLink id="8ea9-e0ad-492b-4eb5" name="Paragon of Metal" hidden="false" collective="false" import="true" targetId="cc2a-46fe-bbf3-6ba2" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="2903-fef6-e839-368b" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c48e-f9ea-9d9d-46aa" type="greaterThan"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="35.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="235.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="2952-52d9-49e2-cbfd" name="Titan Power Fist" publicationId="bde1-6db1-163b-3b76" page="122" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="1198-69f8-54f2-7a5d" name="Titan Power Fist" publicationId="bde1-6db1-163b-3b76" page="122" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="95ba-cda7-b831-6066">-</characteristic>
+            <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">14</characteristic>
+            <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">1</characteristic>
+            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Melee, Sunder, Destructor</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="b2a8-193f-3185-5456" name="Sunder" hidden="false" targetId="20e2-75cf-bc16-cd8f" type="rule"/>
+        <infoLink id="59e8-4430-8b1f-6f69" name="Destructor" hidden="false" targetId="1f93-c765-f7b2-a025" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="ac88-bcf4-d7b4-5c56" name="Twin-linked Mauler Bolt Cannon" publicationId="bde1-6db1-163b-3b76" page="114" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="8398-d59e-6c60-9c3d" name="Twin-linked Mauler Bolt Cannon" publicationId="bde1-6db1-163b-3b76" page="114" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="95ba-cda7-b831-6066">24&quot;</characteristic>
+            <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">6</characteristic>
+            <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">4</characteristic>
+            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Heavy 4, Pinning, Twin-linked</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="1eae-6fbb-9d1a-d038" name="Pinning" hidden="false" targetId="1c96-205c-59a0-3cf2" type="rule"/>
+        <infoLink id="7cd9-8f04-eb3c-1b09" name="Twin-linked" hidden="false" targetId="8542-ee9d-e2fa-52fe" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="f144-1079-11ff-019d" name="Vorax Battle-automata Maniple" publicationId="bde1-6db1-163b-3b76" page="42" hidden="false" collective="false" import="true" type="unit">
+      <categoryLinks>
+        <categoryLink id="1779-4c37-6c7f-b6ea" name="Automata Unit-type:" hidden="false" targetId="d8ab-8e21-e193-63ba" primary="false"/>
+        <categoryLink id="da80-a4b4-47a6-5c31" name="Cybernetica Sub-type:" hidden="false" targetId="2440-b64e-cb24-87f0" primary="false"/>
+        <categoryLink id="e468-fb52-fd0d-7af6" name="Light Sub-type:" hidden="false" targetId="bff2-ae16-74a8-8712" primary="false"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="59fd-998f-8190-baec" name="Vorax" publicationId="bde1-6db1-163b-3b76" page="42" hidden="false" collective="false" import="true" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e36f-739b-f761-a69c" type="min"/>
+            <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7c0f-624e-fac5-81c6" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="244c-1e6b-3768-3c13" name="Vorax" publicationId="bde1-6db1-163b-3b76" page="42" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName="Unit">
+              <characteristics>
+                <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Automata (Cybernetica, Light)</characteristic>
+                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">8</characteristic>
+                <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
+                <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
+                <characteristic name="S" typeId="e478-41d4-a092-48a8">6</characteristic>
+                <characteristic name="T" typeId="c32b-5fdd-3fbe-9b1f">5</characteristic>
+                <characteristic name="W" typeId="57ee-1126-32a9-5672">4</characteristic>
+                <characteristic name="I" typeId="62d3-22d7-2d49-52dc">4</characteristic>
+                <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">3</characteristic>
+                <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">7</characteristic>
+                <characteristic name="Save" typeId="e593-6b3c-f169-04f0">3+</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <infoLinks>
+            <infoLink id="2acb-042e-9147-1084" name="Fleet (X)" hidden="false" targetId="ddc9-0b4b-78da-bbd2" type="rule">
+              <modifiers>
+                <modifier type="set" field="name" value="Fleet (2)"/>
+              </modifiers>
+            </infoLink>
+            <infoLink id="d381-1f2b-bce2-4aab" name="Scout" hidden="false" targetId="aacf-9a7e-982d-b793" type="rule"/>
+            <infoLink id="4d08-9bbf-6883-4c83" name="Hammer of Wrath (X)" hidden="false" targetId="aec0-c3aa-1e4e-1779" type="rule">
+              <modifiers>
+                <modifier type="set" field="name" value="Hammer of Wrath (1)"/>
+              </modifiers>
+            </infoLink>
+          </infoLinks>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="65.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="337a-c368-c0d1-361f" name="Power Blade Array with In-Built Rotar Cannon" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2bef-1121-946c-b117" type="min"/>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a805-35c0-a4e5-67c9" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="cbf7-102c-b2d4-3666" name="Power Blade Array" hidden="false" collective="false" import="true" targetId="2121-ee7c-8ac9-5133" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bd1c-0ed9-0008-5f5c" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e854-42d7-abd3-237d" type="max"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="069b-2935-fc1a-2440" name="Rotor Cannon" hidden="false" collective="false" import="true" targetId="5ce3-3aa5-3f5e-9ead" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0705-697d-f8b6-39e6" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6216-1851-0944-da3b" type="max"/>
+              </constraints>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="57c4-4fa1-cf37-a599" name="One in Three Vorax in the unit, may exchange its Lightning Gun" hidden="false" collective="false" import="true" defaultSelectionEntryId="1eec-44ae-e1a2-1766">
+          <modifiers>
+            <modifier type="increment" field="5d48-0036-be14-baa6" value="1.0">
+              <repeats>
+                <repeat field="selections" scope="f144-1079-11ff-019d" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="59fd-998f-8190-baec" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+            <modifier type="increment" field="f11e-82b3-b9b8-28e6" value="1.0">
+              <repeats>
+                <repeat field="selections" scope="f144-1079-11ff-019d" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="59fd-998f-8190-baec" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f11e-82b3-b9b8-28e6" type="min"/>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5d48-0036-be14-baa6" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="0915-bf0a-d991-9150" name="Irad-Cleanser" hidden="false" collective="false" import="true" targetId="b3c5-237f-e1d2-d9f8" type="selectionEntry">
+              <modifiers>
+                <modifier type="increment" field="15a4-488c-1f42-b018" value="1.0">
+                  <repeats>
+                    <repeat field="selections" scope="f144-1079-11ff-019d" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="59fd-998f-8190-baec" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="15a4-488c-1f42-b018" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="1eec-44ae-e1a2-1766" name="Lightning Gun" hidden="false" collective="false" import="true" targetId="f65c-633a-5865-7f6b" type="selectionEntry"/>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="73a6-8d5c-4352-35c0" name="Paragon of Metal" hidden="false" collective="false" import="true" targetId="cc2a-46fe-bbf3-6ba2" type="selectionEntry">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="f144-1079-11ff-019d" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="59fd-998f-8190-baec" type="greaterThan"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="35.0"/>
+          </costs>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="1d6f-970d-3b89-7886" name="Avenger Gatling Cannon with In-Built Heavy Flamer" hidden="false" collective="false" import="true" type="upgrade">
+      <infoLinks>
+        <infoLink id="9fba-86cf-c0b2-ee3f" name="Rending (X)" hidden="false" targetId="0ac9-fab7-aef3-de1d" type="rule">
+          <modifiers>
+            <modifier type="set" field="name" value="Rending (6+)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="fe76-176c-e443-d0da" name="Template Weapons" hidden="false" targetId="5e0e-88e6-db81-5a70" type="rule"/>
+        <infoLink id="0b32-e6ca-ac24-50a7" name="Avenger Gatling Cannon" hidden="false" targetId="691d-aafb-9299-a873" type="profile"/>
+        <infoLink id="f088-e1df-da98-330c" name="Heavy Flamer" hidden="false" targetId="a6e9-e2e1-150f-b023" type="profile"/>
+      </infoLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="8e68-00af-7bea-571a" name="Las-Impulsor" publicationId="bde1-6db1-163b-3b76" page="115 &amp; 121" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="7d2e-5122-c581-7bef" name="Las-Impulsor (Ranged)" publicationId="bde1-6db1-163b-3b76" page="115" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="95ba-cda7-b831-6066">12&quot;</characteristic>
+            <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">10</characteristic>
+            <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">2</characteristic>
+            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Heavy 2, Sunder, Instant Death</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="1502-1b70-6d2a-7a9e" name="Las-Impulsor (Melee)" publicationId="bde1-6db1-163b-3b76" page="121" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="95ba-cda7-b831-6066">-</characteristic>
+            <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">10</characteristic>
+            <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">1</characteristic>
+            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Melee, Unwieldy, Cumbersome, Armourbane (Melee), Instant Death</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="3e90-b679-199d-3998" name="Sunder" hidden="false" targetId="20e2-75cf-bc16-cd8f" type="rule"/>
+        <infoLink id="91f2-81fc-8a3e-775d" name="Unwieldy" hidden="false" targetId="1570-c21a-881f-8b8a" type="rule"/>
+        <infoLink id="1267-6823-c665-77a8" name="Cumbersome" hidden="false" targetId="d89a-c10e-8a7a-92c3" type="rule"/>
+        <infoLink id="2d81-7ba4-3430-d768" name="Armourbane (X)" hidden="false" targetId="cb59-f920-f071-7cd4" type="rule">
+          <modifiers>
+            <modifier type="set" field="name" value="Armourbane (Melee)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="2518-840e-3e4e-ab7d" name="Instant Death" hidden="false" targetId="9e96-fff1-b916-d9a3" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="a0e4-12d7-ff85-51c4" name="Rapid-Fire Battle Cannon with In-Built Heavy Stubber" publicationId="bde1-6db1-163b-3b76" page="113" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="510f-99ff-c46c-669b" name="Rapid-Fire Battle Cannon" publicationId="bde1-6db1-163b-3b76" page="113" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="95ba-cda7-b831-6066">48&quot;</characteristic>
+            <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">8</characteristic>
+            <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">4</characteristic>
+            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Ordnance 2, Large Blast (5&quot;)</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="a31a-bc56-8f9b-6843" name="Heavy Stubber" hidden="false" targetId="129d-1b6c-7ba2-29ec" type="profile"/>
+        <infoLink id="f7c3-005e-d599-2002" name="Blast" hidden="false" targetId="1d9a-73ef-5f4f-8bd8" type="rule"/>
+        <infoLink id="4814-456f-7b39-bce4" name="Ordnance" hidden="false" targetId="6c55-22c8-1b01-2105" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="0aee-ef5a-9636-1740" name="Thermal Cannon" publicationId="bde1-6db1-163b-3b76" page="117" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="9857-0bd0-4c04-2dcc" name="Thermal Cannon" publicationId="bde1-6db1-163b-3b76" page="117" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="95ba-cda7-b831-6066">36&quot;</characteristic>
+            <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">8</characteristic>
+            <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">1</characteristic>
+            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Heavy 1, Large Blast (5&quot;), Armourbane (Melta)</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="75d7-9e17-68fb-0e71" name="Blast" hidden="false" targetId="1d9a-73ef-5f4f-8bd8" type="rule"/>
+        <infoLink id="7495-65ff-59ef-e4ff" name="Armourbane (X)" hidden="false" targetId="cb59-f920-f071-7cd4" type="rule">
+          <modifiers>
+            <modifier type="set" field="name" value="Armourbane (Melta)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="923a-c8cb-bcf8-b530" name="Thunderstrike Gauntlet" publicationId="bde1-6db1-163b-3b76" page="122" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="fca1-672e-081c-32be" name="Thunderstrike Gauntlet" publicationId="bde1-6db1-163b-3b76" page="122" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="95ba-cda7-b831-6066">-</characteristic>
+            <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">12</characteristic>
+            <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">2</characteristic>
+            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Melee, Sunder</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="d500-aedc-4113-3b28" name="Sunder" hidden="false" targetId="20e2-75cf-bc16-cd8f" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="6a06-cbf5-fbbf-85fe" name="Siege Claw with In-Built Irad-Cleanser" publicationId="bde1-6db1-163b-3b76" page="123" hidden="false" collective="false" import="true" type="upgrade">
+      <infoLinks>
+        <infoLink id="3cfe-9c89-8984-ae67" name="Irad-Cleanser" hidden="false" targetId="484b-1446-7bac-46d9" type="profile"/>
+        <infoLink id="8c6b-57c4-2713-eae3" name="Fleshbane" hidden="false" targetId="40cd-9505-253c-e76f" type="rule"/>
+        <infoLink id="54df-aa10-c2d8-38c8" name="Rad-Phage" hidden="false" targetId="8189-e963-d2e5-5d3d" type="rule"/>
+        <infoLink id="b8a3-1b09-e9d0-c887" name="Brutal (X)" hidden="false" targetId="5079-1fec-d32b-8b84" type="rule">
+          <modifiers>
+            <modifier type="set" field="name" value="Brutal (2)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="5638-546a-97b3-bd28" name="Sunder" hidden="false" targetId="20e2-75cf-bc16-cd8f" type="rule"/>
+        <infoLink id="9e01-a4d9-4e7a-917a" name="Wrecker" hidden="false" targetId="ba77-a802-55df-da67" type="rule"/>
+        <infoLink id="325c-050a-0021-e99f" name="Siege Claw" hidden="false" targetId="f417-99e0-bb03-dfa7" type="profile"/>
+      </infoLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
       </costs>
     </selectionEntry>
   </sharedSelectionEntries>
@@ -3298,6 +4187,12 @@ When deployed onto the battlefield (either at the start of the battle or when ar
     </rule>
     <rule id="e51e-cae1-d9e7-d317" name="Galvanic Traction Drive" publicationId="bde1-6db1-163b-3b76" page="104" hidden="false">
       <description>A model with this special rule must re-roll failed Dangerous Terrain tests.</description>
+    </rule>
+    <rule id="d242-cb71-bc7f-eadd" name="Ardex-Defensor" publicationId="bde1-6db1-163b-3b76" page="102" hidden="false">
+      <description>A model with the Knight or Titan Unit Sub-types that has weapons with this special rule may make the Overwatch Reaction when it is triggered by models that do not have the Knight, Titan, Super-heavy, or Lumbering Flyer Unit Sub-types, or that have fewer than 8 Wounds. When making Shooting Attacks as part of the Overwatch Reaction, the Reacting model may only make Shooting Attacks with weapons with this special rule.</description>
+    </rule>
+    <rule id="66b8-7232-1ed3-3f70" name="God-Engine" publicationId="bde1-6db1-163b-3b76" page="104" hidden="false">
+      <description>A model with this special rule ignores all Psychic Powers and Cybertheurgic Rites and Attacks made by Psychic and Cybertheurgic Weapons. In addition, a model with this special rule ignores the effects of the Haywire and Disruption (X) special rules. In all cases, weapons which benefit from these special rules must attempt to damage a model with this special rule normally using the attack’s Strength value. In addition, all friendly Mechanicum units with at least one model within 24&quot; of a model with this special rule gain the Fearless special rule.</description>
     </rule>
   </sharedRules>
   <sharedProfiles>

--- a/2022 - Mechanicum.cat
+++ b/2022 - Mechanicum.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="c247-da79-1654-d39e" name="2022 - Mechanicum" revision="2" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="12" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="c247-da79-1654-d39e" name="2022 - Mechanicum" revision="3" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="13" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entryLinks>
     <entryLink id="29c6-0ec7-0162-e817" name="Mechanicum" hidden="false" collective="false" import="false" targetId="ddf5-d792-3146-6e9a" type="selectionEntry">
       <constraints>
@@ -9,154 +9,163 @@
         <categoryLink id="e8be-9a28-67c2-ab93" name="New CategoryLink" hidden="false" targetId="e90d-e5a8-f42d-da84" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="12ef-d6e7-3e43-41f7" name="Archmagos Prime" hidden="false" collective="false" import="true" targetId="d0f2-ee39-450c-39db" type="selectionEntry">
+    <entryLink id="12ef-d6e7-3e43-41f7" name="Archmagos Prime (Placeholder)" hidden="false" collective="false" import="true" targetId="d0f2-ee39-450c-39db" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="b654-9601-210e-2023" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="ed2f-e502-9c88-ef9e" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="943e-3900-7eb5-e5ab" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="c24f-27c9-1759-4427" name="Archmagos Prime on Abeyant" hidden="false" collective="false" import="true" targetId="3821-7503-6139-3054" type="selectionEntry">
+    <entryLink id="c24f-27c9-1759-4427" name="Archmagos Prime on Abeyant (Placeholder)" hidden="false" collective="false" import="true" targetId="3821-7503-6139-3054" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="7fc8-bff9-1ce8-4ab5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="fec0-6e63-9264-bfd2" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="4592-5ca2-9c47-09ba" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="850d-b62e-8f76-b1be" name="Magos Dominus" hidden="false" collective="false" import="true" targetId="2dcd-d6c5-9f57-0084" type="selectionEntry">
+    <entryLink id="850d-b62e-8f76-b1be" name="Magos Dominus (Placeholder)" hidden="false" collective="false" import="true" targetId="2dcd-d6c5-9f57-0084" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="5b02-7a0e-57ce-4c30" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="3984-61d8-2f84-c437" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="ce21-60e8-7612-3909" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="2f3b-dd15-7f5e-9cf7" name="Magos Dominus on Abeyant" hidden="false" collective="false" import="true" targetId="ed8b-48de-1e04-fa9d" type="selectionEntry">
+    <entryLink id="2f3b-dd15-7f5e-9cf7" name="Magos Dominus on Abeyant (Placeholder)" hidden="false" collective="false" import="true" targetId="ed8b-48de-1e04-fa9d" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="071e-1aff-6f80-5a67" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="44e7-ba3a-da35-d5fc" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="ae9b-7528-7813-39d2" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="140c-306c-d09d-265f" name="Calleb Decima Invictus" hidden="true" collective="false" import="true" targetId="a204-6b74-3aeb-0231" type="selectionEntry">
+    <entryLink id="140c-306c-d09d-265f" name="Calleb Decima Invictus (Placeholder)" hidden="true" collective="false" import="true" targetId="a204-6b74-3aeb-0231" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="58b5-6803-6799-0aa9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="3d6b-6612-cc33-5f72" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="ae5d-99ed-bca3-5c51" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="eb03-59c6-97aa-8f6b" name="Tech-Priest Auxilia" hidden="false" collective="false" import="true" targetId="0eae-0c52-1087-a3b0" type="selectionEntry">
+    <entryLink id="eb03-59c6-97aa-8f6b" name="Tech-Priest Auxilia (Placeholder)" hidden="false" collective="false" import="true" targetId="0eae-0c52-1087-a3b0" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="0e6d-0458-4a4d-ca4d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="5ba2-c0ac-fb56-e190" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="d629-dd69-e689-c38a" name="Arcuitor Magisterium" hidden="false" collective="false" import="true" targetId="6f33-657c-a1b4-710e" type="selectionEntry">
+    <entryLink id="d629-dd69-e689-c38a" name="Arcuitor Magisterium (Placeholder)" hidden="false" collective="false" import="true" targetId="6f33-657c-a1b4-710e" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="4833-3ad9-f086-2980" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="0c0f-9a1e-4050-56d4" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="4f46-e279-a2c2-df18" name="Myrmidon Secutor Host" hidden="false" collective="false" import="true" targetId="1869-2d16-d825-04c3" type="selectionEntry">
+    <entryLink id="4f46-e279-a2c2-df18" name="Myrmidon Secutor Host (Placeholder)" hidden="false" collective="false" import="true" targetId="1869-2d16-d825-04c3" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="8567-d030-d756-4c6a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="e0af-3ec1-6313-926e" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="c06a-da74-71b7-fee1" name="Adsecularis Tech-thralls Covenant" hidden="false" collective="false" import="true" targetId="bc2c-076a-209b-f121" type="selectionEntry">
+    <entryLink id="c06a-da74-71b7-fee1" name="Adsecularis Tech-thralls Covenant (Placeholder)" hidden="false" collective="false" import="true" targetId="bc2c-076a-209b-f121" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="b03f-214f-f4e8-8de8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="e761-63e9-40c4-57ff" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="9bef-dc92-297a-da86" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="123c-8d49-5eb2-8e19" name="Thallax Cohort" hidden="false" collective="false" import="true" targetId="25c8-3e0f-e22d-a7eb" type="selectionEntry">
+    <entryLink id="123c-8d49-5eb2-8e19" name="Thallax Cohort (Placeholder)" hidden="false" collective="false" import="true" targetId="25c8-3e0f-e22d-a7eb" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="670f-cf2a-d36d-be6e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="eb58-ed23-c958-3d96" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="02de-e1ca-567c-d897" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="88d1-a0a6-3637-5bf8" name="Scyllax Guardian-Automata Maniple" hidden="false" collective="false" import="true" targetId="57ab-2409-6707-b967" type="selectionEntry">
+    <entryLink id="88d1-a0a6-3637-5bf8" name="Scyllax Guardian-Automata Maniple (Placeholder)" hidden="false" collective="false" import="true" targetId="57ab-2409-6707-b967" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="6658-9df3-d4ac-70d7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="f1b8-f9a4-e1fb-c21f" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="878a-d92e-8123-7041" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="de1b-2a5f-b271-fd61" name="Arlatax Battle-Automata Maniple" hidden="false" collective="false" import="true" targetId="b178-7d35-136f-d305" type="selectionEntry">
+    <entryLink id="de1b-2a5f-b271-fd61" name="Arlatax Battle-Automata Maniple (Placeholder)" hidden="false" collective="false" import="true" targetId="b178-7d35-136f-d305" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="b0c1-fb4e-652e-7630" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="fa0b-cfcd-a68a-1c73" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="a722-3efe-7ccb-6242" name="Ursarax Cohort" hidden="false" collective="false" import="true" targetId="0750-2aed-2d36-8a82" type="selectionEntry">
+    <entryLink id="a722-3efe-7ccb-6242" name="Ursarax Cohort (Placeholder)" hidden="false" collective="false" import="true" targetId="0750-2aed-2d36-8a82" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="d453-d437-1236-00c0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="9ca5-73ce-baf3-ecf1" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="b790-b6dc-b904-118c" name="Vultarax Stratos-Automata Squadron" hidden="false" collective="false" import="true" targetId="0e08-6b7e-8fff-1f02" type="selectionEntry">
+    <entryLink id="b790-b6dc-b904-118c" name="Vultarax Stratos-Automata Squadron (Placeholder)" hidden="false" collective="false" import="true" targetId="0e08-6b7e-8fff-1f02" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="76a8-0091-e9f9-e5e2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="ef35-36e0-2fc3-f8c7" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="6558-9557-4654-31fc" name="Myrmidon Destructor Host" hidden="false" collective="false" import="true" targetId="356f-a88b-1d13-3700" type="selectionEntry">
+    <entryLink id="6558-9557-4654-31fc" name="Myrmidon Destructor Host (Placeholder)" hidden="false" collective="false" import="true" targetId="356f-a88b-1d13-3700" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="23e1-8fa1-49c1-1d77" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="917e-dce4-a4db-c13f" name="New CategoryLink" hidden="false" targetId="9231-183c-b97b-63f9" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="4467-970e-236e-6118" name="Karacnos Assault Tank" hidden="false" collective="false" import="true" targetId="8920-3184-2455-1834" type="selectionEntry">
+    <entryLink id="4467-970e-236e-6118" name="Karacnos Assault Tank (Placeholder)" hidden="false" collective="false" import="true" targetId="8920-3184-2455-1834" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="3691-ade8-41f9-ecf2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="171f-1fac-2302-5a37" name="New CategoryLink" hidden="false" targetId="9231-183c-b97b-63f9" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="30bc-6d27-6a7b-5d02" name="Krios Squadron" hidden="false" collective="false" import="true" targetId="ce87-68e2-0134-3c84" type="selectionEntry">
+    <entryLink id="30bc-6d27-6a7b-5d02" name="Krios Squadron (Placeholder)" hidden="false" collective="false" import="true" targetId="ce87-68e2-0134-3c84" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="90f5-b210-0447-2356" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="8289-0b76-1d71-b7d2" name="New CategoryLink" hidden="false" targetId="9231-183c-b97b-63f9" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="4351-1507-2a58-b11d" name="Knight Moirax Talon" hidden="false" collective="false" import="true" targetId="c21c-3c14-2d2e-4bc0" type="selectionEntry">
+    <entryLink id="4351-1507-2a58-b11d" name="Knight Moirax Talon (Placeholder)" hidden="false" collective="false" import="true" targetId="c21c-3c14-2d2e-4bc0" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="ca25-1bf8-642c-6aa4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="210e-ee21-2c3e-4fd2" name="New CategoryLink" hidden="false" targetId="9231-183c-b97b-63f9" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="9ca0-8d1b-faa7-e89d" name="Mechanicum Knight Magaera" hidden="false" collective="false" import="true" targetId="b582-e53e-5e13-286c" type="selectionEntry">
+    <entryLink id="9ca0-8d1b-faa7-e89d" name="Mechanicum Knight Magaera (Placeholder)" hidden="false" collective="false" import="true" targetId="b582-e53e-5e13-286c" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="6411-f60a-4ee6-fa8a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="76b5-a3b8-07c7-eb28" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="c5d0-e078-888c-4574" name="Mechanicum Knight Styrix" hidden="false" collective="false" import="true" targetId="aae3-4a95-fbce-6d01" type="selectionEntry">
+    <entryLink id="c5d0-e078-888c-4574" name="Mechanicum Knight Styrix (Placeholder)" hidden="false" collective="false" import="true" targetId="aae3-4a95-fbce-6d01" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="9984-1655-436c-e75c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="d445-8c66-903b-de69" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="c7b8-2484-8229-9d47" name="Mechanicum Knight Atrapos" hidden="false" collective="false" import="true" targetId="6405-d682-11c9-35b6" type="selectionEntry">
+    <entryLink id="c7b8-2484-8229-9d47" name="Mechanicum Knight Atrapos (Placeholder)" hidden="false" collective="false" import="true" targetId="6405-d682-11c9-35b6" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="5572-322f-3fd4-df9c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="d947-9ad4-b373-47f7" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="fd4a-8cec-3721-c94f" name="Mechanicum Acastus Knight Asterius" hidden="false" collective="false" import="true" targetId="ccc2-5689-4796-61b4" type="selectionEntry">
+    <entryLink id="fd4a-8cec-3721-c94f" name="Mechanicum Acastus Knight Asterius (Placeholder)" hidden="false" collective="false" import="true" targetId="ccc2-5689-4796-61b4" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="ef49-9452-4d80-69a3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="58ac-b3ec-8a9d-0f89" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="1521-2b96-fcbd-095b" name="Ordinatus Ulator" hidden="false" collective="false" import="true" targetId="1277-aefb-66c5-bd35" type="selectionEntry">
+    <entryLink id="1521-2b96-fcbd-095b" name="Ordinatus Ulator (Placeholder)" hidden="false" collective="false" import="true" targetId="1277-aefb-66c5-bd35" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="5a23-8aaf-d1cc-9a2c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="8f5e-22b8-50e7-1004" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="ac39-4b53-e47f-d54c" name="Ordinatus Aktaeus" hidden="false" collective="false" import="true" targetId="89a5-fa4d-0e01-3a55" type="selectionEntry">
+    <entryLink id="ac39-4b53-e47f-d54c" name="Ordinatus Aktaeus (Placeholder)" hidden="false" collective="false" import="true" targetId="89a5-fa4d-0e01-3a55" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="8eee-4e6f-0d30-cbd6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="3331-9a71-e131-6128" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="6a07-9580-9c41-dbc6" name="Archmagos Anacharis Scoria" hidden="true" collective="false" import="true" targetId="2185-5fd1-2e59-b467" type="selectionEntry">
+    <entryLink id="6a07-9580-9c41-dbc6" name="Archmagos Anacharis Scoria (Placeholder)" hidden="true" collective="false" import="true" targetId="2185-5fd1-2e59-b467" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="1bfa-3de2-bf04-16db" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="d3aa-2699-4210-25dd" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="2583-0dcb-f271-6960" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="60ea-7150-b6b9-7b9b" name="Thanatar Siege-automata Maniple" hidden="false" collective="false" import="true" targetId="2903-fef6-e839-368b" type="selectionEntry">
@@ -187,6 +196,7 @@
       <categoryLinks>
         <categoryLink id="e5b1-a8f4-deff-e3fc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="f7a4-e7ef-9bc9-80b2" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="22c6-2c40-c433-b524" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
       </categoryLinks>
     </entryLink>
   </entryLinks>

--- a/2022 - Titan Legions.cat
+++ b/2022 - Titan Legions.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="c01b-0224-f806-0d23" name="2022 - Titan Legions" revision="2" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="12" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="c01b-0224-f806-0d23" name="2022 - Titan Legions" revision="3" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="12" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <forceEntries>
     <forceEntry id="aebe-bed9-b32f-a8ea" name="Titan Maniple" hidden="false">
       <categoryLinks>
@@ -75,7 +75,7 @@
         <categoryLink id="032c-b742-5238-a7dc" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="d42f-542d-2cba-8d45" name="Secutarii Peltast Phalanx (Placeholder)" hidden="false" collective="false" import="false" targetId="4fc3-7259-f9b0-71cd" type="selectionEntry">
+    <entryLink id="d42f-542d-2cba-8d45" name="Secutarii Peltast Phalanx" hidden="false" collective="false" import="false" targetId="4fc3-7259-f9b0-71cd" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="8940-f885-bcc9-b74f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="a270-c7de-cbbf-fd44" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
@@ -318,6 +318,7 @@
       </infoLinks>
       <categoryLinks>
         <categoryLink id="99ff-110c-e9cb-7051" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="3488-49bf-3eb4-eb5b" name="Titan Legion Min Troop/LoW" hidden="false" targetId="4086-0589-f010-e688" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="d566-e52a-2fd0-0b97" name="Secutarii Hoplite" hidden="false" collective="false" import="true" type="model">
@@ -453,6 +454,7 @@
       </infoLinks>
       <categoryLinks>
         <categoryLink id="0bb4-9db7-e8b6-b2a5" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="0d75-9bd2-a9ea-be2a" name="Titan Legion Min Troop/LoW" hidden="false" targetId="4086-0589-f010-e688" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="b0f8-c05c-0920-4076" name="Secutarii Peltast" hidden="false" collective="false" import="true" type="model">


### PR DESCRIPTION
…based)

This will have a bit number of removals compared to additions as I saved a bunch of space in things like the mech library by having entry links for a few more selections instead of multiple copies of the same ones.
In addition to that it also removed a lot of "if force has equal to 1 of XXX legion" which were no longer required.

Also didn't change AL as a push is due for that from Alphalas.

GST
Moved from GST to Mech Library
Arioch Power Claw
Castellax Battle-Automata Maniple
Darkfire Cannon
Defensor Autocannon Battery
Defensor Bolt Cannon
Defensor Lascannon
Domitar Battle-Automata Maniple
Graviton Hammer
Lightning Gun
Mauler Bolt Cannon
Maxima Bolter
Mori Quake Cannon
Plasma Mortar
Sollex Heavy-Las
Thanatar Siege-automata Maniple
Titan Power Fist
Twin-linked Mauler Bolt Cannon
Vorax Battle-automata Maniple
Ardex-Defensor
God-Engine

Compulsory HQ category added to Crusade and Allied Detachment
Compulsory Troops category added to Crusade and Allied Detachment
Rite of War category added to Crusade and Allied Detachment

Legions Astarties Library
Added "Compulsory HQ" category to Preator
Added "Compulsory HQ" Cata Praetor
Added "Compulsory HQ" Tart Praetor.
Added "Compulsory Troops" category to Assault Squad
Added "Compulsory Troops" category to Breacher Squad
Added "Compulsory Troops" category to Tactical Squad
Added "Compulsory Troops" category to Terminator Indomitus Squad

Dark Angels
Added "Compulsory HQ" to Corswain
Added "Compulsory HQ" to Farith Redloss
Added "Compulsory HQ" to Holguin
Added "Compulsory HQ" to Marduk Sedras
Fixed Hidden variables in root, including removing the "if force is Dark Angels" as the force must be.

Emperors Children
Added "Compulsory HQ" to Captain Lucius
Added "Compulsory HQ" to Captain Saul Tarvits
Added "Compulsory HQ" to Lord Commander Eidolon
Moved Set Hidden variables to Root Entries
Fixed Hidden variables in root, including removing the "if force is Emperors Children" as the force must be.
Added Exemplary requirement to Sunkillers and Legacy requirement to Rylanor

Iron Warriors
Added "Compulsory HQ" to Erasmus Golg
Added "Compulsory HQ" to Kry Vhalen
Added "Compulsory HQ" to Narik Dreygur
Fixed Hidden variables in root, including removing the "if force is Iron Warriors" as the force must be.

White Scars
Added "Compulsory HQ" to Qin Xa
Added "Compulsory HQ" to Tsolomon Khan
Fixed Hidden variables in root, including removing the "if force is White Scars" as the force must be.

Space Wolves
Added "Primarchs Retinue" to Fenisian Wolfpack (also needs to be made a retinue for regular retinues)
Added "Compulsory HQ" to Geigor Fell-Hand
Added "Compulsory HQ" to Hvarl Red-blade
Added "Compulsory Troops" to Grey Slayers (This will need to be watched out when RoW come in that require other units as compulsory)
Added "Compulsory Troops" to Grey Stalkers (This will need to be watched out when RoW come in that require other units as compulsory)
Moved Set Hidden variables to Root Entries
Fixed Hidden variables in root, including removing the "if force is Space Wolves" as the force must be.

Imperial Fists
Added "Compulsory HQ" to Alexis Polux
Added "Compulsory HQ" to Fafnir Rann
Added "Compulsory HQ" to Sigismund
Fixed Hidden variables in root, including removing the "if force is Imperial Fists" as the force must be.

Night Lords
Added "Compulsory HQ" to Contekar
Added "Compulsory HQ" to Flaymaster
Added "Compulsory HQ" to Nakrid Thole
Added "Compulsory HQ" to Sevatar
Fixed Hidden variables in root, including removing the "if force is Night Lords" as the force must be.

Blood Angels
Added "Compulsory HQ" to Raldoron
Added "Compulsory HQ" to Dominion Zephon
Added "Compulsory HQ" to Judicar Aster Crohne
Added "Compulsory HQ" to Praetor
Set hidden variable for Loyalist for Raldoron, Zephon, Aster Chrohne, Sanguinius.
Fixed Hidden variables in root, including removing the "if force is Blood Angels" as the force must be.

Iron Hands
Added "Compulsory HQ" to Autek Mor
Added "Compulsory HQ" to Shadrak Meduson
Fixed Hidden variables in root, including removing the "if force is Iron Hands" as the force must be.

World Eaters
Added "Compulsory HQ" to Surlak
Added "Compulsory HQ" to Kharn
Added "Compulsory HQ" to Shabran
Fixed Hidden variables in root, including removing the "if force is World Eaters" as the force must be.

Ultramarines
Added "Compulsory HQ" to Remus Ventanus
Fixed Hidden variables in root, including removing the "if force is Ultramarines" as the force must be.

Death Guard
Added "Compulsory HQ" to Typhon
Added "Compulsory HQ" to Crysos Murturg
Added "Compulsory HQ" to Durak Rask
Fixed Hidden variables in root, including removing the "if force is Death Guard" as the force must be.

Thousand Sons
Added "Compulsory HQ" to Ahriman
Added "Compulsory HQ" to Amon
Ammitara Occult Intercession Cabal corrected Legacy unit variable as it was set to Allegiance instead of Force
Fixed Hidden variables in root, including removing the "if force is Thousand Sons" as the force must be.

Sons of Horus
Added "Compulsory HQ" to Abaddon
Added "Compulsory HQ" to Garviel
Added "Compulsory HQ" to Maloghurst
Added "Compulsory HQ" to Tybalt Marr
Fixed Hidden variables in root, including removing the "if force is Sons of Horus" as the force must be.

Word Bearers
Added "Compulsory HQ" to Erebus
Added "Compulsory HQ" to Kor Phaeron
Fixed Hidden variables in root, including removing the "if force is Word Bearers" as the force must be.

Salamanders
Added "Compulsory HQ" to Cassian Dracos Reborn
Added "Compulsory HQ" to Nomus Rhy'Tan
Added "Compulsory HQ" to Xiaphas Jurr
Cassian Dracos Reborn now has Legecy Units flag
Nomus Rhy'Tan now has Legacy Units flag
Xiaphas Jurr now has Legacy Units flag

Raven Guard
Added "Compulsory HQ" to Alverex Maun
Fixed Hidden variables in root, including removing the "if force is Raven Guard" as the force must be.

Mech
Added "Compulsory HQ" to Archmagos Anacharis Scoria
Added "Compulsory HQ" to Archmagos Draykavac
Added "Compulsory HQ" to Archmagos Prime
Added "Compulsory HQ" to Archmagos Prime on Abeyant
Added "Compulsory HQ" to Calleb Decima Invictus
Added "Compulsory HQ" to Magos Dominus
Added "Compulsory HQ" to Magos Dominus on Abeyant
Added "Compulsory Troops" to Adsecularis Tech-thralls Covenant
Added "Compulsory Troops" to Scyllax Guardian-Automata
Added "Compulsory Troops" to Thallax Cohort

Not done yet
What AL is done, if Dynat isn't flagged at Compulsory HQ and the links for Grey Slayers and Grey Stalkers will need to be made Compulsory Troops.
