### PR TITLE
Warlord fixes and other bits again

### DIFF
--- a/2022 - Horus Heresy.gst
+++ b/2022 - Horus Heresy.gst
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<gameSystem id="28d4-bd2e-4858-ece6" name="(HH V2) Horus Heresy (2022)" revision="13" battleScribeVersion="2.03" xmlns="http://www.battlescribe.net/schema/gameSystemSchema">
+<gameSystem id="28d4-bd2e-4858-ece6" name="(HH V2) Horus Heresy (2022)" revision="14" battleScribeVersion="2.03" xmlns="http://www.battlescribe.net/schema/gameSystemSchema">
   <publications>
     <publication id="e77a-823a-da94-16b9" name="Warhammer: The Horus Heresy - Age of Darkness Rulebook" shortName="Main Rules" publicationDate="June 18th, 2022"/>
     <publication id="817a-6288-e016-7469" name="Liber Astartes – Loyalist Legiones Astartes Army Book" shortName="LA - Loyalist" publicationDate="June 18th, 2022"/>
@@ -98,6 +98,11 @@
         <characteristicType id="91b3-4335-71bf-3fa9" name="I"/>
         <characteristicType id="d54a-56a6-68c5-ae72" name="A"/>
         <characteristicType id="2490-aa2f-f5db-6070" name="HP"/>
+      </characteristicTypes>
+    </profileType>
+    <profileType id="90b9-7fab-87db-aed3" name="Reactions">
+      <characteristicTypes>
+        <characteristicType id="c627-4637-8de5-65fb" name="Description"/>
       </characteristicTypes>
     </profileType>
   </profileTypes>
@@ -4967,6 +4972,14 @@ Thaumaturge’s Cleansing (Psychic Weapon)</description>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a7ae-8da7-ad16-cea6" type="max"/>
         <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2c74-7db8-469e-8327" type="max"/>
       </constraints>
+      <profiles>
+        <profile id="9e5f-b65f-2f13-f24e" name="Advanced Reaction: Scornful Fire" publicationId="bde1-6db1-163b-3b76" page="17" hidden="false" typeId="90b9-7fab-87db-aed3" typeName="Reactions">
+          <characteristics>
+            <characteristic name="Description" typeId="c627-4637-8de5-65fb">Scornful Fire – This Advanced Reaction may be made once per battle during the Shooting phase when any enemy unit declares a Shooting Attack targeting a unit that includes a model with the Independent Character special rule under the Reactive player’s control which is part of the Mechanicum Detachment. The Reacting unit, and any friendly Mechanicum units eligible to make a Reaction within 12&quot;, may make a Shooting Attack, targeting the unit that triggered this Reaction and following all the usual rules for Shooting Attacks. Any unit that makes a Shooting Attack as part of this Reaction counts as having made a Reaction in this Phase. 
+A unit that makes a Shooting Attack as part of a Scornful Fire Reaction may not make any attacks indirectly (without line of sight) including weapons with the Barrage special rule or other weapons or special rules that otherwise ignore line of sight, and Vehicles may only fire Defensive Weapons. Template weapons may only be used as part of a Scornful Fire Reaction if the target unit is within 8&quot; and must use the Wall of Death rule instead of firing normally.</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
       <costs>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
       </costs>
@@ -6043,7 +6056,7 @@ Hawks – Any models with this special rule gain the Shrouded (6+) special rule 
         <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4c78-410a-98bc-ddd6" type="max"/>
       </constraints>
       <selectionEntryGroups>
-        <selectionEntryGroup id="75c8-9b24-b75b-b137" name="  IV: Iron Warriors" hidden="true" collective="false" import="true">
+        <selectionEntryGroup id="75c8-9b24-b75b-b137" name="  IV: Iron Warriors" publicationId="09c5-eeae-f398-b653" page="176" hidden="true" collective="false" import="true">
           <modifiers>
             <modifier type="set" field="hidden" value="false">
               <conditions>
@@ -6056,15 +6069,15 @@ Hawks – Any models with this special rule gain the Shrouded (6+) special rule 
             <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c966-c487-a925-6913" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="16e5-b616-ae1c-7131" name="Tyrant of the Dodekathon" hidden="false" collective="false" import="true" type="upgrade">
+            <selectionEntry id="16e5-b616-ae1c-7131" name="Tyrant of the Dodekathon" publicationId="09c5-eeae-f398-b653" page="176" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2f5d-baf8-4f9b-c727" type="max"/>
                 <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b14b-42f7-275a-7c2c" type="max"/>
               </constraints>
               <profiles>
-                <profile id="62d3-6c60-660f-c815" name="Tyrant of the Dodekathon" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
+                <profile id="62d3-6c60-660f-c815" name="Tyrant of the Dodekathon" publicationId="09c5-eeae-f398-b653" page="176" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
                   <characteristics>
-                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca">PLACEHOLDER</characteristic>
+                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca">After all armies have been deployed onto the battlefield but before Scout moves and Infiltrators are placed, the controlling player of a Warlord with this Trait may nominate one area of terrain, Building or Fortification on the battlefield. If the chosen item is an area of terrain that provides a Cover Save, then that Cover Save is removed and the area counts as both Difficult Terrain and Dangerous Terrain instead. If the item chosen is a Building or Fortification then all rolls on the Building Damage table made for that Building or Fortification gain a modifier of +1. In addition, an army whose Warlord has this Trait may make an additional Reaction during the opposing player’s Shooting phase as long as the Warlord has not been removed as a casualty.</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
@@ -6072,15 +6085,15 @@ Hawks – Any models with this special rule gain the Shrouded (6+) special rule 
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="e369-6ce6-212b-7420" name="Tyrant of the Lyssatra" hidden="false" collective="false" import="true" type="upgrade">
+            <selectionEntry id="e369-6ce6-212b-7420" name="Tyrant of the Lyssatra" publicationId="09c5-eeae-f398-b653" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2d73-c45f-e61f-357f" type="max"/>
                 <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2aa9-1ac3-0e05-4b2d" type="max"/>
               </constraints>
               <profiles>
-                <profile id="6139-ddbf-b9ec-f5da" name="Tyrant of the Lyssatra" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
+                <profile id="6139-ddbf-b9ec-f5da" name="Tyrant of the Lyssatra" publicationId="09c5-eeae-f398-b653" page="177" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
                   <characteristics>
-                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca">PLACEHOLDER</characteristic>
+                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca">A Warlord with this Trait, and every model with the Infantry Unit Type in a unit it has joined with the Legiones Astartes (Iron Warriors) special rule may choose to roll an additional dice when making a Shooting Attack with any Rapid Fire, Assault or Heavy weapon that does not have the Blast or Template special rules, but these weapons gain the Gets Hot special rule for that Shooting Attack. If a Warlord and/or unit under the effect of this Trait makes the Bitter Fury Reaction, then a single additional dice is added to the number of attacks made by each model after the effects of Bitter Fury have been applied. In addition, whenever a Warlord with this Trait, and any unit it has joined, is the target of an enemy Shooting Attack it must make either the Return Fire or Bitter Fury Reactions if possible – this Reaction does not cost a point of the Reactive player’s Reaction Allotment, but does not allow that unit to make any further Reactions in that Phase and does not allow the Bitter Fury Reaction to be made more than once per battle. However, a Warlord with this Trait and any unit it has joined may make no other Reaction in any Phase, excepting only the Interceptor Advanced Reaction.</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
@@ -6088,13 +6101,13 @@ Hawks – Any models with this special rule gain the Shrouded (6+) special rule 
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="d4ac-f703-5add-8be4" name="Tyrant of the Apolokron" hidden="false" collective="false" import="true" type="upgrade">
+            <selectionEntry id="d4ac-f703-5add-8be4" name="Tyrant of the Apolokron" publicationId="09c5-eeae-f398-b653" page="176" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="12df-eee8-fd51-f207" type="max"/>
                 <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f078-194e-c439-e0a1" type="max"/>
               </constraints>
               <profiles>
-                <profile id="d5a6-b772-ce1b-a0b7" name="Tyrant of the Apolokron" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
+                <profile id="d5a6-b772-ce1b-a0b7" name="Tyrant of the Apolokron" publicationId="09c5-eeae-f398-b653" page="176" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
                   <characteristics>
                     <characteristic name="Text" typeId="c68e-2cda-b67b-baca">A Warlord with this Trait gains the Fearless special rule, but may not join any unit that is not entirely compsed of models with the Legiones Astartes (Iron Warriors) special rule. However, the Warlord and all models in any unit it joins must adhere to the following restrictions: during both the controlling player&apos;s Shooting phase and the Charge sub-phase, the unit must attempt a Shooting Attack and/or Charge if there is an enemy unit within range, and must target the closest enemy unit possible that is within its line of sight and is a valid target for a Shooting Attack or Charge. If two or more targets are equally close then the controlling player chooses which will be the target of a Shooting Attack or Charge. In addition, an army whose Warlord has this Trait may make an additional Reaction during the opposing player&apos;s Shooting phase as long as the Warlord has not been removed as a casualty.</characteristic>
                   </characteristics>
@@ -6165,7 +6178,7 @@ Hawks – Any models with this special rule gain the Shrouded (6+) special rule 
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="fcc6-0dda-a0bd-8072" name="  III: Emperor&apos;s Children (Placeholder)" hidden="true" collective="false" import="true">
+        <selectionEntryGroup id="fcc6-0dda-a0bd-8072" name="  III: Emperor&apos;s Children" publicationId="09c5-eeae-f398-b653" page="152" hidden="true" collective="false" import="true">
           <modifiers>
             <modifier type="set" field="hidden" value="false">
               <conditions>
@@ -6178,15 +6191,23 @@ Hawks – Any models with this special rule gain the Shrouded (6+) special rule 
             <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="98e4-0f15-7203-d6e0" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="57ba-e2df-127d-dfd5" name="PLACEHOLDER" hidden="false" collective="false" import="true" type="upgrade">
+            <selectionEntry id="57ba-e2df-127d-dfd5" name="The Broken Mirror (Traitor only)" publicationId="09c5-eeae-f398-b653" page="152" hidden="false" collective="false" import="true" type="upgrade">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6a71-3953-9cad-5d3e" type="max"/>
                 <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="bd99-108a-d9fb-1d41" type="max"/>
               </constraints>
               <profiles>
-                <profile id="5585-4c6e-1443-acf0" name="PLACEHOLDER" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
+                <profile id="5585-4c6e-1443-acf0" name="The Broken Mirror" publicationId="09c5-eeae-f398-b653" page="152" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
                   <characteristics>
-                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca"/>
+                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca">This Warlord Trait may only be selected by a model with the Traitor Allegiance.
+When a friendly unit comprised of more than one model and within 12&quot; of a Warlord with this Trait, including the Warlord and any unit it has joined, fails a Morale check, instead of Falling Back it must instead suffer one Wound that cannot be negated by any Armour Saves or Damage Mitigation rolls (this Wound is allocated by the unit’s controlling player). Once this Wound has been resolved, the unit is considered to have passed the Morale check and play continues as normal. In addition, an army whose Warlord has this Trait may make an additional Reaction during the opposing player’s Shooting phase as long as the Warlord has not been removed as a casualty.</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
@@ -6194,15 +6215,15 @@ Hawks – Any models with this special rule gain the Shrouded (6+) special rule 
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="ba2c-ab4d-9f97-e339" name="PLACEHOLDER" hidden="false" collective="false" import="true" type="upgrade">
+            <selectionEntry id="ba2c-ab4d-9f97-e339" name="Paragon of Excellence" publicationId="09c5-eeae-f398-b653" page="152" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="aa3c-c16e-8cf6-9d93" type="max"/>
                 <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a4d5-c5e2-c084-b6f5" type="max"/>
               </constraints>
               <profiles>
-                <profile id="967d-7f09-6cd4-e04e" name="PLACEHOLDER" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
+                <profile id="967d-7f09-6cd4-e04e" name="Paragon of Excellence" publicationId="09c5-eeae-f398-b653" page="152" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
                   <characteristics>
-                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca"/>
+                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca">When any friendly unit within 12&quot; of a Warlord with this Trait, including the Warlord and any unit it has joined, passes a Morale check it gains +1 Weapon Skill until the end of the controlling player’s next turn (this benefit can only be applied once per Game Turn to any single unit). In addition, an army whose Warlord has this Trait may make an additional Reaction during the opposing player’s Movement phase as long as the Warlord has not been removed as a casualty.</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
@@ -6210,15 +6231,23 @@ Hawks – Any models with this special rule gain the Shrouded (6+) special rule 
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="0859-6b27-4a66-e937" name="PLACEHOLDER" hidden="false" collective="false" import="true" type="upgrade">
+            <selectionEntry id="0859-6b27-4a66-e937" name="Martyrs of Isstvan (Loyalist only)" publicationId="09c5-eeae-f398-b653" page="152" hidden="false" collective="false" import="true" type="upgrade">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="934a-d656-ee1b-e39d" type="max"/>
                 <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a19d-bab7-9822-86c5" type="max"/>
               </constraints>
               <profiles>
-                <profile id="6499-b0bb-25f5-5cbd" name="PLACEHOLDER" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
+                <profile id="6499-b0bb-25f5-5cbd" name="Martyrs of Isstvan" publicationId="09c5-eeae-f398-b653" page="152" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
                   <characteristics>
-                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca"/>
+                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca">This Warlord Trait may only be selected by a model with the Loyalist Allegiance.
+A Warlord with this Trait and all models in a unit the Warlord has joined that have the Legiones Astartes (Emperor’s Children) special rule gain a bonus of +1 to all To Hit rolls made while locked in combat with an enemy unit that has any version of the Legiones Astartes (X) special rule and the Traitor Allegiance. In addition, an army whose Warlord has this Trait may make an additional Reaction during the opposing player’s Assault phase as long as the Warlord has not been removed as a casualty.</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
@@ -6228,7 +6257,7 @@ Hawks – Any models with this special rule gain the Shrouded (6+) special rule 
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="fa4e-9b26-7244-179d" name="  V: White Scars (Placeholder)" hidden="true" collective="false" import="true">
+        <selectionEntryGroup id="fa4e-9b26-7244-179d" name="  V: White Scars" publicationId="817a-6288-e016-7469" page="178" hidden="true" collective="false" import="true">
           <modifiers>
             <modifier type="set" field="hidden" value="false">
               <conditions>
@@ -6241,15 +6270,23 @@ Hawks – Any models with this special rule gain the Shrouded (6+) special rule 
             <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3ee8-edaf-12ad-5ec2" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="fd20-efc4-b421-b8ef" name="PLACEHOLDER" hidden="false" collective="false" import="true" type="upgrade">
+            <selectionEntry id="fd20-efc4-b421-b8ef" name="Heroes Never Die  (Loyalist only)" publicationId="817a-6288-e016-7469" page="178" hidden="false" collective="false" import="true" type="upgrade">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d766-2fb3-1383-5bd9" type="max"/>
                 <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e21f-621d-e09b-96f3" type="max"/>
               </constraints>
               <profiles>
-                <profile id="ac80-1ea9-97e7-085d" name="PLACEHOLDER" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
+                <profile id="ac80-1ea9-97e7-085d" name="Heroes Never Die" publicationId="817a-6288-e016-7469" page="178" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
                   <characteristics>
-                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca"/>
+                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca">This Warlord Trait may only be selected by a model with the Loyalist Allegiance.
+A Warlord with this Trait, and all models in any unit he joins, gains the Stubborn special rule. Furthermore, if the Warlord is removed as a casualty, all models in any friendly unit composed entirely of models with the Legiones Astartes (White Scars) special rule, from which one or more models can draw a line of sight to the Warlord at the point when he is removed as a casualty, gain the Fearless special rule for the remainder of the battle. In addition, an army whose Warlord has this Trait may make an additional Reaction during the opposing player’s Assault phase as long as the Warlord has not been removed as a casualty. </characteristic>
                   </characteristics>
                 </profile>
               </profiles>
@@ -6257,15 +6294,15 @@ Hawks – Any models with this special rule gain the Shrouded (6+) special rule 
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="c503-afd4-ba91-0f41" name="PLACEHOLDER" hidden="false" collective="false" import="true" type="upgrade">
+            <selectionEntry id="c503-afd4-ba91-0f41" name="Born to the Saddle" publicationId="817a-6288-e016-7469" page="178" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="bd00-65e8-78b3-04bf" type="max"/>
                 <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8f66-b93b-6188-2b83" type="max"/>
               </constraints>
               <profiles>
-                <profile id="7c21-0828-9bec-f4e0" name="PLACEHOLDER" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
+                <profile id="7c21-0828-9bec-f4e0" name="Born to the Saddle" publicationId="817a-6288-e016-7469" page="178" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
                   <characteristics>
-                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca"/>
+                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca">This Warlord and all models in the same army with the Legiones Astartes (White Scars) special rule and the Cavalry Unit Type ignore all the effects of Difficult Terrain and gain a 4+ Invulnerable Save against all Wounds inflicted by failed Dangerous Terrain tests they are called upon to make. In addition, an army whose Warlord has this Trait may make an additional Reaction during the opposing player’s Movement phase as long as the Warlord has not been removed as a casualty.</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
@@ -6273,15 +6310,23 @@ Hawks – Any models with this special rule gain the Shrouded (6+) special rule 
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="8a24-4c1b-ac43-5208" name="PLACEHOLDER" hidden="false" collective="false" import="true" type="upgrade">
+            <selectionEntry id="8a24-4c1b-ac43-5208" name="The Forgotten Sons (Traitor only)" publicationId="817a-6288-e016-7469" page="178" hidden="false" collective="false" import="true" type="upgrade">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ec2b-84e8-cc8a-195c" type="max"/>
                 <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a403-bca4-9575-a70b" type="max"/>
               </constraints>
               <profiles>
-                <profile id="93ce-b682-fd06-6541" name="PLACEHOLDER" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
+                <profile id="93ce-b682-fd06-6541" name="The Forgotten Sons" publicationId="817a-6288-e016-7469" page="178" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
                   <characteristics>
-                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca"/>
+                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca">This Warlord Trait may only be selected by a model with the Traitor Allegiance.
+If an army whose Warlord has this Trait includes an Allied Detachment with the Legiones Astartes (Sons of Horus) special rule, the Warlord and any unit he joins automatically pass any Morale checks or Pinning tests they are called upon to make without any dice being rolled as long as at least one friendly unit with the Legiones Astartes (Sons of Horus) special rule can draw line of sight to the Warlord or his unit. In addition, the Warlord, and any unit he has joined, may make the Death Dealers Reaction (this Advanced Reaction is detailed in Liber Hereticus) without expending a point from the controlling player’s Reaction Allotment and counting all models in that unit that have the Legiones Astartes (White Scars) special rule as though they also had the Legiones Astartes (Sons of Horus) special rule (though they gain none of the benefits of that special rule) – this Advanced Reaction may still only be used once per battle. </characteristic>
                   </characteristics>
                 </profile>
               </profiles>
@@ -6291,7 +6336,7 @@ Hawks – Any models with this special rule gain the Shrouded (6+) special rule 
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="0899-8b4b-2591-afac" name=" X: Iron Hands (Placeholder)" hidden="true" collective="false" import="true">
+        <selectionEntryGroup id="0899-8b4b-2591-afac" name=" X: Iron Hands" publicationId="817a-6288-e016-7469" page="276" hidden="true" collective="false" import="true">
           <modifiers>
             <modifier type="set" field="hidden" value="false">
               <conditions>
@@ -6304,15 +6349,23 @@ Hawks – Any models with this special rule gain the Shrouded (6+) special rule 
             <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ffe2-18a4-e12e-01b4" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="53d2-df81-688e-0b8c" name="PLACEHOLDER" hidden="false" collective="false" import="true" type="upgrade">
+            <selectionEntry id="53d2-df81-688e-0b8c" name="The Eye of Vigilance (Traitor only)" publicationId="817a-6288-e016-7469" page="276" hidden="false" collective="false" import="true" type="upgrade">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f227-aaac-78c8-7739" type="max"/>
                 <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8d3f-91f9-5b0a-7767" type="max"/>
               </constraints>
               <profiles>
-                <profile id="772c-511d-93c3-51a8" name="PLACEHOLDER" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
+                <profile id="772c-511d-93c3-51a8" name="The Eye of Vigilance" publicationId="817a-6288-e016-7469" page="276" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
                   <characteristics>
-                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca"/>
+                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca">This Warlord Trait may only be selected by a model with the Traitor Allegiance.
+A Warlord with this Trait, and all models in any friendly unit that Warlord joins, gains the Preferred Enemy (Loyalist) special rule. In addition, once per battle, while the controlling player is the Reactive Player, the Warlord and any unit the Warlord has joined may make a single Reaction without expending a point from the army’s Reaction Allotment – this can allow the Warlord and his unit to make more than one Reaction in the same Phase, but that unit may not make the same Reaction twice.</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
@@ -6320,15 +6373,15 @@ Hawks – Any models with this special rule gain the Shrouded (6+) special rule 
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="0899-3ff6-2c7d-2070" name="PLACEHOLDER" hidden="false" collective="false" import="true" type="upgrade">
+            <selectionEntry id="0899-3ff6-2c7d-2070" name="Silver-iron Will" publicationId="817a-6288-e016-7469" page="276" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8ac2-88b3-15f9-f3de" type="max"/>
                 <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3747-7d79-0b08-9f02" type="max"/>
               </constraints>
               <profiles>
-                <profile id="5c2c-d77b-2c48-5f3b" name="PLACEHOLDER" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
+                <profile id="5c2c-d77b-2c48-5f3b" name="Silver-iron Will" publicationId="817a-6288-e016-7469" page="276" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
                   <characteristics>
-                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca"/>
+                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca">A Warlord with this Trait and all models in any unit he has joined are never affected by any special rule or effect that lowers a Characteristic – including the Fear (X) and Rad-phage special rules and due to losing an assault where the enemy has inflicted more Wounds. In addition, an army whose Warlord has this Trait may not make Reactions during the Movement phase, but may make an additional Reaction in either one of the opposing player’s Shooting or Assault phases (but not both). If the Warlord is removed as a casualty then this additional Reaction is lost, but the army may make Reactions in the Movement phase as normal in any appropriate Phases after the Warlord has been removed as a casualty.</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
@@ -6336,15 +6389,23 @@ Hawks – Any models with this special rule gain the Shrouded (6+) special rule 
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="b128-c1f2-ced0-2c0a" name="PLACEHOLDER" hidden="false" collective="false" import="true" type="upgrade">
+            <selectionEntry id="b128-c1f2-ced0-2c0a" name="From Hel’s Heart (Loyalist only)" publicationId="817a-6288-e016-7469" page="276" hidden="false" collective="false" import="true" type="upgrade">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b10a-fe95-c1da-6bf5" type="max"/>
                 <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8d66-354a-ca64-1686" type="max"/>
               </constraints>
               <profiles>
-                <profile id="7f9f-c80f-bd1f-c90b" name="PLACEHOLDER" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
+                <profile id="7f9f-c80f-bd1f-c90b" name="From Hel’s Heart" publicationId="817a-6288-e016-7469" page="276" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
                   <characteristics>
-                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca"/>
+                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca">This Warlord Trait may only be selected by a model with the Loyalist Allegiance.
+A Warlord with this Trait, and all models in any unit he joins, gain the Fear (1) special rule and should the Warlord be reduced to 0 Wounds, the controlling player may choose to inflict D6 automatic Hits upon the unit whose attacks caused the final Wound, with these Hits allocated as per the standard rules. Each Hit is resolved using the profile of either any one of the Warlord’s ranged weapons if he lost his last Wound to a Shooting Attack, or using the profile of any one of the Warlord’s melee weapons if he lost his last Wound as part of an Assault, with all Hits resolved using the same profile (if the Wound is lost to neither a Shooting Attack nor a Melee Attack then this rule has no effect and no Hits are inflicted). In addition, an army whose Warlord has this Trait may make an additional Reaction during the opposing player’s Assault phase as long as the Warlord has not been removed as a casualty.</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
@@ -6354,7 +6415,7 @@ Hawks – Any models with this special rule gain the Shrouded (6+) special rule 
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="af62-dc9d-87c1-daf7" name="  VII: Imperial Fists (Placeholder)" hidden="true" collective="false" import="true">
+        <selectionEntryGroup id="af62-dc9d-87c1-daf7" name="  VII: Imperial Fists" publicationId="817a-6288-e016-7469" page="225" hidden="true" collective="false" import="true">
           <modifiers>
             <modifier type="set" field="hidden" value="false">
               <conditions>
@@ -6367,15 +6428,23 @@ Hawks – Any models with this special rule gain the Shrouded (6+) special rule 
             <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8784-0bbd-bfdc-dea2" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="2c7c-efca-f9d3-c135" name="PLACEHOLDER" hidden="false" collective="false" import="true" type="upgrade">
+            <selectionEntry id="2c7c-efca-f9d3-c135" name="Solar Marshal (Loyalist only)" publicationId="817a-6288-e016-7469" page="225" hidden="false" collective="false" import="true" type="upgrade">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="36ea-deb2-fbd2-78a6" type="max"/>
                 <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b4fb-a5c3-9a8c-ca75" type="max"/>
               </constraints>
               <profiles>
-                <profile id="1c56-e4c0-57fe-6348" name="PLACEHOLDER" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
+                <profile id="1c56-e4c0-57fe-6348" name="Solar Marshal" publicationId="817a-6288-e016-7469" page="225" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
                   <characteristics>
-                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca"/>
+                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca">This Warlord Trait may only be selected by a model with the Loyalist Allegiance.
+A Warlord with this Trait and all models in any friendly unit that Warlord joins gain +1 to their Weapon Skill Characteristic when locked in combat with one or more enemy units that have the Traitor Allegiance. In addition, an army whose Warlord has this Trait may make one additional Reaction per turn in any one of the opposing player’s Phases, as long as the Warlord has not been removed as a casualty. This additional Reaction may only be made by the Warlord’s unit and does not allow any unit to make more than one Reaction per Phase.</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
@@ -6383,15 +6452,15 @@ Hawks – Any models with this special rule gain the Shrouded (6+) special rule 
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="e431-fb60-bc92-ac7a" name="PLACEHOLDER" hidden="false" collective="false" import="true" type="upgrade">
+            <selectionEntry id="e431-fb60-bc92-ac7a" name="Warden of Inwit" publicationId="817a-6288-e016-7469" page="225" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8fcb-14a9-d2b1-e7f2" type="max"/>
                 <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2cd6-f952-7d06-01cd" type="max"/>
               </constraints>
               <profiles>
-                <profile id="f9bb-983d-694f-18ce" name="PLACEHOLDER" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
+                <profile id="f9bb-983d-694f-18ce" name="Warden of Inwit" publicationId="817a-6288-e016-7469" page="225" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
                   <characteristics>
-                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca"/>
+                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca">When within 6&quot; of an objective, or within their own Deployment Zone, a Warlord with this Trait, and all models in any friendly unit that Warlord joins, automatically pass any Morale checks or Pinning tests they are called upon to make. In addition, an army whose Warlord has this Trait may make an additional Reaction during the opposing player’s Assault phase as long as the Warlord has not been removed as a casualty.</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
@@ -6399,15 +6468,15 @@ Hawks – Any models with this special rule gain the Shrouded (6+) special rule 
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="e04f-f0cb-1033-2c7d" name="PLACEHOLDER" hidden="false" collective="false" import="true" type="upgrade">
+            <selectionEntry id="e04f-f0cb-1033-2c7d" name="Architect of Devastation" publicationId="817a-6288-e016-7469" page="225" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="81c5-fb73-07ed-32ff" type="max"/>
                 <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3b61-b48f-40d1-dd1f" type="max"/>
               </constraints>
               <profiles>
-                <profile id="4847-d189-f8d3-d4cb" name="PLACEHOLDER" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
+                <profile id="4847-d189-f8d3-d4cb" name="Architect of Devastation" publicationId="817a-6288-e016-7469" page="225" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
                   <characteristics>
-                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca"/>
+                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca">This Warlord, and all models with the Legiones Astartes (Imperial Fists) special rule in any unit he joins, may re-roll failed To Hit rolls of ‘1’ as long as that unit is entirely within an area of Terrain that grants a Cover Save or Embarked within a Fortification. In addition, an army whose Warlord has this Trait may make an additional Reaction during the opposing player’s Shooting phase as long as the Warlord has not been removed as a casualty.</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
@@ -6417,7 +6486,7 @@ Hawks – Any models with this special rule gain the Shrouded (6+) special rule 
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="9eb0-5436-0bce-5df2" name="  VI: Space Wolves (Placeholder)" hidden="true" collective="false" import="true">
+        <selectionEntryGroup id="9eb0-5436-0bce-5df2" name="  VI: Space Wolves" publicationId="817a-6288-e016-7469" page="197" hidden="true" collective="false" import="true">
           <modifiers>
             <modifier type="set" field="hidden" value="false">
               <conditions>
@@ -6430,15 +6499,15 @@ Hawks – Any models with this special rule gain the Shrouded (6+) special rule 
             <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a40a-8469-a6cf-0cf7" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="af06-fd03-5bd5-5bb8" name="PLACEHOLDER" hidden="false" collective="false" import="true" type="upgrade">
+            <selectionEntry id="af06-fd03-5bd5-5bb8" name="Howl of Morkai" publicationId="817a-6288-e016-7469" page="197" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="fd0f-9949-0cf2-53de" type="max"/>
                 <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="5791-12e7-4011-d35c" type="max"/>
               </constraints>
               <profiles>
-                <profile id="6ac5-ba67-6277-9900" name="PLACEHOLDER" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
+                <profile id="6ac5-ba67-6277-9900" name="Howl of Morkai" publicationId="817a-6288-e016-7469" page="197" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
                   <characteristics>
-                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca"/>
+                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca">Once per battle, the controlling player of a Warlord with this Trait may declare the use of this Trait at the start of their player turn. For the duration of that player turn only, all friendly models with the Legiones Astartes (Space Wolves) special rule gain a bonus of +1 Strength if the unit they are part of has successfully Charged an enemy unit. In addition, an army whose Warlord has this Trait may make an additional Reaction in the opposing player’s Movement phase so long as the Warlord has not been removed as a casualty.</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
@@ -6446,15 +6515,15 @@ Hawks – Any models with this special rule gain the Shrouded (6+) special rule 
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="0c77-14d6-b415-dc56" name="PLACEHOLDER" hidden="false" collective="false" import="true" type="upgrade">
+            <selectionEntry id="0c77-14d6-b415-dc56" name="Hunger of the Void" publicationId="817a-6288-e016-7469" page="197" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a910-c1db-1d63-18d7" type="max"/>
                 <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ad54-3ddb-e165-09d7" type="max"/>
               </constraints>
               <profiles>
-                <profile id="dc32-0a70-e63e-53a6" name="PLACEHOLDER" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
+                <profile id="dc32-0a70-e63e-53a6" name="Hunger of the Void" publicationId="817a-6288-e016-7469" page="197" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
                   <characteristics>
-                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca"/>
+                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca">A Warlord with this Trait gains an additional Wound at the end of any Assault phase in which he inflicts at least one unsaved Wound on an enemy model. This can not increase the Warlord’s Wounds Characteristic above his starting value (including any bonuses from Wargear items like Æther-rune armour), but if this effect is triggered while the Warlord has his maximum possible number of Wounds then he instead gains +1 Attacks and Strength until the end of the controlling player’s next turn. In addition, an army whose Warlord has this Trait may make an additional Reaction in the opposing player’s Assault phase so long as the Warlord has not been removed as a casualty.</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
@@ -6462,15 +6531,15 @@ Hawks – Any models with this special rule gain the Shrouded (6+) special rule 
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="99ae-5ddd-0342-51dc" name="PLACEHOLDER" hidden="false" collective="false" import="true" type="upgrade">
+            <selectionEntry id="99ae-5ddd-0342-51dc" name="Crown Breaker" publicationId="817a-6288-e016-7469" page="197" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e9c2-4b03-9177-bf44" type="max"/>
                 <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="43a3-5c41-241f-3100" type="max"/>
               </constraints>
               <profiles>
-                <profile id="29b9-7f6b-6720-b93b" name="PLACEHOLDER" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
+                <profile id="29b9-7f6b-6720-b93b" name="Crown Breaker" publicationId="817a-6288-e016-7469" page="197" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
                   <characteristics>
-                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca"/>
+                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca">The Warlord and all models in any unit he has joined gain the Preferred Enemy (Independent Characters) special rule. Those models also gain the Feel No Pain (5+) special rule when locked in combat with one or more enemy models with the Independent Character special rule. In addition, an army whose Warlord has this Trait may make an additional Reaction in the opposing player’s Movement phase so long as the Warlord has not been removed as a casualty.</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
@@ -6480,7 +6549,7 @@ Hawks – Any models with this special rule gain the Shrouded (6+) special rule 
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="6cba-65a7-52c5-05e2" name="  I: Dark Angels (Placeholder)" hidden="true" collective="false" import="true">
+        <selectionEntryGroup id="6cba-65a7-52c5-05e2" name="  I: Dark Angels" publicationId="817a-6288-e016-7469" page="152" hidden="true" collective="false" import="true">
           <modifiers>
             <modifier type="set" field="hidden" value="false">
               <conditions>
@@ -6493,15 +6562,19 @@ Hawks – Any models with this special rule gain the Shrouded (6+) special rule 
             <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f96c-7788-b7be-899b" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="7e91-27d0-042e-23a2" name="PLACEHOLDER" hidden="false" collective="false" import="true" type="upgrade">
+            <selectionEntry id="7e91-27d0-042e-23a2" name="Marshal of the Crown" publicationId="817a-6288-e016-7469" page="152" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8f32-d2a8-ace8-ab17" type="max"/>
                 <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d7b0-d70c-54c5-73ef" type="max"/>
               </constraints>
               <profiles>
-                <profile id="2010-3bb7-9a40-3b78" name="PLACEHOLDER" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
+                <profile id="2010-3bb7-9a40-3b78" name="Marshal of the Crown" publicationId="817a-6288-e016-7469" page="152" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
                   <characteristics>
-                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca"/>
+                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca">A Warlord with this Trait must select one of the Hexagrammaton Unit Sub-types. All units that include at least one model with the corresponding Unit Sub-type and at least one model with line of sight to the Warlord gain +1 Leadership (to a maximum of 10). In addition, an army whose Warlord has this Trait may make an additional Reaction in a Phase of the opponent’s turn dictated by the Hexagrammaton Unit Sub-type possessed by the Warlord:
+• Deathwing, Dreadwing – Assault phase
+• Stormwing, Ironwing – Shooting phase
+• Ravenwing, Firewing – Movement phase
+This additional Reaction may only be made as long as the Warlord has not been removed as a casualty</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
@@ -6509,29 +6582,13 @@ Hawks – Any models with this special rule gain the Shrouded (6+) special rule 
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="b2c8-3b11-3f3e-7b7a" name="PLACEHOLDER" hidden="false" collective="false" import="true" type="upgrade">
+            <selectionEntry id="b2c8-3b11-3f3e-7b7a" name="Seneschal of the Keys" publicationId="817a-6288-e016-7469" page="152" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1dfe-d786-e44a-c9b5" type="max"/>
                 <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2fef-2fa5-2ea4-a6b6" type="max"/>
               </constraints>
               <profiles>
-                <profile id="4fa8-deac-a9a4-c426" name="PLACEHOLDER" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
-                  <characteristics>
-                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca"/>
-                  </characteristics>
-                </profile>
-              </profiles>
-              <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="0133-b8f5-33a6-cfd4" name="PLACEHOLDER" hidden="false" collective="false" import="true" type="upgrade">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2752-5a8d-66ac-76ba" type="max"/>
-                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="480f-232e-9a2c-9da6" type="max"/>
-              </constraints>
-              <profiles>
-                <profile id="0bf8-9c06-d740-c4f1" name="PLACEHOLDER" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
+                <profile id="4fa8-deac-a9a4-c426" name="Seneschal of the Keys" publicationId="817a-6288-e016-7469" page="152" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
                   <characteristics>
                     <characteristic name="Text" typeId="c68e-2cda-b67b-baca"/>
                   </characteristics>
@@ -6543,7 +6600,7 @@ Hawks – Any models with this special rule gain the Shrouded (6+) special rule 
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="655a-c3c6-380c-7d64" name=" XII: World Eaters (Placeholder)" hidden="true" collective="false" import="true">
+        <selectionEntryGroup id="655a-c3c6-380c-7d64" name=" XII: World Eaters" publicationId="09c5-eeae-f398-b653" page="216" hidden="true" collective="false" import="true">
           <modifiers>
             <modifier type="set" field="hidden" value="false">
               <conditions>
@@ -6556,15 +6613,23 @@ Hawks – Any models with this special rule gain the Shrouded (6+) special rule 
             <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4d83-b8f9-71e3-89c9" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="cf1a-36a8-19e8-8922" name="PLACEHOLDER" hidden="false" collective="false" import="true" type="upgrade">
+            <selectionEntry id="cf1a-36a8-19e8-8922" name="Blood Hunger (Traitor only)" publicationId="09c5-eeae-f398-b653" page="216" hidden="false" collective="false" import="true" type="upgrade">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8657-3675-d851-ce3b" type="max"/>
                 <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e81e-9842-7322-ee95" type="max"/>
               </constraints>
               <profiles>
-                <profile id="aeaa-284d-8d0d-b8e6" name="PLACEHOLDER" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
+                <profile id="aeaa-284d-8d0d-b8e6" name="Blood Hunger" publicationId="09c5-eeae-f398-b653" page="216" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
                   <characteristics>
-                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca"/>
+                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca">This Warlord Trait may only be selected by a model with the Traitor Allegiance.
+A Warlord with this Trait gains a bonus Wound whenever a melee attack it has made causes an enemy model to be removed as a casualty (this may raise the model’s Wounds score above its starting value, but no higher than 6 Wounds). In addition, a Warlord with this Trait, and any unit it has joined, must declare a Charge in any of the Controlling player’s Assault phases where there is an enemy unit within 12&quot; and line of sight of the Warlord or its unit, and must always target the closest enemy unit if possible. Furthermore, an army whose Warlord has this Trait may make an additional Reaction during the opposing player’s Movement phase as long as the Warlord has not been removed as a casualty. </characteristic>
                   </characteristics>
                 </profile>
               </profiles>
@@ -6572,15 +6637,15 @@ Hawks – Any models with this special rule gain the Shrouded (6+) special rule 
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="4ed5-30f0-7bea-dd86" name="PLACEHOLDER" hidden="false" collective="false" import="true" type="upgrade">
+            <selectionEntry id="4ed5-30f0-7bea-dd86" name="Cloaked in Blood" publicationId="09c5-eeae-f398-b653" page="216" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="53a3-3792-5487-3b08" type="max"/>
                 <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8b17-f2d9-6c15-5f11" type="max"/>
               </constraints>
               <profiles>
-                <profile id="e277-863a-5618-0ade" name="PLACEHOLDER" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
+                <profile id="e277-863a-5618-0ade" name="Cloaked in Blood" publicationId="09c5-eeae-f398-b653" page="216" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
                   <characteristics>
-                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca"/>
+                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca">Any model that does not have the Legiones Astartes (World Eaters) special rule must reduce its Leadership by -2 while locked in combat with this Warlord or any unit that includes this Warlord. In addition, an army whose Warlord has this Trait may make an additional Reaction during the opposing player’s Movement phase as long as the Warlord has not been removed as a casualty. </characteristic>
                   </characteristics>
                 </profile>
               </profiles>
@@ -6588,15 +6653,15 @@ Hawks – Any models with this special rule gain the Shrouded (6+) special rule 
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="11b3-ac83-e1e4-1233" name="PLACEHOLDER" hidden="false" collective="false" import="true" type="upgrade">
+            <selectionEntry id="11b3-ac83-e1e4-1233" name="The Butcher’s Claws" publicationId="09c5-eeae-f398-b653" page="216" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b8de-ca32-11fd-b6d8" type="max"/>
                 <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3ef9-d750-d2a8-3311" type="max"/>
               </constraints>
               <profiles>
-                <profile id="b191-c9c8-018d-be16" name="PLACEHOLDER" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
+                <profile id="b191-c9c8-018d-be16" name="The Butcher’s Claws" publicationId="09c5-eeae-f398-b653" page="216" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
                   <characteristics>
-                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca"/>
+                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca">When a Warlord with this Trait, and all models with the Legiones Astartes (World Eaters) special rule in a unit that it has joined, gain a bonus attack from the Violence Incarnate clause of the Legiones Astartes (World Eaters) special rule they also gain +1 Strength for the remainder of that turn. In addition, an army whose Warlord has this Trait may make an additional Reaction during the opposing player’s Assault phase as long as the Warlord has not been removed as a casualty. </characteristic>
                   </characteristics>
                 </profile>
               </profiles>
@@ -6606,7 +6671,7 @@ Hawks – Any models with this special rule gain the Shrouded (6+) special rule 
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="a8bf-22c3-6760-3f96" name=" XIV: Death Guard (Placeholder)" hidden="true" collective="false" import="true">
+        <selectionEntryGroup id="a8bf-22c3-6760-3f96" name=" XIV: Death Guard" publicationId="09c5-eeae-f398-b653" page="234" hidden="true" collective="false" import="true">
           <modifiers>
             <modifier type="set" field="hidden" value="false">
               <conditions>
@@ -6619,15 +6684,23 @@ Hawks – Any models with this special rule gain the Shrouded (6+) special rule 
             <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c934-c4ef-309e-caaf" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="45e8-8798-b2a0-5bd5" name="PLACEHOLDER" hidden="false" collective="false" import="true" type="upgrade">
+            <selectionEntry id="45e8-8798-b2a0-5bd5" name="The Reaper’s Visage (Traitor only)" publicationId="09c5-eeae-f398-b653" page="234" hidden="false" collective="false" import="true" type="upgrade">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2305-66ef-6e57-27c5" type="max"/>
                 <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="25b0-9d79-8d10-a3a5" type="max"/>
               </constraints>
               <profiles>
-                <profile id="c6a5-da53-617f-783d" name="PLACEHOLDER" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
+                <profile id="c6a5-da53-617f-783d" name="The Reaper’s Visage" publicationId="09c5-eeae-f398-b653" page="234" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
                   <characteristics>
-                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca"/>
+                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca">This Warlord Trait may only be selected by a model with the Traitor Allegiance.
+Any enemy unit with at least one model within 12&quot; of a Warlord with this Trait must reduce the Leadership of all models in that unit by -2 whenever making a Leadership test, a Morale check, or attempting to Regroup – unless that unit also includes at least one model with the Independent Character special rule or the Primarch Unit Type. In addition, an army whose Warlord has this Trait may make an additional Reaction during the opposing player’s Assault phase as long as the Warlord has not been removed as a casualty. </characteristic>
                   </characteristics>
                 </profile>
               </profiles>
@@ -6635,15 +6708,15 @@ Hawks – Any models with this special rule gain the Shrouded (6+) special rule 
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="85bb-05da-1a50-cdba" name="PLACEHOLDER" hidden="false" collective="false" import="true" type="upgrade">
+            <selectionEntry id="85bb-05da-1a50-cdba" name="Witch Hunter" publicationId="09c5-eeae-f398-b653" page="234" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8fb9-a2d7-be76-4d12" type="max"/>
                 <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2890-0157-4a20-8f93" type="max"/>
               </constraints>
               <profiles>
-                <profile id="88fb-c5d9-60b3-7edf" name="PLACEHOLDER" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
+                <profile id="88fb-c5d9-60b3-7edf" name="Witch Hunter" publicationId="09c5-eeae-f398-b653" page="234" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
                   <characteristics>
-                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca"/>
+                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca">A Warlord with this Trait gains +1 to his Toughness and Weapon Skill when locked in combat with any unit that includes at least one model with the Psyker Sub-type. All friendly units composed entirely of models with the Legiones Astartes (Death Guard) special rule, and with at least one model within 12&quot; of the Warlord gain a 6+ Invulnerable Save against any Hits inflicted by a Psychic Weapon, Psychic Power or Perils of the Warp. In addition, an army whose Warlord has this Trait may make an additional Reaction during the opposing player’s Assault phase as long as the Warlord has not been removed as a casualty.</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
@@ -6651,15 +6724,15 @@ Hawks – Any models with this special rule gain the Shrouded (6+) special rule 
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="7f14-89b3-5e18-e522" name="PLACEHOLDER" hidden="false" collective="false" import="true" type="upgrade">
+            <selectionEntry id="7f14-89b3-5e18-e522" name="The Blood of Barbarus" publicationId="09c5-eeae-f398-b653" page="234" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a417-3f4a-5141-16e4" type="max"/>
                 <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9228-e026-1803-7185" type="max"/>
               </constraints>
               <profiles>
-                <profile id="5a51-f239-0ae5-23e2" name="PLACEHOLDER" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
+                <profile id="5a51-f239-0ae5-23e2" name="The Blood of Barbarus" publicationId="09c5-eeae-f398-b653" page="234" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
                   <characteristics>
-                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca"/>
+                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca">Any Hits with the Rending (X), Murderous Strike (X), Poisoned (X) or Fleshbane special rule allocated to a Warlord with this Trait, or any model with the Legiones Astartes (Death Guard) special rule in a unit he joins, only gain the benefit of those special rules on a D6 roll of a 6 instead of the value listed as part of that special rule. In addition, an army whose Warlord has this Trait may make an additional Reaction during the opposing player’s Shooting phase as long as the Warlord has not been removed as a casualty.</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
@@ -6669,7 +6742,7 @@ Hawks – Any models with this special rule gain the Shrouded (6+) special rule 
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="e8b6-feff-5339-dda2" name=" XIII: Ultramarines (Placeholder)" hidden="true" collective="false" import="true">
+        <selectionEntryGroup id="e8b6-feff-5339-dda2" name=" XIII: Ultramarines" publicationId="817a-6288-e016-7469" page="292" hidden="true" collective="false" import="true">
           <modifiers>
             <modifier type="set" field="hidden" value="false">
               <conditions>
@@ -6682,15 +6755,23 @@ Hawks – Any models with this special rule gain the Shrouded (6+) special rule 
             <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="04c5-8510-1cd2-b6bc" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="1c01-4039-4fcb-0bdd" name="PLACEHOLDER" hidden="false" collective="false" import="true" type="upgrade">
+            <selectionEntry id="1c01-4039-4fcb-0bdd" name="The Burden of Kings (Loyalist only)" publicationId="817a-6288-e016-7469" page="292" hidden="false" collective="false" import="true" type="upgrade">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="fd84-5b7b-5b93-a37e" type="max"/>
                 <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9c25-23a3-c8b8-f809" type="max"/>
               </constraints>
               <profiles>
-                <profile id="cf7d-08c6-7dde-6236" name="PLACEHOLDER" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
+                <profile id="cf7d-08c6-7dde-6236" name="The Burden of Kings" publicationId="817a-6288-e016-7469" page="292" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
                   <characteristics>
-                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca"/>
+                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca">This Warlord Trait may only be selected by a model with the Loyalist Allegiance.
+In any Phase in which one or more Wounds has been allocated to a Warlord with this Trait, whether saved or unsaved, the Warlord gains the It Will Not Die (4+) and Fearless special rules until the end of the Warlord’s controlling player’s next turn. In addition, an army whose Warlord has this Trait may, once in each of the opposing player’s turns, make a single Reaction without spending a point of the controlling player’s Reaction Allotment, as long as the Reaction is made by the Warlord or a unit the Warlord has joined.</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
@@ -6698,15 +6779,15 @@ Hawks – Any models with this special rule gain the Shrouded (6+) special rule 
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="759e-de8a-912f-5c93" name="PLACEHOLDER" hidden="false" collective="false" import="true" type="upgrade">
+            <selectionEntry id="759e-de8a-912f-5c93" name="The Aegis of Wisdom" publicationId="817a-6288-e016-7469" page="292" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3751-5e53-7119-e720" type="max"/>
                 <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="5539-1a68-3e62-1ee8" type="max"/>
               </constraints>
               <profiles>
-                <profile id="4ea5-efa5-5b49-1e08" name="PLACEHOLDER" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
+                <profile id="4ea5-efa5-5b49-1e08" name="The Aegis of Wisdom" publicationId="817a-6288-e016-7469" page="292" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
                   <characteristics>
-                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca"/>
+                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca">Any friendly unit made up entirely of models with the Legiones Astartes (Ultramarines) special rule that can draw a line of sight to a Warlord with this Warlord Trait, may, when called upon to Regroup, use the Warlord’s Leadership Characteristic for that test, and if successful the unit may make Shooting Attacks and declare Charges as normal, ignoring the normal restrictions for units that have Regrouped in the same turn. In addition, an army whose Warlord has this Trait may make an additional Reaction during the opposing player’s Shooting phase as long as the Warlord has not been removed as a casualty.</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
@@ -6714,15 +6795,23 @@ Hawks – Any models with this special rule gain the Shrouded (6+) special rule 
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="0935-10ca-2c5f-5c9a" name="PLACEHOLDER" hidden="false" collective="false" import="true" type="upgrade">
+            <selectionEntry id="0935-10ca-2c5f-5c9a" name="Pride’s Dark Power (Traitor only)" publicationId="817a-6288-e016-7469" page="292" hidden="false" collective="false" import="true" type="upgrade">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ae34-8d11-2cd4-469e" type="max"/>
                 <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="766f-a1b6-bac4-c6ef" type="max"/>
               </constraints>
               <profiles>
-                <profile id="8b2e-cdb8-25b1-9f43" name="PLACEHOLDER" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
+                <profile id="8b2e-cdb8-25b1-9f43" name="Pride’s Dark Power" publicationId="817a-6288-e016-7469" page="292" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
                   <characteristics>
-                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca"/>
+                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca">This Warlord Trait may only be selected by a model with the Traitor Allegiance.
+Once per battle, a Warlord with this Warlord Trait may, at the start of any one Phase in either players’ turn, choose to use his Leadership Characteristic in place of his Toughness when resolving any To Wound rolls made against it until the end of that Phase (thus, a Warlord with Leadership 10 that chooses to activate this Trait at the start of the enemy player’s Shooting phase would treat his Toughness as if it was 10 until the end of that Phase). In addition, an army whose Warlord has this Trait may make an additional Reaction during the opposing player’s Assault phase as long as the Warlord has not been removed as a casualty. </characteristic>
                   </characteristics>
                 </profile>
               </profiles>
@@ -6732,7 +6821,7 @@ Hawks – Any models with this special rule gain the Shrouded (6+) special rule 
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="61ac-f6a6-6ae2-89c4" name=" IX: Blood Angels (Placeholder)" hidden="true" collective="false" import="true">
+        <selectionEntryGroup id="61ac-f6a6-6ae2-89c4" name=" IX: Blood Angels" publicationId="817a-6288-e016-7469" page="250" hidden="true" collective="false" import="true">
           <modifiers>
             <modifier type="set" field="hidden" value="false">
               <conditions>
@@ -6745,15 +6834,23 @@ Hawks – Any models with this special rule gain the Shrouded (6+) special rule 
             <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="caf4-9860-3581-c2eb" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="be09-319c-faf7-0555" name="PLACEHOLDER" hidden="false" collective="false" import="true" type="upgrade">
+            <selectionEntry id="be09-319c-faf7-0555" name="Encarmine Paladin (Loyalist only)" publicationId="817a-6288-e016-7469" page="250" hidden="false" collective="false" import="true" type="upgrade">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9069-a422-5789-5f4e" type="max"/>
                 <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="edc0-47aa-c98b-90df" type="max"/>
               </constraints>
               <profiles>
-                <profile id="ad05-1af3-a63c-cb64" name="PLACEHOLDER" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
+                <profile id="ad05-1af3-a63c-cb64" name="Encarmine Paladin" publicationId="817a-6288-e016-7469" page="250" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
                   <characteristics>
-                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca"/>
+                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca">This Warlord Trait may only be selected by a model with the Loyalist Allegiance.
+A Warlord with this Trait gains the Fear (1) special rule when the enemy army has the Traitor Allegiance. Whenever a Warlord with this Trait is on the winning side of a combat in which the Warlord was Engaged and that includes at least one enemy model with the Traitor Allegiance, he increases the value of his Fear special rule by one point at the end of the Assault phase in which the combat is won, to a maximum of Fear (4). For example, if a Warlord with this Trait and the Fear (1) special rule is locked in combat with an enemy unit with the Traitor Allegiance and wins the resulting combat, his Fear special rule would become Fear (2) at the end of that Assault phase. In addition, an army whose Warlord has this Trait may make an additional Reaction during the opposing player’s Assault phase as long as the Warlord has not been removed as a casualty.</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
@@ -6761,15 +6858,15 @@ Hawks – Any models with this special rule gain the Shrouded (6+) special rule 
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="9c6a-574f-f70f-1df7" name="PLACEHOLDER" hidden="false" collective="false" import="true" type="upgrade">
+            <selectionEntry id="9c6a-574f-f70f-1df7" name="Paragon of Unity" publicationId="817a-6288-e016-7469" page="250" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="af21-1c08-34d0-44d5" type="max"/>
                 <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="79d2-5269-bd38-79cb" type="max"/>
               </constraints>
               <profiles>
-                <profile id="f1bc-3993-b686-c353" name="PLACEHOLDER" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
+                <profile id="f1bc-3993-b686-c353" name="Paragon of Unity" publicationId="817a-6288-e016-7469" page="250" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
                   <characteristics>
-                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca"/>
+                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca">Any friendly unit made up entirely of models with the Legiones Astartes (Blood Angels) special rule that can draw a line of sight to a Warlord with this Trait, to any model in a unit this Warlord has joined, or to any model that is Engaged in a combat which this Warlord is part of, gains a bonus of +1 to their Leadership Characteristic, to a maximum of 10. In addition, an army whose Warlord has this Trait may make an additional Reaction during the opposing player’s Assault phase as long as the Warlord has not been removed as a casualty.</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
@@ -6777,15 +6874,23 @@ Hawks – Any models with this special rule gain the Shrouded (6+) special rule 
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="9211-63df-a5ec-b698" name="PLACEHOLDER" hidden="false" collective="false" import="true" type="upgrade">
+            <selectionEntry id="9211-63df-a5ec-b698" name="Thrall of the Red Thirst (Traitor only)" publicationId="817a-6288-e016-7469" page="250" hidden="false" collective="false" import="true" type="upgrade">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="badd-fd72-9198-5f08" type="max"/>
                 <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d78b-be73-bb8d-77fd" type="max"/>
               </constraints>
               <profiles>
-                <profile id="a08c-217e-089d-d31b" name="PLACEHOLDER" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
+                <profile id="a08c-217e-089d-d31b" name="Thrall of the Red Thirst" publicationId="817a-6288-e016-7469" page="250" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
                   <characteristics>
-                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca"/>
+                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca">This Warlord Trait may only be selected by a model with the Traitor Allegiance.
+If, at the start of the controlling player’s Charge sub-phase, there are any enemy units with at least one model within 12&quot; of a Warlord with this Trait, or any model in a unit this Warlord has joined, and the Warlord and any unit he has joined are eligible to make a Charge, then the controlling player must declare a Charge for the Warlord and any unit he has joined targeting that enemy unit. If there is more than one potential target then the Warlord’s controlling player may select any of those units to be the target of the Charge. Whenever this Warlord and any unit he has joined make a successful Charge that is not Disordered, the Warlord and all other models in a unit the Warlord has joined gain +2 attacks, instead of the standard +1 attack granted for Charging. In addition, an army whose Warlord has this Trait may make an additional Reaction during the opposing player’s Movement phase as long as the Warlord has not been removed as a casualty.</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
@@ -6795,7 +6900,7 @@ Hawks – Any models with this special rule gain the Shrouded (6+) special rule 
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="4e7b-2af8-0383-644f" name="  VIII: Night Lords (Placeholder)" hidden="true" collective="false" import="true">
+        <selectionEntryGroup id="4e7b-2af8-0383-644f" name="  VIII: Night Lords" publicationId="09c5-eeae-f398-b653" page="196" hidden="true" collective="false" import="true">
           <modifiers>
             <modifier type="set" field="hidden" value="false">
               <conditions>
@@ -6808,13 +6913,20 @@ Hawks – Any models with this special rule gain the Shrouded (6+) special rule 
             <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a588-2dfc-d56f-b4da" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="cb7d-eb31-f002-72c4" name="PLACEHOLDER" hidden="false" collective="false" import="true" type="upgrade">
+            <selectionEntry id="cb7d-eb31-f002-72c4" name="Warmonger (Traitor only)" publicationId="09c5-eeae-f398-b653" page="196" hidden="false" collective="false" import="true" type="upgrade">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4a0c-bf60-b6d2-6b50" type="max"/>
                 <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="78c6-4648-7baf-8e43" type="max"/>
               </constraints>
               <profiles>
-                <profile id="71ea-b86f-e00f-86c1" name="PLACEHOLDER" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
+                <profile id="71ea-b86f-e00f-86c1" name="Warmonger" publicationId="09c5-eeae-f398-b653" page="196" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
                   <characteristics>
                     <characteristic name="Text" typeId="c68e-2cda-b67b-baca"/>
                   </characteristics>
@@ -6824,13 +6936,13 @@ Hawks – Any models with this special rule gain the Shrouded (6+) special rule 
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="1d0c-7e32-b8e2-bc7d" name="PLACEHOLDER" hidden="false" collective="false" import="true" type="upgrade">
+            <selectionEntry id="1d0c-7e32-b8e2-bc7d" name="Flaymaster" publicationId="09c5-eeae-f398-b653" page="196" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="282e-4f54-7511-aee8" type="max"/>
                 <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0dc3-f399-8bb4-8136" type="max"/>
               </constraints>
               <profiles>
-                <profile id="24d3-3121-c902-30a7" name="PLACEHOLDER" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
+                <profile id="24d3-3121-c902-30a7" name="Flaymaster" publicationId="09c5-eeae-f398-b653" page="196" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
                   <characteristics>
                     <characteristic name="Text" typeId="c68e-2cda-b67b-baca"/>
                   </characteristics>
@@ -6840,13 +6952,13 @@ Hawks – Any models with this special rule gain the Shrouded (6+) special rule 
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="f0cd-3b80-db54-a061" name="PLACEHOLDER" hidden="false" collective="false" import="true" type="upgrade">
+            <selectionEntry id="f0cd-3b80-db54-a061" name="Jadhek Clanlord" publicationId="09c5-eeae-f398-b653" page="196" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1b62-0dbe-b9e3-d2f9" type="max"/>
                 <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4bdb-6754-ee5d-4276" type="max"/>
               </constraints>
               <profiles>
-                <profile id="374f-b35c-4dde-ffb6" name="PLACEHOLDER" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
+                <profile id="374f-b35c-4dde-ffb6" name="Jadhek Clanlord" publicationId="09c5-eeae-f398-b653" page="196" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
                   <characteristics>
                     <characteristic name="Text" typeId="c68e-2cda-b67b-baca"/>
                   </characteristics>
@@ -6858,7 +6970,7 @@ Hawks – Any models with this special rule gain the Shrouded (6+) special rule 
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="0bb7-5fa2-b765-d27d" name="XIX: Raven Guard (Placeholder)" hidden="true" collective="false" import="true">
+        <selectionEntryGroup id="0bb7-5fa2-b765-d27d" name="XIX: Raven Guard" publicationId="817a-6288-e016-7469" page="328" hidden="true" collective="false" import="true">
           <modifiers>
             <modifier type="set" field="hidden" value="false">
               <conditions>
@@ -6871,15 +6983,23 @@ Hawks – Any models with this special rule gain the Shrouded (6+) special rule 
             <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2640-9d96-3aad-d699" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="bbb2-94d9-2474-4ff1" name="PLACEHOLDER" hidden="false" collective="false" import="true" type="upgrade">
+            <selectionEntry id="bbb2-94d9-2474-4ff1" name="The Bane of Tyrants (Loyalist only)" publicationId="817a-6288-e016-7469" page="328" hidden="false" collective="false" import="true" type="upgrade">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="492e-4d60-b702-8c21" type="max"/>
                 <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a47f-12de-f2e9-ba7c" type="max"/>
               </constraints>
               <profiles>
-                <profile id="fedf-2a24-a535-60a6" name="PLACEHOLDER" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
+                <profile id="fedf-2a24-a535-60a6" name="The Bane of Tyrants" publicationId="817a-6288-e016-7469" page="328" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
                   <characteristics>
-                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca"/>
+                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca">This Warlord Trait may only be selected by a model with the Loyalist Allegiance.
+This Warlord increases his Attacks and Strength Characteristics by +1 when Engaged in a Challenge, and by +2 when Engaged in a Challenge with the enemy Warlord. In addition, an army whose Warlord has this Trait may make an additional Reaction during their opponent’s Assault phase as long as the Warlord has not been removed as a casualty.</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
@@ -6887,15 +7007,23 @@ Hawks – Any models with this special rule gain the Shrouded (6+) special rule 
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="7c70-1f95-e09b-40d9" name="PLACEHOLDER" hidden="false" collective="false" import="true" type="upgrade">
+            <selectionEntry id="7c70-1f95-e09b-40d9" name="No Gods or Masters (Traitor only)" publicationId="817a-6288-e016-7469" page="328" hidden="false" collective="false" import="true" type="upgrade">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d1b6-321b-f2b0-796a" type="max"/>
                 <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="aecb-929c-23b1-5f3b" type="max"/>
               </constraints>
               <profiles>
-                <profile id="bdda-a7f8-151b-5b25" name="PLACEHOLDER" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
+                <profile id="bdda-a7f8-151b-5b25" name="No Gods or Masters" publicationId="817a-6288-e016-7469" page="328" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
                   <characteristics>
-                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca"/>
+                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca">This Warlord Trait may only be selected by a model with the Traitor Allegiance.
+When in base to base contact with an enemy Infantry or Cavalry model whose Weapon Skill, Strength or Initiative is higher than this Warlord’s, a Warlord with this Trait increases their Weapon Skill, Strength and/or Initiative to match those of the enemy model with the highest value in that Characteristic that it is in base contact with. In addition, an army whose Warlord has this Trait may, once per battle, make a single Reaction without spending a point of the controlling player’s Reaction Allotment, as long as the Reaction is made by the Warlord or a unit the Warlord has joined.</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
@@ -6903,15 +7031,15 @@ Hawks – Any models with this special rule gain the Shrouded (6+) special rule 
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="b660-b411-2493-231f" name="PLACEHOLDER" hidden="false" collective="false" import="true" type="upgrade">
+            <selectionEntry id="b660-b411-2493-231f" name="The Hidden Hand" publicationId="817a-6288-e016-7469" page="328" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b061-b4cd-b616-6c1e" type="max"/>
                 <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="5cbd-6f98-6834-54a4" type="max"/>
               </constraints>
               <profiles>
-                <profile id="ea28-63ef-bf6d-7af8" name="PLACEHOLDER" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
+                <profile id="ea28-63ef-bf6d-7af8" name="The Hidden Hand" publicationId="817a-6288-e016-7469" page="328" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
                   <characteristics>
-                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca"/>
+                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca">While a Warlord with this Trait is in Reserves, the controlling player may choose to re-roll all failed Reserves rolls and when deployed to the battlefield the Warlord and all models in any unit he has joined gain the Fleet (2) special rule. In addition, an army whose Warlord has this Trait may make an additional Reaction during the opposing player’s Movement phase as long as the Warlord has not been removed as a casualty.</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
@@ -6921,7 +7049,7 @@ Hawks – Any models with this special rule gain the Shrouded (6+) special rule 
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="3377-34f2-e8f4-e84c" name=" XVIII: Salamanders" hidden="true" collective="false" import="true">
+        <selectionEntryGroup id="3377-34f2-e8f4-e84c" name=" XVIII: Salamanders" publicationId="817a-6288-e016-7469" page="309" hidden="true" collective="false" import="true">
           <modifiers>
             <modifier type="set" field="hidden" value="false">
               <conditions>
@@ -6934,11 +7062,11 @@ Hawks – Any models with this special rule gain the Shrouded (6+) special rule 
             <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6ba3-a81b-5760-72e6" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="7875-539f-85ce-34f6" name="The Weight of Duty" hidden="true" collective="false" import="true" type="upgrade">
+            <selectionEntry id="7875-539f-85ce-34f6" name="The Weight of Duty (Loyalist only)" publicationId="817a-6288-e016-7469" page="309" hidden="false" collective="false" import="true" type="upgrade">
               <modifiers>
-                <modifier type="set" field="hidden" value="false">
+                <modifier type="set" field="hidden" value="true">
                   <conditions>
-                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
                   </conditions>
                 </modifier>
               </modifiers>
@@ -6957,11 +7085,11 @@ Hawks – Any models with this special rule gain the Shrouded (6+) special rule 
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="452c-a94f-9574-1f47" name="Redemption of Flames" hidden="true" collective="false" import="true" type="upgrade">
+            <selectionEntry id="452c-a94f-9574-1f47" name="Redemption of Flames (Traitor only)" publicationId="817a-6288-e016-7469" page="309" hidden="false" collective="false" import="true" type="upgrade">
               <modifiers>
-                <modifier type="set" field="hidden" value="false">
+                <modifier type="set" field="hidden" value="true">
                   <conditions>
-                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo"/>
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo"/>
                   </conditions>
                 </modifier>
               </modifiers>
@@ -6980,7 +7108,7 @@ Hawks – Any models with this special rule gain the Shrouded (6+) special rule 
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="6ebb-9611-037a-a786" name="Promethean Will" hidden="false" collective="false" import="true" type="upgrade">
+            <selectionEntry id="6ebb-9611-037a-a786" name="Promethean Will" publicationId="817a-6288-e016-7469" page="309" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1835-7ba2-8d09-4b59" type="max"/>
                 <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3a13-93cd-4031-c6d6" type="max"/>
@@ -6998,7 +7126,7 @@ Hawks – Any models with this special rule gain the Shrouded (6+) special rule 
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="050a-0b05-638b-d6ad" name=" XVII: Word Bearers (Placeholder)" hidden="true" collective="false" import="true">
+        <selectionEntryGroup id="050a-0b05-638b-d6ad" name=" XVII: Word Bearers" publicationId="09c5-eeae-f398-b653" page="304" hidden="true" collective="false" import="true">
           <modifiers>
             <modifier type="set" field="hidden" value="false">
               <conditions>
@@ -7011,15 +7139,23 @@ Hawks – Any models with this special rule gain the Shrouded (6+) special rule 
             <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="192c-5cd9-49b9-4453" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="1feb-8835-0210-dd4f" name="PLACEHOLDER" hidden="false" collective="false" import="true" type="upgrade">
+            <selectionEntry id="1feb-8835-0210-dd4f" name="Enslaved by Darkness (Traitor only)" publicationId="09c5-eeae-f398-b653" page="304" hidden="false" collective="false" import="true" type="upgrade">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c323-8abb-95d7-1bba" type="max"/>
                 <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c0f4-1ce9-a21d-8953" type="max"/>
               </constraints>
               <profiles>
-                <profile id="9ece-e772-07fa-1a5d" name="PLACEHOLDER" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
+                <profile id="9ece-e772-07fa-1a5d" name="Enslaved by Darkness" publicationId="09c5-eeae-f398-b653" page="304" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
                   <characteristics>
-                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca"/>
+                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca">This Warlord Trait may only be selected by a model with the Traitor Allegiance and the Corrupted Unit Sub-type.
+A Warlord with this Trait modifies his Strength and Toughness by a value determined by the current Game Turn: +1 on Game Turns 1, 2 &amp; 3 , no modifier on turns 4 &amp; 5, and -1 on Game Turns 6+. When targeted by any weapon or special rule that targets the Daemon Unit Type, this Warlord is counted as though it had that Unit Type. In addition, an army whose Warlord has this Trait may make an additional Reaction during the opposing player’s Movement phase as long as the Warlord has not been removed as a casualty.</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
@@ -7027,15 +7163,15 @@ Hawks – Any models with this special rule gain the Shrouded (6+) special rule 
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="d9e3-a0e9-492d-d45b" name="PLACEHOLDER" hidden="false" collective="false" import="true" type="upgrade">
+            <selectionEntry id="d9e3-a0e9-492d-d45b" name="Unswerving Devotion" publicationId="09c5-eeae-f398-b653" page="304" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c813-5bbe-4965-5620" type="max"/>
                 <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e180-7d40-4700-529b" type="max"/>
               </constraints>
               <profiles>
-                <profile id="acd6-8152-e78b-6dcd" name="PLACEHOLDER" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
+                <profile id="acd6-8152-e78b-6dcd" name="Unswerving Devotion" publicationId="09c5-eeae-f398-b653" page="304" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
                   <characteristics>
-                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca"/>
+                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca">Any units that include at least one model with the Legiones Astartes (Word Bearers) special rule and have at least one model within 6&quot; of a Warlord with this Trait (including the Warlord himself and any unit he has joined) automatically pass the first failed Morale check or Pinning test they are called upon to make each turn. In addition, an army whose Warlord has this Trait may make an additional Reaction during the opposing player’s Shooting phase as long as the Warlord has not been removed as a casualty.</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
@@ -7043,15 +7179,15 @@ Hawks – Any models with this special rule gain the Shrouded (6+) special rule 
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="2d93-454d-ea4f-5759" name="PLACEHOLDER" hidden="false" collective="false" import="true" type="upgrade">
+            <selectionEntry id="2d93-454d-ea4f-5759" name="Iconoclast" publicationId="09c5-eeae-f398-b653" page="304" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="83fb-ad39-efb5-98f8" type="max"/>
                 <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a504-cb4f-93cb-3c76" type="max"/>
               </constraints>
               <profiles>
-                <profile id="5c65-60cb-3e61-1559" name="PLACEHOLDER" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
+                <profile id="5c65-60cb-3e61-1559" name="Iconoclast" publicationId="09c5-eeae-f398-b653" page="304" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
                   <characteristics>
-                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca"/>
+                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca">A Warlord with this Trait, and any unit he has joined, gain a bonus of +1 Attack when locked in combat with an enemy unit that includes at least one model with the Independent Character special rule, a Legion vexilla or a Legion standard. When making a Shooting Attack or Melee Attack targeting a Fortification, Building or other Terrain piece with a Toughness Characteristic, they gain a bonus of +2 to their Strength or the Strength of any weapons used. In addition, an army whose Warlord has this Trait may make an additional Reaction during the opposing player’s Assault phase as long as the Warlord has not been removed as a casualty.</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
@@ -7061,7 +7197,7 @@ Hawks – Any models with this special rule gain the Shrouded (6+) special rule 
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="8fba-5b15-b959-4a17" name=" XVI: Sons of Horus (Placeholder)" hidden="true" collective="false" import="true">
+        <selectionEntryGroup id="8fba-5b15-b959-4a17" name=" XVI: Sons of Horus" publicationId="09c5-eeae-f398-b653" page="282" hidden="true" collective="false" import="true">
           <modifiers>
             <modifier type="set" field="hidden" value="false">
               <conditions>
@@ -7074,15 +7210,23 @@ Hawks – Any models with this special rule gain the Shrouded (6+) special rule 
             <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="292d-8e60-a191-ffd8" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="989c-1089-47c6-60c4" name="PLACEHOLDER" hidden="false" collective="false" import="true" type="upgrade">
+            <selectionEntry id="989c-1089-47c6-60c4" name="Chosen by Dark Gods (Traitor only)" publicationId="09c5-eeae-f398-b653" page="282" hidden="false" collective="false" import="true" type="upgrade">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8dce-40e9-e4aa-7d43" type="max"/>
                 <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="5a74-5c91-9e1d-2f36" type="max"/>
               </constraints>
               <profiles>
-                <profile id="b6bd-4421-6d5b-0b73" name="PLACEHOLDER" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
+                <profile id="b6bd-4421-6d5b-0b73" name="Chosen by Dark Gods" publicationId="09c5-eeae-f398-b653" page="282" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
                   <characteristics>
-                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca"/>
+                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca">This Warlord Trait may only be selected by a model with the Traitor Allegiance.
+The controlling player of a Warlord with this Trait may choose to roll a D6 at the start of each of that player’s turns. On the roll of a 2-5, the Warlord’s Strength and Toughness Characteristics are increased by +1 until the start of the controlling player’s next turn, and on the roll of a 6 the Warlord may also regain a single Wound (this may not take that model’s Wound score above its starting amount). However, on the roll of a 1 the Warlord suffers a single Wound instead which cannot be negated by any Saving Throw (including Invulnerable Saves) or Damage Mitigation roll (but can be regained as normal, either by this Trait or another special rule that restores Wounds). In addition, an army whose Warlord has this Trait may make an additional Reaction during the opposing player’s Movement phase as long as the Warlord has not been removed as a casualty.</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
@@ -7090,15 +7234,23 @@ Hawks – Any models with this special rule gain the Shrouded (6+) special rule 
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="2a11-8ffa-623b-5f66" name="PLACEHOLDER" hidden="false" collective="false" import="true" type="upgrade">
+            <selectionEntry id="2a11-8ffa-623b-5f66" name="Wolf of Luna (Loyalist only)" publicationId="09c5-eeae-f398-b653" page="282" hidden="false" collective="false" import="true" type="upgrade">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7a60-9519-c96b-5623" type="max"/>
                 <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ff28-4006-9ce4-d693" type="max"/>
               </constraints>
               <profiles>
-                <profile id="f3d7-0128-16db-b68c" name="PLACEHOLDER" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
+                <profile id="f3d7-0128-16db-b68c" name="Wolf of Luna" publicationId="09c5-eeae-f398-b653" page="282" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
                   <characteristics>
-                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca"/>
+                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca">This Warlord Trait may only be selected by a model with the Loyalist Allegiance.
+A Warlord with this Trait may only join a unit composed entirely of models with both the Legiones Astartes (Sons of Horus) special rule and the Loyalist Allegiance. Both the Warlord and any unit it joins gain +1 Attack on any turn in which they successfully Charge, or are successfully charged by, an enemy unit that includes any models with both the Legiones Astartes (X) special rule and the Traitor Allegiance. These increases are in addition to any other bonuses granted by other special rules. In addition, an army whose Warlord has this Trait may make an additional Reaction during the opposing player’s Assault phase as long as the Warlord has not been removed as a casualty. </characteristic>
                   </characteristics>
                 </profile>
               </profiles>
@@ -7106,15 +7258,15 @@ Hawks – Any models with this special rule gain the Shrouded (6+) special rule 
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="c7f9-9954-ac14-fee2" name="PLACEHOLDER" hidden="false" collective="false" import="true" type="upgrade">
+            <selectionEntry id="c7f9-9954-ac14-fee2" name="The Armour of Pride" publicationId="09c5-eeae-f398-b653" page="282" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="467a-583b-bff9-0ece" type="max"/>
                 <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="86ac-2779-cc62-d210" type="max"/>
               </constraints>
               <profiles>
-                <profile id="6db0-85e5-85c2-18d5" name="PLACEHOLDER" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
+                <profile id="6db0-85e5-85c2-18d5" name="The Armour of Pride" publicationId="09c5-eeae-f398-b653" page="282" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
                   <characteristics>
-                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca"/>
+                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca">The first time in any battle when a Warlord with this Trait is reduced to 0 Wounds for any reason, the controlling player must immediately make a Leadership test for that model. If the Test is failed then the Warlord is removed as a casualty as normal, but if the Test is passed then the Warlord is not removed as a casualty, remains in play and regains D3 Wounds. This has no effect against attacks or rules which remove the model as a casualty without inflicting Wounds or against attacks with the Instant Death special rule. In addition, an army whose Warlord has this Trait may make an additional Reaction during the opposing player’s Shooting phase as long as the Warlord has not been removed as a casualty. </characteristic>
                   </characteristics>
                 </profile>
               </profiles>
@@ -7124,7 +7276,7 @@ Hawks – Any models with this special rule gain the Shrouded (6+) special rule 
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="0402-be48-5bfc-9b31" name=" XV: Thousand Sons" hidden="true" collective="false" import="true">
+        <selectionEntryGroup id="0402-be48-5bfc-9b31" name=" XV: Thousand Sons" publicationId="09c5-eeae-f398-b653" page="256" hidden="true" collective="false" import="true">
           <modifiers>
             <modifier type="set" field="hidden" value="false">
               <conditions>
@@ -7137,11 +7289,11 @@ Hawks – Any models with this special rule gain the Shrouded (6+) special rule 
             <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="fbb2-3451-5d7c-7fcd" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="3ebb-a8ef-429f-d050" name="Evoker of Pain" hidden="true" collective="false" import="true" type="upgrade">
+            <selectionEntry id="3ebb-a8ef-429f-d050" name="Evoker of Pain (Traitor only)" publicationId="09c5-eeae-f398-b653" page="256" hidden="false" collective="false" import="true" type="upgrade">
               <modifiers>
-                <modifier type="set" field="hidden" value="false">
+                <modifier type="set" field="hidden" value="true">
                   <conditions>
-                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo"/>
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo"/>
                   </conditions>
                 </modifier>
               </modifiers>
@@ -7160,13 +7312,13 @@ Hawks – Any models with this special rule gain the Shrouded (6+) special rule 
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="d64d-37bc-905a-3e30" name="Magister of Prospero" hidden="false" collective="false" import="true" type="upgrade">
+            <selectionEntry id="d64d-37bc-905a-3e30" name="Magister of Prospero" publicationId="09c5-eeae-f398-b653" page="256" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4ba7-29a8-a010-e2c9" type="max"/>
                 <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="cee3-4aca-b486-2bc6" type="max"/>
               </constraints>
               <profiles>
-                <profile id="3e72-239a-2dee-f9aa" name="Magister of Prospero" page="256" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
+                <profile id="3e72-239a-2dee-f9aa" name="Magister of Prospero" publicationId="09c5-eeae-f398-b653" page="256" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
                   <characteristics>
                     <characteristic name="Text" typeId="c68e-2cda-b67b-baca">A Warlord with this Trait , and any model with the Legiones Astartes (Thousand Sons) special rule in a unit it joins that makes a Psychic check (such as when using the Force or Psychic Focus special rules) may roll an additional dice and discard the highest rolled dice before determining the result of the Check. In addition, whose Warlord has this Trait may make an additional Reaction during the opposing player’s Movement phase long as the Warlord has not been removed as a casualty.</characteristic>
                   </characteristics>
@@ -7176,7 +7328,7 @@ Hawks – Any models with this special rule gain the Shrouded (6+) special rule 
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="26aa-aeb8-133f-03c0" name="Eidolon of Suffering" hidden="false" collective="false" import="true" type="upgrade">
+            <selectionEntry id="26aa-aeb8-133f-03c0" name="Eidolon of Suffering" publicationId="09c5-eeae-f398-b653" page="256" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6399-1be6-8139-6388" type="max"/>
                 <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9633-a5f5-0018-e17b" type="max"/>
@@ -7194,7 +7346,7 @@ Hawks – Any models with this special rule gain the Shrouded (6+) special rule 
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="be90-69c4-929e-c852" name="XX: Alpha Legion (Placeholder)" hidden="true" collective="false" import="true">
+        <selectionEntryGroup id="be90-69c4-929e-c852" name="XX: Alpha Legion" publicationId="09c5-eeae-f398-b653" page="332" hidden="true" collective="false" import="true">
           <modifiers>
             <modifier type="set" field="hidden" value="false">
               <conditions>
@@ -7207,15 +7359,23 @@ Hawks – Any models with this special rule gain the Shrouded (6+) special rule 
             <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="73e2-0e8e-bc95-bb94" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="47d2-7b7d-3818-5fdd" name="PLACEHOLDER" hidden="false" collective="false" import="true" type="upgrade">
+            <selectionEntry id="47d2-7b7d-3818-5fdd" name="The Mobius Configuration (Loyalist Only)" publicationId="09c5-eeae-f398-b653" page="332" hidden="false" collective="false" import="true" type="upgrade">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9334-2e15-a1fe-912c" type="max"/>
                 <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ec62-054b-2aa2-fd2a" type="max"/>
               </constraints>
               <profiles>
-                <profile id="6fdb-415d-d441-40a2" name="PLACEHOLDER" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
+                <profile id="6fdb-415d-d441-40a2" name="The Mobius Configuration" publicationId="09c5-eeae-f398-b653" page="332" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
                   <characteristics>
-                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca"/>
+                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca">This Warlord Trait may only be selected for a model with the Loyalist Allegiance.
+An army whose Warlord has this Trait counts any Allied Detachment that has any version of the Legiones Astartes (X) special rule as though it had the Fellow Warriors level of Alliance, regardless of the variant of the Legiones Astartes (X) special rule it has. Units from this Allied Detachment that are removed as casualties do not score Victory points for the opposing player, regardless of the Mission Objectives in play, and if all models that were part of the Allied Detachment have been removed as casualties at the end of the battle, the controlling player gains +1 Victory point. No unit in the Allied Detachment may make Reactions of any kind, but the first unit in the Primary Detachment to make a Reaction each turn does not use up a point of the controlling player’s Reaction Allotment when making that Reaction.</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
@@ -7223,15 +7383,15 @@ Hawks – Any models with this special rule gain the Shrouded (6+) special rule 
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="7f8e-c94e-b089-3558" name="PLACEHOLDER" hidden="false" collective="false" import="true" type="upgrade">
+            <selectionEntry id="7f8e-c94e-b089-3558" name="Master of Lies" publicationId="09c5-eeae-f398-b653" page="332" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7fac-2e7a-3ee4-347a" type="max"/>
                 <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="60cb-bac7-55cf-b36b" type="max"/>
               </constraints>
               <profiles>
-                <profile id="b0c6-309d-2989-3008" name="PLACEHOLDER" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
+                <profile id="b0c6-309d-2989-3008" name="Master of Lies" publicationId="09c5-eeae-f398-b653" page="332" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
                   <characteristics>
-                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca"/>
+                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca">An army whose Warlord has this Trait, may, at the start of the battle once all players have deployed all of their units onto the battlefield (including Infiltrators and Scouts) and any rolls to Seize the Initiative have been made, select up to three units that are under their control. The selected units may be redeployed as the controlling player wishes, within the constraints of the mission being played – they may be placed into Reserves, but may not be brought out of Reserves and onto the battlefield or assigned to a Deep Strike Assault, Subterranean Assault or Flanking Assault. In addition, an army whose Warlord has this Trait may make an additional Reaction during the opposing player’s Movement phase as long as the Warlord has not been removed as a casualty.</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
@@ -7239,15 +7399,78 @@ Hawks – Any models with this special rule gain the Shrouded (6+) special rule 
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="d7a5-4b0c-7fe1-2258" name="PLACEHOLDER" hidden="false" collective="false" import="true" type="upgrade">
+            <selectionEntry id="d7a5-4b0c-7fe1-2258" name="Hydran Excursor" publicationId="09c5-eeae-f398-b653" page="332" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="bed6-eb06-b033-b04a" type="max"/>
                 <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8664-0283-01f2-44c8" type="max"/>
               </constraints>
               <profiles>
-                <profile id="f0fa-29b9-780a-4a58" name="PLACEHOLDER" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
+                <profile id="f0fa-29b9-780a-4a58" name="Hydran Excursor" publicationId="09c5-eeae-f398-b653" page="332" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
                   <characteristics>
-                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca"/>
+                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca">A Warlord with this Trait, must select any one variant of the Legiones Astartes (X) special rule other than Legiones Astartes (Alpha Legion) at the start of the battle, before any models are deployed. The Warlord and any unit he has joined gain a bonus of +1 to all To Hit rolls made against models with the chosen variant of the Legiones Astartes (X) special rule. In addition, an army whose Warlord has this Trait may make an additional Reaction during the Shooting phase as long as the Warlord has not been removed as a casualty.</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="6745-e221-cd80-057e" name="    Mechanicum" publicationId="bde1-6db1-163b-3b76" page="16" hidden="true" collective="false" import="true">
+          <modifiers>
+            <modifier type="set" field="hidden" value="false">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ddf5-d792-3146-6e9a" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="610d-1d4a-c873-f911" type="max"/>
+            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f6a5-62e7-9bef-eb0d" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="6df3-b52e-27dc-de41" name="A Soul of Cold Iron" publicationId="bde1-6db1-163b-3b76" page="16" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6b31-b21b-17f8-c737" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="08b8-9f59-d7dd-5f99" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="1808-e2d8-8d9d-fe8d" name="A Soul of Cold Iron" publicationId="bde1-6db1-163b-3b76" page="16" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
+                  <characteristics>
+                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca">A Warlord with this Trait and any friendly unit with at least one model within 6&quot; that is Pinned may still move and declare Charges, but is limited to only firing Snap Shots until it is no longer Pinned. In addition, an army whose Warlord has this Trait may make an additional Reaction during their opponent’s Movement phase as long as the Warlord has not been removed as a casualty</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="34f8-053a-3802-6207" name="The Logic of Victory" publicationId="bde1-6db1-163b-3b76" page="16" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="487f-772e-d34e-61de" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2387-88ed-4698-660d" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="3333-c7c5-db36-cc43" name="The Logic of Victory" publicationId="bde1-6db1-163b-3b76" page="16" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
+                  <characteristics>
+                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca">If, at no point during this Warlord’s controlling player’s turn as the Active player, a Warlord with this Trait has neither made a Shooting Attack or been locked in combat then they gain an additional Reaction in each Phase of the following turn as the Reactive player. In addition, a Warlord with this Trait and any unit it has joined gains +1 WS and +1 BS when making attacks as part of any Reaction and +3 Initiative or +3 Movement when making a move as part of any Reaction.</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="ab8f-29a2-a435-8a49" name="The Science of Slaughter" publicationId="bde1-6db1-163b-3b76" page="16" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e57c-0b1c-53fa-6fb7" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1077-ab88-1a25-42b9" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="dd61-a29c-8f79-6d8e" name="The Science of Slaughter" publicationId="bde1-6db1-163b-3b76" page="16" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
+                  <characteristics>
+                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca">On the second turn of each combat a Warlord with this Trait is engaged in, and each turn it is locked in the same combat after that, it gains a bonus of +1 to its WS and +1 Strength (to a maximum of 10). Once a given combat has ended and the Warlord is no longer locked in combat, the Warlord’s WS and Strength Characteristics are reset to the original values. In addition, an army whose Warlord has this Trait may make an additional Reaction during their opponent’s Assault phase as long as the Warlord has not been removed as a casualty.</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
@@ -7876,10 +8099,6 @@ In addition, when moving in Hover mode, the controlling player may choose to inf
     <rule id="c6e2-3d5a-b8f9-005c" name="Neutron-flux" publicationId="a716-c1c4-7b26-8424" page="123" hidden="false">
       <description>A weapon with this special rule gains the Instant Death special rule when targeting models with the Automata Unit Type.</description>
     </rule>
-    <rule id="8c83-e084-bb04-d98c" name="Advanced Reaction:Combat Air Patrol" publicationId="a716-c1c4-7b26-8424" page="123" hidden="false">
-      <description>Combat Air Patrol – This Advanced Reaction may be made whenever any enemy model that has the Vehicle Unit Type and the Flyer Sub-type enters the battlefield from Reserves. The Reactive player may nominate any one model that has been assigned to Combat Air Patrol. Once the enemy model with the Vehicle Unit Type and Flyer Sub-type that triggered this Reaction has finished any and all Movement as it is brought into play, the chosen model assigned to Combat Air Patrol is brought into play from any point on the edge of the battlefield, moving into play as if it had entered play from Reserves. Once the Combat Air Patrol model has finished its Movement it may immediately make a Shooting Attack targeting the enemy model that triggered this Reaction – as long as it has finished its Movement with line of sight to that model.
-Only models with the Vehicle Unit Type and Flyer Sub-type may make the Combat Air Patrol Reaction.</description>
-    </rule>
     <rule id="93e9-2806-e822-bfaf" name="Techmarine Covenant" publicationId="a716-c1c4-7b26-8424" page="125" hidden="false">
       <description>A Techmarine Covenant is selected as any other unit, using up a single Force Organisation slot and bought in the same manner. However, before the first turn begins and any models are deployed to the battlefield, all models in a Techmarine Covenant must be assigned to another unit from the same Detachment of the army they were selected as part of. Legion Techmarines that have not selected a Legion Spatha combat bike or Legion Scimitar jetbike may only be assigned to units composed entirely of models with the Infantry Unit Type and the same Legiones Astartes (X) special rule as the Legion Techmarine, and may not join units with Terminator armour of any kind. Legion Techmarines that have selected a Legion Spatha combat bike may only be assigned to units composed entirely of models with Legion Spatha combat bikes and the same Legiones Astartes (X) special rule as the Legion Techmarine, and any Legion Techmarines that have selected a Legion Scimitar jetbike may only be assigned to units composed entirely of models with Legion Scimitar jetbikes and the same Legiones Astartes (X) special rule as the Legion Techmarine. No Legion Techmarine may be assigned to any unit that includes one or more models with the Independent Character special rule or Unique Sub-type (but such models may join a unit that includes a Legion Techmarine as normal during either deployment or any following turn). No more than one Legion Techmarine may be assigned to any given unit.
 Once assigned to a unit, the Legion Techmarine is considered part of that unit and may not leave it under any circumstances – if that unit is removed as a casualty then the Legion Techmarine is removed as well. In battles using Victory points, no Victory points are ever scored for removing a Legion Techmarine as a casualty. When assigned to a unit, a Legion Techmarine gains all of the special rules (with the exception of those that specifically forbid it, such as the Bitter Duty special rule) and Unit Sub-types listed for the unit to which it is attached, but does not gain access to any additional Wargear options available to the unit to which it is assigned.</description>
@@ -8163,6 +8382,12 @@ Maxima :When destroyed, a model with this special rule resolves Hits caused by C
         <characteristic name="Strength" typeId="17ff-12e7-77d3-2fbe">3</characteristic>
         <characteristic name="AP" typeId="f431-a7b9-d9d0-36c9">4</characteristic>
         <characteristic name="Type" typeId="2159-62b6-4337-d516">Assault 4, Force</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="0ab2-3765-d019-2730" name="Advanced Reaction: Combat Air Patrol" publicationId="a716-c1c4-7b26-8424" page="123" hidden="false" typeId="90b9-7fab-87db-aed3" typeName="Reactions">
+      <characteristics>
+        <characteristic name="Description" typeId="c627-4637-8de5-65fb">Combat Air Patrol – This Advanced Reaction may be made whenever any enemy model that has the Vehicle Unit Type and the Flyer Sub-type enters the battlefield from Reserves. The Reactive player may nominate any one model that has been assigned to Combat Air Patrol. Once the enemy model with the Vehicle Unit Type and Flyer Sub-type that triggered this Reaction has finished any and all Movement as it is brought into play, the chosen model assigned to Combat Air Patrol is brought into play from any point on the edge of the battlefield, moving into play as if it had entered play from Reserves. Once the Combat Air Patrol model has finished its Movement it may immediately make a Shooting Attack targeting the enemy model that triggered this Reaction – as long as it has finished its Movement with line of sight to that model.
+Only models with the Vehicle Unit Type and Flyer Sub-type may make the Combat Air Patrol Reaction.</characteristic>
       </characteristics>
     </profile>
   </sharedProfiles>

--- a/2022 - Legiones Astartes.cat
+++ b/2022 - Legiones Astartes.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="6393-649c-7213-a327" name="(HH V2) Legions Astartes" revision="36" battleScribeVersion="2.03" authorName="Various" authorUrl="https://github.com/BSData/horus-heresy" library="true" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="13" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="6393-649c-7213-a327" name="(HH V2) Legions Astartes" revision="37" battleScribeVersion="2.03" authorName="Various" authorUrl="https://github.com/BSData/horus-heresy" library="true" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="14" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <profileTypes>
     <profileType id="7002-2f9a-59c4-2742" name="Prosperine Arcana">
       <characteristicTypes>
@@ -15171,6 +15171,9 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
               </entryLinks>
             </selectionEntryGroup>
           </selectionEntryGroups>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+          </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
@@ -21975,6 +21978,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
       <infoLinks>
         <infoLink id="b405-1b16-1394-a0dc" name="Legiones Astartes (X)" hidden="false" targetId="61cf-75c2-56cd-2a31" type="rule"/>
         <infoLink id="0fb3-066c-3fc9-919e" name="Talons of the Legion" hidden="false" targetId="1703-5d6d-048c-7287" type="rule"/>
+        <infoLink id="eb5f-a709-f768-73cb" name="Advanced Reaction: Combat Air Patrol" hidden="false" targetId="0ab2-3765-d019-2730" type="profile"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="4520-160b-f580-ec31" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>

--- a/2022 - Mech Library.cat
+++ b/2022 - Mech Library.cat
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="3129-da35-55e0-642d" name="2022 - Mech Library" revision="4" battleScribeVersion="2.03" library="true" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="12" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="3129-da35-55e0-642d" name="2022 - Mech Library" revision="5" battleScribeVersion="2.03" library="true" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="14" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <categoryEntries>
     <categoryEntry id="4086-0589-f010-e688" name="Titan Legion Min Troop/LoW" hidden="false"/>
+    <categoryEntry id="57a1-ae47-ff1b-36e4" name="Cybertheurgist" publicationId="bde1-6db1-163b-3b76" page="92-96" hidden="false"/>
   </categoryEntries>
   <sharedSelectionEntries>
     <selectionEntry id="e825-c60e-e6c3-60f0" name="Photon Gauntlet" publicationId="bde1-6db1-163b-3b76" page="117" hidden="false" collective="false" import="true" type="upgrade">
@@ -489,40 +490,171 @@
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="8b4c-01f4-f39f-7c55" name="Archmagos Draykavac (Placeholder)" publicationId="bde1-6db1-163b-3b76" page="60" hidden="true" collective="false" import="true" type="unit">
+    <selectionEntry id="8b4c-01f4-f39f-7c55" name="Archmagos Draykavac" publicationId="bde1-6db1-163b-3b76" page="60" hidden="true" collective="false" import="true" type="unit">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
             <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="greaterThan"/>
           </conditions>
         </modifier>
+        <modifier type="add" field="category" value="7d95-f9d1-440a-67bd"/>
       </modifiers>
       <constraints>
         <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c9ef-5940-dfd1-cb76" type="max"/>
       </constraints>
+      <profiles>
+        <profile id="ef26-ae17-8c5f-049b" name="Archmagos Draykavac" publicationId="bde1-6db1-163b-3b76" page="60" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName="Unit">
+          <modifiers>
+            <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Infantry (Character, Monstrous, Antigrav, Cybertheurgist, Unique)">
+              <conditions>
+                <condition field="selections" scope="8b4c-01f4-f39f-7c55" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="9dd5-bfd0-50c9-25c2" type="equalTo"/>
+              </conditions>
+            </modifier>
+            <modifier type="set" field="c32b-5fdd-3fbe-9b1f" value="7">
+              <conditions>
+                <condition field="selections" scope="8b4c-01f4-f39f-7c55" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="9dd5-bfd0-50c9-25c2" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <characteristics>
+            <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Character, Cybertheurgist, Unique)</characteristic>
+            <characteristic name="Move" typeId="893e-2d76-8f04-44e5">6</characteristic>
+            <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">5</characteristic>
+            <characteristic name="BS" typeId="74ae-c840-0036-d244">5</characteristic>
+            <characteristic name="S" typeId="e478-41d4-a092-48a8">5</characteristic>
+            <characteristic name="T" typeId="c32b-5fdd-3fbe-9b1f">6</characteristic>
+            <characteristic name="W" typeId="57ee-1126-32a9-5672">4</characteristic>
+            <characteristic name="I" typeId="62d3-22d7-2d49-52dc">4</characteristic>
+            <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">2</characteristic>
+            <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">10</characteristic>
+            <characteristic name="Save" typeId="e593-6b3c-f169-04f0">2+</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="97f7-826f-b7f0-15de" name="Cruel Taskmaster" publicationId="bde1-6db1-163b-3b76" page="61" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
+          <characteristics>
+            <characteristic name="Text" typeId="c68e-2cda-b67b-baca">If chosen as the army’s Warlord, Archmagos Draykavac automatically has Cruel Taskmaster as his Warlord Trait and may not select any other.
+Cruel Taskmaster – If any friendly unit with at least one model within 12&quot; of a Warlord with this Trait fails a Morale check or Pinning test, the controlling player may choose to remove a single model from that unit as a casualty, without any Armour Saves or Damage Mitigation rolls being made, and instead have the unit automatically pass the Morale check or Pinning test without re-rolling any dice.</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules>
+        <rule id="6efd-6227-fa9e-1ea3" name="Liquifractor" publicationId="bde1-6db1-163b-3b76" page="61" hidden="false">
+          <description>Archmagos Draykavac may exchange all his attacks in an Assault phase for a single special Liquifractor attack. This attack Hits automatically and may be used against a single model in base contact with Draykavac at Initiative step 1. To resolve the attack, Draykavac’s player rolls 2D6. If the target has a Toughness Characteristic, they suffer a number of Wounds equal to Draykavac’s roll minus their Toughness Characteristic with an AP value of 2. If the target has an Armour Value, reduce the rolled value by half of the Armour Value struck; the result is the number of Penetrating Hits the Vehicle suffers. For example, if Archmagos Draykavac’s player rolls a result of 9 against a Karacnos Assault Tank with a Front Armour Value of 14 (halved to 7), two Penetrating Hits are inflicted (9-7=2).</description>
+        </rule>
+        <rule id="772d-eca4-f823-35bd" name="Incursus Cybertheurgist" publicationId="bde1-6db1-163b-3b76" page="61" hidden="false">
+          <description>Archmagos Draykavac has the Artificia Machina and Ephemera Incursus Cybertheurgic Arcana, and has all Rites and weapons that are part of those Arcana.</description>
+        </rule>
+        <rule id="cf9e-42d8-ee4d-f5f3" name="High Techno-arcana: Stataraga" publicationId="bde1-6db1-163b-3b76" page="61" hidden="false">
+          <description>Archmagos Draykavac may be chosen as an HQ choice in a Traitor Allegiance Mechanicum Detachment, and may also be taken as a Troops choice in an army using the Divisio Tactica: Questoris Household. As part of a Questoris Knights Detachment, Archmagos Draykavac allows Castellax Battle-automata Maniples and Vorax Battle-automata Maniples to be chosen as non-Compulsory Troops choices for any Detachment in which he is included</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="3d04-70b8-12cc-8cef" name="Battlesmith (X)" hidden="false" targetId="5d57-4d02-1e36-4a82" type="rule">
+          <modifiers>
+            <modifier type="set" field="name" value="Battlesmith (3+)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="c651-6822-b6f8-4a48" name="Firing Protocols (X)" hidden="false" targetId="32a3-f599-5c92-2945" type="rule">
+          <modifiers>
+            <modifier type="set" field="name" value="Firing Protocols (2)"/>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="8b4c-01f4-f39f-7c55" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="9dd5-bfd0-50c9-25c2" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+        <infoLink id="2990-ed54-79f6-4bed" name="Preferred Enemy (X)" hidden="false" targetId="37ab-d4db-891a-de8c" type="rule">
+          <modifiers>
+            <modifier type="set" field="name" value="Preferred Enemy (Infantry)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="23d5-ba06-421d-dfcb" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule"/>
+        <infoLink id="227c-ac61-2fe9-bc65" name="Stubborn" hidden="false" targetId="7989-1f2c-a43d-82ae" type="rule"/>
+        <infoLink id="a282-1e6a-565d-cc6a" name="Traitor" hidden="false" targetId="eff2-8b0e-21da-2f0d" type="rule"/>
+        <infoLink id="15d1-5846-5b65-2e9a" name="Pride of Place" hidden="false" targetId="f83c-9442-8102-5da4" type="rule">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="8b4c-01f4-f39f-7c55" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="9dd5-bfd0-50c9-25c2" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="535d-121f-5839-a712" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="ab7c-4dce-52a0-3b2a" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
+        <categoryLink id="ca1a-d504-80f8-2b44" name="Cybertheurgist" hidden="false" targetId="57a1-ae47-ff1b-36e4" primary="false"/>
+      </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="60b4-29cf-1e6e-2a87" name="Draykavac" hidden="false" collective="false" import="true" type="model">
+        <selectionEntry id="1e24-6126-d3d2-5aba" name="Djinn-skein" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b655-65c1-01a9-1e77" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="054f-8b94-48e9-35a2" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5e35-ae3c-98a7-3c0c" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2b6c-481c-4494-0a3c" type="max"/>
           </constraints>
-          <selectionEntries>
-            <selectionEntry id="7789-b912-d5d3-ff2b" name=" Abeyant" hidden="false" collective="false" import="true" type="upgrade">
-              <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
+          <profiles>
+            <profile id="e884-4204-2aed-1983" name="Djinn-skein" hidden="false" typeId="2a1f-7837-f0ef-be44" typeName="Wargear Item">
+              <characteristics>
+                <characteristic name="Description" typeId="347e-ee4a-764f-6be3">Archmagos Draykavac increases the Ballistic Skill of any unit he joins by +1. In addition, while Archmagos Draykavac is present on the battlefield and not Embarked in a Building or on a unit with the Transport Unit Sub-type and not locked in combat, the controlling player may re-roll any Scatter rolls made (whether as part of a weapon attack or the deployment of a model or unit), as long as Archmagos Draykavac has line of sight to the unit targeted by the attack or the point chosen as the target of the deployment.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="240.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
         <entryLink id="09c2-496c-1a2f-caf7" name="Warlord" hidden="false" collective="false" import="true" targetId="0176-56a3-d590-b103" type="selectionEntry"/>
+        <entryLink id="6055-57e9-8d45-c7dd" name=" Abeyant" hidden="false" collective="false" import="true" targetId="9dd5-bfd0-50c9-25c2" type="selectionEntry">
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0"/>
+          </costs>
+        </entryLink>
+        <entryLink id="6f06-3dd3-a757-f7bb" name="Paragon Blade" hidden="false" collective="false" import="true" targetId="2ab9-0e45-405e-056b" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="62d7-e6c8-cefb-02a4" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="29cc-fe4b-bf22-197b" type="max"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="8389-c368-1fcf-bf97" name="Graviton Gun" hidden="false" collective="false" import="true" targetId="5303-5a3e-de51-1707" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6e7c-54bb-3635-60c8" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="def8-b8a6-7870-9571" type="max"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="35dd-831f-0e39-5148" name="Cortex Controller" hidden="false" collective="false" import="true" targetId="2fda-455f-d34d-97e0" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d604-32f6-39f6-830b" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b571-a60b-49ba-4e97" type="max"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="2488-1b46-7385-0fb6" name="Machinator Array" hidden="false" collective="false" import="true" targetId="66f5-697c-605c-f1bb" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4be6-059c-d995-861a" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2475-6ea8-031b-73d0" type="max"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="8583-0f85-c95a-74d2" name="Mechanicum Protectiva" hidden="false" collective="false" import="true" targetId="7908-9b34-c5bb-21c2" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c483-2586-dcba-76e3" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f5c6-b20f-160d-6a29" type="max"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="5beb-4ce4-78b3-5887" name="Artificia Machina" hidden="false" collective="false" import="true" targetId="51ed-f978-9a5e-1e04" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9f20-00ce-8065-a54a" type="min"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="f978-9bec-6cc0-85b8" name="Ephemera Incursus" hidden="false" collective="false" import="true" targetId="12fc-d4d8-d36c-6f14" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="db4e-e2a3-3e8e-b605" type="min"/>
+          </constraints>
+        </entryLink>
       </entryLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="240.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="3ca1-6daa-7f73-22f4" name="Binaric Stratagems" publicationId="bde1-6db1-163b-3b76" page="102" hidden="false" collective="false" import="true" type="upgrade">
@@ -3569,6 +3701,11 @@ Invulnerable Saves granted by a mag-inverter shield do not stack with other Invu
                 <condition field="selections" scope="c48e-f9ea-9d9d-46aa" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5331-31f3-87ed-5ebe" type="equalTo"/>
               </conditions>
             </modifier>
+            <modifier type="set" field="15c6-ecce-8258-7e00" value="1.0">
+              <conditions>
+                <condition field="selections" scope="primary-category" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4f85-eb33-30c9-8f51" type="instanceOf"/>
+              </conditions>
+            </modifier>
           </modifiers>
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ce6c-c4a0-3622-b76b" type="min"/>
@@ -3637,8 +3774,16 @@ Invulnerable Saves granted by a mag-inverter shield do not stack with other Invu
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="4c16-20c7-f928-2aa6" name="Thanatar Calix" hidden="false" collective="false" import="true" type="upgrade">
+                  <modifiers>
+                    <modifier type="set" field="2f6a-1de2-c92c-d63b" value="1.0">
+                      <conditions>
+                        <condition field="selections" scope="primary-category" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4f85-eb33-30c9-8f51" type="instanceOf"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
                   <constraints>
                     <constraint field="selections" scope="2903-fef6-e839-368b" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e22a-28db-8399-2c86" type="max"/>
+                    <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2f6a-1de2-c92c-d63b" type="min"/>
                   </constraints>
                   <profiles>
                     <profile id="df17-9de2-31bf-f684" name="Thanatar Calix" publicationId="bde1-6db1-163b-3b76" page="46" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName="Unit">
@@ -3657,6 +3802,18 @@ Invulnerable Saves granted by a mag-inverter shield do not stack with other Invu
                       </characteristics>
                     </profile>
                   </profiles>
+                  <rules>
+                    <rule id="48be-ab7a-6431-5d25" name="Avatar of Destruction" publicationId="bde1-6db1-163b-3b76" page="101" hidden="true">
+                      <modifiers>
+                        <modifier type="set" field="hidden" value="false">
+                          <conditions>
+                            <condition field="selections" scope="primary-category" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4f85-eb33-30c9-8f51" type="instanceOf"/>
+                          </conditions>
+                        </modifier>
+                      </modifiers>
+                      <description>A single Thanatar Siege-automata Maniple unit consisting of a single model may be taken as a non-Compulsory HQ choice in a Detachment that includes a model with this special rule. This model must be replaced with a Thanatar-Calix and may not take the Paragon of Metal upgrade. While wholly within 6&quot; of a Thanatar-Calix taken as an HQ choice in this way, friendly Myrmidon Secutor Hosts and Myrmidon Destructor Hosts gain the Line Unit Sub-type and add +1 to the Wounds score used to determine if they win a combat in the Assault phase.</description>
+                    </rule>
+                  </rules>
                   <infoLinks>
                     <infoLink id="47a6-bf07-a5c0-fa73" name="Hammer of Wrath (X)" hidden="false" targetId="aec0-c3aa-1e4e-1779" type="rule">
                       <modifiers>
@@ -3701,9 +3858,14 @@ Invulnerable Saves granted by a mag-inverter shield do not stack with other Invu
             <entryLink id="8ea9-e0ad-492b-4eb5" name="Paragon of Metal" hidden="false" collective="false" import="true" targetId="cc2a-46fe-bbf3-6ba2" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="hidden" value="true">
-                  <conditions>
-                    <condition field="selections" scope="2903-fef6-e839-368b" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c48e-f9ea-9d9d-46aa" type="greaterThan"/>
-                  </conditions>
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="primary-category" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4f85-eb33-30c9-8f51" type="instanceOf"/>
+                        <condition field="selections" scope="2903-fef6-e839-368b" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c48e-f9ea-9d9d-46aa" type="greaterThan"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
                 </modifier>
               </modifiers>
               <costs>
@@ -4012,6 +4174,380 @@ Invulnerable Saves granted by a mag-inverter shield do not stack with other Invu
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
       </costs>
     </selectionEntry>
+    <selectionEntry id="9dd5-bfd0-50c9-25c2" name=" Abeyant" hidden="false" collective="false" import="true" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a81b-a191-fcb8-f43e" type="max"/>
+      </constraints>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="7908-9b34-c5bb-21c2" name="Mechanicum Protectiva" hidden="false" collective="false" import="true" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4f0e-2878-6e2c-eaeb" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="69de-85b2-7a04-eaf2" name="Mechanicum Protectiva" hidden="false" typeId="2a1f-7837-f0ef-be44" typeName="Wargear Item">
+          <characteristics>
+            <characteristic name="Description" typeId="347e-ee4a-764f-6be3">A model with a Mechanicum Protectiva gains a 4+ Invulnerable Save.
+Invulnerable Saves granted by a Mechanicum Protectiva do not stack with other Invulnerable Saves, but can benefit from rules (like cyber-familiar) that specifically increase existing Saves. If a model has another Invulnerable Save then the controlling player must choose which one to use.</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="27ff-3ae1-5cb6-774b" name="Feudal Hierarchy" publicationId="bde1-6db1-163b-3b76" page="104" hidden="false" collective="false" import="true" type="upgrade">
+      <modifiers>
+        <modifier type="set" field="3bfe-5668-c301-81f0" value="2.0">
+          <conditions>
+            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2cd1-fe10-db22-54bd" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ba13-315d-0773-9e1f" type="max"/>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6f75-29a0-d321-91d3" type="max"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3bfe-5668-c301-81f0" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="26cd-3bd0-9e15-48db" type="min"/>
+      </constraints>
+      <rules>
+        <rule id="23bf-6360-311d-fcee" name="Feudal Hierarchy" publicationId="bde1-6db1-163b-3b76" page="104" hidden="false">
+          <description>A single Detachment may not include both an Archmagos Prime and an Archmagos Prime on Abeyant</description>
+        </rule>
+      </rules>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="d342-dbdb-33ec-5191" name="Artificia Cybernetica" publicationId="bde1-6db1-163b-3b76" hidden="false" collective="false" import="true" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c2ef-891c-51e8-5728" type="max"/>
+      </constraints>
+      <selectionEntries>
+        <selectionEntry id="dead-87ed-fb0d-0628" name="Cybernetica Exortus (Cybertheurgic Rite)" publicationId="bde1-6db1-163b-3b76" page="94" hidden="false" collective="true" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="255b-8955-ef87-9ea2" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d9e4-d354-e70d-8649" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="11fa-16c9-2547-4274" name="Cybernetica Exortus (Cybertheurgic Rite)" publicationId="bde1-6db1-163b-3b76" page="94" hidden="false" typeId="5405-b3c6-e8d0-4e77" typeName="Psychic Power">
+              <characteristics>
+                <characteristic name="Description" typeId="4c0f-7e2f-586c-9305">Instead of making a Shooting Attack, a Cybertheurgist with this Cybertheurgic Rite may select a single friendly unit with a model within 12&quot; which contains at least one model with the Automata Unit Type and apply one of the following effects to all models with the Automata Unit Type in the unit:
+• When making a Charge roll for the unit in the same turn as this Rite is used, roll an additional dice and discard the lowest rolled dice before determining the results of the Charge roll.
+• The unit (not each individual model) ignores the first Wound inflicted upon it in each Shooting Attack that targets it until the beginning of the controlling player’s next player turn. Simply discard that Wound without allocating it to a model.
+• The unit adds +1 to its BS for the remainder of the Shooting phase in which this power is used.
+• Until the start of the controlling player’s next turn as the Active player, the unit may ignore the restriction against making Reactions imposed by the Automata Unit Type.
+The Cybertheurgist’s controlling player may choose to make a Cybertheurgy check before using this power, if the Check is successful then two different options may be applied to the target unit instead of one. If the Check is failed then no options may be chosen and the Cybertheurgist suffers Cybertheurgic Feedback.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="d3cc-0712-8f4a-7f56" name="Mordeo Cogita (Cybertheurgic Weapon)" publicationId="bde1-6db1-163b-3b76" hidden="false" collective="true" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="875e-e2b2-4fb0-788e" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5892-ea07-8441-baca" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="7ef2-3f6b-9f48-a8c8" name="Mordeo Cogita (Cybertheurgic Weapon)" publicationId="bde1-6db1-163b-3b76" page="95" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+              <characteristics>
+                <characteristic name="Range" typeId="95ba-cda7-b831-6066">12&quot;</characteristic>
+                <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">10</characteristic>
+                <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">1</characteristic>
+                <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Assault 1, Data-djinn, Instant Death, Cybertheurgic Focus</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <infoLinks>
+            <infoLink id="0e3c-94c8-78cf-eae4" name="Cybertheurgic Focus" hidden="false" targetId="f420-6cdb-5d9b-ef30" type="rule"/>
+            <infoLink id="f09f-6a66-a4a4-e67e" name="Data-djinn" hidden="false" targetId="3e2e-cdc0-8a31-06f6" type="rule"/>
+            <infoLink id="582d-1b43-a9b5-2d9f" name="Instant Death" hidden="false" targetId="9e96-fff1-b916-d9a3" type="rule"/>
+          </infoLinks>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="51ed-f978-9a5e-1e04" name="Artificia Machina" publicationId="bde1-6db1-163b-3b76" page="94" hidden="false" collective="false" import="true" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="191e-da91-3bc0-6ceb" type="max"/>
+      </constraints>
+      <selectionEntries>
+        <selectionEntry id="5e23-856f-186d-618c" name="Animatus Integro (Cybertheurgic Rite)" publicationId="bde1-6db1-163b-3b76" page="94" hidden="false" collective="true" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5944-ea7e-411e-f651" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="475b-312f-188b-e845" type="min"/>
+          </constraints>
+          <profiles>
+            <profile id="ccb9-cbbc-d6b4-ff6b" name="Animatus Integro (Cybertheurgic Rite)" publicationId="bde1-6db1-163b-3b76" page="94" hidden="false" typeId="5405-b3c6-e8d0-4e77" typeName="Psychic Power">
+              <characteristics>
+                <characteristic name="Description" typeId="4c0f-7e2f-586c-9305">Instead of making a Shooting Attack, a Cybertheurgist with this Cybertheurgic Rite may apply the effects of any version of the Battlesmith (X) special rule they have to a single model with the Vehicle, Dreadnought or Automata Unit Type that is within 12&quot; of the Cybertheurgist. The effect is rolled for as normally required by the Battlesmith (X) special rule, but does not require the Cybertheurgist to be in base contact or Embarked upon the model. If successful, the controlling player may choose to make a Cybertheurgy check for the Cybertheurgist model, if successful then the effect of the Battlesmith (X) special rule is applied twice without further rolls (i.e., an additional Wound is restored, or an additional Weapon Destroyed result removed from the target, etc.). If the Cybertheurgy check is failed then the Cybertheurgist suffers Cybertheurgic Feedback.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="caa2-99d2-b7a0-21b7" name="Animatus Excindor (Cybertheurgic Weapon)" publicationId="bde1-6db1-163b-3b76" page="94" hidden="false" collective="true" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f44e-ecb9-5287-4fda" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="038e-117d-ec60-b6a9" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="d964-0897-cc8a-f4a0" name="Animatus Excindor (Cybertheurgic Weapon)" publicationId="bde1-6db1-163b-3b76" page="94" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+              <characteristics>
+                <characteristic name="Range" typeId="95ba-cda7-b831-6066">12&quot;</characteristic>
+                <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">1</characteristic>
+                <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">1</characteristic>
+                <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Assault D6, Haywire, Data-djinn, Cybertheurgic Focus</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <infoLinks>
+            <infoLink id="45e1-c3ec-7f8b-7021" name="Data-djinn" hidden="false" targetId="3e2e-cdc0-8a31-06f6" type="rule"/>
+            <infoLink id="337e-b4bc-6363-b413" name="Cybertheurgic Focus" hidden="false" targetId="f420-6cdb-5d9b-ef30" type="rule"/>
+          </infoLinks>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="b627-88f0-ee8c-c43c" name="Artificia Reductor" publicationId="bde1-6db1-163b-3b76" page="96" hidden="false" collective="false" import="true" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1c8e-aaf1-7efa-f4c6" type="max"/>
+      </constraints>
+      <selectionEntries>
+        <selectionEntry id="d46c-b64d-855c-37f5" name="Porta Fractis (Cybertheurgic Rite)" publicationId="bde1-6db1-163b-3b76" page="96" hidden="false" collective="true" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5748-7f1e-fae0-ed19" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ae65-37c3-e8e6-dc1e" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="90f2-78f1-92ea-3c5a" name="Porta Fractis (Cybertheurgic Rite)" publicationId="bde1-6db1-163b-3b76" page="96" hidden="false" typeId="5405-b3c6-e8d0-4e77" typeName="Psychic Power">
+              <characteristics>
+                <characteristic name="Description" typeId="4c0f-7e2f-586c-9305">Instead of making a Shooting Attack, a Cybertheurgist with this Cybertheurgic Rite may select a single Building, Fortification or enemy unit with the Transport Unit Sub-type that has an enemy unit Embarked within and is within 12&quot; of the Cybertheurgist and must then make a Cybertheurgy check. If the Check is successful then the enemy unit Embarked on the chosen target must immediately make an emergency Disembarkation and once Disembarked must make a Pinning test. If the Cybertheurgy check is failed then the Cybertheurgist suffers Cybertheurgic Feedback.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="f8bb-912d-7f54-eb0e" name="Manos Ruinus (Cybertheurgic Weapon)" publicationId="bde1-6db1-163b-3b76" page="96" hidden="false" collective="true" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f67e-3b2a-2481-819e" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e154-33fa-a001-f3e2" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="eae8-bb40-578b-1fc2" name="Manos Ruinus (Cybertheurgic Weapon)" publicationId="bde1-6db1-163b-3b76" page="96" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+              <characteristics>
+                <characteristic name="Range" typeId="95ba-cda7-b831-6066">-</characteristic>
+                <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">10</characteristic>
+                <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">1</characteristic>
+                <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Melee, Data-djinn, Armourbane, Exoshock (3+), Unwieldy, Cumbersome, Cybertheurgic Focus</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <infoLinks>
+            <infoLink id="06b4-be75-38f9-0f46" name="Data-djinn" hidden="false" targetId="3e2e-cdc0-8a31-06f6" type="rule"/>
+            <infoLink id="ab1a-cd94-09f7-2135" name="Armourbane (X)" hidden="false" targetId="cb59-f920-f071-7cd4" type="rule"/>
+            <infoLink id="a2e9-5096-a43f-5119" name="Exoshock (X)" hidden="false" targetId="69ca-318a-b47a-7a3c" type="rule">
+              <modifiers>
+                <modifier type="set" field="name" value="Exoshock (3+)"/>
+              </modifiers>
+            </infoLink>
+            <infoLink id="31e1-3386-6936-1978" name="Unwieldy" hidden="false" targetId="1570-c21a-881f-8b8a" type="rule"/>
+            <infoLink id="a294-1f5a-bb4b-097f" name="Cumbersome" hidden="false" targetId="d89a-c10e-8a7a-92c3" type="rule"/>
+            <infoLink id="bca5-a9fd-fd46-f58d" name="Cybertheurgic Focus" hidden="false" targetId="f420-6cdb-5d9b-ef30" type="rule"/>
+          </infoLinks>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="12fc-d4d8-d36c-6f14" name="Ephemera Incursus" publicationId="bde1-6db1-163b-3b76" page="95" hidden="false" collective="false" import="true" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e7fd-f043-090d-e79c" type="max"/>
+      </constraints>
+      <selectionEntries>
+        <selectionEntry id="0c41-188d-3206-fb63" name="Ephemera Perfidiae (Cybertheurgic Rite)" publicationId="bde1-6db1-163b-3b76" page="95" hidden="false" collective="true" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7945-2055-8c27-fda5" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ff24-d09e-b3dc-19dc" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="90d2-faf0-e267-7e00" name="Ephemera Perfidiae (Cybertheurgic Rite)" publicationId="bde1-6db1-163b-3b76" page="95" hidden="false" typeId="5405-b3c6-e8d0-4e77" typeName="Psychic Power">
+              <characteristics>
+                <characteristic name="Description" typeId="4c0f-7e2f-586c-9305">Instead of making a Shooting Attack, a Cybertheurgist with this Cybertheurgic Rite may select a single enemy unit with a model within 12&quot; that is entirely composed of models with the Vehicle or Automata Unit Type. The Cybertheurgist’s controlling player may immediately make a Shooting Attack as if they controlled the chosen unit – this Shooting Attack may target any unit that is considered an enemy unit by the Cybertheurgist’s controlling player and is made as Snap Shots. The Cybertheurgist may choose to make a Cybertheurgy check before making this Shooting Attack, if successful the Shooting Attack is made using the Cybertheurgist’s BS and is not made as Snap Shots. If the Check is failed then the Cybertheurgist suffers Cybertheurgic Feedback and no Shooting Attack is made. An enemy unit used to make a Shooting Attack with this Rite may attack normally in its controlling player’s turn and gains the Hatred (Cybertheurgists) special rule for the rest of the battle.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="17f3-49ff-d6da-c8d1" name="Ephemera Exocluo (Cybertheurgic Weapon)" publicationId="bde1-6db1-163b-3b76" page="95" hidden="false" collective="true" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2e72-fb09-75b2-d7f1" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3a7f-7acc-120b-735a" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="a84a-1d7b-36f3-d1aa" name="Ephemera Exocluo (Cybertheurgic Weapon)" publicationId="bde1-6db1-163b-3b76" page="95" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+              <characteristics>
+                <characteristic name="Range" typeId="95ba-cda7-b831-6066">24&quot;</characteristic>
+                <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">3</characteristic>
+                <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">-</characteristic>
+                <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Assault 6, Data-djinn, Blind, Vox Silence,	Cybertheurgic Focus</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <infoLinks>
+            <infoLink id="f54f-ff37-6bb4-9a02" name="Cybertheurgic Focus" hidden="false" targetId="f420-6cdb-5d9b-ef30" type="rule"/>
+            <infoLink id="f248-4b0a-9b48-a06f" name="Data-djinn" hidden="false" targetId="3e2e-cdc0-8a31-06f6" type="rule"/>
+            <infoLink id="ac54-46d5-89c4-d7b8" name="Blind" hidden="false" targetId="d836-747d-07d6-2b63" type="rule"/>
+            <infoLink id="5aaf-3c18-aaae-c2c3" name="Vox Silence" hidden="false" targetId="919e-7a5b-6283-3cff" type="rule"/>
+          </infoLinks>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="25df-a541-0d05-6f61" name="Ephemera Lacyraemarta" publicationId="bde1-6db1-163b-3b76" page="96" hidden="false" collective="false" import="true" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ae85-7ea2-45c7-c7bc" type="max"/>
+      </constraints>
+      <selectionEntries>
+        <selectionEntry id="96a2-9e4a-e3cb-d5f4" name="Ephemera Instigare (Cybertheurgic Rite)" publicationId="bde1-6db1-163b-3b76" page="96" hidden="false" collective="true" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8ed7-0060-288f-aa04" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="43ee-d32b-650a-9c19" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="1e26-2025-57fd-080e" name="Ephemera Instigare (Cybertheurgic Rite)" publicationId="bde1-6db1-163b-3b76" page="96" hidden="false" typeId="5405-b3c6-e8d0-4e77" typeName="Psychic Power">
+              <characteristics>
+                <characteristic name="Description" typeId="4c0f-7e2f-586c-9305">Instead of making a Shooting Attack, a Cybertheurgist with this Cybertheurgic Rite may select a single friendly unit within 12&quot; that is entirely composed of models with the Infantry Unit Type and is of the Mechanicum Faction. The chosen unit may immediately move a number of inches up to twice its unmodified Initiative Characteristic directly towards the nearest enemy unit. If the chosen unit has mixed Initiative Characteristics, use the highest unmodified Characteristic. The Cybertheurgist’s controlling player may choose to make a Cybertheurgy check for the Cybertheurgist. If the Check is successful, then the chosen unit gains the Hammer of Wrath (1) and Furious Charge (1) special rules until the end of the subsequent Assault phase. If the Check is failed, the chosen unit and the Cybertheurgist suffer Cybertheurgic Feedback.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <infoLinks>
+            <infoLink id="d58c-6b87-7108-b1a0" name="Hammer of Wrath (X)" hidden="false" targetId="aec0-c3aa-1e4e-1779" type="rule">
+              <modifiers>
+                <modifier type="set" field="name" value="Hammer of Wrath (1)"/>
+              </modifiers>
+            </infoLink>
+            <infoLink id="1371-d2ce-9902-4e8c" name="Furious Charge (X)" hidden="false" targetId="2821-9269-862f-0554" type="rule">
+              <modifiers>
+                <modifier type="set" field="name" value="Furious Charge (1)"/>
+              </modifiers>
+            </infoLink>
+          </infoLinks>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="7aca-b21b-891e-3c52" name="Ephemera Excrusis (Cybertheurgic Weapon)" publicationId="bde1-6db1-163b-3b76" page="96" hidden="false" collective="true" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="aea6-d96f-475e-dd2d" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="18ae-e271-cc3b-22e5" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="007a-5f81-6323-4931" name="Ephemera Excrusis (Cybertheurgic Weapon)" publicationId="bde1-6db1-163b-3b76" page="96" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+              <characteristics>
+                <characteristic name="Range" typeId="95ba-cda7-b831-6066">-</characteristic>
+                <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">*</characteristic>
+                <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">3</characteristic>
+                <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Melee, Fleshbane, Rad-phage,  Concussive (3), Cybertheurgic Focus</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <infoLinks>
+            <infoLink id="d166-d1f6-0a11-fc29" name="Fleshbane" hidden="false" targetId="40cd-9505-253c-e76f" type="rule"/>
+            <infoLink id="75e8-993b-f406-245c" name="Rad-Phage" hidden="false" targetId="8189-e963-d2e5-5d3d" type="rule"/>
+            <infoLink id="5755-3446-ab31-49aa" name="Concussive (X)" hidden="false" targetId="7ce5-1bfb-64e6-f826" type="rule">
+              <modifiers>
+                <modifier type="set" field="name" value="Concussive (3)"/>
+              </modifiers>
+            </infoLink>
+            <infoLink id="9dda-2365-f1b9-1a47" name="Cybertheurgic Focus" hidden="false" targetId="f420-6cdb-5d9b-ef30" type="rule"/>
+          </infoLinks>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="73fe-4e82-6207-a09a" name="Arc Blaster" publicationId="bde1-6db1-163b-3b76" page="113" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="6cb7-b1f7-5f95-814d" name="Arc Blaster" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="95ba-cda7-b831-6066">24&quot;</characteristic>
+            <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">6</characteristic>
+            <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">5</characteristic>
+            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Heavy 4, Shred, Disruption (4+)</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="a189-98f6-a655-2731" name="Shred" hidden="false" targetId="5e7e-1628-8174-6f2c" type="rule"/>
+        <infoLink id="7515-0f1b-67cd-f9ea" name="Disruption (X)" hidden="false" targetId="4eb9-9e5e-bb27-3644" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="dd74-951d-8540-5ea1" name="Lightning Lock" publicationId="bde1-6db1-163b-3b76" page="113" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="f1d7-08a2-bd66-2f80" name="Lightning Lock" publicationId="bde1-6db1-163b-3b76" page="113" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="95ba-cda7-b831-6066">18&quot;</characteristic>
+            <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">4</characteristic>
+            <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">-</characteristic>
+            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Heavy 1, Blast (3&quot;), Rending (4+), Shred, Exoshock (4+)</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="fe00-acf9-39c9-3499" name="Rending (X)" hidden="false" targetId="0ac9-fab7-aef3-de1d" type="rule">
+          <modifiers>
+            <modifier type="set" field="name" value="Rending (4+)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="36dd-1931-cb97-787e" name="Shred" hidden="false" targetId="5e7e-1628-8174-6f2c" type="rule"/>
+        <infoLink id="72a1-30d6-58ea-410d" name="Exoshock (X)" hidden="false" targetId="69ca-318a-b47a-7a3c" type="rule">
+          <modifiers>
+            <modifier type="set" field="name" value="Exoshock (4+)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="d284-2126-b24b-c3da" name="Blast" hidden="false" targetId="1d9a-73ef-5f4f-8bd8" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
   </sharedSelectionEntries>
   <sharedSelectionEntryGroups>
     <selectionEntryGroup id="1b29-a58e-296c-3946" name="Household Ranks" hidden="true" collective="false" import="true">
@@ -4165,6 +4701,162 @@ Preceptor: Any units of Armiger Warglaives or Armiger Helverins that have at lea
         </selectionEntry>
       </selectionEntries>
     </selectionEntryGroup>
+    <selectionEntryGroup id="c36b-a6a2-9cb2-b090" name="Orders of High Techno-arcana" publicationId="bde1-6db1-163b-3b76" page="98" hidden="false" collective="false" import="true">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="982a-7267-a5bb-3229" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9780-13f0-c1ca-107c" type="max"/>
+      </constraints>
+      <selectionEntries>
+        <selectionEntry id="2cd1-fe10-db22-54bd" name="Archimandrite" publicationId="bde1-6db1-163b-3b76" page="98" hidden="false" collective="false" import="true" type="upgrade">
+          <rules>
+            <rule id="3295-4acb-b579-75b7" name="Archimandrite" publicationId="bde1-6db1-163b-3b76" page="98" hidden="false">
+              <description>• Bonds of Vassalage: A model with this special rule must be the army’s Warlord. In addition, a Mechanicum army that includes a model with this special rule may include a Mechanicum Allied Detachment. An Archmagos Prime or Archmagos Prime on Abeyant included in this Allied Detachment cannot select the Archimandrite Order of High Techno-arcana.
+
+• Magister Theurgica: A model with this special rule may select an additional Cybertheurgic Arcana from those available to it.
+
+• Master Technomancer: Models with the Battlesmith (X) special rule in a Detachment that includes a model with this special rule may add the following effect to the list of options they may apply to units with the Vehicle, Dreadnought or Automata Unit Type targeted by the Battlesmith (X) rule:
+- Until the end of the Shooting phase, the target unit may make Shooting Attacks using the Ballistic Skill of the model that successfully used the Battlesmith (X) rule.
+- Until the end of the Shooting phase, the target gains the Power of the Machine Spirit special rule. This effect may only be applied to units with the Vehicle Unit Type.</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="9bcd-f556-5740-2f9f" name="Cybernetica" publicationId="bde1-6db1-163b-3b76" page="99" hidden="false" collective="false" import="true" type="upgrade">
+          <rules>
+            <rule id="2218-0cd7-1d91-407f" name="Cybernetica" publicationId="bde1-6db1-163b-3b76" page="99" hidden="false">
+              <description>• Cohorts Cybernetica: All Castellax Battle-automata Maniples in a Detachment that includes a model with this special rule gain the Line Unit Sub-type.
+
+• Networked Sensorium Protocols: When making Shooting Attacks, models with the Automata Unit Type in a Detachment that includes a model with this special rule reduce the benefits of any Cover Save the target unit has by -2 (a 4+ becoming a 6+, a 5+ being ignored entirely, and so on) if the model making the Shooting Attack is within 12&quot; of two or more friendly models with cortex controllers.
+
+• Preservation Protocols: A model with this special rule gains the Patris Cybernetica special rule. In addition, when joined to a unit with the Automata Unit Type, any Wounds which would be allocated to the Character (even those caused by the Precision Strikes (X) or Sniper special rules) may instead be allocated to a model with the Automata Unit Type first.</description>
+            </rule>
+          </rules>
+          <infoLinks>
+            <infoLink id="882c-7f2d-e0ed-193a" name="Patris Cybernetica" hidden="false" targetId="0893-4bd0-d5a1-14db" type="rule"/>
+          </infoLinks>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="bd4b-63fa-928c-887d" name="Lacyraemarta" publicationId="bde1-6db1-163b-3b76" page="99" hidden="false" collective="false" import="true" type="upgrade">
+          <rules>
+            <rule id="35bb-61ef-92ac-71ec" name="Lacyraemarta" publicationId="bde1-6db1-163b-3b76" page="99" hidden="false">
+              <description>• Incorruptible Flesh: Any Hits allocated to a model with this special rule, or any model with the Infantry Unit Type in a unit they join, with the Rending (X), Poisoned (X) or Fleshbane special rules only affect that model on a D6 roll of a 6 instead of their usual effect.
+
+• Opus Viscera: If a model with the Battlesmith (X) special rule in a Detachment that includes a model with this special rule is in base contact with at least one model in a unit comprised of only models with the Infantry Unit Type during the Shooting phase, they can attempt to enhance that unit instead of making a Shooting Attack. Roll a D6. If the result is equal to or more than the value listed in brackets as part of the Battlesmith (X) rule, then one of the following effects may be applied to the unit this model is in base contact with:
+- Restore a lost Wound. This will not return a model that has been previously removed from the battle.
+- The unit may immediately move a number of inches equal to twice the Initiative Characteristic of the majority of models in the unit. This movement is not Running, and therefore, if the unit did not Run in the Movement phase, it may still make Shooting Attacks and declare a Charge as normal for the remainder of the turn.
+
+• The Sanguine Hook: A model with this special rule gains the Ephemera Lacyraemarta Cybertheurgic Arcana, but may not select any other Cybertheurgic Arcana from those available with the Cybertheurgist special rule.</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="1247-a94b-070d-2a7b" name="Macrotek" publicationId="bde1-6db1-163b-3b76" page="100" hidden="false" collective="false" import="true" type="upgrade">
+          <rules>
+            <rule id="9f38-c49a-e26b-40e9" name="Macrotek" publicationId="bde1-6db1-163b-3b76" page="100" hidden="false">
+              <description>• High Enginseer: Tech-Priest Auxilia units in a Detachment that includes a model with this special rule may be taken as Troops choices. However, any Tech-Priest Auxilia that are taken in this way must choose the Enginseer Techno-arcana.
+
+• Moderati Munitoria: During the battle’s set-up, but before Objective markers have been placed or deployment has been determined, the player that controls a model with this special rule may choose to alter the terrain set-up on the battlefield. The player that controls a model with this special rule may choose to move up to three pieces of terrain each up to 6&quot;, so long as their final position is not within 2&quot; of another piece of terrain. If two or more players control models with this special rule, they roll off. They then take turns choosing and moving terrain, starting with the winner of the roll-off, until each player has moved three pieces of terrain, or chosen to pass. A piece of terrain can only be moved once by this rule.
+
+• Rector Aedificii: Models with the Battlesmith (X) special rule in a Detachment that includes a model with this special rule may repair Buildings in addition to units with the Vehicle, Dreadnought or Automata Unit Type. In addition, they add the following effects to the list of options they may apply to models targeted by the Battlesmith (X) rule:
+- Until the start of the controlling player’s next turn, any Hits allocated to the chosen model, with the Breaching (X), Exoshock (X) or Rending (X) special rules only affect that model on a D6 roll of a 6 instead of their usual effect.</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="5e62-8d7e-a487-0490" name="Malagra" publicationId="bde1-6db1-163b-3b76" page="100" hidden="false" collective="false" import="true" type="upgrade">
+          <rules>
+            <rule id="ddb0-51e0-9185-1b5f" name="Malagra" publicationId="bde1-6db1-163b-3b76" page="100" hidden="false">
+              <description>• Ictus Insidiae: Any models with the Character Unit Sub-type in a Detachment that includes a model with this special rule may upgrade a machinator array or servo-arm they are equipped with to include an in-built prehensile data-spike for +10 points.
+
+• Interfector Auxilia: Tech-Priest Auxilia units in a Detachment that includes a model with this special rule may choose the Interfector Techno-arcana instead of Enginseer, Lachrimallus, or Reductor options.
+- Interfector: Tech-Priests and Magos Auxilia in the unit are each equipped with a prehensile data-spike. In addition, models in the unit gain the Scout special rule.
+
+• Sacred Mission: A single Arcuitor Magisterium unit in a Detachment that includes a model with this special rule may be taken as an HQ choice. A unit taken in this way loses the Hunter Killer special rule and instead gains the Scout and Court of Executioners special rules. Note that this unit is still a 0-1 choice, so if it is taken as an HQ, another Arcuitor Magisterium unit cannot be taken as an Elites choice and vice versa.
+- Court of Executioners: A unit with this special rule may include up to two additional Arcuitor Magisterium for 110 points each. When deployed onto the battlefield (either at the start of the battle or when arriving from Reserves), all models with this special rule in a unit must be deployed within unit coherency, but afterwards operate independently and are not treated as a unit.
+
+• Scindex-malagrus: A model with this special rule gains the Preferred Enemy (Characters), Precision Strikes (5+) and the Monster Hunter special rules. In addition, a model with this special rule increases their Weapon Skill Characteristic to 5 and Attacks Characteristic to 3.</description>
+            </rule>
+          </rules>
+          <infoLinks>
+            <infoLink id="3879-8145-0a76-f742" name="Preferred Enemy (X)" hidden="false" targetId="37ab-d4db-891a-de8c" type="rule">
+              <modifiers>
+                <modifier type="set" field="name" value="Preferred Enemy (Characters)"/>
+              </modifiers>
+            </infoLink>
+            <infoLink id="7c46-e53d-6dd6-8d7d" name="Precision Strikes (X)" hidden="false" targetId="2206-8497-8fe1-e973" type="rule">
+              <modifiers>
+                <modifier type="set" field="name" value="Precision Strikes (5+)"/>
+              </modifiers>
+            </infoLink>
+            <infoLink id="b6fc-e305-2627-95c4" name="Monster Hunter" hidden="false" targetId="118d-58ce-8611-ab15" type="rule"/>
+          </infoLinks>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="8305-5ac6-f395-e570" name="Myrmidax" publicationId="bde1-6db1-163b-3b76" page="101" hidden="false" collective="false" import="true" type="upgrade">
+          <rules>
+            <rule id="e4ad-3f1e-c347-5d0a" name="Myrmidax" publicationId="bde1-6db1-163b-3b76" page="101" hidden="false">
+              <description>• Avatar of Destruction: A single Thanatar Siege-automata Maniple unit consisting of a single model may be taken as a non-Compulsory HQ choice in a Detachment that includes a model with this special rule. This model must be replaced with a Thanatar-Calix and may not take the Paragon of Metal upgrade. While wholly within 6&quot; of a Thanatar-Calix taken as an HQ choice in this way, friendly Myrmidon Secutor Hosts and Myrmidon Destructor Hosts gain the Line Unit Sub-type and add +1 to the Wounds score used to determine if they win a combat in the Assault phase.
+
+• The Myrmidon Host: Myrmidon Secutor Hosts in a Detachment that includes a model with this special rule may be taken as Troops choices and Myrmidon Destructor Hosts may be taken as Elites choices.
+
+• Vessel of Destruction: A model with this special rule gains the Hatred (Everything) and Bulky (3) special rules. In addition, a model with this special rule increases their Wound Characteristic to 5.</description>
+            </rule>
+          </rules>
+          <infoLinks>
+            <infoLink id="2931-aa55-9066-e89b" name="Bulky (X)" hidden="false" targetId="676c-7b75-4b6f-9405" type="rule">
+              <modifiers>
+                <modifier type="set" field="name" value="Bulky (3)"/>
+              </modifiers>
+            </infoLink>
+            <infoLink id="e7e8-4a46-8209-6455" name="Hatred (X)" hidden="false" targetId="dc0b-fe69-6b71-e0a4" type="rule">
+              <modifiers>
+                <modifier type="set" field="name" value="Hatred (Everything)"/>
+              </modifiers>
+            </infoLink>
+          </infoLinks>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="73dc-f5bb-be45-2547" name="Reductor" publicationId="bde1-6db1-163b-3b76" page="101" hidden="false" collective="false" import="true" type="upgrade">
+          <rules>
+            <rule id="bb15-1388-a02c-6ff5" name="Reductor" publicationId="bde1-6db1-163b-3b76" page="101" hidden="false">
+              <description>• Demolisher: Models with the Battlesmith (X) special rule in a Detachment that includes a model with this special rule may target Buildings with the Battlesmith (X) special rule, in addition to models with the Vehicle, Dreadnought or Automata Unit Type. However, they may neither choose any option in the Battlesmith (X) special rule that restores lost Wounds or Hull Points, nor options that repair Weapon Destroyed or Immobilised results. Instead they may only choose from the following effects:
+- Cause a target Building or model with the Vehicle Unit Type to lose a single Hull Point.
+- Inflict an automatic Wound with no Saves of any kind to a model with the Dreadnought or Automata Unit Type.
+- Inflict an automatic Weapon Destroyed result on a Building or model with the Vehicle Unit Type. The target does not lose a Hull Point as a result of this effect.
+- Inflict an automatic Immobilised result on a model with the Vehicle Unit Type. The target does not lose a Hull Point as a result of this effect.
+
+• Harbinger of Devastation: During the battle’s set-up, but before Objective markers have been placed or deployment has been determined, the player that controls a model with this special rule may nominate up to three areas of terrain, Buildings, or Fortifications. If the chosen item is an area of terrain that provides a Cover Save, then that Cover Save is removed and the area counts as both Difficult Terrain and Dangerous Terrain. If the item chosen is a Building or Fortification then all rolls on the Building Damage table made for that Building or Fortification gain a modifier of +1. If two or more players control models with this special rule, they roll off. They then take turns nominating terrain, starting with the winner of the roll-off, until each player has nominated three pieces of terrain, or chosen to pass. A piece of terrain can only be nominated once by this rule.
+
+• Secrets of Annihilation: A model with this special rule gains the Artificia Reductor Cybertheurgic Arcana, but may not select any other Cybertheurgic Arcana from those available with the Cybertheurgist special rule.</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="bd27-d2a1-da2b-f649" name="Cybertheurgic Arcana" publicationId="bde1-6db1-163b-3b76" page="94" hidden="false" collective="false" import="true">
+      <entryLinks>
+        <entryLink id="a86a-b799-0077-c457" name="Artificia Machina" hidden="false" collective="false" import="true" targetId="51ed-f978-9a5e-1e04" type="selectionEntry"/>
+        <entryLink id="adc1-f74a-b8f5-c935" name="Artificia Cybernetica" hidden="false" collective="false" import="true" targetId="d342-dbdb-33ec-5191" type="selectionEntry"/>
+        <entryLink id="0098-1b87-a87d-08fb" name="Ephemera Incursus" hidden="false" collective="false" import="true" targetId="12fc-d4d8-d36c-6f14" type="selectionEntry"/>
+        <entryLink id="6018-be9c-b4f9-76d0" name="Ephemera Lacyraemarta" hidden="false" collective="false" import="true" targetId="25df-a541-0d05-6f61" type="selectionEntry"/>
+        <entryLink id="0c98-b1ae-1e0c-218d" name="Artificia Reductor" hidden="false" collective="false" import="true" targetId="b627-88f0-ee8c-c43c" type="selectionEntry"/>
+      </entryLinks>
+    </selectionEntryGroup>
   </sharedSelectionEntryGroups>
   <sharedRules>
     <rule id="41ab-227d-9d91-8001" name="Flank Speed" publicationId="bde1-6db1-163b-3b76" page="104" hidden="false">
@@ -4193,6 +4885,21 @@ When deployed onto the battlefield (either at the start of the battle or when ar
     </rule>
     <rule id="66b8-7232-1ed3-3f70" name="God-Engine" publicationId="bde1-6db1-163b-3b76" page="104" hidden="false">
       <description>A model with this special rule ignores all Psychic Powers and Cybertheurgic Rites and Attacks made by Psychic and Cybertheurgic Weapons. In addition, a model with this special rule ignores the effects of the Haywire and Disruption (X) special rules. In all cases, weapons which benefit from these special rules must attempt to damage a model with this special rule normally using the attack’s Strength value. In addition, all friendly Mechanicum units with at least one model within 24&quot; of a model with this special rule gain the Fearless special rule.</description>
+    </rule>
+    <rule id="f83c-9442-8102-5da4" name="Pride of Place" publicationId="bde1-6db1-163b-3b76" page="106" hidden="false">
+      <description>A model with this special rule may not embark upon any model with the Transport Unit Sub-type, regardless of its Unit Type or any special rules the model with the Transport Sub-type may have.</description>
+    </rule>
+    <rule id="f420-6cdb-5d9b-ef30" name="Cybertheurgic Focus" publicationId="bde1-6db1-163b-3b76" page="94" hidden="false">
+      <description>Before making any To Hit rolls with this weapon, the Cybertheurgist must make a Cybertheurgy check. If the Check is passed then the Cybertheurgist may attack as normal using the profile shown for this weapon. If the Check is failed then the Cybertheurgist suffers Cybertheurgic Feedback, and if the model is not removed as a casualty then it may attack as normal but may not use this weapon.</description>
+    </rule>
+    <rule id="3e2e-cdc0-8a31-06f6" name="Data-djinn" publicationId="bde1-6db1-163b-3b76" page="103" hidden="false">
+      <description>When allocated to a model that does not have the Automata, Vehicle or Dreadnought Unit Types or is not a Building or Fortification, any Hits from a weapon with this special rule automatically fail to Wound without any dice being rolled and regardless of the weapon’s Strength or the target’s Toughness.</description>
+    </rule>
+    <rule id="919e-7a5b-6283-3cff" name="Vox Silence" publicationId="bde1-6db1-163b-3b76" page="111" hidden="false">
+      <description>Any models with the Infantry or Cavalry Unit Types in a unit that suffers one or more Hits from a weapon with this special rule must reduce their Leadership by -2 until the start of their controlling player’s next turn. This modifier is not cumulative, and any given unit can only be affected by a single instance of the Vox Silence special rule at a time. Nor is it cumulative with other special rules that negatively modify Leadership. Always use the highest single modifier among those applicable. In addition, units affected by this special rule do not gain the benefits of nuncio vox, command vox or other similar Wargear items until the start of their controlling player’s next turn. Units that include one or more models with the Stubborn special rule ignore this effect.</description>
+    </rule>
+    <rule id="0893-4bd0-d5a1-14db" name="Patris Cybernetica" publicationId="bde1-6db1-163b-3b76" page="106" hidden="false">
+      <description>An Independent Character with this special rule may join a unit composed of models with the Automata Unit Type or Monstrous Unit Sub-type. However they cannot join a unit which contains models of any other Unit Type if the model with this rule also has the Automata or Dreadnought Unit Type, or the Monstrous Unit Sub-type.</description>
     </rule>
   </sharedRules>
   <sharedProfiles>

--- a/2022 - Mechanicum.cat
+++ b/2022 - Mechanicum.cat
@@ -87,7 +87,6 @@
       <categoryLinks>
         <categoryLink id="6658-9df3-d4ac-70d7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="f1b8-f9a4-e1fb-c21f" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="878a-d92e-8123-7041" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="de1b-2a5f-b271-fd61" name="Arlatax Battle-Automata Maniple (Placeholder)" hidden="false" collective="false" import="true" targetId="b178-7d35-136f-d305" type="selectionEntry">

--- a/2022 - Mechanicum.cat
+++ b/2022 - Mechanicum.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="c247-da79-1654-d39e" name="2022 - Mechanicum" revision="3" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="13" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="c247-da79-1654-d39e" name="2022 - Mechanicum" revision="4" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="14" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entryLinks>
     <entryLink id="29c6-0ec7-0162-e817" name="Mechanicum" hidden="false" collective="false" import="false" targetId="ddf5-d792-3146-6e9a" type="selectionEntry">
       <constraints>
@@ -51,6 +51,13 @@
       </categoryLinks>
     </entryLink>
     <entryLink id="d629-dd69-e689-c38a" name="Arcuitor Magisterium (Placeholder)" hidden="false" collective="false" import="true" targetId="6f33-657c-a1b4-710e" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <conditions>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="greaterThan"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="4833-3ad9-f086-2980" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="0c0f-9a1e-4050-56d4" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
@@ -175,6 +182,13 @@
       </categoryLinks>
     </entryLink>
     <entryLink id="3c04-f537-6cf1-65bc" name="Castellax Battle-Automata Maniple " hidden="false" collective="false" import="true" targetId="537f-846d-90e3-2526" type="selectionEntry">
+      <modifiers>
+        <modifier type="add" field="category" value="6399-5c65-7833-1025">
+          <conditions>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9bcd-f556-5740-2f9f" type="greaterThan"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="b52a-0f4e-b317-2bcd" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="12ad-c3f3-cdb7-1735" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
@@ -199,6 +213,76 @@
         <categoryLink id="22c6-2c40-c433-b524" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
       </categoryLinks>
     </entryLink>
+    <entryLink id="0d52-bf5d-15d6-0470" name="Tech-Priest Auxilia (Placeholder)" hidden="true" collective="false" import="true" targetId="0eae-0c52-1087-a3b0" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <conditions>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1247-a94b-070d-2a7b" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="22e8-b76e-e559-5ac5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="093d-3993-8774-9f21" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="a311-28b2-65d1-193d" name="Arcuitor Magisterium (Placeholder)" hidden="true" collective="false" import="true" targetId="6f33-657c-a1b4-710e" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="greaterThan"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5e62-8d7e-a487-0490" type="greaterThan"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="ac20-54eb-277f-85ca" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="a52f-f980-0f7d-36c3" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="d1c5-ff4b-1a9e-2a92" name="Thanatar Siege-automata Maniple" hidden="true" collective="false" import="true" targetId="2903-fef6-e839-368b" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <conditions>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8305-5ac6-f395-e570" type="greaterThan"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="19e9-28c4-f881-a0b3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="db76-cda6-0690-9f5c" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="3ca2-40e2-1b7e-b0b3" name="Myrmidon Secutor Host (Placeholder)" hidden="true" collective="false" import="true" targetId="1869-2d16-d825-04c3" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <conditions>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8305-5ac6-f395-e570" type="greaterThan"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="e4bc-e382-e2f4-1151" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="6609-996b-bd48-3075" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="001b-6e55-0b99-c015" name="Myrmidon Destructor Host (Placeholder)" hidden="true" collective="false" import="true" targetId="356f-a88b-1d13-3700" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <conditions>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8305-5ac6-f395-e570" type="greaterThan"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="9a3c-7e17-b013-675c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="7c96-b532-93cb-02c2" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+      </categoryLinks>
+    </entryLink>
   </entryLinks>
   <sharedSelectionEntries>
     <selectionEntry id="7c8d-b21a-1f72-7e22" name="Upgrade Points (Placeholders)" hidden="false" collective="false" import="true" type="upgrade">
@@ -210,26 +294,143 @@
       <constraints>
         <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7627-04e3-89f2-e14f" type="max"/>
       </constraints>
+      <profiles>
+        <profile id="17bc-b919-f988-4e8a" name="Archmagos Prime" publicationId="bde1-6db1-163b-3b76" page="20" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName="Unit">
+          <modifiers>
+            <modifier type="set" field="cc42-7ed5-7092-5c84" value="5">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5e62-8d7e-a487-0490" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="set" field="f111-2ce5-dd12-d6b0" value="3">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5e62-8d7e-a487-0490" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="set" field="57ee-1126-32a9-5672" value="5">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8305-5ac6-f395-e570" type="greaterThan"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <characteristics>
+            <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Cybertheurgist, Character)</characteristic>
+            <characteristic name="Move" typeId="893e-2d76-8f04-44e5">6</characteristic>
+            <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
+            <characteristic name="BS" typeId="74ae-c840-0036-d244">5</characteristic>
+            <characteristic name="S" typeId="e478-41d4-a092-48a8">5</characteristic>
+            <characteristic name="T" typeId="c32b-5fdd-3fbe-9b1f">5</characteristic>
+            <characteristic name="W" typeId="57ee-1126-32a9-5672">3</characteristic>
+            <characteristic name="I" typeId="62d3-22d7-2d49-52dc">4</characteristic>
+            <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">2</characteristic>
+            <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">10</characteristic>
+            <characteristic name="Save" typeId="e593-6b3c-f169-04f0">2+</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
       <categoryLinks>
         <categoryLink id="fc8b-7c82-9965-120f" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
         <categoryLink id="699b-4a76-ee6f-f722" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="2eab-eaf4-105a-f2a0" name="Cybertheurgist" hidden="false" targetId="57a1-ae47-ff1b-36e4" primary="false"/>
       </categoryLinks>
-      <selectionEntries>
-        <selectionEntry id="1e18-34a0-fdae-d2d5" name="Archmagos Prime " publicationId="bde1-6db1-163b-3b76" page="20" hidden="false" collective="false" import="true" type="model">
+      <selectionEntryGroups>
+        <selectionEntryGroup id="f96e-eae0-68fa-be28" name="Cybertheurgic Arcana" hidden="false" collective="false" import="true">
+          <modifiers>
+            <modifier type="set" field="3701-d454-88b0-a947" value="2.0">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2cd1-fe10-db22-54bd" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="set" field="b3d1-0513-1249-ae81" value="2.0">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2cd1-fe10-db22-54bd" type="greaterThan"/>
+              </conditions>
+            </modifier>
+          </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="878f-00fd-c5a4-fea9" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0f0f-c00f-03d5-77e0" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3701-d454-88b0-a947" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b3d1-0513-1249-ae81" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="a196-485d-c1fc-b6cb" name="Warlord" hidden="false" collective="false" import="true" targetId="0176-56a3-d590-b103" type="selectionEntry"/>
+            <entryLink id="b805-864e-e177-a3e8" name="Ephemera Lacyraemarta" hidden="true" collective="false" import="true" targetId="25df-a541-0d05-6f61" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="hidden" value="false">
+                  <conditions>
+                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bd4b-63fa-928c-887d" type="greaterThan"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+            </entryLink>
+            <entryLink id="0ff0-07e8-a1b1-9fbd" name="Artificia Machina" hidden="false" collective="false" import="true" targetId="51ed-f978-9a5e-1e04" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bd4b-63fa-928c-887d" type="greaterThan"/>
+                        <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="73dc-f5bb-be45-2547" type="greaterThan"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
+            </entryLink>
+            <entryLink id="7ded-27cc-e57e-bf87" name="Ephemera Incursus" hidden="false" collective="false" import="true" targetId="12fc-d4d8-d36c-6f14" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bd4b-63fa-928c-887d" type="greaterThan"/>
+                        <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="73dc-f5bb-be45-2547" type="greaterThan"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
+            </entryLink>
+            <entryLink id="8aba-8369-430a-d197" name="Artificia Cybernetica" hidden="false" collective="false" import="true" targetId="d342-dbdb-33ec-5191" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bd4b-63fa-928c-887d" type="greaterThan"/>
+                        <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="73dc-f5bb-be45-2547" type="greaterThan"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
+            </entryLink>
+            <entryLink id="756e-9e13-103f-1228" name="Artificia Reductor" hidden="true" collective="false" import="true" targetId="b627-88f0-ee8c-c43c" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="hidden" value="false">
+                  <conditions>
+                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="73dc-f5bb-be45-2547" type="greaterThan"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+            </entryLink>
           </entryLinks>
-          <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="830a-54b7-2ab0-8382" name="Upgrade Points (Placeholders)" hidden="false" collective="false" import="true" targetId="7c8d-b21a-1f72-7e22" type="selectionEntry"/>
+        <entryLink id="34f8-3711-2e5b-5bad" name="Warlord" hidden="false" collective="false" import="true" targetId="0176-56a3-d590-b103" type="selectionEntry">
+          <modifiers>
+            <modifier type="set" field="ff1b-f9d7-b417-c057" value="1.0">
+              <conditions>
+                <condition field="selections" scope="d0f2-ee39-450c-39db" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2cd1-fe10-db22-54bd" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ff1b-f9d7-b417-c057" type="min"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="fe5d-5729-e3c2-771e" name="Upgrade Points (Placeholders)" hidden="false" collective="false" import="true" targetId="7c8d-b21a-1f72-7e22" type="selectionEntry"/>
+        <entryLink id="4417-2a5d-c0ec-dd84" name="Orders of High Techno-arcana" hidden="false" collective="false" import="true" targetId="c36b-a6a2-9cb2-b090" type="selectionEntryGroup"/>
+        <entryLink id="3ed3-cc97-d116-35df" name="Feudal Hierarchy" hidden="false" collective="false" import="true" targetId="27ff-3ae1-5cb6-774b" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="155.0"/>
@@ -239,27 +440,138 @@
       <constraints>
         <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3a42-ed80-41ab-7cb1" type="max"/>
       </constraints>
+      <profiles>
+        <profile id="4707-5f1c-c47a-07e0" name="Archmagos Prime on Abeyant" publicationId="bde1-6db1-163b-3b76" page="22" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName="Unit">
+          <modifiers>
+            <modifier type="set" field="cc42-7ed5-7092-5c84" value="5">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5e62-8d7e-a487-0490" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="set" field="f111-2ce5-dd12-d6b0" value="3">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5e62-8d7e-a487-0490" type="greaterThan"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <characteristics>
+            <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Monstrous, Antigrav, Cybertheurgist, Character)</characteristic>
+            <characteristic name="Move" typeId="893e-2d76-8f04-44e5">6</characteristic>
+            <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
+            <characteristic name="BS" typeId="74ae-c840-0036-d244">5</characteristic>
+            <characteristic name="S" typeId="e478-41d4-a092-48a8">5</characteristic>
+            <characteristic name="T" typeId="c32b-5fdd-3fbe-9b1f">6</characteristic>
+            <characteristic name="W" typeId="57ee-1126-32a9-5672">5</characteristic>
+            <characteristic name="I" typeId="62d3-22d7-2d49-52dc">3</characteristic>
+            <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">2</characteristic>
+            <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">10</characteristic>
+            <characteristic name="Save" typeId="e593-6b3c-f169-04f0">2+</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
       <categoryLinks>
         <categoryLink id="8bf8-9627-3e73-b8bc" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
         <categoryLink id="6a96-9d2f-a329-7562" name="Monstrous Sub-type:" hidden="false" targetId="7d95-f9d1-440a-67bd" primary="false"/>
         <categoryLink id="ff95-2620-6ec4-9e60" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
       </categoryLinks>
-      <selectionEntries>
-        <selectionEntry id="0738-353d-bfc2-3c6d" name="Archmagos Prime on Abeyant" publicationId="bde1-6db1-163b-3b76" page="22" hidden="false" collective="false" import="true" type="model">
+      <selectionEntryGroups>
+        <selectionEntryGroup id="1906-287d-d848-d9b6" name="Cybertheurgic Arcana" hidden="false" collective="false" import="true">
+          <modifiers>
+            <modifier type="set" field="e268-664b-629f-444b" value="2.0">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2cd1-fe10-db22-54bd" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="set" field="737d-08c3-9945-3527" value="2.0">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2cd1-fe10-db22-54bd" type="greaterThan"/>
+              </conditions>
+            </modifier>
+          </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e6f3-51e9-7a76-292e" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3e0f-719e-7b0c-a282" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e268-664b-629f-444b" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="737d-08c3-9945-3527" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="390b-6386-3362-3c62" name="Warlord" hidden="false" collective="false" import="true" targetId="0176-56a3-d590-b103" type="selectionEntry"/>
+            <entryLink id="c9c8-73e7-da3a-94b6" name="Ephemera Lacyraemarta" hidden="true" collective="false" import="true" targetId="25df-a541-0d05-6f61" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="hidden" value="false">
+                  <conditions>
+                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bd4b-63fa-928c-887d" type="greaterThan"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+            </entryLink>
+            <entryLink id="6aef-752f-c493-d67a" name="Artificia Machina" hidden="false" collective="false" import="true" targetId="51ed-f978-9a5e-1e04" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bd4b-63fa-928c-887d" type="greaterThan"/>
+                        <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="73dc-f5bb-be45-2547" type="greaterThan"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
+            </entryLink>
+            <entryLink id="9a09-1b52-c2a1-8a67" name="Ephemera Incursus" hidden="false" collective="false" import="true" targetId="12fc-d4d8-d36c-6f14" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bd4b-63fa-928c-887d" type="greaterThan"/>
+                        <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="73dc-f5bb-be45-2547" type="greaterThan"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
+            </entryLink>
+            <entryLink id="5eed-b694-9170-88dc" name="Artificia Cybernetica" hidden="false" collective="false" import="true" targetId="d342-dbdb-33ec-5191" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bd4b-63fa-928c-887d" type="greaterThan"/>
+                        <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="73dc-f5bb-be45-2547" type="greaterThan"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
+            </entryLink>
+            <entryLink id="221a-4910-3210-71d0" name="Artificia Reductor" hidden="true" collective="false" import="true" targetId="b627-88f0-ee8c-c43c" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="hidden" value="false">
+                  <conditions>
+                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="73dc-f5bb-be45-2547" type="greaterThan"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+            </entryLink>
           </entryLinks>
-          <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
       <entryLinks>
         <entryLink id="11bd-b0d7-ac49-5e45" name="Upgrade Points (Placeholders)" hidden="false" collective="false" import="true" targetId="7c8d-b21a-1f72-7e22" type="selectionEntry"/>
+        <entryLink id="080a-3d66-7fa3-b65d" name="Warlord" hidden="false" collective="false" import="true" targetId="0176-56a3-d590-b103" type="selectionEntry">
+          <modifiers>
+            <modifier type="set" field="a96c-007d-083d-b58c" value="1.0">
+              <conditions>
+                <condition field="selections" scope="3821-7503-6139-3054" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2cd1-fe10-db22-54bd" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a96c-007d-083d-b58c" type="min"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="51ec-4169-13a5-abe4" name="Orders of High Techno-arcana" hidden="false" collective="false" import="true" targetId="c36b-a6a2-9cb2-b090" type="selectionEntryGroup"/>
+        <entryLink id="a990-eb17-4c30-6fbb" name="Feudal Hierarchy" hidden="false" collective="false" import="true" targetId="27ff-3ae1-5cb6-774b" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="185.0"/>
@@ -271,22 +583,9 @@
         <categoryLink id="176d-fff6-f157-330a" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="a16c-e7f6-08fc-a357" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
       </categoryLinks>
-      <selectionEntries>
-        <selectionEntry id="4a2d-63b4-6d19-0e60" name="Magos Dominus" publicationId="bde1-6db1-163b-3b76" page="24" hidden="false" collective="false" import="true" type="model">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="024c-d512-9532-95f8" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0471-4b2f-6020-b6cb" type="max"/>
-          </constraints>
-          <entryLinks>
-            <entryLink id="8203-c3ae-baa1-45f9" name="Warlord" hidden="false" collective="false" import="true" targetId="0176-56a3-d590-b103" type="selectionEntry"/>
-          </entryLinks>
-          <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
       <entryLinks>
         <entryLink id="a63a-9dfe-ee64-913c" name="Upgrade Points (Placeholders)" hidden="false" collective="false" import="true" targetId="7c8d-b21a-1f72-7e22" type="selectionEntry"/>
+        <entryLink id="9dcc-9b17-198f-5691" name="Warlord" hidden="false" collective="false" import="true" targetId="0176-56a3-d590-b103" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="75.0"/>
@@ -299,22 +598,9 @@
         <categoryLink id="f75f-bd69-3fb1-c37d" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="ad3f-ad1c-6a50-2d8c" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
       </categoryLinks>
-      <selectionEntries>
-        <selectionEntry id="61ec-7e8f-3cb2-eea2" name="Magos Dominus on Abeyant" publicationId="bde1-6db1-163b-3b76" page="25" hidden="false" collective="false" import="true" type="model">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="840f-7afb-7ada-2311" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f43f-6c6e-38c5-4b57" type="max"/>
-          </constraints>
-          <entryLinks>
-            <entryLink id="e6f4-dfdb-0ce7-7628" name="Warlord" hidden="false" collective="false" import="true" targetId="0176-56a3-d590-b103" type="selectionEntry"/>
-          </entryLinks>
-          <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
       <entryLinks>
         <entryLink id="1380-c529-afc1-fec4" name="Upgrade Points (Placeholders)" hidden="false" collective="false" import="true" targetId="7c8d-b21a-1f72-7e22" type="selectionEntry"/>
+        <entryLink id="fc61-b732-41ab-b1b8" name="Warlord" hidden="false" collective="false" import="true" targetId="0176-56a3-d590-b103" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="105.0"/>
@@ -324,7 +610,7 @@
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="greaterThan"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="greaterThan"/>
           </conditions>
         </modifier>
       </modifiers>
@@ -334,22 +620,21 @@
       <categoryLinks>
         <categoryLink id="4870-4291-805f-07db" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
       </categoryLinks>
-      <selectionEntries>
-        <selectionEntry id="4c5f-370c-7dfe-c488" name="Calleb Decima Invictus" publicationId="bde1-6db1-163b-3b76" page="26" hidden="false" collective="false" import="true" type="model">
+      <selectionEntryGroups>
+        <selectionEntryGroup id="0ad9-b637-48ef-d9ca" name="Guardian Retinue" hidden="false" collective="false" import="true">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6d2a-c0d2-b4bb-41c0" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="47a1-0cdf-9ad4-4ca9" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a3bd-333f-c92b-7cca" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="060c-f269-5410-5819" name="Warlord" hidden="false" collective="false" import="true" targetId="0176-56a3-d590-b103" type="selectionEntry"/>
+            <entryLink id="aaf4-a361-cb00-532c" name="Tech-Priest Auxilia (Placeholder)" hidden="false" collective="false" import="true" targetId="0eae-0c52-1087-a3b0" type="selectionEntry"/>
+            <entryLink id="28da-44a5-3785-0b1d" name="Scyllax Guardian-Automata Maniple (Placeholder)" hidden="false" collective="false" import="true" targetId="57ab-2409-6707-b967" type="selectionEntry"/>
           </entryLinks>
-          <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
       <entryLinks>
         <entryLink id="f0bb-1603-401f-ad2a" name="Upgrade Points (Placeholders)" hidden="false" collective="false" import="true" targetId="7c8d-b21a-1f72-7e22" type="selectionEntry"/>
+        <entryLink id="bc40-d9d2-9a73-a9e6" name="Warlord" hidden="false" collective="false" import="true" targetId="0176-56a3-d590-b103" type="selectionEntry"/>
+        <entryLink id="d123-3dad-767a-3dab" name="Feudal Hierarchy" hidden="false" collective="false" import="true" targetId="27ff-3ae1-5cb6-774b" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="200.0"/>
@@ -362,6 +647,92 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9b4a-a1f4-d598-6560" type="min"/>
             <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="64d9-295f-21ea-27d9" type="max"/>
           </constraints>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="00db-3638-6000-b067" name="Techno-Arcana" publicationId="bde1-6db1-163b-3b76" page="29" hidden="false" collective="false" import="true">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="99b2-12de-3b94-b707" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="18fd-06bd-5c73-1019" type="max"/>
+              </constraints>
+              <selectionEntries>
+                <selectionEntry id="42f9-e690-11a6-4b1a" name="Enginseer" publicationId="bde1-6db1-163b-3b76" page="29" hidden="false" collective="false" import="true" type="upgrade">
+                  <modifiers>
+                    <modifier type="set" field="a71b-2300-5eb8-03dc" value="1.0">
+                      <conditionGroups>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="primary-category" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9b5d-fac7-799b-d7e7" type="instanceOf"/>
+                            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1247-a94b-070d-2a7b" type="greaterThan"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a71b-2300-5eb8-03dc" type="min"/>
+                  </constraints>
+                  <rules>
+                    <rule id="ca01-10d0-a753-6fa2" name="Enginseer" publicationId="bde1-6db1-163b-3b76" page="29" hidden="false">
+                      <description>Tech-Priests and Magos Auxilia in the unit are each equipped with a servo-arm. While the unit contains any number of Servo-automata, Tech-Priests and Magos Auxilia in the unit improve their Battlesmith (X) special rule to Battlesmith (4+). </description>
+                    </rule>
+                  </rules>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="94f3-8a54-ed2e-5cfb" name="Lachrimallus" publicationId="bde1-6db1-163b-3b76" page="29" hidden="false" collective="false" import="true" type="upgrade">
+                  <rules>
+                    <rule id="3452-6b13-669c-e68c" name="Lachrimallus" publicationId="bde1-6db1-163b-3b76" page="29" hidden="false">
+                      <description>Tech-Priests, Magos Auxilia and Servo-automata in the unit have the Feel No Pain (5+) special rule. Friendly Adsecularis Tech-thrall units with at least one model within 6&quot; of one or more Tech-Priest or Magos Auxilia with this special rule add +1 to their Feel No Pain Damage Mitigation rolls or the Feel No Pain (6+) special rule if they do not already possess the Feel No Pain (X) special rule. </description>
+                    </rule>
+                  </rules>
+                  <infoLinks>
+                    <infoLink id="64bc-bbee-5358-be8a" name="Feel No Pain (X)" hidden="false" targetId="ec46-ff29-32e0-c2aa" type="rule"/>
+                  </infoLinks>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="0749-4e5b-1bf4-a4ab" name="Reductor" publicationId="bde1-6db1-163b-3b76" page="29" hidden="false" collective="false" import="true" type="upgrade">
+                  <rules>
+                    <rule id="dbfc-425c-3aa6-9123" name="Reductor" publicationId="bde1-6db1-163b-3b76" page="29" hidden="false">
+                      <description>Tech-Priests and Magos Auxilia in the unit are each equipped with a servo-arm, and all models in the unit gain the Sunder and Wrecker special rules. Magos Auxilia may exchange their servo-arm for either a conversion beamer or graviton imploder for +25 points each. </description>
+                    </rule>
+                  </rules>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="757a-cd91-e5f1-b5f7" name="Interfector" hidden="true" collective="false" import="true" type="upgrade">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="false">
+                      <conditions>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5e62-8d7e-a487-0490" type="greaterThan"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <rules>
+                    <rule id="7043-476d-533c-93a2" name="Interfector" publicationId="bde1-6db1-163b-3b76" page="100" hidden="false">
+                      <description>Tech-Priests and Magos Auxilia in the unit are each equipped with a prehensile data-spike. In addition, models in the unit gain the Scout special rule.</description>
+                    </rule>
+                  </rules>
+                  <infoLinks>
+                    <infoLink id="522d-e3ed-7ce3-92fe" name="Scout" hidden="false" targetId="aacf-9a7e-982d-b793" type="rule"/>
+                  </infoLinks>
+                  <entryLinks>
+                    <entryLink id="6a15-2014-925e-8d4c" name=" Prehensile Data-Spike" hidden="false" collective="true" import="true" targetId="2a20-c068-3230-ad17" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0e2e-79f2-0021-77f3" type="min"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ce85-1432-520f-0da3" type="max"/>
+                      </constraints>
+                    </entryLink>
+                  </entryLinks>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0"/>
           </costs>
@@ -394,26 +765,41 @@
       </costs>
     </selectionEntry>
     <selectionEntry id="6f33-657c-a1b4-710e" name="Arcuitor Magisterium (Placeholder)" publicationId="bde1-6db1-163b-3b76" page="30" hidden="true" collective="false" import="true" type="unit">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="greaterThan"/>
-          </conditions>
-        </modifier>
-      </modifiers>
       <selectionEntries>
         <selectionEntry id="b9e8-8c2b-084c-1952" name="Arcuitor" publicationId="bde1-6db1-163b-3b76" page="30" hidden="false" collective="false" import="true" type="model">
+          <modifiers>
+            <modifier type="set" field="b335-3906-c30c-81d8" value="3.0">
+              <conditions>
+                <condition field="selections" scope="primary-category" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4f85-eb33-30c9-8f51" type="instanceOf"/>
+              </conditions>
+            </modifier>
+          </modifiers>
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b42a-2aa0-028a-7865" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b335-3906-c30c-81d8" type="max"/>
           </constraints>
+          <rules>
+            <rule id="6957-b5ed-1429-1231" name="Court of Executioners" publicationId="bde1-6db1-163b-3b76" page="100" hidden="false">
+              <description>A unit with this special rule may include up to two additional Arcuitor Magisterium for 110 points each. When deployed onto the battlefield (either at the start of the battle or when arriving from Reserves), all models with this special rule in a unit must be deployed within unit coherency, but afterwards operate independently and are not treated as a unit.</description>
+            </rule>
+          </rules>
+          <infoLinks>
+            <infoLink id="f23f-5b3c-2874-6306" name="Scout" hidden="false" targetId="aacf-9a7e-982d-b793" type="rule"/>
+          </infoLinks>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="110.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
         <selectionEntryGroup id="4ed0-53aa-6a8b-10fe" name="Hunter Killer" hidden="false" collective="false" import="true">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="primary-category" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4f85-eb33-30c9-8f51" type="instanceOf"/>
+              </conditions>
+            </modifier>
+          </modifiers>
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2024-57a7-0e42-2a3e" type="max"/>
           </constraints>
@@ -443,7 +829,7 @@ This unit may be upgraded freely as described in their profile, though they may 
         <entryLink id="c52b-c6b0-8dc4-9546" name="Upgrade Points (Placeholders)" hidden="false" collective="false" import="true" targetId="7c8d-b21a-1f72-7e22" type="selectionEntry"/>
       </entryLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="85.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="-25.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="1869-2d16-d825-04c3" name="Myrmidon Secutor Host (Placeholder)" publicationId="bde1-6db1-163b-3b76" page="32" hidden="false" collective="false" import="true" type="unit">
@@ -830,29 +1216,49 @@ This unit may be upgraded freely as described in their profile, though they may 
         <categoryLink id="1048-d3fc-35af-c693" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="75ce-3f3b-dc4a-ecad" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
       </categoryLinks>
-      <selectionEntries>
-        <selectionEntry id="42df-5e10-be80-f13a" name="Anacharis Scoria" publicationId="bde1-6db1-163b-3b76" page="62" hidden="false" collective="false" import="true" type="model">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1565-e3d8-ebc6-89c9" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bdf5-456d-95ed-c766" type="max"/>
-          </constraints>
-          <entryLinks>
-            <entryLink id="2dc5-2c49-78b8-6a9b" name="Warlord" hidden="false" collective="false" import="true" targetId="0176-56a3-d590-b103" type="selectionEntry">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c03e-735c-c6af-7c13" type="min"/>
-              </constraints>
-            </entryLink>
-          </entryLinks>
-          <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
       <entryLinks>
         <entryLink id="acc5-93d9-18f8-008f" name="Upgrade Points (Placeholders)" hidden="false" collective="false" import="true" targetId="7c8d-b21a-1f72-7e22" type="selectionEntry"/>
+        <entryLink id="8fca-c03a-73a7-e888" name="Warlord" hidden="false" collective="false" import="true" targetId="0176-56a3-d590-b103" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1b6d-6b67-f0eb-d494" type="min"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="d607-72a9-d945-8779" name="Feudal Hierarchy" hidden="false" collective="false" import="true" targetId="27ff-3ae1-5cb6-774b" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="365.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="2a20-c068-3230-ad17" name=" Prehensile Data-Spike" publicationId="bde1-6db1-163b-3b76" page="123" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="2406-ef6a-7e5f-bf1b" name=" Prehensile Data-Spike" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="95ba-cda7-b831-6066">-</characteristic>
+            <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">5</characteristic>
+            <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">4</characteristic>
+            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Melee, Breaching (4+), Murderous Strike (6+), Reach (2)</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="77a6-d876-9bb2-7883" name="Breaching (X)" hidden="false" targetId="a760-f736-1bf3-fa3c" type="rule">
+          <modifiers>
+            <modifier type="set" field="name" value="Breaching (4+)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="34c3-c042-3e68-3202" name="Murderous Strike (X)" hidden="false" targetId="93b9-1454-0e7c-42ae" type="rule">
+          <modifiers>
+            <modifier type="set" field="name" value="Murderous Strike (6+)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="78cb-7697-69e7-1948" name="Reach (X)" hidden="false" targetId="19bf-62a2-5737-890b" type="rule">
+          <modifiers>
+            <modifier type="set" field="name" value="Reach (2)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
       </costs>
     </selectionEntry>
   </sharedSelectionEntries>

--- a/2022 - Questoris Household.cat
+++ b/2022 - Questoris Household.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="92b4-d476-8b4c-e7ef" name="2022 - Questoris Household" revision="2" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="12" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="92b4-d476-8b4c-e7ef" name="2022 - Questoris Household" revision="3" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="14" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <forceEntries>
     <forceEntry id="28d3-4be2-608d-bf8a" name="Questoris Household Force Organisation Chart" hidden="false">
       <categoryLinks>
@@ -118,13 +118,7 @@
         <categoryLink id="9f63-749f-01c1-f860" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="8651-9463-821d-db3a" name="Archmagos Draykavac (Placeholder)" hidden="false" collective="false" import="true" targetId="8b4c-01f4-f39f-7c55" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="5008-a53a-6786-d9cf" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="8ff1-561d-b9e0-a956" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-      </categoryLinks>
-    </entryLink>
-    <entryLink id="a1b2-9894-0769-31af" name="Castellax Battle-Automata Maniple " hidden="true" collective="false" import="true" targetId="537f-846d-90e3-2526" type="selectionEntry">
+    <entryLink id="a1b2-9894-0769-31af" name="Castellax Battle-Automata Maniple " hidden="true" collective="false" import="false" targetId="537f-846d-90e3-2526" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
@@ -137,7 +131,7 @@
         <categoryLink id="a47d-d432-118d-bd75" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="cbc2-40d7-1ad8-6430" name="Vorax Battle-automata Maniple" hidden="true" collective="false" import="true" targetId="f144-1079-11ff-019d" type="selectionEntry">
+    <entryLink id="cbc2-40d7-1ad8-6430" name="Vorax Battle-automata Maniple" hidden="true" collective="false" import="false" targetId="f144-1079-11ff-019d" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
@@ -148,6 +142,12 @@
       <categoryLinks>
         <categoryLink id="dff8-4608-5fa0-9dbd" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="4264-d41e-828b-e3e0" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="a855-6cea-2eb6-3f9f" name="Archmagos Draykavac" hidden="false" collective="false" import="false" targetId="8b4c-01f4-f39f-7c55" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="bea2-c10e-0d10-7b82" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="5eea-7318-5183-f1e4" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
       </categoryLinks>
     </entryLink>
   </entryLinks>


### PR DESCRIPTION
GST
All Legion and the Mech Warlord traits added / finished
Made "Reactions" profile

Added the Mech advanced reaction

LA
Added Combat air partrol reaction and linked it into Xyphon interceptor.

Mech Library
Archmagos Draykavac completed
Added Cybertheurgic Arcana SSEG and the SE's for each.
Added Order's of High Techno-arcana and started some linking.

Mech 
Started to flesh out some of the Mech stuff

Questoris Knights
Added root for Archmagos Draykavac. and unhide links for Cassy and Vorax if he is taken.

