### PR TITLE
More Mechy Updates (just Elites and HQ to finish)

### DIFF
--- a/2022 - Mech Library.cat
+++ b/2022 - Mech Library.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="3129-da35-55e0-642d" name="2022 - Mech Library" revision="5" battleScribeVersion="2.03" library="true" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="14" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="3129-da35-55e0-642d" name="2022 - Mech Library" revision="5" battleScribeVersion="2.03" library="true" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="15" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <categoryEntries>
     <categoryEntry id="4086-0589-f010-e688" name="Titan Legion Min Troop/LoW" hidden="false"/>
     <categoryEntry id="57a1-ae47-ff1b-36e4" name="Cybertheurgist" publicationId="bde1-6db1-163b-3b76" page="92-96" hidden="false"/>
@@ -3148,9 +3148,14 @@ Invulnerable Saves granted by a mag-inverter shield do not stack with other Invu
           <profiles>
             <profile id="2b2b-6a5d-8e25-8dfa" name="Castellax" publicationId="bde1-6db1-163b-3b76" page="37" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName="Unit">
               <modifiers>
-                <modifier type="increment" field="f111-2ce5-dd12-d6b0" value="1">
+                <modifier type="increment" field="57ee-1126-32a9-5672" value="1">
                   <conditions>
-                    <condition field="selections" scope="ab78-91e2-bb5c-9da3" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2121-ee7c-8ac9-5133" type="equalTo"/>
+                    <condition field="selections" scope="ab78-91e2-bb5c-9da3" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="cc2a-46fe-bbf3-6ba2" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="increment" field="cc42-7ed5-7092-5c84" value="1">
+                  <conditions>
+                    <condition field="selections" scope="ab78-91e2-bb5c-9da3" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="cc2a-46fe-bbf3-6ba2" type="equalTo"/>
                   </conditions>
                 </modifier>
               </modifiers>
@@ -3196,44 +3201,85 @@ Invulnerable Saves granted by a mag-inverter shield do not stack with other Invu
                 </entryLink>
               </entryLinks>
             </selectionEntryGroup>
-            <selectionEntryGroup id="ef5c-5de1-f9e9-cee9" name="B) May Exchange both Melee Weapons for:" hidden="false" collective="false" import="true" defaultSelectionEntryId="4489-7b65-efb9-4aa8">
+            <selectionEntryGroup id="ef5c-5de1-f9e9-cee9" name="B) May Exchange both Melee Weapons for:" hidden="false" collective="false" import="true" defaultSelectionEntryId="af01-d4da-d454-2d29">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5fd7-68b0-a7d5-b8b5" type="max"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2475-8aae-97e6-b889" type="min"/>
               </constraints>
-              <entryLinks>
-                <entryLink id="4489-7b65-efb9-4aa8" name="Shock Charger" hidden="false" collective="false" import="true" targetId="3234-492f-9ebf-f23c" type="selectionEntry">
-                  <modifiers>
-                    <modifier type="set" field="name" value="Two Shock Charger"/>
-                  </modifiers>
-                </entryLink>
-                <entryLink id="3534-5161-38c0-2e9d" name="Siege Wrecker" hidden="false" collective="false" import="true" targetId="178d-8a3a-bfda-7443" type="selectionEntry"/>
-                <entryLink id="d14d-8ddf-a1c7-8391" name="Power Blade Array" hidden="false" collective="false" import="true" targetId="2121-ee7c-8ac9-5133" type="selectionEntry">
-                  <modifiers>
-                    <modifier type="set" field="name" value="Two Power Blade Array"/>
-                  </modifiers>
-                </entryLink>
-              </entryLinks>
+              <selectionEntries>
+                <selectionEntry id="cf13-fe20-b0a5-88e3" name="Siege Wrecker &amp; Shock Charger" hidden="false" collective="false" import="true" type="upgrade">
+                  <entryLinks>
+                    <entryLink id="c874-628d-f075-71b0" name="Siege Wrecker" hidden="false" collective="true" import="true" targetId="178d-8a3a-bfda-7443" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1d98-c81c-d3ff-a863" type="min"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dddf-41f4-a971-5dcf" type="max"/>
+                      </constraints>
+                    </entryLink>
+                    <entryLink id="ac2a-9e7e-e955-9460" name="Shock Charger" hidden="false" collective="true" import="true" targetId="3234-492f-9ebf-f23c" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5b79-7ce4-bd06-a0ae" type="min"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5f09-8bc0-268a-a4d5" type="max"/>
+                      </constraints>
+                    </entryLink>
+                  </entryLinks>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="b48d-19d0-6116-af9d" name="Two Power Blade Arrays*" hidden="false" collective="false" import="true" type="upgrade">
+                  <rules>
+                    <rule id="5163-d31f-e2ff-b4f2" name="Two Power Blade Arrays*" publicationId="bde1-6db1-163b-3b76" page="37" hidden="false">
+                      <description>A Castellax with two power blade arrays gains an additional Attack.</description>
+                    </rule>
+                  </rules>
+                  <entryLinks>
+                    <entryLink id="53f7-0e77-0d69-7639" name="Power Blade Array" hidden="false" collective="false" import="true" targetId="2121-ee7c-8ac9-5133" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ef6c-fd23-95da-b815" type="min"/>
+                        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8428-80d0-ef90-ce59" type="max"/>
+                      </constraints>
+                    </entryLink>
+                  </entryLinks>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="af01-d4da-d454-2d29" name="Two Shock Chargers*" hidden="false" collective="false" import="true" type="upgrade">
+                  <rules>
+                    <rule id="5592-2df6-fcd5-a9f2" name="Two Shock Chargers*" publicationId="bde1-6db1-163b-3b76" page="37" hidden="false">
+                      <description>*A Castellax with two shock chargers gains an additional Attack. This additional Attack is not included in the characteristics profile above.</description>
+                    </rule>
+                  </rules>
+                  <entryLinks>
+                    <entryLink id="046f-df9b-f1a2-85f0" name="Shock Charger" hidden="false" collective="false" import="true" targetId="3234-492f-9ebf-f23c" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0437-cdbd-ea42-71ef" type="min"/>
+                        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fb05-ed4d-61f3-965b" type="max"/>
+                      </constraints>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntry>
+              </selectionEntries>
             </selectionEntryGroup>
             <selectionEntryGroup id="f012-80da-f40b-3cbd" name="C) Shock Charger / Power Blades may Exchange In-Built Bolter for:" hidden="false" collective="false" import="true" defaultSelectionEntryId="8081-f97c-b25c-affd">
               <modifiers>
-                <modifier type="increment" field="c6d4-44b8-d12d-4ca7" value="2.0">
+                <modifier type="increment" field="c6d4-44b8-d12d-4ca7" value="1.0">
                   <repeats>
-                    <repeat field="selections" scope="ab78-91e2-bb5c-9da3" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2121-ee7c-8ac9-5133" repeats="1" roundUp="false"/>
-                    <repeat field="selections" scope="ab78-91e2-bb5c-9da3" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3234-492f-9ebf-f23c" repeats="1" roundUp="false"/>
+                    <repeat field="selections" scope="ab78-91e2-bb5c-9da3" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b48d-19d0-6116-af9d" repeats="1" roundUp="false"/>
+                    <repeat field="selections" scope="ab78-91e2-bb5c-9da3" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="af01-d4da-d454-2d29" repeats="1" roundUp="false"/>
                   </repeats>
                 </modifier>
-                <modifier type="increment" field="0a49-dc8a-95be-56d5" value="2.0">
+                <modifier type="increment" field="0a49-dc8a-95be-56d5" value="1.0">
                   <repeats>
-                    <repeat field="selections" scope="ab78-91e2-bb5c-9da3" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3234-492f-9ebf-f23c" repeats="1" roundUp="false"/>
-                    <repeat field="selections" scope="ab78-91e2-bb5c-9da3" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2121-ee7c-8ac9-5133" repeats="1" roundUp="false"/>
+                    <repeat field="selections" scope="ab78-91e2-bb5c-9da3" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="af01-d4da-d454-2d29" repeats="1" roundUp="false"/>
+                    <repeat field="selections" scope="ab78-91e2-bb5c-9da3" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b48d-19d0-6116-af9d" repeats="1" roundUp="false"/>
                   </repeats>
                 </modifier>
-                <modifier type="decrement" field="c6d4-44b8-d12d-4ca7" value="2.0"/>
+                <modifier type="decrement" field="c6d4-44b8-d12d-4ca7" value="1.0"/>
               </modifiers>
               <constraints>
                 <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c6d4-44b8-d12d-4ca7" type="min"/>
-                <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0a49-dc8a-95be-56d5" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0a49-dc8a-95be-56d5" type="max"/>
               </constraints>
               <entryLinks>
                 <entryLink id="8081-f97c-b25c-affd" name="Bolter" hidden="false" collective="false" import="true" targetId="1ade-0c02-5612-252b" type="selectionEntry">
@@ -3390,6 +3436,18 @@ Invulnerable Saves granted by a mag-inverter shield do not stack with other Invu
           </constraints>
           <profiles>
             <profile id="c21f-a007-c5e0-83ea" name="Domitar" publicationId="bde1-6db1-163b-3b76" page="31" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName="Unit">
+              <modifiers>
+                <modifier type="increment" field="cc42-7ed5-7092-5c84" value="1">
+                  <conditions>
+                    <condition field="selections" scope="200f-3379-95a3-c3a4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="cc2a-46fe-bbf3-6ba2" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="increment" field="57ee-1126-32a9-5672" value="1">
+                  <conditions>
+                    <condition field="selections" scope="200f-3379-95a3-c3a4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="cc2a-46fe-bbf3-6ba2" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
               <characteristics>
                 <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Automata (Cybernetica)</characteristic>
                 <characteristic name="Move" typeId="893e-2d76-8f04-44e5">8</characteristic>
@@ -3678,15 +3736,9 @@ Invulnerable Saves granted by a mag-inverter shield do not stack with other Invu
       </costs>
     </selectionEntry>
     <selectionEntry id="2903-fef6-e839-368b" name="Thanatar Siege-automata Maniple" publicationId="bde1-6db1-163b-3b76" page="46" hidden="false" collective="false" import="true" type="unit">
-      <rules>
-        <rule id="eccf-b13c-2b8f-6939" name="Thanatar Maniple" publicationId="bde1-6db1-163b-3b76" page="110" hidden="false">
-          <description>When deployed onto the battlefield (either at the start of the battle or when arriving from Reserves) all models in the unit must be placed within unit coherency, but afterwards operate independently and are not treated asa single unit.</description>
-        </rule>
-      </rules>
       <categoryLinks>
         <categoryLink id="d13c-fa11-113a-6b4b" name="Automata Unit-type:" hidden="false" targetId="d8ab-8e21-e193-63ba" primary="false"/>
         <categoryLink id="ae51-75de-b9f6-61c2" name="Cybernetica Sub-type:" hidden="false" targetId="2440-b64e-cb24-87f0" primary="false"/>
-        <categoryLink id="140c-e71f-33aa-62da" name="Light Sub-type:" hidden="false" targetId="bff2-ae16-74a8-8712" primary="false"/>
         <categoryLink id="0f64-8711-75d2-ad9b" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
       </categoryLinks>
       <selectionEntries>
@@ -3712,6 +3764,11 @@ Invulnerable Saves granted by a mag-inverter shield do not stack with other Invu
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ce6c-c4a0-3622-b76b" type="min"/>
             <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="15c6-ecce-8258-7e00" type="max"/>
           </constraints>
+          <rules>
+            <rule id="c149-a9f6-4cbe-aa10" name="Thanatar Maniple" publicationId="bde1-6db1-163b-3b76" page="110" hidden="false">
+              <description>When deployed onto the battlefield (either at the start of the battle or when arriving from Reserves) all models in the unit must be placed within unit coherency, but afterwards operate independently and are not treated asa single unit.</description>
+            </rule>
+          </rules>
           <selectionEntryGroups>
             <selectionEntryGroup id="3a98-3aba-8cca-3ce8" name="A single Thanatar-Cavas in the Maniple may be replaced with a Thanatar Calix" hidden="false" collective="false" import="true" defaultSelectionEntryId="5331-31f3-87ed-5ebe">
               <constraints>
@@ -3722,18 +3779,30 @@ Invulnerable Saves granted by a mag-inverter shield do not stack with other Invu
                 <selectionEntry id="5331-31f3-87ed-5ebe" name="Thanatar Cavas" hidden="false" collective="false" import="true" type="upgrade">
                   <profiles>
                     <profile id="891f-90ee-c496-ce0d" name="Thanatar Cavas" publicationId="bde1-6db1-163b-3b76" page="46" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName="Unit">
+                      <modifiers>
+                        <modifier type="increment" field="cc42-7ed5-7092-5c84" value="1">
+                          <conditions>
+                            <condition field="selections" scope="2903-fef6-e839-368b" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="cc2a-46fe-bbf3-6ba2" type="equalTo"/>
+                          </conditions>
+                        </modifier>
+                        <modifier type="increment" field="57ee-1126-32a9-5672" value="1">
+                          <conditions>
+                            <condition field="selections" scope="2903-fef6-e839-368b" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="cc2a-46fe-bbf3-6ba2" type="equalTo"/>
+                          </conditions>
+                        </modifier>
+                      </modifiers>
                       <characteristics>
-                        <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Automata (Cybernetica, Light)</characteristic>
+                        <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Automata (Cybernetica, Heavy)</characteristic>
                         <characteristic name="Move" typeId="893e-2d76-8f04-44e5">8</characteristic>
-                        <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
+                        <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">3</characteristic>
                         <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
-                        <characteristic name="S" typeId="e478-41d4-a092-48a8">6</characteristic>
-                        <characteristic name="T" typeId="c32b-5fdd-3fbe-9b1f">5</characteristic>
-                        <characteristic name="W" typeId="57ee-1126-32a9-5672">4</characteristic>
-                        <characteristic name="I" typeId="62d3-22d7-2d49-52dc">4</characteristic>
+                        <characteristic name="S" typeId="e478-41d4-a092-48a8">8</characteristic>
+                        <characteristic name="T" typeId="c32b-5fdd-3fbe-9b1f">8</characteristic>
+                        <characteristic name="W" typeId="57ee-1126-32a9-5672">7</characteristic>
+                        <characteristic name="I" typeId="62d3-22d7-2d49-52dc">3</characteristic>
                         <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">3</characteristic>
                         <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">7</characteristic>
-                        <characteristic name="Save" typeId="e593-6b3c-f169-04f0">3+</characteristic>
+                        <characteristic name="Save" typeId="e593-6b3c-f169-04f0">2+</characteristic>
                       </characteristics>
                     </profile>
                   </profiles>
@@ -3788,18 +3857,30 @@ Invulnerable Saves granted by a mag-inverter shield do not stack with other Invu
                   </constraints>
                   <profiles>
                     <profile id="df17-9de2-31bf-f684" name="Thanatar Calix" publicationId="bde1-6db1-163b-3b76" page="46" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName="Unit">
+                      <modifiers>
+                        <modifier type="increment" field="cc42-7ed5-7092-5c84" value="1">
+                          <conditions>
+                            <condition field="selections" scope="2903-fef6-e839-368b" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="cc2a-46fe-bbf3-6ba2" type="equalTo"/>
+                          </conditions>
+                        </modifier>
+                        <modifier type="increment" field="57ee-1126-32a9-5672" value="1">
+                          <conditions>
+                            <condition field="selections" scope="2903-fef6-e839-368b" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="cc2a-46fe-bbf3-6ba2" type="equalTo"/>
+                          </conditions>
+                        </modifier>
+                      </modifiers>
                       <characteristics>
-                        <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Automata (Cybernetica, Light)</characteristic>
+                        <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Automata (Cybernetica, Heavy)</characteristic>
                         <characteristic name="Move" typeId="893e-2d76-8f04-44e5">8</characteristic>
-                        <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
+                        <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">3</characteristic>
                         <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
-                        <characteristic name="S" typeId="e478-41d4-a092-48a8">6</characteristic>
-                        <characteristic name="T" typeId="c32b-5fdd-3fbe-9b1f">5</characteristic>
-                        <characteristic name="W" typeId="57ee-1126-32a9-5672">4</characteristic>
-                        <characteristic name="I" typeId="62d3-22d7-2d49-52dc">4</characteristic>
+                        <characteristic name="S" typeId="e478-41d4-a092-48a8">8</characteristic>
+                        <characteristic name="T" typeId="c32b-5fdd-3fbe-9b1f">8</characteristic>
+                        <characteristic name="W" typeId="57ee-1126-32a9-5672">7</characteristic>
+                        <characteristic name="I" typeId="62d3-22d7-2d49-52dc">3</characteristic>
                         <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">3</characteristic>
                         <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">7</characteristic>
-                        <characteristic name="Save" typeId="e593-6b3c-f169-04f0">3+</characteristic>
+                        <characteristic name="Save" typeId="e593-6b3c-f169-04f0">2+</characteristic>
                       </characteristics>
                     </profile>
                   </profiles>
@@ -3928,13 +4009,25 @@ Invulnerable Saves granted by a mag-inverter shield do not stack with other Invu
         <categoryLink id="e468-fb52-fd0d-7af6" name="Light Sub-type:" hidden="false" targetId="bff2-ae16-74a8-8712" primary="false"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="59fd-998f-8190-baec" name="Vorax" publicationId="bde1-6db1-163b-3b76" page="42" hidden="false" collective="false" import="true" type="model">
+        <selectionEntry id="6711-d580-b463-bc7e" name="Vorax" publicationId="bde1-6db1-163b-3b76" page="42" hidden="false" collective="false" import="true" type="model">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e36f-739b-f761-a69c" type="min"/>
-            <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7c0f-624e-fac5-81c6" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ade9-d7ad-8024-68dc" type="min"/>
+            <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5505-f1cf-a3e4-60d6" type="max"/>
           </constraints>
           <profiles>
-            <profile id="244c-1e6b-3768-3c13" name="Vorax" publicationId="bde1-6db1-163b-3b76" page="42" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName="Unit">
+            <profile id="c5ce-739c-885a-960b" name="Vorax" publicationId="bde1-6db1-163b-3b76" page="42" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName="Unit">
+              <modifiers>
+                <modifier type="increment" field="cc42-7ed5-7092-5c84" value="1">
+                  <conditions>
+                    <condition field="selections" scope="f144-1079-11ff-019d" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="cc2a-46fe-bbf3-6ba2" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="increment" field="57ee-1126-32a9-5672" value="1">
+                  <conditions>
+                    <condition field="selections" scope="f144-1079-11ff-019d" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="cc2a-46fe-bbf3-6ba2" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
               <characteristics>
                 <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Automata (Cybernetica, Light)</characteristic>
                 <characteristic name="Move" typeId="893e-2d76-8f04-44e5">8</characteristic>
@@ -3951,13 +4044,13 @@ Invulnerable Saves granted by a mag-inverter shield do not stack with other Invu
             </profile>
           </profiles>
           <infoLinks>
-            <infoLink id="2acb-042e-9147-1084" name="Fleet (X)" hidden="false" targetId="ddc9-0b4b-78da-bbd2" type="rule">
+            <infoLink id="963f-8d5b-228b-aee8" name="Fleet (X)" hidden="false" targetId="ddc9-0b4b-78da-bbd2" type="rule">
               <modifiers>
                 <modifier type="set" field="name" value="Fleet (2)"/>
               </modifiers>
             </infoLink>
-            <infoLink id="d381-1f2b-bce2-4aab" name="Scout" hidden="false" targetId="aacf-9a7e-982d-b793" type="rule"/>
-            <infoLink id="4d08-9bbf-6883-4c83" name="Hammer of Wrath (X)" hidden="false" targetId="aec0-c3aa-1e4e-1779" type="rule">
+            <infoLink id="05fa-5f99-01fa-8186" name="Scout" hidden="false" targetId="aacf-9a7e-982d-b793" type="rule"/>
+            <infoLink id="bac5-1453-370b-d20f" name="Hammer of Wrath (X)" hidden="false" targetId="aec0-c3aa-1e4e-1779" type="rule">
               <modifiers>
                 <modifier type="set" field="name" value="Hammer of Wrath (1)"/>
               </modifiers>
@@ -3967,22 +4060,22 @@ Invulnerable Saves granted by a mag-inverter shield do not stack with other Invu
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="65.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="337a-c368-c0d1-361f" name="Power Blade Array with In-Built Rotar Cannon" hidden="false" collective="false" import="true" type="upgrade">
+        <selectionEntry id="cff3-2ddf-4024-f463" name="Two Power Blade Arrays with In-Built Rotar Cannons" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2bef-1121-946c-b117" type="min"/>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a805-35c0-a4e5-67c9" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a440-7ca1-4048-6005" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2e98-54a5-27f5-62d1" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="cbf7-102c-b2d4-3666" name="Power Blade Array" hidden="false" collective="false" import="true" targetId="2121-ee7c-8ac9-5133" type="selectionEntry">
+            <entryLink id="c311-0ae9-b3d6-2ca4" name="Power Blade Array" hidden="false" collective="true" import="true" targetId="2121-ee7c-8ac9-5133" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bd1c-0ed9-0008-5f5c" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e854-42d7-abd3-237d" type="max"/>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a932-5045-69d6-37cb" type="min"/>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1500-724d-9062-8de1" type="max"/>
               </constraints>
             </entryLink>
-            <entryLink id="069b-2935-fc1a-2440" name="Rotor Cannon" hidden="false" collective="false" import="true" targetId="5ce3-3aa5-3f5e-9ead" type="selectionEntry">
+            <entryLink id="f4fc-e562-6969-7d11" name="Rotor Cannon" hidden="false" collective="true" import="true" targetId="5ce3-3aa5-3f5e-9ead" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0705-697d-f8b6-39e6" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6216-1851-0944-da3b" type="max"/>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ed98-65b1-1bee-06b1" type="min"/>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="77fb-c42d-ae64-6b18" type="max"/>
               </constraints>
             </entryLink>
           </entryLinks>
@@ -3992,49 +4085,51 @@ Invulnerable Saves granted by a mag-inverter shield do not stack with other Invu
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
-        <selectionEntryGroup id="57c4-4fa1-cf37-a599" name="One in Three Vorax in the unit, may exchange its Lightning Gun" hidden="false" collective="false" import="true" defaultSelectionEntryId="1eec-44ae-e1a2-1766">
+        <selectionEntryGroup id="c99b-a219-75af-8360" name="1 in 3 may exchange Lightning Gun for Irad Cleanser" hidden="false" collective="false" import="true" defaultSelectionEntryId="790e-ea6f-ecbc-d374">
           <modifiers>
-            <modifier type="increment" field="5d48-0036-be14-baa6" value="1.0">
+            <modifier type="decrement" field="3429-9e15-406c-1f0b" value="1.0"/>
+            <modifier type="increment" field="87fd-4c2e-8d99-e5cb" value="1.0">
               <repeats>
-                <repeat field="selections" scope="f144-1079-11ff-019d" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="59fd-998f-8190-baec" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="f144-1079-11ff-019d" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
-            <modifier type="increment" field="f11e-82b3-b9b8-28e6" value="1.0">
+            <modifier type="increment" field="3429-9e15-406c-1f0b" value="1.0">
               <repeats>
-                <repeat field="selections" scope="f144-1079-11ff-019d" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="59fd-998f-8190-baec" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="f144-1079-11ff-019d" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f11e-82b3-b9b8-28e6" type="min"/>
-            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5d48-0036-be14-baa6" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3429-9e15-406c-1f0b" type="min"/>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="87fd-4c2e-8d99-e5cb" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="0915-bf0a-d991-9150" name="Irad-Cleanser" hidden="false" collective="false" import="true" targetId="b3c5-237f-e1d2-d9f8" type="selectionEntry">
+            <entryLink id="790e-ea6f-ecbc-d374" name="Lightning Gun" hidden="false" collective="true" import="true" targetId="f65c-633a-5865-7f6b" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e82f-cbeb-63e9-116a" type="max"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="bfea-5a9f-3cc8-147a" name="Irad-Cleanser" hidden="false" collective="false" import="true" targetId="b3c5-237f-e1d2-d9f8" type="selectionEntry">
               <modifiers>
-                <modifier type="increment" field="15a4-488c-1f42-b018" value="1.0">
+                <modifier type="increment" field="80be-28b5-97f0-9437" value="1.0">
                   <repeats>
-                    <repeat field="selections" scope="f144-1079-11ff-019d" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="59fd-998f-8190-baec" repeats="1" roundUp="false"/>
+                    <repeat field="selections" scope="f144-1079-11ff-019d" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
                   </repeats>
                 </modifier>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="15a4-488c-1f42-b018" type="max"/>
+                <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="80be-28b5-97f0-9437" type="max"/>
               </constraints>
-              <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
-              </costs>
             </entryLink>
-            <entryLink id="1eec-44ae-e1a2-1766" name="Lightning Gun" hidden="false" collective="false" import="true" targetId="f65c-633a-5865-7f6b" type="selectionEntry"/>
           </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="73a6-8d5c-4352-35c0" name="Paragon of Metal" hidden="false" collective="false" import="true" targetId="cc2a-46fe-bbf3-6ba2" type="selectionEntry">
+        <entryLink id="03c7-9ccc-e943-5c5e" name="Paragon of Metal" hidden="false" collective="false" import="true" targetId="cc2a-46fe-bbf3-6ba2" type="selectionEntry">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="f144-1079-11ff-019d" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="59fd-998f-8190-baec" type="greaterThan"/>
+                <condition field="selections" scope="f144-1079-11ff-019d" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="greaterThan"/>
               </conditions>
             </modifier>
           </modifiers>
@@ -4549,6 +4644,387 @@ The Cybertheurgist’s controlling player may choose to make a Cybertheurgy chec
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
       </costs>
     </selectionEntry>
+    <selectionEntry id="9faf-7242-dc40-c3e5" name="Incunabulan Jet Pack" publicationId="bde1-6db1-163b-3b76" page="130" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="49e3-0125-7461-31f6" name="Incunabulan Jet Pack" publicationId="bde1-6db1-163b-3b76" page="130" hidden="false" typeId="2a1f-7837-f0ef-be44" typeName="Wargear Item">
+          <characteristics>
+            <characteristic name="Description" typeId="347e-ee4a-764f-6be3">A unit composed entirely of models with Incunabulan jet packs may choose to increase its Move Characteristic by +6&quot; and ignore terrain while Moving during the Movement phase. A unit that ends or begins its movement in Dangerous Terrain will still need to take Dangerous Terrain tests as normal, even when employing Incunabulan jet packs and treats Difficult Terrain as Dangerous Terrain. In addition to the bonus to Move during the Movement phase, a unit composed entirely of models with Incunabulan jet packs may make an additional Move of 6&quot; during the Shooting phase. This Move must be taken after the unit has completed any Shooting Attacks, is not limited by the weapons fired by that unit during the Shooting phase and ignores terrain in the same manner as moves made using a Incunabulan jet pack in the Movement phase.
+Any model with an Incunabulan jet pack also gains the Bulky (2) and Deep Strike special rules, or if it already has the Bulky (2) special rule it gains the Bulky (3) special rule instead. Models with an Incunabulan jet pack may Embark on models with the Transport Unit Sub-type, contrary to the normal Transport rules, but still must take into account their size due to the Bulky (X) special rule.
+During any Reaction that allows a unit to Move, a unit composed entirely of models with Incunabulan jet packs increases the distance of that Move by 6 and allows it to ignore terrain in the same manner as other Incunabulan jet pack moves.</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="c38c-c6f1-faa2-2d6a" name="Deep Strike" hidden="false" targetId="f1e1-986f-c783-ca9e" type="rule"/>
+        <infoLink id="aee4-9a2d-e7b0-3359" name="Bulky (X)" hidden="false" targetId="676c-7b75-4b6f-9405" type="rule">
+          <modifiers>
+            <modifier type="set" field="name" value="Bulky (2 or 3)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="6fcf-8cdd-fd59-3363" name="Jet Infantry:" hidden="false" targetId="0b85-37e7-40ef-7388" primary="false"/>
+      </categoryLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="30b5-2dcd-6b27-067c" name="Utan Jump Booster" publicationId="bde1-6db1-163b-3b76" page="130" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="94a1-e8ec-8bb1-1d1c" name="Utan Jump Booster" publicationId="bde1-6db1-163b-3b76" page="130" hidden="false" typeId="2a1f-7837-f0ef-be44" typeName="Wargear Item">
+          <characteristics>
+            <characteristic name="Description" typeId="347e-ee4a-764f-6be3">A unit composed entirely of models with Utan jump boosters may set its Move Characteristic to a value of 12 for the duration of the controlling player’s turn. This allows the unit to move up to 12&quot;, regardless of the Movement Characteristic shown on its profile and gain any other benefits of a Movement Characteristic of 12 (including the bonus to Charge distance, see the Horus Heresy: Age of Darkness rulebook, page 181). In addition, the unit ignores terrain while Moving and Charging. A unit that ends or begins its movement or a Charge in Dangerous Terrain will still need to take Dangerous Terrain tests as normal, even when employing Utan jump boosters, and treats all Difficult Terrain as Dangerous Terrain.
+A unit composed entirely of models with Utan jump boosters may not Run. During Reactions made in any Phase, a unit composed entirely of models with Utan jump boosters may not activate them to gain any bonus to their Movement Characteristic. Any model with an Utan jump booster also gains the Deep Strike special rule. Additionally, models with an Utan jump booster may Embark on models with the Transport Unit Sub-type, contrary to the normal Transport rules, but still must take into account their Unit Type and their size due to the Bulky (X) special rule.</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="7210-9d7a-e39a-7ef8" name="Deep Strike" hidden="false" targetId="f1e1-986f-c783-ca9e" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="18da-a26c-bdd4-8a5f" name="Rad Furnace" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="a491-f0a7-4128-1e84" name="Rad Furnace" hidden="false" typeId="2a1f-7837-f0ef-be44" typeName="Wargear Item">
+          <characteristics>
+            <characteristic name="Description" typeId="347e-ee4a-764f-6be3">Any melee Hits allocated to models locked in combat with one or more units that include a model with a rad furnace require one lower result To Wound than they would normally, to a minimum of 2+. This effect is not cumulative with itself if more than one model in a combat has a rad furnace. Models with rad furnaces are immune to the effects of rad grenades, the Rad-phage special rule and the rad furnaces of models they are locked in combat with. In addition, Hits from weapons with the Rad-phage special rule that are allocated to a model with a rad furnace only successfully wound on a To Wound roll of a 6+.</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="dc95-1744-94e2-2c52" name="Prehensile Dataspike" publicationId="bde1-6db1-163b-3b76" page="123" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="a18f-cc83-7c96-9ad0" name="Prehensile Dataspike" publicationId="bde1-6db1-163b-3b76" page="123" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="95ba-cda7-b831-6066">-</characteristic>
+            <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">5</characteristic>
+            <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">4</characteristic>
+            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Melee, Breaching (4+), Murderous Strike (6+), Reach (2)</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="f5b6-3658-50da-3184" name="Breaching (X)" hidden="false" targetId="a760-f736-1bf3-fa3c" type="rule">
+          <modifiers>
+            <modifier type="set" field="name" value="Breaching (4+)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="3023-845e-ebc2-ea6e" name="Murderous Strike (X)" hidden="false" targetId="93b9-1454-0e7c-42ae" type="rule">
+          <modifiers>
+            <modifier type="set" field="name" value="Murderous Strike (6+)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="dc2b-c9fa-bebe-e051" name="Reach (X)" hidden="false" targetId="19bf-62a2-5737-890b" type="rule">
+          <modifiers>
+            <modifier type="set" field="name" value="Reach (2)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="71cf-978d-0444-a3f1" name="Lucifex" publicationId="bde1-6db1-163b-3b76" page="119" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="6ada-1b1d-a0ab-391d" name="Lucifex" publicationId="bde1-6db1-163b-3b76" page="119" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="95ba-cda7-b831-6066">8&quot;</characteristic>
+            <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">2</characteristic>
+            <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">5</characteristic>
+            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Pistol 1, Fleshbane, Rad-phage</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="2176-0408-f2ae-5a07" name="Fleshbane" hidden="false" targetId="40cd-9505-253c-e76f" type="rule"/>
+        <infoLink id="42f5-77a4-22be-8392" name="Rad-Phage" hidden="false" targetId="8189-e963-d2e5-5d3d" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="5d14-047a-bc9c-5d00" name="Irradiation Engine" publicationId="bde1-6db1-163b-3b76" page="119" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="e842-c681-5a2c-b33d" name="Irradiation Engine" publicationId="bde1-6db1-163b-3b76" page="119" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="95ba-cda7-b831-6066">Template</characteristic>
+            <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">4</characteristic>
+            <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">3</characteristic>
+            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Heavy 1, Fleshbane, Rad-phage, Torrent (12&quot;)</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="9b78-9cb8-b92f-b553" name="Fleshbane" hidden="false" targetId="40cd-9505-253c-e76f" type="rule"/>
+        <infoLink id="7ed6-4778-94ba-2c28" name="Rad-Phage" hidden="false" targetId="8189-e963-d2e5-5d3d" type="rule"/>
+        <infoLink id="04d5-b937-8376-8e30" name="Torrent (X)" hidden="false" targetId="5cfb-fc94-e6db-43b8" type="rule">
+          <modifiers>
+            <modifier type="set" field="name" value="Torrent (12&quot;)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="22dd-5ea8-a078-fd88" name="Template Weapons" hidden="false" targetId="5e0e-88e6-db81-5a70" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="6491-5e10-ba7e-e0d3" name="Las-lock" publicationId="bde1-6db1-163b-3b76" page="117" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="3284-5778-fb70-5f43" name="Las-lock" publicationId="bde1-6db1-163b-3b76" page="117" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="95ba-cda7-b831-6066">18&quot;</characteristic>
+            <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">4</characteristic>
+            <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">6</characteristic>
+            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Assault 2</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="3519-b118-7c6e-2343" name="Photon Thruster" publicationId="bde1-6db1-163b-3b76" page="117" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="e5b3-3ecf-f310-e629" name="Photon Thruster" publicationId="bde1-6db1-163b-3b76" page="117" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="95ba-cda7-b831-6066">24&quot;</characteristic>
+            <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">6</characteristic>
+            <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">2</characteristic>
+            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Assault 2, Blind, Lance, Gets Hot</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="4941-db15-07f7-cdf8" name="Blind" hidden="false" targetId="d836-747d-07d6-2b63" type="rule"/>
+        <infoLink id="9329-c4d0-e4d4-89b5" name="Lance" hidden="false" targetId="3d6b-9e0b-56f0-8a1e" type="rule"/>
+        <infoLink id="8a98-70a4-be07-664a" name="Gets Hot" hidden="false" targetId="679f-9d97-5ace-a652" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="c651-d95e-6aa9-c3de" name="Graviton Imploder" publicationId="bde1-6db1-163b-3b76" page="116" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="14fd-3c03-871d-8882" name="Graviton Imploder" publicationId="bde1-6db1-163b-3b76" page="116" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="95ba-cda7-b831-6066">18&quot;</characteristic>
+            <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">*</characteristic>
+            <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">3</characteristic>
+            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Heavy 2, Graviton Pulse*, Concussive (1), Haywire</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="ce43-602e-424b-cd35" name="Graviton Pulse" hidden="false" targetId="5b9c-2738-616c-abdf" type="rule"/>
+        <infoLink id="4fb8-7ee9-44bb-e204" name="Concussive (X)" hidden="false" targetId="7ce5-1bfb-64e6-f826" type="rule">
+          <modifiers>
+            <modifier type="set" field="name" value="Concussive (1)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="c304-d90b-4d5f-868a" name="Haywire" hidden="false" targetId="1dd4-7a75-5c59-8425" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="2397-a3fd-81e6-4ced" name="Conversion Beamer" publicationId="bde1-6db1-163b-3b76" page="115" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="8fec-3374-8f9e-3999" name="Conversion Beamer (1)" publicationId="bde1-6db1-163b-3b76" page="115" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="95ba-cda7-b831-6066">Up to 18&quot;</characteristic>
+            <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">6</characteristic>
+            <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">-</characteristic>
+            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Heavy 1, Blast (3&quot;), Blind</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="9e43-3980-4c10-4b88" name="Conversion Beamer (2)" publicationId="bde1-6db1-163b-3b76" page="115" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="95ba-cda7-b831-6066">More than 18&quot;-42&quot;</characteristic>
+            <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">8</characteristic>
+            <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">4</characteristic>
+            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Heavy 1, Blast (3&quot;), Blind</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="6501-0f61-f551-79eb" name="Conversion Beamer (3)" publicationId="bde1-6db1-163b-3b76" page="115" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="95ba-cda7-b831-6066">More than 42&quot;-72&quot;</characteristic>
+            <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">10</characteristic>
+            <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">1</characteristic>
+            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Heavy 1, Blast (3&quot;), Blind</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="115a-86e7-896f-b872" name="Graviton Pulsar" publicationId="bde1-6db1-163b-3b76" page="116" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="55ff-edab-513a-1c36" name="Graviton Pulsar" publicationId="bde1-6db1-163b-3b76" page="116" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="95ba-cda7-b831-6066">24&quot;</characteristic>
+            <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">*</characteristic>
+            <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">4</characteristic>
+            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Heavy 2, Blast (3&quot;), Concussive (1), Graviton Pulse*, Haywire</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="1714-99b1-7326-7609" name="Blast" hidden="false" targetId="1d9a-73ef-5f4f-8bd8" type="rule"/>
+        <infoLink id="928a-e20d-5788-ddaf" name="Concussive (X)" hidden="false" targetId="7ce5-1bfb-64e6-f826" type="rule">
+          <modifiers>
+            <modifier type="set" field="name" value="Concussive (1)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="d35e-3bda-2270-3fde" name="Graviton Pulse" hidden="false" targetId="5b9c-2738-616c-abdf" type="rule"/>
+        <infoLink id="fb9a-58f9-d015-9a78" name="Haywire" hidden="false" targetId="1dd4-7a75-5c59-8425" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="0dd0-0edf-9526-cc6b" name="Volkite Veuglaire" publicationId="bde1-6db1-163b-3b76" page="119" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="3807-1122-4d21-e4df" name="Volkite Veuglaire" publicationId="bde1-6db1-163b-3b76" page="119" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="95ba-cda7-b831-6066">30&quot;</characteristic>
+            <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">6</characteristic>
+            <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">4</characteristic>
+            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Heavy 5, Deflagrate</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="566b-4fc6-9d5c-10cd" name="Pulsar-Fusil" publicationId="bde1-6db1-163b-3b76" page="117" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="8f41-f592-7d19-105c" name="Pulsar-Fusil" publicationId="bde1-6db1-163b-3b76" page="117" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="95ba-cda7-b831-6066">36&quot;</characteristic>
+            <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">9</characteristic>
+            <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">2</characteristic>
+            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Ordnance 4, Pinning</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="7eff-579d-f126-e7d3" name="Pinning" hidden="false" targetId="1c96-205c-59a0-3cf2" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="0575-c2d8-d3c5-d38f" name="Lorica Thallax" publicationId="bde1-6db1-163b-3b76" page="124" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="0751-8d7c-eb3a-aa5b" name="Lorica Thallax" publicationId="bde1-6db1-163b-3b76" page="124" hidden="false" typeId="2a1f-7837-f0ef-be44" typeName="Wargear Item">
+          <characteristics>
+            <characteristic name="Description" typeId="347e-ee4a-764f-6be3">The Lorica Thallax confers a 4+ Armour Save. In addition, a unit that includes any models with Lorica Thallax may not make Sweeping Advances.</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+    </selectionEntry>
+    <selectionEntry id="4cc0-c7df-7157-6bf0" name="Volkite Incinerator" publicationId="bde1-6db1-163b-3b76" page=" &amp; 123" hidden="false" collective="false" import="true" type="upgrade">
+      <selectionEntries>
+        <selectionEntry id="169a-febb-72f0-ad32" name="Volkite incinerator (Ranged)" hidden="false" collective="true" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5f5e-4add-c78a-0929" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0a6d-fa94-2b4c-eff3" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="6771-2e74-2cc2-3a80" name="Volkite incinerator (Ranged)" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+              <characteristics>
+                <characteristic name="Range" typeId="95ba-cda7-b831-6066">10&quot;</characteristic>
+                <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">5</characteristic>
+                <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">5</characteristic>
+                <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Assault 2, Deflagrate</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <infoLinks>
+            <infoLink id="2bca-f8d1-dc31-245a" name="Deflagrate" hidden="false" targetId="60bc-f79a-67ae-be4f" type="rule"/>
+          </infoLinks>
+        </selectionEntry>
+        <selectionEntry id="9149-00e8-dd49-c213" name="Volkite incinerator (Melee)" hidden="false" collective="true" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e0df-ff1f-55f5-5c8f" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c102-6153-af74-05c4" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="bec3-1e3b-7c06-bc10" name="Volkite incinerator (Melee)" publicationId="bde1-6db1-163b-3b76" page="123" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+              <characteristics>
+                <characteristic name="Range" typeId="95ba-cda7-b831-6066">-</characteristic>
+                <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">6</characteristic>
+                <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">2</characteristic>
+                <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Melee, Instant Death, Prisoned</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="e26b-cddc-2eeb-4320" name="Prisoned" publicationId="bde1-6db1-163b-3b76" hidden="false">
+              <description>A weapon with this special rule may only target models with the Infantry Unit Type, and a model attacking with a weapon with this special rule makes only a single attack (regardless of any other factors).</description>
+            </rule>
+          </rules>
+          <infoLinks>
+            <infoLink id="e4db-a990-aa36-e516" name="Instant Death" hidden="false" targetId="9e96-fff1-b916-d9a3" type="rule"/>
+          </infoLinks>
+        </selectionEntry>
+      </selectionEntries>
+    </selectionEntry>
+    <selectionEntry id="9033-c395-43b3-5612" name="Arc Scourge" publicationId="bde1-6db1-163b-3b76" page="120" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="8d18-694a-4a47-498f" name="Arc Scourge" publicationId="bde1-6db1-163b-3b76" page="120" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="95ba-cda7-b831-6066">-</characteristic>
+            <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">+2</characteristic>
+            <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">3</characteristic>
+            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Melee, Rampage (D3), Disruption (5+)</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="062c-cfbf-608d-f0d0" name="Rampage (X)" hidden="false" targetId="3efb-2a2c-2d0b-92fc" type="rule">
+          <modifiers>
+            <modifier type="set" field="name" value="Rampage (D3)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="81aa-3408-7179-421d" name="Disruption (X)" hidden="false" targetId="4eb9-9e5e-bb27-3644" type="rule">
+          <modifiers>
+            <modifier type="set" field="name" value="Disruption (5+)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+    </selectionEntry>
+    <selectionEntry id="9978-8a9e-ab4b-5e0f" name="Light Autocannon" publicationId="bde1-6db1-163b-3b76" page="114" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="34ec-dac5-0fc4-3ee6" name="Light Autocannon" publicationId="bde1-6db1-163b-3b76" page="114" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="95ba-cda7-b831-6066">36&quot;</characteristic>
+            <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">6</characteristic>
+            <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">4</characteristic>
+            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Assault 2</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+    </selectionEntry>
+    <selectionEntry id="3d50-2f85-06ff-6aee" name="Close Combat Weapon" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="e28e-91f4-86a4-15a6" name="Close Combat Weapon" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="95ba-cda7-b831-6066">-</characteristic>
+            <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">User</characteristic>
+            <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">-</characteristic>
+            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Melee</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+    </selectionEntry>
   </sharedSelectionEntries>
   <sharedSelectionEntryGroups>
     <selectionEntryGroup id="1b29-a58e-296c-3946" name="Household Ranks" hidden="true" collective="false" import="true">
@@ -4901,6 +5377,9 @@ When deployed onto the battlefield (either at the start of the battle or when ar
     </rule>
     <rule id="0893-4bd0-d5a1-14db" name="Patris Cybernetica" publicationId="bde1-6db1-163b-3b76" page="106" hidden="false">
       <description>An Independent Character with this special rule may join a unit composed of models with the Automata Unit Type or Monstrous Unit Sub-type. However they cannot join a unit which contains models of any other Unit Type if the model with this rule also has the Automata or Dreadnought Unit Type, or the Monstrous Unit Sub-type.</description>
+    </rule>
+    <rule id="50f4-db05-3e45-467f" name="Djinn-Sight" publicationId="bde1-6db1-163b-3b76" page="104" hidden="false">
+      <description>When making Shooting Attacks, djinn-sight reduces the benefits of any Cover Save the target unit has by -2 (a 4+ becoming a 6+, a 5+ being ignored entirely, and so on). Additionally, Infiltrators may not be set up within 24&quot; of units with this special rule, regardless of line of sight.</description>
     </rule>
   </sharedRules>
   <sharedProfiles>

--- a/2022 - Mechanicum.cat
+++ b/2022 - Mechanicum.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="c247-da79-1654-d39e" name="2022 - Mechanicum" revision="5" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="14" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="c247-da79-1654-d39e" name="2022 - Mechanicum" revision="4" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="15" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entryLinks>
     <entryLink id="29c6-0ec7-0162-e817" name="Mechanicum" hidden="false" collective="false" import="false" targetId="ddf5-d792-3146-6e9a" type="selectionEntry">
       <constraints>
@@ -110,58 +110,58 @@
     <entryLink id="6558-9557-4654-31fc" name="Myrmidon Destructor Host (Placeholder)" hidden="false" collective="false" import="true" targetId="356f-a88b-1d13-3700" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="23e1-8fa1-49c1-1d77" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="917e-dce4-a4db-c13f" name="New CategoryLink" hidden="false" targetId="9231-183c-b97b-63f9" primary="true"/>
+        <categoryLink id="66c0-0a59-046b-249b" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="4467-970e-236e-6118" name="Karacnos Assault Tank (Placeholder)" hidden="false" collective="false" import="true" targetId="8920-3184-2455-1834" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="3691-ade8-41f9-ecf2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="171f-1fac-2302-5a37" name="New CategoryLink" hidden="false" targetId="9231-183c-b97b-63f9" primary="true"/>
+        <categoryLink id="1e5d-4224-528c-7cba" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="30bc-6d27-6a7b-5d02" name="Krios Squadron (Placeholder)" hidden="false" collective="false" import="true" targetId="ce87-68e2-0134-3c84" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="90f5-b210-0447-2356" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="8289-0b76-1d71-b7d2" name="New CategoryLink" hidden="false" targetId="9231-183c-b97b-63f9" primary="true"/>
+        <categoryLink id="4b9e-daec-dd50-1582" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="4351-1507-2a58-b11d" name="Knight Moirax Talon (Placeholder)" hidden="false" collective="false" import="true" targetId="c21c-3c14-2d2e-4bc0" type="selectionEntry">
+    <entryLink id="4351-1507-2a58-b11d" name="Knight Moirax Talon" hidden="false" collective="false" import="true" targetId="c21c-3c14-2d2e-4bc0" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="ca25-1bf8-642c-6aa4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="210e-ee21-2c3e-4fd2" name="New CategoryLink" hidden="false" targetId="9231-183c-b97b-63f9" primary="true"/>
+        <categoryLink id="ff46-2a7c-d938-8c35" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="9ca0-8d1b-faa7-e89d" name="Mechanicum Knight Magaera (Placeholder)" hidden="false" collective="false" import="true" targetId="b582-e53e-5e13-286c" type="selectionEntry">
+    <entryLink id="9ca0-8d1b-faa7-e89d" name="Mechanicum Knight Magaera" hidden="false" collective="false" import="true" targetId="b582-e53e-5e13-286c" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="6411-f60a-4ee6-fa8a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="76b5-a3b8-07c7-eb28" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="c5d0-e078-888c-4574" name="Mechanicum Knight Styrix (Placeholder)" hidden="false" collective="false" import="true" targetId="aae3-4a95-fbce-6d01" type="selectionEntry">
+    <entryLink id="c5d0-e078-888c-4574" name="Mechanicum Knight Styrix" hidden="false" collective="false" import="true" targetId="aae3-4a95-fbce-6d01" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="9984-1655-436c-e75c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="d445-8c66-903b-de69" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="c7b8-2484-8229-9d47" name="Mechanicum Knight Atrapos (Placeholder)" hidden="false" collective="false" import="true" targetId="6405-d682-11c9-35b6" type="selectionEntry">
+    <entryLink id="c7b8-2484-8229-9d47" name="Mechanicum Knight Atrapos" hidden="false" collective="false" import="true" targetId="6405-d682-11c9-35b6" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="5572-322f-3fd4-df9c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="d947-9ad4-b373-47f7" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="fd4a-8cec-3721-c94f" name="Mechanicum Acastus Knight Asterius (Placeholder)" hidden="false" collective="false" import="true" targetId="ccc2-5689-4796-61b4" type="selectionEntry">
+    <entryLink id="fd4a-8cec-3721-c94f" name="Mechanicum Acastus Knight Asterius" hidden="false" collective="false" import="true" targetId="ccc2-5689-4796-61b4" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="ef49-9452-4d80-69a3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="58ac-b3ec-8a9d-0f89" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="1521-2b96-fcbd-095b" name="Ordinatus Ulator (Placeholder)" hidden="false" collective="false" import="true" targetId="1277-aefb-66c5-bd35" type="selectionEntry">
+    <entryLink id="1521-2b96-fcbd-095b" name="Ordinatus Ulator" hidden="false" collective="false" import="true" targetId="1277-aefb-66c5-bd35" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="5a23-8aaf-d1cc-9a2c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="8f5e-22b8-50e7-1004" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="ac39-4b53-e47f-d54c" name="Ordinatus Aktaeus (Placeholder)" hidden="false" collective="false" import="true" targetId="89a5-fa4d-0e01-3a55" type="selectionEntry">
+    <entryLink id="ac39-4b53-e47f-d54c" name="Ordinatus Aktaeus" hidden="false" collective="false" import="true" targetId="89a5-fa4d-0e01-3a55" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="8eee-4e6f-0d30-cbd6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="3331-9a71-e131-6128" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
@@ -205,7 +205,7 @@
         <categoryLink id="099a-66ab-81aa-4ac7" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="cb9d-dcbd-a336-3687" name="Archmagos Draykavac (Placeholder)" hidden="false" collective="false" import="true" targetId="8b4c-01f4-f39f-7c55" type="selectionEntry">
+    <entryLink id="cb9d-dcbd-a336-3687" name="Archmagos Draykavac" hidden="false" collective="false" import="true" targetId="8b4c-01f4-f39f-7c55" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="e5b1-a8f4-deff-e3fc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="f7a4-e7ef-9bc9-80b2" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
@@ -582,19 +582,6 @@
         <categoryLink id="176d-fff6-f157-330a" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="a16c-e7f6-08fc-a357" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
       </categoryLinks>
-      <selectionEntryGroups>
-        <selectionEntryGroup id="d25c-4387-bc06-f2c2" name="Cybertheurgic Arcana" hidden="false" collective="false" import="true">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0e0a-7223-a059-1897" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="388e-df43-ecb0-4d15" type="max"/>
-          </constraints>
-          <entryLinks>
-            <entryLink id="0b39-9c59-e7eb-5f79" name="Artificia Machina" hidden="false" collective="false" import="true" targetId="51ed-f978-9a5e-1e04" type="selectionEntry"/>
-            <entryLink id="786a-f446-e4fd-2fd0" name="Ephemera Incursus" hidden="false" collective="false" import="true" targetId="12fc-d4d8-d36c-6f14" type="selectionEntry"/>
-            <entryLink id="1d1d-c3ea-cbb0-77af" name="Artificia Cybernetica" hidden="false" collective="false" import="true" targetId="d342-dbdb-33ec-5191" type="selectionEntry"/>
-          </entryLinks>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
       <entryLinks>
         <entryLink id="a63a-9dfe-ee64-913c" name="Upgrade Points (Placeholders)" hidden="false" collective="false" import="true" targetId="7c8d-b21a-1f72-7e22" type="selectionEntry"/>
         <entryLink id="9dcc-9b17-198f-5691" name="Warlord" hidden="false" collective="false" import="true" targetId="0176-56a3-d590-b103" type="selectionEntry"/>
@@ -610,19 +597,6 @@
         <categoryLink id="f75f-bd69-3fb1-c37d" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="ad3f-ad1c-6a50-2d8c" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
       </categoryLinks>
-      <selectionEntryGroups>
-        <selectionEntryGroup id="a48c-a776-d7d9-ed46" name="Cybertheurgic Arcana" hidden="false" collective="false" import="true">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8db4-36a5-0914-faff" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a637-80c8-c366-1add" type="max"/>
-          </constraints>
-          <entryLinks>
-            <entryLink id="ffb9-4231-60f4-15a1" name="Artificia Machina" hidden="false" collective="false" import="true" targetId="51ed-f978-9a5e-1e04" type="selectionEntry"/>
-            <entryLink id="bf1c-a1b8-52b6-383f" name="Ephemera Incursus" hidden="false" collective="false" import="true" targetId="12fc-d4d8-d36c-6f14" type="selectionEntry"/>
-            <entryLink id="39b4-0eb4-15c2-293e" name="Artificia Cybernetica" hidden="false" collective="false" import="true" targetId="d342-dbdb-33ec-5191" type="selectionEntry"/>
-          </entryLinks>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
       <entryLinks>
         <entryLink id="1380-c529-afc1-fec4" name="Upgrade Points (Placeholders)" hidden="false" collective="false" import="true" targetId="7c8d-b21a-1f72-7e22" type="selectionEntry"/>
         <entryLink id="fc61-b732-41ab-b1b8" name="Warlord" hidden="false" collective="false" import="true" targetId="0176-56a3-d590-b103" type="selectionEntry"/>
@@ -895,13 +869,53 @@ This unit may be upgraded freely as described in their profile, though they may 
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="60.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="bc2c-076a-209b-f121" name="Adsecularis Tech-thralls Covenant (Placeholder)" publicationId="bde1-6db1-163b-3b76" page="34" hidden="false" collective="false" import="true" type="unit">
+    <selectionEntry id="bc2c-076a-209b-f121" name="Adsecularis Tech-thralls Covenant" publicationId="bde1-6db1-163b-3b76" page="34" hidden="false" collective="false" import="true" type="unit">
+      <categoryLinks>
+        <categoryLink id="8ee7-e36b-9a79-6998" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+        <categoryLink id="2d6d-c8c5-9da8-958a" name="Line Sub-type:" hidden="false" targetId="6399-5c65-7833-1025" primary="false"/>
+        <categoryLink id="09f4-c088-2ec8-fac3" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+      </categoryLinks>
       <selectionEntries>
         <selectionEntry id="ce84-58bb-48ce-c2ea" name="Tech-thralls" publicationId="bde1-6db1-163b-3b76" page="34" hidden="false" collective="false" import="true" type="model">
           <constraints>
             <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e552-32cc-3642-0e0c" type="min"/>
             <constraint field="selections" scope="parent" value="30.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9ec5-879e-bc9d-cd5c" type="max"/>
           </constraints>
+          <profiles>
+            <profile id="38d0-8350-7538-3992" name="Tech-thralls" publicationId="bde1-6db1-163b-3b76" page="34" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName="Unit">
+              <characteristics>
+                <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Heavy, Line)</characteristic>
+                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">6</characteristic>
+                <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">2</characteristic>
+                <characteristic name="BS" typeId="74ae-c840-0036-d244">2</characteristic>
+                <characteristic name="S" typeId="e478-41d4-a092-48a8">3</characteristic>
+                <characteristic name="T" typeId="c32b-5fdd-3fbe-9b1f">3</characteristic>
+                <characteristic name="W" typeId="57ee-1126-32a9-5672">1</characteristic>
+                <characteristic name="I" typeId="62d3-22d7-2d49-52dc">2</characteristic>
+                <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">1</characteristic>
+                <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">6</characteristic>
+                <characteristic name="Save" typeId="e593-6b3c-f169-04f0">6+</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="25bc-4839-6589-9bf6" name="The Rite of Pure Thought" publicationId="bde1-6db1-163b-3b76" page="108" hidden="false">
+              <description>A unit with this special rule may not make any Reactions or Sweeping Advance moves.</description>
+            </rule>
+          </rules>
+          <infoLinks>
+            <infoLink id="6b8d-144a-ed22-93b9" name="Stubborn" hidden="false" targetId="7989-1f2c-a43d-82ae" type="rule"/>
+            <infoLink id="563c-051c-8f43-87c8" name="Feel No Pain (X)" hidden="false" targetId="ec46-ff29-32e0-c2aa" type="rule">
+              <modifiers>
+                <modifier type="set" field="name" value="Feel No Pain (5+)"/>
+              </modifiers>
+            </infoLink>
+            <infoLink id="2d5d-d9a0-f549-dd25" name="Hatred (X)" hidden="false" targetId="dc0b-fe69-6b71-e0a4" type="rule">
+              <modifiers>
+                <modifier type="set" field="name" value="Hatred (Everything)"/>
+              </modifiers>
+            </infoLink>
+          </infoLinks>
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="3.0"/>
           </costs>
@@ -909,6 +923,13 @@ This unit may be upgraded freely as described in their profile, though they may 
       </selectionEntries>
       <selectionEntryGroups>
         <selectionEntryGroup id="2e3a-ada7-2088-0cf0" name="Dedicated Transport" hidden="false" collective="false" import="true">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="bc2c-076a-209b-f121" value="20.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="greaterThan"/>
+              </conditions>
+            </modifier>
+          </modifiers>
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5197-9aab-7ca4-f807" type="max"/>
           </constraints>
@@ -918,19 +939,49 @@ This unit may be upgraded freely as described in their profile, though they may 
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="0e1f-d9e4-fc13-42e7" name="Upgrade Points (Placeholders)" hidden="false" collective="false" import="true" targetId="7c8d-b21a-1f72-7e22" type="selectionEntry"/>
+        <entryLink id="7e27-4d23-f110-7b88" name="Close Combat Weapon" hidden="false" collective="false" import="true" targetId="3d50-2f85-06ff-6aee" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bd61-6bad-431a-98fa" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b3f1-fa8d-6a89-aede" type="max"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="c934-a096-3675-9e72" name="Las-lock" hidden="false" collective="false" import="true" targetId="6491-5e10-ba7e-e0d3" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="23e1-94e5-3af0-cfa5" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a7f6-5bb3-df31-f51b" type="max"/>
+          </constraints>
+        </entryLink>
       </entryLinks>
       <costs>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="25c8-3e0f-e22d-a7eb" name="Thallax Cohort (Placeholder)" publicationId="bde1-6db1-163b-3b76" page="35" hidden="false" collective="false" import="true" type="unit">
+    <selectionEntry id="25c8-3e0f-e22d-a7eb" name="Thallax Cohort" publicationId="bde1-6db1-163b-3b76" page="35" hidden="false" collective="false" import="true" type="unit">
+      <categoryLinks>
+        <categoryLink id="a931-cb12-df9f-d7f6" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="f2b4-5412-c364-0696" name="Jet Infantry:" hidden="false" targetId="0b85-37e7-40ef-7388" primary="false"/>
+      </categoryLinks>
       <selectionEntries>
         <selectionEntry id="acc0-4cf8-5c18-a8d1" name="Thallax" publicationId="bde1-6db1-163b-3b76" page="35" hidden="false" collective="false" import="true" type="model">
           <constraints>
             <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="36cf-b9a4-51a8-9f72" type="min"/>
             <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6c73-2da3-780b-17a7" type="max"/>
           </constraints>
+          <infoLinks>
+            <infoLink id="0999-e4d0-9a02-9caf" name="Bulky (X)" hidden="false" targetId="676c-7b75-4b6f-9405" type="rule">
+              <modifiers>
+                <modifier type="set" field="name" value="Bulky (2)"/>
+              </modifiers>
+            </infoLink>
+            <infoLink id="a76f-dc01-1ce4-cef5" name="Data-djinn" hidden="false" targetId="3e2e-cdc0-8a31-06f6" type="rule"/>
+            <infoLink id="79ae-ce1d-c450-0e02" name="Feel No Pain (X)" hidden="false" targetId="ec46-ff29-32e0-c2aa" type="rule">
+              <modifiers>
+                <modifier type="set" field="name" value="Feel No Pain (6+)"/>
+              </modifiers>
+            </infoLink>
+            <infoLink id="3c71-f645-9aa2-cbd9" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule"/>
+            <infoLink id="978e-3c0b-b26a-ec1e" name="Stubborn" hidden="false" targetId="7989-1f2c-a43d-82ae" type="rule"/>
+          </infoLinks>
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="37.0"/>
           </costs>
@@ -945,23 +996,239 @@ This unit may be upgraded freely as described in their profile, though they may 
             <entryLink id="8107-e184-a844-b499" name="Triaros Armoured Conveyor " hidden="false" collective="false" import="true" targetId="2484-a122-76a2-b142" type="selectionEntry"/>
           </entryLinks>
         </selectionEntryGroup>
+        <selectionEntryGroup id="91e5-01b6-3dc0-5587" name="1 in 3 models may exchange their lightning gun for one of the following:" hidden="false" collective="false" import="true">
+          <modifiers>
+            <modifier type="increment" field="65a4-9b52-5801-fa1e" value="1.0">
+              <repeats>
+                <repeat field="selections" scope="25c8-3e0f-e22d-a7eb" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="65a4-9b52-5801-fa1e" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="f244-4d47-0c07-518f" name="Multi-Laser" hidden="false" collective="false" import="true" targetId="003b-af4b-0094-f5c3" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fa0b-17a1-0f2f-79bf" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="6d70-4441-261e-2f8a" name="Irad-Cleanser" hidden="false" collective="false" import="true" targetId="b3c5-237f-e1d2-d9f8" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dea9-a85c-9404-9a51" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="f9cf-38f3-25ed-68aa" name="Phased Plasma-Fusil" hidden="false" collective="false" import="true" targetId="17c6-afe9-c5da-d9b6" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a936-51aa-b593-0129" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="b432-4a83-4520-0f1d" name="Multi-Melta" hidden="false" collective="false" import="true" targetId="9332-3834-cf3a-56b4" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2bf7-3ed3-3fc6-8ed0" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="3363-6327-de6d-002f" name="Photon Thruster" hidden="false" collective="false" import="true" targetId="3519-b118-7c6e-2343" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9e9a-091b-845e-6cfc" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="1963-d393-5465-aacf" name="Any model with a Lightning Gun may take:" hidden="false" collective="false" import="true">
+          <modifiers>
+            <modifier type="increment" field="dc0e-9228-eeb0-8825" value="1.0">
+              <repeats>
+                <repeat field="selections" scope="25c8-3e0f-e22d-a7eb" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+            <modifier type="decrement" field="dc0e-9228-eeb0-8825" value="1.0">
+              <repeats>
+                <repeat field="selections" scope="25c8-3e0f-e22d-a7eb" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="91e5-01b6-3dc0-5587" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dc0e-9228-eeb0-8825" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="cbf2-d148-db6c-f0b5" name="Chain Bayonet" hidden="false" collective="false" import="true" targetId="bd82-cef6-67f8-19b5" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7b18-05dd-0e4e-ea92" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="c206-42ba-739f-6f0e" name="Upgrade Points (Placeholders)" hidden="false" collective="false" import="true" targetId="7c8d-b21a-1f72-7e22" type="selectionEntry"/>
+        <entryLink id="e4d7-e91a-3950-a14d" name="Lorica Thallax" hidden="false" collective="false" import="true" targetId="0575-c2d8-d3c5-d38f" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b8d3-3538-230a-6a85" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9830-90c5-dff3-d137" type="min"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="4330-a558-fb77-55e2" name="Incunabulan Jet Pack" hidden="false" collective="false" import="true" targetId="9faf-7242-dc40-c3e5" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f7ae-0f50-5eb8-8c15" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a8d2-8234-df09-a502" type="min"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="871a-a2d6-481c-3aa0" name="Frag Grenades" hidden="false" collective="false" import="true" targetId="cf9c-327b-3449-00d7" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9dc5-c009-7a9e-5969" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2c0c-5871-1384-d84f" type="min"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="0ff6-7c2b-ce2b-199b" name="Lightning Gun" hidden="false" collective="false" import="true" targetId="f65c-633a-5865-7f6b" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5f8e-0f42-d426-dfc0" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8d89-1e5c-972b-6e83" type="min"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="67e9-a5fe-d28d-f41b" name="Meltabombs" hidden="false" collective="false" import="true" targetId="b9dd-3b21-f3f8-78e3" type="selectionEntry">
+          <modifiers>
+            <modifier type="increment" field="d2ee-04cb-5f8a-2642" value="5.0">
+              <repeats>
+                <repeat field="selections" scope="25c8-3e0f-e22d-a7eb" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4a64-03ad-24f8-575d" type="max"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="6535-cc9d-cf59-c82c" name="Close Combat Weapon" hidden="false" collective="false" import="true" targetId="3d50-2f85-06ff-6aee" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ebc6-aeec-2063-8277" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="484c-6b65-dbe3-0ed7" type="max"/>
+          </constraints>
+        </entryLink>
       </entryLinks>
       <costs>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="14.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="57ab-2409-6707-b967" name="Scyllax Guardian-Automata Maniple (Placeholder)" publicationId="bde1-6db1-163b-3b76" page="36" hidden="false" collective="false" import="true" type="unit">
+    <selectionEntry id="57ab-2409-6707-b967" name="Scyllax Guardian-Automata Maniple" publicationId="bde1-6db1-163b-3b76" page="36" hidden="false" collective="false" import="true" type="unit">
+      <categoryLinks>
+        <categoryLink id="07b9-a447-feb6-8bfe" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+        <categoryLink id="807c-edb4-9721-da11" name="Line Sub-type:" hidden="false" targetId="6399-5c65-7833-1025" primary="false"/>
+        <categoryLink id="e3b7-cbc5-ca8e-80e2" name="Automata Unit-type:" hidden="false" targetId="d8ab-8e21-e193-63ba" primary="false"/>
+      </categoryLinks>
       <selectionEntries>
         <selectionEntry id="b707-5b11-0c1c-e5a1" name="Scyllax" publicationId="bde1-6db1-163b-3b76" page="36" hidden="false" collective="false" import="true" type="model">
           <constraints>
             <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9b34-d9b8-7b3d-fbf4" type="min"/>
             <constraint field="selections" scope="parent" value="16.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6b5f-12e4-0ef5-35a1" type="max"/>
           </constraints>
+          <profiles>
+            <profile id="4342-476a-75c5-063c" name="Scyllax" publicationId="bde1-6db1-163b-3b76" page="36" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName="Unit">
+              <characteristics>
+                <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Automata (Guardian, Heavy, Line)</characteristic>
+                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">6</characteristic>
+                <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">3</characteristic>
+                <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
+                <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
+                <characteristic name="T" typeId="c32b-5fdd-3fbe-9b1f">5</characteristic>
+                <characteristic name="W" typeId="57ee-1126-32a9-5672">2</characteristic>
+                <characteristic name="I" typeId="62d3-22d7-2d49-52dc">3</characteristic>
+                <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">3</characteristic>
+                <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">6</characteristic>
+                <characteristic name="Save" typeId="e593-6b3c-f169-04f0">4+</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="9185-e0fe-fb16-d9bb" name="Guardian Unit Sub-type" publicationId="bde1-6db1-163b-3b76" page="91" hidden="false">
+              <description>• Units including models with the Guardian Unit Sub-type may Embark freely upon models with the Transport Unit Sub-type and within Buildings and Fortifications as if they had the Infantry Type, even if their Unit Type would normally restrict this.
+• Units including models with the Guardian Unit Sub-type may be joined by friendly models with the Character Unit Sub-type or Independent Character special rule, and when they are joined in this manner may make Reactions, even if their Unit Type would normally restrict this.
+• If a unit contains any models with the Guardian Unit Sub-type as well as one or more models with the Character Unit Sub-type, any Wounds which would be allocated to the Character (even those caused by the Precision Strikes (X) or Sniper special rules) may instead be allocated to a model with the Guardian Unit Sub-type first.
+• Unless they are joined by a friendly Character, all models with the Guardian Unit Sub-type suffer the following provisions:
+-	Reduce their Movement Characteristic by -2 and may not Run.
+-	Reduce their Initiative Characteristic to 1.</description>
+            </rule>
+          </rules>
+          <infoLinks>
+            <infoLink id="4679-fa2e-bafa-55c3" name="Move Through Cover" hidden="false" targetId="2b6f-bfec-759e-1746" type="rule"/>
+            <infoLink id="0c41-d591-8f11-140c" name="Night Vision" hidden="false" targetId="683e-b4f2-f032-d31b" type="rule"/>
+            <infoLink id="5099-7f9f-41b6-aa8a" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule"/>
+            <infoLink id="d084-a195-c74d-1901" name="Support Squad" hidden="false" targetId="768e-56d6-ca52-24ae" type="rule"/>
+          </infoLinks>
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="89ed-ac7c-70ea-754b" name="Scyllax Combat Array" publicationId="bde1-6db1-163b-3b76" page="120" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4c65-0993-acbe-4a2e" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="976d-9976-5a9b-f572" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="822d-3834-6ff9-1666" name="Scyllax Combat Array - Dismember" publicationId="bde1-6db1-163b-3b76" page="120" hidden="false" collective="true" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="aa91-e193-6015-27d4" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e621-dedb-56d9-b98d" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="2489-e832-e4bb-7913" name="Scyllax Combat Array - Dismember" publicationId="bde1-6db1-163b-3b76" page="120" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+                  <characteristics>
+                    <characteristic name="Range" typeId="95ba-cda7-b831-6066">-</characteristic>
+                    <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">+3</characteristic>
+                    <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">2</characteristic>
+                    <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Melee, Cumbersome, Unwieldy</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <infoLinks>
+                <infoLink id="a2fc-783e-0a6d-fc31" name="Cumbersome" hidden="false" targetId="d89a-c10e-8a7a-92c3" type="rule"/>
+                <infoLink id="8e23-d54c-53b8-0bba" name="Unwieldy" hidden="false" targetId="1570-c21a-881f-8b8a" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="dc9e-6feb-d3ef-895f" name="Scyllax Combat Array - Standard" publicationId="bde1-6db1-163b-3b76" page="120" hidden="false" collective="true" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c273-63a3-e3ae-aabf" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bd2f-9640-13b7-4447" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="7504-8cd7-8a69-2880" name="Scyllax Combat Array - Standard" publicationId="bde1-6db1-163b-3b76" page="120" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+                  <characteristics>
+                    <characteristic name="Range" typeId="95ba-cda7-b831-6066">-</characteristic>
+                    <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">User</characteristic>
+                    <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">5</characteristic>
+                    <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Melee, Shred</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <infoLinks>
+                <infoLink id="5f56-22a9-7536-a80b" name="Shred" hidden="false" targetId="5e7e-1628-8174-6f2c" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
@@ -974,94 +1241,601 @@ This unit may be upgraded freely as described in their profile, though they may 
             <entryLink id="3754-bded-c722-2d2d" name="Triaros Armoured Conveyor " hidden="false" collective="false" import="true" targetId="2484-a122-76a2-b142" type="selectionEntry"/>
           </entryLinks>
         </selectionEntryGroup>
+        <selectionEntryGroup id="a77e-e8bf-d3be-1f5a" name="Any Scyllax may exchange their Kraken Bolter for one of the following:" hidden="false" collective="false" import="true" defaultSelectionEntryId="1edf-09ae-b2bd-0e09">
+          <modifiers>
+            <modifier type="increment" field="c0f3-11f5-b88b-f2b3" value="1.0">
+              <repeats>
+                <repeat field="selections" scope="57ab-2409-6707-b967" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+            <modifier type="increment" field="861f-e927-6a54-6e68" value="1.0">
+              <repeats>
+                <repeat field="selections" scope="57ab-2409-6707-b967" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+            <modifier type="decrement" field="c0f3-11f5-b88b-f2b3" value="4.0"/>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c0f3-11f5-b88b-f2b3" type="min"/>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="861f-e927-6a54-6e68" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="1edf-09ae-b2bd-0e09" name="Kraken Bolter" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="16.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ccce-9755-daf4-8cf1" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="a53c-d0cb-32db-1c8c" name="Kraken Bolter (Default)" hidden="false" targetId="89fa-8b2e-18d6-2b58" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <entryLinks>
+            <entryLink id="39e3-a27c-c0e0-c79c" name="Maxima Bolter" hidden="false" collective="false" import="true" targetId="1d3e-1b60-d133-ea0d" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="16.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f217-2093-5b2c-9ff9" type="max"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="8aba-c1e9-96a2-3cc9" name="Flamer" hidden="false" collective="false" import="true" targetId="9f41-82e2-90f6-973a" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="16.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5a32-8642-bcfc-2d3e" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="a1d0-f941-cc78-3502" name="Rotor Cannon" hidden="false" collective="false" import="true" targetId="5ce3-3aa5-3f5e-9ead" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="16.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8652-ed8f-86a6-e4cd" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="c022-f1ef-9976-0d61" name="Volkite Charger" hidden="false" collective="false" import="true" targetId="6f6e-ad55-e093-6503" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="16.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ffd2-f6ca-4f6b-4bfe" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="9018-1b22-c738-9356" name="For every four models in the unit, one Scyllax may exchange their Kraken Bolter for::" hidden="false" collective="false" import="true">
+          <modifiers>
+            <modifier type="increment" field="6ec0-4ae6-110a-496a" value="1.0">
+              <repeats>
+                <repeat field="selections" scope="57ab-2409-6707-b967" value="4.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6ec0-4ae6-110a-496a" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="d874-db25-f278-a506" name="Graviton Gun" hidden="false" collective="false" import="true" targetId="5303-5a3e-de51-1707" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1832-76df-32c9-39b8" type="max"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="ca30-e98b-aa02-79f5" name="Plasma Gun" hidden="false" collective="false" import="true" targetId="f0d1-332b-c719-ede7" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="46fb-0ccb-cf1e-5552" type="max"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="a4eb-de4f-a2fc-375e" name="Irad-Cleanser" hidden="false" collective="false" import="true" targetId="b3c5-237f-e1d2-d9f8" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1709-c2d3-fa7b-0a82" type="max"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="2a2a-f36f-6f31-cc36" name="Meltagun" hidden="false" collective="false" import="true" targetId="4ebd-57e0-3560-e568" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="720b-5743-c863-b759" type="max"/>
+              </constraints>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="960c-342f-a812-5215" name="Upgrade Points (Placeholders)" hidden="false" collective="false" import="true" targetId="7c8d-b21a-1f72-7e22" type="selectionEntry"/>
+        <entryLink id="19ae-c9ad-17dc-534a" name="Rad Furnace" hidden="false" collective="false" import="true" targetId="18da-a26c-bdd4-8a5f" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8944-72d4-adb0-ebaa" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f3ca-fb0d-d8ee-b9f9" type="max"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="d0e9-5d40-40d0-0ceb" name="Frag Grenades" hidden="false" collective="false" import="true" targetId="cf9c-327b-3449-00d7" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e59d-1817-2c39-1a91" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c7fd-65fd-1f3b-6d2e" type="max"/>
+          </constraints>
+        </entryLink>
       </entryLinks>
       <costs>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="b178-7d35-136f-d305" name="Arlatax Battle-Automata Maniple (Placeholder)" publicationId="bde1-6db1-163b-3b76" page="40" hidden="false" collective="false" import="true" type="unit">
+    <selectionEntry id="b178-7d35-136f-d305" name="Arlatax Battle-Automata Maniple" publicationId="bde1-6db1-163b-3b76" page="40" hidden="false" collective="false" import="true" type="unit">
+      <categoryLinks>
+        <categoryLink id="891f-df7d-04cb-caf1" name="Automata Unit-type:" hidden="false" targetId="d8ab-8e21-e193-63ba" primary="false"/>
+        <categoryLink id="f9ac-c447-beb5-ba0f" name="Cybernetica Sub-type:" hidden="false" targetId="2440-b64e-cb24-87f0" primary="false"/>
+      </categoryLinks>
       <selectionEntries>
         <selectionEntry id="e713-beb2-95dd-51cb" name="Arlatax" publicationId="bde1-6db1-163b-3b76" page="40" hidden="false" collective="false" import="true" type="model">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b21d-8f95-b377-6504" type="min"/>
             <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4fd3-aff9-ce5c-8c78" type="max"/>
           </constraints>
+          <profiles>
+            <profile id="7031-4235-6d87-c2a3" name="Arlatax" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName="Unit">
+              <modifiers>
+                <modifier type="increment" field="cc42-7ed5-7092-5c84" value="1">
+                  <conditions>
+                    <condition field="selections" scope="e713-beb2-95dd-51cb" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="cc2a-46fe-bbf3-6ba2" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="increment" field="57ee-1126-32a9-5672" value="1">
+                  <conditions>
+                    <condition field="selections" scope="e713-beb2-95dd-51cb" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="cc2a-46fe-bbf3-6ba2" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <characteristics>
+                <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Automata (Cybernetica)</characteristic>
+                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">8</characteristic>
+                <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
+                <characteristic name="BS" typeId="74ae-c840-0036-d244">3</characteristic>
+                <characteristic name="S" typeId="e478-41d4-a092-48a8">7</characteristic>
+                <characteristic name="T" typeId="c32b-5fdd-3fbe-9b1f">6</characteristic>
+                <characteristic name="W" typeId="57ee-1126-32a9-5672">4</characteristic>
+                <characteristic name="I" typeId="62d3-22d7-2d49-52dc">4</characteristic>
+                <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">3</characteristic>
+                <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">7</characteristic>
+                <characteristic name="Save" typeId="e593-6b3c-f169-04f0">3+</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <infoLinks>
+            <infoLink id="8a1d-8708-a025-bb17" name="Hammer of Wrath (X)" hidden="false" targetId="aec0-c3aa-1e4e-1779" type="rule">
+              <modifiers>
+                <modifier type="set" field="name" value="Hammer of Wrath (1)"/>
+              </modifiers>
+            </infoLink>
+          </infoLinks>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="a32e-b620-ee42-737d" name="Melee Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="5a9d-5fa0-5c22-c3a7">
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="233a-5f7b-103a-7f22" type="min"/>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2705-2339-f1ce-d05a" type="max"/>
+              </constraints>
+              <selectionEntries>
+                <selectionEntry id="5a9d-5fa0-5c22-c3a7" name="Power Blade Arrays With In-Built Light Autocannon*" hidden="false" collective="false" import="true" type="upgrade">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="642a-18be-c72d-5cf6" type="max"/>
+                  </constraints>
+                  <rules>
+                    <rule id="eef3-4bdf-4f70-9740" name="Power Blade Arrays With In-Built Light Autocannon*" publicationId="bde1-6db1-163b-3b76" page="40" hidden="false">
+                      <description>* An Arlatax with two power blade arrays gains an additional Attack. This additional Attack is not included in the characteristics profile above.</description>
+                    </rule>
+                  </rules>
+                  <selectionEntries>
+                    <selectionEntry id="2e78-ef5f-0355-37dc" name="Power Blade Array" publicationId="bde1-6db1-163b-3b76" page="122" hidden="false" collective="true" import="true" type="upgrade">
+                      <profiles>
+                        <profile id="909d-e3f3-25be-a060" name="Power Blade Array" publicationId="bde1-6db1-163b-3b76" page="122" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+                          <characteristics>
+                            <characteristic name="Range" typeId="95ba-cda7-b831-6066">-</characteristic>
+                            <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">User</characteristic>
+                            <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">4</characteristic>
+                            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Melee, Breaching (5+)</characteristic>
+                          </characteristics>
+                        </profile>
+                      </profiles>
+                      <infoLinks>
+                        <infoLink id="50f6-4bb0-0816-6d49" name="Breaching (X)" hidden="false" targetId="a760-f736-1bf3-fa3c" type="rule">
+                          <modifiers>
+                            <modifier type="set" field="name" value="Breaching (5+)"/>
+                          </modifiers>
+                        </infoLink>
+                      </infoLinks>
+                      <costs>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                      </costs>
+                    </selectionEntry>
+                    <selectionEntry id="8f35-0d01-7cc3-b558" name="Light Autocannon" publicationId="bde1-6db1-163b-3b76" page="114" hidden="false" collective="true" import="true" type="upgrade">
+                      <profiles>
+                        <profile id="e71b-e137-8d96-bc1d" name="Light Autocannon" publicationId="bde1-6db1-163b-3b76" page="114" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+                          <characteristics>
+                            <characteristic name="Range" typeId="95ba-cda7-b831-6066">36&quot;</characteristic>
+                            <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">6</characteristic>
+                            <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">4</characteristic>
+                            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Assault 2</characteristic>
+                          </characteristics>
+                        </profile>
+                      </profiles>
+                      <costs>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                      </costs>
+                    </selectionEntry>
+                  </selectionEntries>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+              <entryLinks>
+                <entryLink id="77e3-a902-4afa-7e7c" name="Arc Scourge" hidden="false" collective="false" import="true" targetId="9033-c395-43b3-5612" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="name" value="Arc Scourge*"/>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1187-784b-e0d0-a25a" type="max"/>
+                  </constraints>
+                  <rules>
+                    <rule id="accc-4f5d-a4b3-64d0" name="Arc Scourge*" hidden="false">
+                      <description>* An Arlatax with two power blade arrays gains an additional Attack. This additional Attack is not included in the characteristics profile above.</description>
+                    </rule>
+                  </rules>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0"/>
+                  </costs>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks>
+            <entryLink id="8acc-eb0b-b57d-d81c" name="Utan Jump Booster" hidden="false" collective="false" import="true" targetId="30b5-2dcd-6b27-067c" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a60b-5e52-3d88-76e9" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="63eb-015f-769c-63c1" type="max"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="c9b9-b9ea-4ee9-4597" name="Atomantic Deflector" hidden="false" collective="false" import="true" targetId="38fb-9a0b-edef-a497" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bd4d-4e7b-57dd-955e" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="15ae-9aed-5854-6424" type="max"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="bdfe-7490-232e-7437" name="Plasma Cannon" hidden="false" collective="false" import="true" targetId="43f5-3815-6b3a-a363" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d53c-31ed-1120-e86c" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a373-42c2-fe5d-dadf" type="max"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="6a82-3c05-8cb9-2fc1" name="Paragon of Metal" hidden="false" collective="false" import="true" targetId="cc2a-46fe-bbf3-6ba2" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="b178-7d35-136f-d305" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="greaterThan"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="35.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="135.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
-      <entryLinks>
-        <entryLink id="f02e-8f8a-69e6-7067" name="Upgrade Points (Placeholders)" hidden="false" collective="false" import="true" targetId="7c8d-b21a-1f72-7e22" type="selectionEntry"/>
-      </entryLinks>
       <costs>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="0750-2aed-2d36-8a82" name="Ursarax Cohort (Placeholder)" publicationId="bde1-6db1-163b-3b76" page="41" hidden="false" collective="false" import="true" type="unit">
+    <selectionEntry id="0750-2aed-2d36-8a82" name="Ursarax Cohort" publicationId="bde1-6db1-163b-3b76" page="41" hidden="false" collective="false" import="true" type="unit">
+      <categoryLinks>
+        <categoryLink id="8c6d-9086-eab1-a7e1" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+      </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="b22c-d1f6-9e4c-90e0" name="Ursarax" publicationId="bde1-6db1-163b-3b76" page="41" hidden="false" collective="false" import="true" type="model">
+        <selectionEntry id="2087-99e6-1519-5bf2" name="Ursarax" publicationId="bde1-6db1-163b-3b76" page="41" hidden="false" collective="false" import="true" type="model">
           <constraints>
-            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4fda-0551-7b0d-927d" type="min"/>
-            <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b00f-7a69-9ad5-70e5" type="max"/>
+            <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e132-357c-d440-6015" type="max"/>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9e79-03e5-fe0b-99f3" type="min"/>
           </constraints>
+          <infoLinks>
+            <infoLink id="384c-1dfb-f9a9-99ee" name="Feel No Pain (X)" hidden="false" targetId="ec46-ff29-32e0-c2aa" type="rule">
+              <modifiers>
+                <modifier type="set" field="name" value="Feel No Pain (6+)"/>
+              </modifiers>
+            </infoLink>
+            <infoLink id="4e13-c588-0c99-1995" name="Stubborn" hidden="false" targetId="7989-1f2c-a43d-82ae" type="rule"/>
+            <infoLink id="0bcc-05ee-8315-5815" name="Bulky (X)" hidden="false" targetId="676c-7b75-4b6f-9405" type="rule">
+              <modifiers>
+                <modifier type="set" field="name" value="Bulky (2)"/>
+              </modifiers>
+            </infoLink>
+          </infoLinks>
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="45.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="2d62-c506-e7de-4e60" name="Melee Weapons" hidden="false" collective="false" import="true" defaultSelectionEntryId="77aa-34b7-07b6-84c6">
+          <modifiers>
+            <modifier type="decrement" field="b790-520b-18e0-93da" value="3.0"/>
+            <modifier type="increment" field="21c6-fc42-abac-9900" value="1.0">
+              <repeats>
+                <repeat field="selections" scope="0750-2aed-2d36-8a82" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+            <modifier type="increment" field="b790-520b-18e0-93da" value="1.0">
+              <repeats>
+                <repeat field="selections" scope="0750-2aed-2d36-8a82" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b790-520b-18e0-93da" type="min"/>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="21c6-fc42-abac-9900" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="709c-ef33-7654-982e" name="Two Power Fists*" hidden="false" collective="false" import="true" type="upgrade">
+              <modifiers>
+                <modifier type="increment" field="bbe0-7cfc-7c00-94f5" value="1.0">
+                  <repeats>
+                    <repeat field="selections" scope="0750-2aed-2d36-8a82" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bbe0-7cfc-7c00-94f5" type="max"/>
+              </constraints>
+              <rules>
+                <rule id="00a3-1b03-7bf6-1c27" name="Two Power Fists*" publicationId="bde1-6db1-163b-3b76" page="41" hidden="false">
+                  <description>*An Ursarax with two power fists gains an additional Attack.</description>
+                </rule>
+              </rules>
+              <infoLinks>
+                <infoLink id="3831-ddca-89ec-d25d" name="Specialist Weapon" hidden="false" targetId="1a1f-3c9b-b097-5886" type="rule"/>
+                <infoLink id="69e4-799b-40b5-44ed" name="Unwieldy" hidden="false" targetId="1570-c21a-881f-8b8a" type="rule"/>
+                <infoLink id="65a0-393c-5221-76e9" name="Power Fist" hidden="false" targetId="5103-7522-7419-fdc4" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <entryLinks>
+            <entryLink id="77aa-34b7-07b6-84c6" name="Pair of Lightning Claws" hidden="false" collective="false" import="true" targetId="a6d2-b3a9-6d2c-1f6f" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="name" value="Pair of Lightning Claws*"/>
+              </modifiers>
+              <rules>
+                <rule id="803d-3b7c-2f64-3aae" name="Pair of Lightning Claws*" publicationId="bde1-6db1-163b-3b76" page="41" hidden="false">
+                  <description>An Ursarax with two lightning claws gains two additional Attacks. These additional Attacks are not included in the characteristics profile above.</description>
+                </rule>
+              </rules>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="f1ea-32d2-d945-9fc7" name="Upgrade Points (Placeholders)" hidden="false" collective="false" import="true" targetId="7c8d-b21a-1f72-7e22" type="selectionEntry"/>
+        <entryLink id="4d6d-fcb7-a97e-c77c" name="Frag Grenades" hidden="false" collective="false" import="true" targetId="cf9c-327b-3449-00d7" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2834-649d-f558-6d51" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ec5c-1349-237d-f68f" type="max"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="1f15-5607-f4a9-d8c2" name="Lorica Thallax" hidden="false" collective="false" import="true" targetId="0575-c2d8-d3c5-d38f" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="690d-7b91-b0e4-83f2" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="69df-4667-788d-2486" type="max"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="2b92-6980-7c49-6d3f" name="Utan Jump Booster" hidden="false" collective="false" import="true" targetId="30b5-2dcd-6b27-067c" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6dfa-01fb-1df6-2f43" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9b00-e039-94b4-f820" type="max"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="2bad-22a5-6fe8-d946" name="Volkite Incinerator" hidden="false" collective="false" import="true" targetId="4cc0-c7df-7157-6bf0" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5f41-a066-a7c9-5816" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3b71-ead8-68f9-eb3c" type="max"/>
+          </constraints>
+        </entryLink>
       </entryLinks>
       <costs>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="0e08-6b7e-8fff-1f02" name="Vultarax Stratos-Automata Squadron (Placeholder)" publicationId="bde1-6db1-163b-3b76" page="43" hidden="false" collective="false" import="true" type="unit">
+    <selectionEntry id="0e08-6b7e-8fff-1f02" name="Vultarax Stratos-Automata Squadron" publicationId="bde1-6db1-163b-3b76" page="43" hidden="false" collective="false" import="true" type="unit">
+      <categoryLinks>
+        <categoryLink id="eb08-ad92-7257-4980" name="Automata Unit-type:" hidden="false" targetId="d8ab-8e21-e193-63ba" primary="false"/>
+        <categoryLink id="dbd6-f6ad-4b5a-db84" name="Cybernetica Sub-type:" hidden="false" targetId="2440-b64e-cb24-87f0" primary="false"/>
+      </categoryLinks>
       <selectionEntries>
         <selectionEntry id="c731-8052-ca8a-0b37" name="Vultarax" publicationId="bde1-6db1-163b-3b76" page="43" hidden="false" collective="false" import="true" type="model">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cacc-92b5-fcd4-b67d" type="min"/>
             <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3692-8ae3-31a9-fd73" type="max"/>
           </constraints>
+          <profiles>
+            <profile id="33cf-ea59-a668-2430" name="Vultarax" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName="Unit">
+              <modifiers>
+                <modifier type="increment" field="cc42-7ed5-7092-5c84" value="1">
+                  <conditions>
+                    <condition field="selections" scope="c731-8052-ca8a-0b37" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="cc2a-46fe-bbf3-6ba2" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="increment" field="57ee-1126-32a9-5672" value="1">
+                  <conditions>
+                    <condition field="selections" scope="c731-8052-ca8a-0b37" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="cc2a-46fe-bbf3-6ba2" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <characteristics>
+                <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Automata (Antigrav, Cybernetica)</characteristic>
+                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">8</characteristic>
+                <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">3</characteristic>
+                <characteristic name="BS" typeId="74ae-c840-0036-d244">5</characteristic>
+                <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
+                <characteristic name="T" typeId="c32b-5fdd-3fbe-9b1f">6</characteristic>
+                <characteristic name="W" typeId="57ee-1126-32a9-5672">4</characteristic>
+                <characteristic name="I" typeId="62d3-22d7-2d49-52dc">3</characteristic>
+                <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">2</characteristic>
+                <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">7</characteristic>
+                <characteristic name="Save" typeId="e593-6b3c-f169-04f0">3+</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="caae-a4be-7597-5364" name="Surveillance Protocols" publicationId="bde1-6db1-163b-3b76" page="108" hidden="false">
+              <description>A model with this special rule and the Cybernetica Unit Sub-type may ignore the Programmed Behaviour provision described as part of that Sub-type during the Charge sub-phase.</description>
+            </rule>
+          </rules>
+          <infoLinks>
+            <infoLink id="096d-151b-aa69-8584" name="It Will Not Die (X)" hidden="false" targetId="2784-d0be-a4e2-890f" type="rule">
+              <modifiers>
+                <modifier type="set" field="name" value="It Will Not Die (5+)"/>
+              </modifiers>
+            </infoLink>
+            <infoLink id="0008-984f-4cee-1f05" name="Night Vision" hidden="false" targetId="683e-b4f2-f032-d31b" type="rule"/>
+            <infoLink id="8b44-a8df-a390-f398" name="Djinn-Sight" hidden="false" targetId="50f4-db05-3e45-467f" type="rule"/>
+          </infoLinks>
+          <selectionEntries>
+            <selectionEntry id="163f-5b84-490b-b332" name="Stratos Thrusters" publicationId="bde1-6db1-163b-3b76" page="130" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="11ec-0cf8-5dcd-9593" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bd7c-394f-e7cf-3bc2" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="e90a-5837-2524-80f0" name="Stratos Thrusters" publicationId="bde1-6db1-163b-3b76" page="130" hidden="false" typeId="2a1f-7837-f0ef-be44" typeName="Wargear Item">
+                  <characteristics>
+                    <characteristic name="Description" typeId="347e-ee4a-764f-6be3">A unit composed entirely of models with Stratos thrusters may set its Move Characteristic to a value of 16&quot; for the duration of the controlling player’s turn. This allows the unit to move up to 16&quot;, regardless of the Movement Characteristic shown on its profile and gain any other benefits of a Movement Characteristic of 16&quot; (including the bonus to Charge distance). In addition, Stratos thrusters allow units to hover above the battlefield and thus ignore the effects of Difficult Terrain and Dangerous Terrain at all times.</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <entryLinks>
+            <entryLink id="c5f5-0be4-0ee6-7d3e" name="Paragon of Metal" hidden="false" collective="false" import="true" targetId="cc2a-46fe-bbf3-6ba2" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="0e08-6b7e-8fff-1f02" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="greaterThan"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="35.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="8949-3747-5b25-f22c" name="Arc Blaster" hidden="false" collective="false" import="true" targetId="73fe-4e82-6207-a09a" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d838-ff7e-f3e1-b628" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3ecb-cd3b-f403-39a0" type="max"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="add0-a068-7a2c-58e9" name="Havoc Launcher" hidden="false" collective="false" import="true" targetId="bde9-5abf-ec3d-2273" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5f51-b39c-39d3-af5f" type="min"/>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f81f-424f-0ae2-9734" type="max"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="8a51-d0c8-70bb-bc60" name="Atomantic Deflector" hidden="false" collective="false" import="true" targetId="38fb-9a0b-edef-a497" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b65f-7206-571f-db3e" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="aa99-2051-903d-410f" type="max"/>
+              </constraints>
+            </entryLink>
+          </entryLinks>
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="125.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
-      <entryLinks>
-        <entryLink id="013c-55f4-bb0c-ea93" name="Upgrade Points (Placeholders)" hidden="false" collective="false" import="true" targetId="7c8d-b21a-1f72-7e22" type="selectionEntry"/>
-      </entryLinks>
       <costs>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="356f-a88b-1d13-3700" name="Myrmidon Destructor Host (Placeholder)" publicationId="bde1-6db1-163b-3b76" page="47" hidden="false" collective="false" import="true" type="unit">
+    <selectionEntry id="356f-a88b-1d13-3700" name="Myrmidon Destructor Host" publicationId="bde1-6db1-163b-3b76" page="47" hidden="false" collective="false" import="true" type="unit">
+      <infoLinks>
+        <infoLink id="bd8c-840b-bc7b-bf2e" name="Bulky (X)" hidden="false" targetId="676c-7b75-4b6f-9405" type="rule">
+          <modifiers>
+            <modifier type="set" field="name" value="Bulky (3)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="428c-4ab6-623b-ed18" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule"/>
+        <infoLink id="da5f-b641-135d-0989" name="Stubborn" hidden="false" targetId="7989-1f2c-a43d-82ae" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="dd54-d5d1-0a67-2cc1" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="300d-bc70-c03a-6048" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+      </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="ad85-e96a-2d4f-8bf8" name="Myrmidon Destructor" publicationId="bde1-6db1-163b-3b76" page="47" hidden="false" collective="false" import="true" type="model">
-          <constraints>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="db48-ac75-9cd4-856a" type="min"/>
-            <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9dd8-e9c2-6ec5-2398" type="max"/>
-          </constraints>
-          <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="40.0"/>
-          </costs>
-        </selectionEntry>
         <selectionEntry id="ef1e-ad56-2550-340f" name="Destructor Lord" publicationId="bde1-6db1-163b-3b76" page="47" hidden="false" collective="false" import="true" type="model">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fce1-eb08-91af-1d01" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b43a-ecbc-bf5e-cbf2" type="max"/>
           </constraints>
+          <profiles>
+            <profile id="cde5-2155-962e-422a" name="Destructor Lord" publicationId="bde1-6db1-163b-3b76" page="47" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName="Unit">
+              <characteristics>
+                <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Destructor Lord: Infantry (Character, Heavy)</characteristic>
+                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">6</characteristic>
+                <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
+                <characteristic name="BS" typeId="74ae-c840-0036-d244">5</characteristic>
+                <characteristic name="S" typeId="e478-41d4-a092-48a8">5</characteristic>
+                <characteristic name="T" typeId="c32b-5fdd-3fbe-9b1f">5</characteristic>
+                <characteristic name="W" typeId="57ee-1126-32a9-5672">4</characteristic>
+                <characteristic name="I" typeId="62d3-22d7-2d49-52dc">2</characteristic>
+                <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">3</characteristic>
+                <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">9</characteristic>
+                <characteristic name="Save" typeId="e593-6b3c-f169-04f0">3+</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <categoryLinks>
+            <categoryLink id="2d1a-287f-ad7c-773b" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
+          </categoryLinks>
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="5b01-caa5-329f-f44a" name="Myrmidon Destructor" publicationId="bde1-6db1-163b-3b76" page="47" hidden="false" collective="false" import="true" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8072-65d9-572d-5d2c" type="min"/>
+            <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fbd6-d73d-28bb-0cad" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="5d23-99a0-af42-f914" name="Myrmidon Destructor" publicationId="bde1-6db1-163b-3b76" page="47" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName="Unit">
+              <characteristics>
+                <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Destructor Lord: Infantry (Heavy)</characteristic>
+                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">6</characteristic>
+                <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
+                <characteristic name="BS" typeId="74ae-c840-0036-d244">5</characteristic>
+                <characteristic name="S" typeId="e478-41d4-a092-48a8">5</characteristic>
+                <characteristic name="T" typeId="c32b-5fdd-3fbe-9b1f">5</characteristic>
+                <characteristic name="W" typeId="57ee-1126-32a9-5672">4</characteristic>
+                <characteristic name="I" typeId="62d3-22d7-2d49-52dc">2</characteristic>
+                <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">2</characteristic>
+                <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">8</characteristic>
+                <characteristic name="Save" typeId="e593-6b3c-f169-04f0">3+</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="40.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
         <selectionEntryGroup id="05bd-0a8e-eca3-3c4a" name="Dedicated Transport" hidden="false" collective="false" import="true">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="356f-a88b-1d13-3700" value="6.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="greaterThan"/>
+              </conditions>
+            </modifier>
+          </modifiers>
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f1ac-c344-b582-66f1" type="max"/>
           </constraints>
@@ -1069,157 +1843,483 @@ This unit may be upgraded freely as described in their profile, though they may 
             <entryLink id="4c26-d0e9-132e-6b0f" name="Triaros Armoured Conveyor " hidden="false" collective="false" import="true" targetId="2484-a122-76a2-b142" type="selectionEntry"/>
           </entryLinks>
         </selectionEntryGroup>
+        <selectionEntryGroup id="ce89-88f5-b3c1-1ee9" name="Any model in the unit may exchange their volkite culverin for one of the following:" hidden="false" collective="false" import="true" defaultSelectionEntryId="7387-77c2-49e8-24c8">
+          <modifiers>
+            <modifier type="decrement" field="4654-88f3-028e-0daa" value="3.0"/>
+            <modifier type="increment" field="b350-5fd4-b4a3-82aa" value="1.0">
+              <repeats>
+                <repeat field="selections" scope="356f-a88b-1d13-3700" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+            <modifier type="increment" field="4654-88f3-028e-0daa" value="1.0">
+              <repeats>
+                <repeat field="selections" scope="356f-a88b-1d13-3700" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4654-88f3-028e-0daa" type="min"/>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b350-5fd4-b4a3-82aa" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="6ed7-a013-8d90-a538" name="Conversion Beamer" hidden="false" collective="false" import="true" targetId="2397-a3fd-81e6-4ced" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a87f-4816-a78c-ebad" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="cf45-da38-f42a-0741" name="Darkfire Cannon" hidden="false" collective="false" import="true" targetId="6f3d-9a42-da1d-2c2e" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="27e7-da33-2337-498e" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="bf62-7757-6e0d-da28" name="Graviton Imploder" hidden="false" collective="false" import="true" targetId="c651-d95e-6aa9-c3de" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="178f-c32c-a064-5977" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="997c-885a-a541-0f23" name="Irradiation Engine" hidden="false" collective="false" import="true" targetId="5d14-047a-bc9c-5d00" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ee07-ad2a-1c06-c268" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="7387-77c2-49e8-24c8" name="Volkite Culverin" hidden="false" collective="false" import="true" targetId="170d-44e0-455c-8207" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="350b-70ab-83c2-fa5c" type="max"/>
+              </constraints>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="669c-d5d3-050e-b457" name="Upgrade Points (Placeholders)" hidden="false" collective="false" import="true" targetId="7c8d-b21a-1f72-7e22" type="selectionEntry"/>
+        <entryLink id="1234-0881-fe9a-fb33" name="Shock Charger" hidden="false" collective="false" import="true" targetId="3234-492f-9ebf-f23c" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c11f-d236-0f58-21d1" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a7c2-8507-f960-414a" type="max"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="b0ab-2aea-dba5-04b3" name="Refractor Field" hidden="false" collective="false" import="true" targetId="a06a-55a5-070b-1d0e" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="14bd-d10b-d0a7-947d" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9aa4-6ed4-6a65-f3c6" type="max"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="5b85-56df-9cbf-57b6" name="Frag Grenades" hidden="false" collective="false" import="true" targetId="cf9c-327b-3449-00d7" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2686-8381-2b8a-ce1c" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7e49-f5be-0d49-5e3f" type="max"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="16ce-90f6-396e-3453" name="Krak Grenades" hidden="false" collective="false" import="true" targetId="99df-2421-acf7-a5ad" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8a53-a207-c89c-2b54" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ac88-dc74-3950-594d" type="max"/>
+          </constraints>
+        </entryLink>
       </entryLinks>
       <costs>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="65.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="8920-3184-2455-1834" name="Karacnos Assault Tank (Placeholder)" publicationId="bde1-6db1-163b-3b76" page="48" hidden="false" collective="false" import="true" type="unit">
-      <selectionEntries>
-        <selectionEntry id="15ae-630b-77b0-8c97" name="Karacnos" publicationId="bde1-6db1-163b-3b76" page="48" hidden="false" collective="false" import="true" type="model">
+    <selectionEntry id="8920-3184-2455-1834" name="Karacnos Assault Tank" publicationId="bde1-6db1-163b-3b76" page="48" hidden="false" collective="false" import="true" type="unit">
+      <profiles>
+        <profile id="476c-ddd5-0c77-770b" name="Karacnos" publicationId="bde1-6db1-163b-3b76" page="48" hidden="false" typeId="2fae-b053-3f78-e7b2" typeName="Vehicle">
+          <characteristics>
+            <characteristic name="Unit Type" typeId="e555-4aed-dfcc-c0b4">Vehicle</characteristic>
+            <characteristic name="Move" typeId="3614-4a2d-bffb-90e4">12</characteristic>
+            <characteristic name="BS" typeId="51fb-b7d9-aa59-863d">4</characteristic>
+            <characteristic name="Front" typeId="0ef8-a648-01d0-08ee">14</characteristic>
+            <characteristic name="Side" typeId="f150-c0dc-c192-9cb3">12</characteristic>
+            <characteristic name="Rear" typeId="8d4e-2aea-fffc-d556">12</characteristic>
+            <characteristic name="HP" typeId="a76c-83b1-602f-9e62">5</characteristic>
+            <characteristic name="Transport Capacity" typeId="0c90-79e2-f768-e547"/>
+            <characteristic name="Access Points" typeId="e217-1b1e-9494-3e3e"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules>
+        <rule id="6634-4243-b2d0-39e6" name="Hazardous Munitions" publicationId="bde1-6db1-163b-3b76" page="105" hidden="false">
+          <description>If a model with this special rule suffers an Explodes result on the Vehicle Damage table as a result of a Melee or Shooting Attack, the Explodes result causes nearby units to suffer a Str 8, AP 4 Hit for each model within D6+6&quot; instead of the usual damage and area of effect.</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="01ed-559b-53f5-9da9" name="Galvanic Traction Drive" hidden="false" targetId="e51e-cae1-d9e7-d317" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="3154-57c0-da0d-61c8" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
+      </categoryLinks>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="e961-a164-9671-36f8" name="Hull (Front) Mounted Hunter-Killer Missiles" hidden="false" collective="false" import="true">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7a38-9eee-9195-d4a3" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4507-f1fe-5186-bd53" type="max"/>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c5f8-c24d-eb7f-15b2" type="max"/>
           </constraints>
-          <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
+          <entryLinks>
+            <entryLink id="1949-514b-893b-97b9" name="Hunter-Killer Missile" hidden="false" collective="false" import="true" targetId="1bf8-72f8-c331-6900" type="selectionEntry">
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="9571-5119-6c7c-ed1d" name="Upgrade Points (Placeholders)" hidden="false" collective="false" import="true" targetId="7c8d-b21a-1f72-7e22" type="selectionEntry"/>
+        <entryLink id="6d98-583b-6484-c97d" name="Flare Shield" hidden="false" collective="false" import="true" targetId="0e77-6285-22bb-1534" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8fb0-01ea-3781-83ad" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="607e-faa4-999e-c0b6" type="max"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="3fa1-fa4e-e319-68ad" name="Searchlights" hidden="false" collective="false" import="true" targetId="4ae3-79b4-6051-505e" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="48dc-964e-901e-5ab1" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="72a6-db64-b4e2-a25d" type="max"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="5b4d-6256-6e05-6280" name="Shock Ram" hidden="false" collective="false" import="true" targetId="e22e-df78-c49b-7b98" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6363-18d0-db99-7979" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3c7f-0206-4b1e-fa13" type="max"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="13a7-7d49-5ab4-996a" name="Karacnos Mortar Battery" hidden="false" collective="false" import="true" targetId="2b9f-41fb-a0a8-285e" type="selectionEntry">
+          <modifiers>
+            <modifier type="set" field="name" value="Hull (Front) Mounted Karacnos Mortar Battery"/>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5a70-32d9-7802-97b3" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0661-abbd-7511-7b90" type="min"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="f2f4-73b1-065d-09f4" name="Lightning Lock" hidden="false" collective="false" import="true" targetId="dd74-951d-8540-5ea1" type="selectionEntry">
+          <modifiers>
+            <modifier type="set" field="name" value="Sponson Mounted Lightning Locks"/>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f2ee-c48e-3d13-43db" type="min"/>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="283f-249e-a431-dff7" type="max"/>
+          </constraints>
+        </entryLink>
       </entryLinks>
       <costs>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="225.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="ce87-68e2-0134-3c84" name="Krios Squadron (Placeholder)" publicationId="bde1-6db1-163b-3b76" page="49" hidden="false" collective="false" import="true" type="unit">
+    <selectionEntry id="ce87-68e2-0134-3c84" name="Krios Squadron" publicationId="bde1-6db1-163b-3b76" page="49" hidden="false" collective="false" import="true" type="unit">
+      <categoryLinks>
+        <categoryLink id="c4aa-2ea1-7395-2961" name="Fast Vehicles" hidden="false" targetId="0ea2-efb5-b7af-226e" primary="false"/>
+        <categoryLink id="a179-577f-cd12-e576" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
+      </categoryLinks>
       <selectionEntries>
         <selectionEntry id="a6c8-1f76-580d-d901" name="Krios" publicationId="bde1-6db1-163b-3b76" page="49" hidden="false" collective="false" import="true" type="model">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7ea5-4d53-b861-8867" type="min"/>
             <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="da01-bded-3106-bd5b" type="max"/>
           </constraints>
+          <profiles>
+            <profile id="0d8f-f51e-e76b-e6aa" name="Krios Battle Tank" publicationId="bde1-6db1-163b-3b76" page="49" hidden="false" typeId="2fae-b053-3f78-e7b2" typeName="Vehicle">
+              <modifiers>
+                <modifier type="set" field="name" value="Krios Venator Tank Destroyer">
+                  <conditions>
+                    <condition field="selections" scope="a6c8-1f76-580d-d901" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="566b-4fc6-9d5c-10cd" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <characteristics>
+                <characteristic name="Unit Type" typeId="e555-4aed-dfcc-c0b4">Vehicle (Fast)</characteristic>
+                <characteristic name="Move" typeId="3614-4a2d-bffb-90e4">16</characteristic>
+                <characteristic name="BS" typeId="51fb-b7d9-aa59-863d">4</characteristic>
+                <characteristic name="Front" typeId="0ef8-a648-01d0-08ee">13</characteristic>
+                <characteristic name="Side" typeId="f150-c0dc-c192-9cb3">12</characteristic>
+                <characteristic name="Rear" typeId="8d4e-2aea-fffc-d556">10</characteristic>
+                <characteristic name="HP" typeId="a76c-83b1-602f-9e62">4</characteristic>
+                <characteristic name="Transport Capacity" typeId="0c90-79e2-f768-e547"/>
+                <characteristic name="Access Points" typeId="e217-1b1e-9494-3e3e"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <infoLinks>
+            <infoLink id="ec7c-c20a-85b4-a19f" name="Galvanic Traction Drive" hidden="false" targetId="e51e-cae1-d9e7-d317" type="rule"/>
+            <infoLink id="53da-c7cc-4ecd-6183" name="It Will Not Die (X)" hidden="false" targetId="2784-d0be-a4e2-890f" type="rule">
+              <modifiers>
+                <modifier type="set" field="name" value="It Will Not Die (6+)"/>
+              </modifiers>
+            </infoLink>
+          </infoLinks>
+          <categoryLinks>
+            <categoryLink id="be91-18eb-a67a-8b36" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+          </categoryLinks>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="ce42-140a-6427-9dfd" name="Hull (Front) Mounted Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="0540-4761-0685-b2f2">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="08dd-09a6-8d77-b53b" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c5ea-0310-089c-792a" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="0540-4761-0685-b2f2" name="Lightning Cannon " hidden="false" collective="false" import="true" targetId="31eb-9c83-cc5e-ef2d" type="selectionEntry"/>
+                <entryLink id="38cf-952d-9601-d493" name="Pulsar-Fusil" hidden="false" collective="false" import="true" targetId="566b-4fc6-9d5c-10cd" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0"/>
+                  </costs>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="cc12-3552-7c4b-7d3b" name="Any Krios in the squadron may take any of the following options:" hidden="false" collective="false" import="true">
+              <selectionEntries>
+                <selectionEntry id="36f9-8862-7a52-2928" name="Two Centreline Mounted Volkite Calivers" hidden="false" collective="false" import="true" type="upgrade">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e229-2a5a-7bf3-b572" type="max"/>
+                  </constraints>
+                  <infoLinks>
+                    <infoLink id="3e2a-8d80-61ae-cf99" name="Volkite Caliver" hidden="false" targetId="00a0-68df-defd-2a3a" type="profile"/>
+                    <infoLink id="56ef-edfc-f937-00db" name="Deflagrate" hidden="false" targetId="60bc-f79a-67ae-be4f" type="rule"/>
+                  </infoLinks>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="30.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+              <entryLinks>
+                <entryLink id="b2c4-9aaa-07db-a001" name="Hunter-Killer Missile" hidden="false" collective="false" import="true" targetId="1bf8-72f8-c331-6900" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="name" value="Hull (Front) Mounted Hunter-Killer Missiles"/>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d1ba-02e2-93b3-db5d" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                  </costs>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks>
+            <entryLink id="da1e-b01e-67f5-1b36" name="Searchlights" hidden="false" collective="false" import="true" targetId="4ae3-79b4-6051-505e" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b745-5105-24b2-cc71" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ebff-8c19-ee96-4e41" type="max"/>
+              </constraints>
+            </entryLink>
+          </entryLinks>
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="125.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
-      <entryLinks>
-        <entryLink id="8383-241a-bfa9-b698" name="Upgrade Points (Placeholders)" hidden="false" collective="false" import="true" targetId="7c8d-b21a-1f72-7e22" type="selectionEntry"/>
-      </entryLinks>
       <costs>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="c21c-3c14-2d2e-4bc0" name="Knight Moirax Talon (Placeholder)" publicationId="bde1-6db1-163b-3b76" page="50" hidden="false" collective="false" import="true" type="unit">
+    <selectionEntry id="1277-aefb-66c5-bd35" name="Ordinatus Ulator" publicationId="bde1-6db1-163b-3b76" page="56" hidden="false" collective="false" import="true" type="unit">
+      <profiles>
+        <profile id="844f-1242-2d23-343d" name="Ordinatus Ulator" publicationId="bde1-6db1-163b-3b76" page="56" hidden="false" typeId="2fae-b053-3f78-e7b2" typeName="Vehicle">
+          <characteristics>
+            <characteristic name="Unit Type" typeId="e555-4aed-dfcc-c0b4">Vehicle (Super-heavy)</characteristic>
+            <characteristic name="Move" typeId="3614-4a2d-bffb-90e4">-</characteristic>
+            <characteristic name="BS" typeId="51fb-b7d9-aa59-863d">4</characteristic>
+            <characteristic name="Front" typeId="0ef8-a648-01d0-08ee">14</characteristic>
+            <characteristic name="Side" typeId="f150-c0dc-c192-9cb3">13</characteristic>
+            <characteristic name="Rear" typeId="8d4e-2aea-fffc-d556">13</characteristic>
+            <characteristic name="HP" typeId="a76c-83b1-602f-9e62">14</characteristic>
+            <characteristic name="Transport Capacity" typeId="0c90-79e2-f768-e547"/>
+            <characteristic name="Access Points" typeId="e217-1b1e-9494-3e3e"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="42b5-7679-56b0-6bea" name="It Will Not Die (X)" hidden="false" targetId="2784-d0be-a4e2-890f" type="rule">
+          <modifiers>
+            <modifier type="set" field="name" value="It Will Not Die (6+)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="1aa4-d116-94d4-5b9a" name="Reactor Meltdown (X)" hidden="false" targetId="3b0e-4a45-9bdd-91dc" type="rule">
+          <modifiers>
+            <modifier type="set" field="name" value="Reactor Meltdown (Major)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="7ee2-f364-4a7d-9415" name="Reinforced Structure" hidden="false" targetId="5b0d-5362-e961-f3b0" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="bada-ebff-8f90-0b2c" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
+        <categoryLink id="4cd2-af0c-e2d2-1c91" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+      </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="de25-2bc1-39a7-31b5" name="Knight Moirax" publicationId="bde1-6db1-163b-3b76" page="50" hidden="false" collective="false" import="true" type="model">
+        <selectionEntry id="808a-6ab8-6d40-6006" name="Ordinatus Dispersion Shield" publicationId="bde1-6db1-163b-3b76" page="126" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b36d-ed69-a0a2-cf97" type="min"/>
-            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d6c3-d267-5a4f-f0c3" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6852-6dab-cbe1-f2cf" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0cd2-f606-9d73-d163" type="max"/>
           </constraints>
+          <profiles>
+            <profile id="110b-b86e-c1d0-0936" name="Ordinatus Dispersion Shield" publicationId="bde1-6db1-163b-3b76" page="126" hidden="false" typeId="2a1f-7837-f0ef-be44" typeName="Wargear Item">
+              <characteristics>
+                <characteristic name="Description" typeId="347e-ee4a-764f-6be3">For the duration of the first Game Turn, all Shooting Attacks made against a model with an Ordinatus dispersion shield that target the model’s Front or Side Armour values, or any indirect Shooting Attacks (such as those with the Barrage special rule) are reduced by -2 Strength, and any Explodes results on the Vehicle Damage table are ignored.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="200.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
           </costs>
         </selectionEntry>
-      </selectionEntries>
-      <entryLinks>
-        <entryLink id="5344-19d2-208f-74d9" name="Upgrade Points (Placeholders)" hidden="false" collective="false" import="true" targetId="7c8d-b21a-1f72-7e22" type="selectionEntry"/>
-      </entryLinks>
-      <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="b582-e53e-5e13-286c" name="Mechanicum Knight Magaera (Placeholder)" publicationId="bde1-6db1-163b-3b76" page="52" hidden="false" collective="false" import="true" type="unit">
-      <selectionEntries>
-        <selectionEntry id="d3f5-b12d-88c0-032b" name="Mechanicum Knight Magaera" publicationId="bde1-6db1-163b-3b76" page="52" hidden="false" collective="false" import="true" type="model">
+        <selectionEntry id="3029-6abc-2c5b-7c9e" name="Sonic Destructor" publicationId="bde1-6db1-163b-3b76" page="119" hidden="false" collective="false" import="true" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="name" value="One Hull (Front) Mounted Sonic Destructor"/>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d6e1-aee4-cccc-5a13" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="48f7-c997-aa32-e878" type="min"/>
+          </constraints>
+          <profiles>
+            <profile id="628e-09a2-4967-a037" name="Sonic Destructor" publicationId="bde1-6db1-163b-3b76" page="119" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+              <characteristics>
+                <characteristic name="Range" typeId="95ba-cda7-b831-6066"/>
+                <characteristic name="Strength" typeId="24d9-b8e1-a355-2458"/>
+                <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d"/>
+                <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Destroyer 1, Large Blast (5&quot;), Sonic Wave, Pinning, Armourbane (Ranged), Murderous Strike (5+), Ignores Cover</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="8e53-b538-e67a-4966" name="Sonic Wave" publicationId="bde1-6db1-163b-3b76" page="108" hidden="false">
+              <description>When making a Shooting Attack with this weapon, place the Large Blast (5&quot;) marker so that its edge touches the Front hull of the firing model. Instead of scattering this Blast marker, move the template in a direct line away from the firing model, travelling in any direction within the weapon’s 45° forward firing arc until its maximum range is reached or the template leaves the battlefield. All models the template passes over suffer a single automatic Hit. Flyers are also Hit if the template passes over their base. Should a model with the Knight, Titan, Super-heavy Vehicle, Building or Fortification Unit Type be Hit by this attack, increase the Strength of the attack to 10.</description>
+            </rule>
+          </rules>
+          <infoLinks>
+            <infoLink id="6c83-b38a-e611-55aa" name="Destroyer" hidden="false" targetId="44d6-09b2-3bd3-b2d6" type="rule"/>
+            <infoLink id="d77c-16fe-6ca3-cb27" name="Blast" hidden="false" targetId="1d9a-73ef-5f4f-8bd8" type="rule"/>
+            <infoLink id="b6b8-9309-aac8-9771" name="Murderous Strike (X)" hidden="false" targetId="93b9-1454-0e7c-42ae" type="rule">
+              <modifiers>
+                <modifier type="set" field="name" value="Murderous Strike (5+)"/>
+              </modifiers>
+            </infoLink>
+            <infoLink id="ce3d-b616-f3a1-1a2e" name="Pinning" hidden="false" targetId="1c96-205c-59a0-3cf2" type="rule"/>
+            <infoLink id="8fa0-04b1-17fe-42e8" name="Armourbane (X)" hidden="false" targetId="cb59-f920-f071-7cd4" type="rule">
+              <modifiers>
+                <modifier type="set" field="name" value="Armourbane (Ranged)"/>
+              </modifiers>
+            </infoLink>
+            <infoLink id="2bcb-7f63-51b8-8657" name="Ignores Cover" hidden="false" targetId="fdb5-59e2-c446-1cbc" type="rule"/>
+          </infoLinks>
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
-        <entryLink id="76d4-b4f0-abb3-233f" name="Upgrade Points (Placeholders)" hidden="false" collective="false" import="true" targetId="7c8d-b21a-1f72-7e22" type="selectionEntry"/>
-      </entryLinks>
-      <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="400.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="aae3-4a95-fbce-6d01" name="Mechanicum Knight Styrix (Placeholder)" publicationId="bde1-6db1-163b-3b76" page="53" hidden="false" collective="false" import="true" type="unit">
-      <selectionEntries>
-        <selectionEntry id="d976-aeb8-4445-9256" name="Mechanicum Knight Styrix" publicationId="bde1-6db1-163b-3b76" page="3" hidden="false" collective="false" import="true" type="model">
-          <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
-      <entryLinks>
-        <entryLink id="a463-16c1-4f3d-40b2" name="Upgrade Points (Placeholders)" hidden="false" collective="false" import="true" targetId="7c8d-b21a-1f72-7e22" type="selectionEntry"/>
-      </entryLinks>
-      <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="410.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="6405-d682-11c9-35b6" name="Mechanicum Knight Atrapos (Placeholder)" publicationId="bde1-6db1-163b-3b76" page="54" hidden="false" collective="false" import="true" type="unit">
-      <selectionEntries>
-        <selectionEntry id="66fe-2570-751e-f544" name="Mechanicum Knight Atrapos" publicationId="bde1-6db1-163b-3b76" page="54" hidden="false" collective="false" import="true" type="model">
-          <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
-      <entryLinks>
-        <entryLink id="629f-ff51-252c-5ba2" name="Upgrade Points (Placeholders)" hidden="false" collective="false" import="true" targetId="7c8d-b21a-1f72-7e22" type="selectionEntry"/>
-      </entryLinks>
-      <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="500.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="ccc2-5689-4796-61b4" name="Mechanicum Acastus Knight Asterius (Placeholder)" publicationId="bde1-6db1-163b-3b76" page="55" hidden="false" collective="false" import="true" type="unit">
-      <selectionEntries>
-        <selectionEntry id="7a37-b53a-beda-6aa4" name="Mechanicum Acastus Knight Asterius" publicationId="bde1-6db1-163b-3b76" page="55" hidden="false" collective="false" import="true" type="model">
-          <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
-      <entryLinks>
-        <entryLink id="631c-13ff-58ec-617e" name="Upgrade Points (Placeholders)" hidden="false" collective="false" import="true" targetId="7c8d-b21a-1f72-7e22" type="selectionEntry"/>
-      </entryLinks>
-      <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="625.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="1277-aefb-66c5-bd35" name="Ordinatus Ulator (Placeholder)" publicationId="bde1-6db1-163b-3b76" page="56" hidden="false" collective="false" import="true" type="unit">
-      <selectionEntries>
-        <selectionEntry id="abf2-482d-b344-b447" name="Ordinatus Ulator" publicationId="bde1-6db1-163b-3b76" page="56" hidden="false" collective="false" import="true" type="model">
-          <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
-      <entryLinks>
-        <entryLink id="338c-5cf0-c956-4df7" name="Upgrade Points (Placeholders)" hidden="false" collective="false" import="true" targetId="7c8d-b21a-1f72-7e22" type="selectionEntry"/>
+        <entryLink id="e738-292e-da14-66c3" name="Volkite Culverin" hidden="false" collective="false" import="true" targetId="170d-44e0-455c-8207" type="selectionEntry">
+          <modifiers>
+            <modifier type="set" field="name" value="One Hull (Rear) Mounted Volkite Culverin"/>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="80bc-ec34-246e-56c6" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7b01-b63b-d673-7af0" type="max"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="6e5b-361b-5d1f-0689" name="Volkite Culverin" hidden="false" collective="false" import="true" targetId="170d-44e0-455c-8207" type="selectionEntry">
+          <modifiers>
+            <modifier type="set" field="name" value="Two Sponson Mounted Volkite Culverins"/>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="26bf-7c41-b461-de34" type="max"/>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4471-c23e-3604-fa6e" type="min"/>
+          </constraints>
+        </entryLink>
       </entryLinks>
       <costs>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="1075.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="89a5-fa4d-0e01-3a55" name="Ordinatus Aktaeus (Placeholder)" publicationId="bde1-6db1-163b-3b76" page="57" hidden="false" collective="false" import="true" type="unit">
+    <selectionEntry id="89a5-fa4d-0e01-3a55" name="Ordinatus Aktaeus" publicationId="bde1-6db1-163b-3b76" page="57" hidden="false" collective="false" import="true" type="unit">
+      <profiles>
+        <profile id="8f03-b2a0-b259-a356" name="Ordinatus Aktaeus" publicationId="bde1-6db1-163b-3b76" page="57" hidden="false" typeId="2fae-b053-3f78-e7b2" typeName="Vehicle">
+          <characteristics>
+            <characteristic name="Unit Type" typeId="e555-4aed-dfcc-c0b4">Vehicle (Super-heavy, Transport)</characteristic>
+            <characteristic name="Move" typeId="3614-4a2d-bffb-90e4">-</characteristic>
+            <characteristic name="BS" typeId="51fb-b7d9-aa59-863d">4</characteristic>
+            <characteristic name="Front" typeId="0ef8-a648-01d0-08ee">14</characteristic>
+            <characteristic name="Side" typeId="f150-c0dc-c192-9cb3">13</characteristic>
+            <characteristic name="Rear" typeId="8d4e-2aea-fffc-d556">13</characteristic>
+            <characteristic name="HP" typeId="a76c-83b1-602f-9e62">14</characteristic>
+            <characteristic name="Transport Capacity" typeId="0c90-79e2-f768-e547">42</characteristic>
+            <characteristic name="Access Points" typeId="e217-1b1e-9494-3e3e">The Ordinatus Aktaeus has two Access Points, one on either side of the hull (in any orientation).</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules>
+        <rule id="ef34-76df-c134-302e" name="Terrestrial Disregard" publicationId="bde1-6db1-163b-3b76" page="110" hidden="false">
+          <description>Instead of using the normal rules for Subterranean Assault, when a model with this special rule enters play via Subterranean Assault, place an Apocalyptic Blast marker (10&quot;) anywhere on the battlefield that is at least 1&quot; from any enemy model, battlefield edge or piece of Impassable Terrain and then scatter that marker (see the Scatter rules on page 152 of the Horus Heresy: Age of Darkness rulebook).
+If the marker’s final position is within 1&quot; of an enemy model, any battlefield edge or a piece of Impassable Terrain, then the controlling player’s opponent may move that model to any position within 18&quot; that is more than 1&quot; from any enemy model, battlefield edge or piece of Impassable Terrain. If there is no suitable position within 18&quot;, then the model may be repositioned by the controlling player’s opponent anywhere on the battlefield that is more than 1&quot; from any enemy model, battlefield edge or piece of Impassable Terrain.
+Once the final position of the marker has been determined, the controlling player may place the model with this special rule on the battlefield so long as the centre of the marker is underneath part of the model’s hull, and the model remains more than 1&quot; away from any enemy model. After the model has been placed, each Fortification within 6&quot; of it immediately suffers D6 Str 10, AP 2 Hits, and nearby units suffer one S10, AP 2 Hit for each model within 6&quot; of the model. Any unit that suffers one or more Hits from this effect must take an immediate Pinning test.
+The area under the Apocalyptic Blast marker (10&quot;) is treated as Difficult Terrain and Dangerous Terrain for the remainder of the battle.</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="b76e-7891-6614-2e18" name="It Will Not Die (X)" hidden="false" targetId="2784-d0be-a4e2-890f" type="rule">
+          <modifiers>
+            <modifier type="set" field="name" value="It Will Not Die (6+)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="afdf-16d2-8c37-bfd9" name="Reactor Meltdown (X)" hidden="false" targetId="3b0e-4a45-9bdd-91dc" type="rule">
+          <modifiers>
+            <modifier type="set" field="name" value="Reactor Meltdown (Major)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="fb06-e4bf-f374-e5b4" name="Reinforced Structure" hidden="false" targetId="5b0d-5362-e961-f3b0" type="rule"/>
+        <infoLink id="565c-f3ae-d92b-1685" name="Subterranean Assault" hidden="false" targetId="33d4-d46d-7f47-3ad2" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="bd10-1dfe-07bf-f938" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+        <categoryLink id="4445-4267-604e-58a8" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
+      </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="0887-e38c-9d70-ccd5" name="Ordinatus Aktaeus" publicationId="bde1-6db1-163b-3b76" page="57" hidden="false" collective="false" import="true" type="model">
+        <selectionEntry id="9e55-edca-5116-d240" name="Centreline Mounted Terrebrax Rocket Battery" publicationId="bde1-6db1-163b-3b76" page="118" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="11a5-5df2-f7bc-4539" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4e95-dab2-5554-7d6c" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="0467-907b-9f6f-bbb7" name="Terrebrax Rocket Battery" publicationId="bde1-6db1-163b-3b76" page="118" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+              <characteristics>
+                <characteristic name="Range" typeId="95ba-cda7-b831-6066">48&quot;</characteristic>
+                <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">7</characteristic>
+                <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">5</characteristic>
+                <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Heavy 12</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="48d5-2a48-5d6c-87a8" name="Aktaeus Class Seismic Excavator Macro-Drill" publicationId="bde1-6db1-163b-3b76" page="124" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1455-12b4-5a48-c1eb" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="50de-893f-b2a5-d786" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="602f-34ad-7780-be3c" name="Aktaeus Class Seismic Excavator Macro-Drill" publicationId="bde1-6db1-163b-3b76" page="124" hidden="false" typeId="2a1f-7837-f0ef-be44" typeName="Wargear Item">
+              <characteristics>
+                <characteristic name="Description" typeId="347e-ee4a-764f-6be3">The Aktaeus class seismic excavator macro-drill grants the Ordinatus Aktaeus the Ordinatus Transport Bay special rule.
+In addition, once per battle, at the end of the controlling player’s Movement phase, the Ordinatus Aktaeus may employ its seismic excavator macro-drill to cause a Seismic Shockwave. When this occurs, the Ordinatus Aktaeus cannot move for the rest of the battle and counts as a vehicle that has suffered an irreparable Immobilised result on the Vehicle Damage table (although no Hull Point loss is suffered). Units may not choose to Embark or Disembark in a turn in which the Seismic Shockwave ability is used, but may do so as normal in subsequent turns.
+At the beginning of each of the controlling player’s Shooting phases for the rest of the battle after the Ordinatus Aktaeus has employed its seismic excavator macro-drill to cause a Seismic Shockwave, pick a point within 6&quot; of the front of the hull of the Ordinatus Aktaeus (for the purposes of determining this point you should use the Front arc of the unit). All units, friendly or enemy (excluding the Ordinatus Aktaeus itself), within a number of inches equal to the current Game Turn number multiplied by 6 of this point suffer D6 Str 7, AP 4 Hits with the Pinning special rule. Models with the Vehicle Unit Type are hit on their weakest Armour Facing. Should a model with the Vehicle Unit Type suffer a Penetrating Hit from this attack, it immediately suffers from Crew Shaken in addition to any other effect.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
-      <entryLinks>
-        <entryLink id="4372-bfcb-3bde-afa9" name="Upgrade Points (Placeholders)" hidden="false" collective="false" import="true" targetId="7c8d-b21a-1f72-7e22" type="selectionEntry"/>
-      </entryLinks>
       <costs>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="800.0"/>
       </costs>
@@ -1254,7 +2354,7 @@ This unit may be upgraded freely as described in their profile, though they may 
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="365.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="2a20-c068-3230-ad17" name=" Prehensile Data-Spike" publicationId="bde1-6db1-163b-3b76" page="123" hidden="false" collective="false" import="true" type="upgrade">
+    <selectionEntry id="2a20-c068-3230-ad17" name="Prehensile Data-Spike" publicationId="bde1-6db1-163b-3b76" page="123" hidden="false" collective="false" import="true" type="upgrade">
       <profiles>
         <profile id="2406-ef6a-7e5f-bf1b" name=" Prehensile Data-Spike" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
           <characteristics>
@@ -1282,6 +2382,437 @@ This unit may be upgraded freely as described in their profile, though they may 
           </modifiers>
         </infoLink>
       </infoLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="ccc2-5689-4796-61b4" name="Mechanicum Acastus Knight Asterius" publicationId="bde1-6db1-163b-3b76" page="55" hidden="false" collective="false" import="true" type="unit">
+      <profiles>
+        <profile id="5a88-5eab-ad14-64a0" name="Mechanicum Acastus Knight Asterius" publicationId="bde1-6db1-163b-3b76" page="87" hidden="false" typeId="75b5-9f7a-156e-6889" typeName="Knights and Titans">
+          <characteristics>
+            <characteristic name="Unit Type" typeId="3c44-1e2a-23fe-c9e0">Vehicle (Knight)</characteristic>
+            <characteristic name="Move" typeId="7f12-0cc3-9dcd-25bc">12</characteristic>
+            <characteristic name="WS" typeId="4227-8eed-0c5c-a2d9">4</characteristic>
+            <characteristic name="BS" typeId="6c5a-df71-fefa-2ee3">4</characteristic>
+            <characteristic name="S" typeId="02ba-082e-e385-1ede">10</characteristic>
+            <characteristic name="Front" typeId="0d00-68d8-0535-e898">14</characteristic>
+            <characteristic name="Side" typeId="cb92-5809-d327-6981">13</characteristic>
+            <characteristic name="Rear" typeId="8fa4-6e34-29c4-d8c6">12</characteristic>
+            <characteristic name="I" typeId="91b3-4335-71bf-3fa9">3</characteristic>
+            <characteristic name="A" typeId="d54a-56a6-68c5-ae72">3</characteristic>
+            <characteristic name="HP" typeId="2490-aa2f-f5db-6070">9</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="92d2-7373-149d-cb12" name="Catastrophic Explosion" hidden="false" targetId="a13f-e697-6017-5a04" type="rule"/>
+        <infoLink id="ea89-c254-2fc0-edd2" name="It Will Not Die (X)" hidden="false" targetId="2784-d0be-a4e2-890f" type="rule">
+          <modifiers>
+            <modifier type="set" field="name" value="It Will Not Die (6+)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="2e6d-ab1c-59a1-f48d" name="Night Vision" hidden="false" targetId="683e-b4f2-f032-d31b" type="rule"/>
+        <infoLink id="9eb4-352b-08a2-716f" name="Macro-extinction Targeting Protocols" hidden="false" targetId="359e-2a2e-3a01-42e7" type="rule"/>
+      </infoLinks>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="2f78-69c3-fd78-43f2" name="Arm Mounted Twin-Linked Heavy Conversion Beam Cannon" hidden="false" collective="false" import="true" defaultSelectionEntryId="8183-c411-6b59-3742">
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1560-6f71-ec4a-6a5e" type="min"/>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="025b-76c4-75b0-3105" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="8183-c411-6b59-3742" name="Heavy Conversion Beam Cannon" hidden="false" collective="false" import="true" targetId="7c47-e2e9-dc42-e838" type="selectionEntry"/>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="932d-e092-656f-2f02" name="Hull (Front) Mounted Karacnos Mortar Battery" hidden="false" collective="false" import="true" defaultSelectionEntryId="e731-ba8b-286f-1d55">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ff3a-53a8-fd03-986f" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="24d8-b111-9437-3776" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="e731-ba8b-286f-1d55" name="Karacnos Mortar Battery" hidden="false" collective="false" import="true" targetId="2b9f-41fb-a0a8-285e" type="selectionEntry"/>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="47fb-46ce-c58d-55e3" name="Hull (Front) Mounted Volkite Culverin" hidden="false" collective="false" import="true" defaultSelectionEntryId="9e9c-05d4-6bfe-dc9f">
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4136-5ba8-a884-497d" type="min"/>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="17d0-2d47-4f64-0bf7" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="9e9c-05d4-6bfe-dc9f" name="Volkite Culverin" hidden="false" collective="false" import="true" targetId="170d-44e0-455c-8207" type="selectionEntry"/>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="0fed-bb8e-ae25-6b8b" name="Ion Shield" hidden="false" collective="false" import="true" targetId="dde9-961b-5765-21a2" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e64f-5206-79e8-8892" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="56dd-43cb-72a8-029e" type="max"/>
+          </constraints>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="625.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="6405-d682-11c9-35b6" name="Mechanicum Knight Atrapos" publicationId="bde1-6db1-163b-3b76" page="54" hidden="false" collective="false" import="true" type="unit">
+      <constraints>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="dabf-c65a-b661-20c0" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="3028-b8e1-5465-209b" name="Mechanicum Knight Atrapos" publicationId="bde1-6db1-163b-3b76" page="54" hidden="false" typeId="75b5-9f7a-156e-6889" typeName="Knights and Titans">
+          <characteristics>
+            <characteristic name="Unit Type" typeId="3c44-1e2a-23fe-c9e0">Vehicle (Knight)</characteristic>
+            <characteristic name="Move" typeId="7f12-0cc3-9dcd-25bc">14</characteristic>
+            <characteristic name="WS" typeId="4227-8eed-0c5c-a2d9">4</characteristic>
+            <characteristic name="BS" typeId="6c5a-df71-fefa-2ee3">4</characteristic>
+            <characteristic name="S" typeId="02ba-082e-e385-1ede">9</characteristic>
+            <characteristic name="Front" typeId="0d00-68d8-0535-e898">13</characteristic>
+            <characteristic name="Side" typeId="cb92-5809-d327-6981">12</characteristic>
+            <characteristic name="Rear" typeId="8fa4-6e34-29c4-d8c6">12</characteristic>
+            <characteristic name="I" typeId="91b3-4335-71bf-3fa9">4</characteristic>
+            <characteristic name="A" typeId="d54a-56a6-68c5-ae72">4</characteristic>
+            <characteristic name="HP" typeId="2490-aa2f-f5db-6070">8</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="c3e4-d48a-b145-8820" name="Night Vision" hidden="false" targetId="683e-b4f2-f032-d31b" type="rule"/>
+        <infoLink id="e934-d22c-a028-5551" name="Flank Speed" hidden="false" targetId="41ab-227d-9d91-8001" type="rule"/>
+        <infoLink id="c900-fa1d-551d-0ccc" name="Catastrophic Destruction" hidden="false" targetId="c41f-6ac9-6909-44c4" type="rule"/>
+      </infoLinks>
+      <selectionEntries>
+        <selectionEntry id="dad2-d4d4-fca4-2b1b" name="Arm Mounted Atrapos Phasecutter" publicationId="bde1-6db1-163b-3b76" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bff5-adb9-e1f0-59bb" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8b8e-a838-4ad0-b4a2" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="b84c-efdc-b281-1bd0" name="Ordnance" hidden="false" targetId="6c55-22c8-1b01-2105" type="rule"/>
+            <infoLink id="c508-3246-c1b7-f9ae" name="Cumbersome" hidden="false" targetId="d89a-c10e-8a7a-92c3" type="rule"/>
+            <infoLink id="510a-f0a8-c563-8b9c" name="Armourbane (X)" hidden="false" targetId="cb59-f920-f071-7cd4" type="rule">
+              <modifiers>
+                <modifier type="set" field="name" value="Armourbane (Melee)"/>
+              </modifiers>
+            </infoLink>
+            <infoLink id="83e9-dac5-67b5-e13e" name="Instant Death" hidden="false" targetId="9e96-fff1-b916-d9a3" type="rule"/>
+            <infoLink id="8db9-9fd2-520c-6e20" name="Atrapos Phasecutter (Ranged)" hidden="false" targetId="ba87-6ceb-1c1c-6bf1" type="profile"/>
+            <infoLink id="49f6-c5ae-8c83-7ffc" name="Atrapos Phasecutter (Melee)" hidden="false" targetId="93f8-ea60-d968-53e1" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="9d35-be89-f8f3-4624" name="Arm Mounted Singularity Cannon" publicationId="bde1-6db1-163b-3b76" page="116" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9a16-4c3a-ba82-3903" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a138-d298-b0ae-77e6" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="f86c-62b0-f8d5-b444" name="Blast" hidden="false" targetId="1d9a-73ef-5f4f-8bd8" type="rule"/>
+            <infoLink id="0383-b6f7-6549-36fa" name="Haywire" hidden="false" targetId="1dd4-7a75-5c59-8425" type="rule"/>
+            <infoLink id="1b9b-ef2c-c0b1-84d7" name="Concussive (X)" hidden="false" targetId="7ce5-1bfb-64e6-f826" type="rule">
+              <modifiers>
+                <modifier type="set" field="name" value="Concussive (1)"/>
+              </modifiers>
+            </infoLink>
+            <infoLink id="ee8b-3762-c3fb-532c" name="Singularity Cannon" hidden="false" targetId="bf38-57a9-62e8-e77c" type="profile"/>
+            <infoLink id="e911-e24b-d16f-74d0" name="Graviton Singularity" hidden="false" targetId="68b3-f712-fcf1-8839" type="rule"/>
+          </infoLinks>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <entryLinks>
+        <entryLink id="a363-2012-5305-9acc" name="Ion Shield" hidden="false" collective="false" import="true" targetId="dde9-961b-5765-21a2" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="732a-29b1-8fa5-e0bf" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b66b-7d1d-8192-7937" type="max"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="5350-39d1-daf7-3822" name="Flare Shield" hidden="false" collective="false" import="true" targetId="0e77-6285-22bb-1534" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2adb-579b-96dc-f601" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0fe4-c195-dd4a-5d7d" type="max"/>
+          </constraints>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="500.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="aae3-4a95-fbce-6d01" name="Mechanicum Knight Styrix" publicationId="bde1-6db1-163b-3b76" page="53" hidden="false" collective="false" import="true" type="unit">
+      <profiles>
+        <profile id="2ef3-13e7-2b0f-0d15" name="Mechanicum Knight Styrix" publicationId="bde1-6db1-163b-3b76" page="53" hidden="false" typeId="75b5-9f7a-156e-6889" typeName="Knights and Titans">
+          <characteristics>
+            <characteristic name="Unit Type" typeId="3c44-1e2a-23fe-c9e0">Vehicle (Knight)</characteristic>
+            <characteristic name="Move" typeId="7f12-0cc3-9dcd-25bc">10</characteristic>
+            <characteristic name="WS" typeId="4227-8eed-0c5c-a2d9">4</characteristic>
+            <characteristic name="BS" typeId="6c5a-df71-fefa-2ee3">4</characteristic>
+            <characteristic name="S" typeId="02ba-082e-e385-1ede">8</characteristic>
+            <characteristic name="Front" typeId="0d00-68d8-0535-e898">13</characteristic>
+            <characteristic name="Side" typeId="cb92-5809-d327-6981">12</characteristic>
+            <characteristic name="Rear" typeId="8fa4-6e34-29c4-d8c6">12</characteristic>
+            <characteristic name="I" typeId="91b3-4335-71bf-3fa9">2</characteristic>
+            <characteristic name="A" typeId="d54a-56a6-68c5-ae72">3</characteristic>
+            <characteristic name="HP" typeId="2490-aa2f-f5db-6070">7</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="0ef0-90de-31a7-e777" name="Night Vision" hidden="false" targetId="683e-b4f2-f032-d31b" type="rule"/>
+        <infoLink id="356d-2f9f-7a07-7b62" name="Overtaxed Reactor" hidden="false" targetId="5f22-e7a4-4141-ee2e" type="rule"/>
+      </infoLinks>
+      <selectionEntries>
+        <selectionEntry id="fea6-d32c-554d-b5a3" name="Arm Mounted Volkite Chieorovile" publicationId="bde1-6db1-163b-3b76" page="119" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="13d4-09bf-b5bb-4cd2" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7af0-ae8a-ea28-a598" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="8e0d-3691-c82c-7d24" name="Deflagrate" hidden="false" targetId="60bc-f79a-67ae-be4f" type="rule"/>
+            <infoLink id="9eab-3391-1ada-3411" name="Volkite Chieorovile" hidden="false" targetId="3446-4746-db76-a21d" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="23c4-aeb9-3875-c059" name="May exchange its Arm Mounted Reaper Chainsword for:" hidden="false" collective="false" import="true" defaultSelectionEntryId="d886-29fd-d700-9c2d">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7bcb-8d6e-d12e-b6da" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="92bb-9bf0-ee3d-07a5" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="d886-29fd-d700-9c2d" name="Reaper Chainsword" hidden="false" collective="false" import="true" targetId="2164-1725-d032-ed49" type="selectionEntry"/>
+            <entryLink id="9284-9099-ec8f-79f0" name="Siege Claw with In-Built Irad-Cleanser" hidden="false" collective="false" import="true" targetId="6a06-cbf5-fbbf-85fe" type="selectionEntry">
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="a523-2cff-3419-5b9c" name="Hull (Front) Mounted Graviton Gun" hidden="false" collective="false" import="true" defaultSelectionEntryId="df8f-ba5f-a073-604e">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ba7a-fbae-0c2a-d035" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3997-f81c-caf5-8ce0" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="df8f-ba5f-a073-604e" name="Graviton Gun" hidden="false" collective="false" import="true" targetId="5303-5a3e-de51-1707" type="selectionEntry"/>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="b463-a2b8-2e47-4e3f" name="Flare Shield" hidden="false" collective="false" import="true" targetId="0e77-6285-22bb-1534" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ca74-66bd-e1f7-d056" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cfdd-bb10-98ad-4295" type="max"/>
+          </constraints>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="410.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="b582-e53e-5e13-286c" name="Mechanicum Knight Magaera" publicationId="bde1-6db1-163b-3b76" page="52" hidden="false" collective="false" import="true" type="unit">
+      <profiles>
+        <profile id="9483-e5f6-60f5-88a0" name="Mechanicum Knight Magaera" publicationId="bde1-6db1-163b-3b76" page="52" hidden="false" typeId="75b5-9f7a-156e-6889" typeName="Knights and Titans">
+          <characteristics>
+            <characteristic name="Unit Type" typeId="3c44-1e2a-23fe-c9e0">Vehicle (Knight)</characteristic>
+            <characteristic name="Move" typeId="7f12-0cc3-9dcd-25bc">10</characteristic>
+            <characteristic name="WS" typeId="4227-8eed-0c5c-a2d9">4</characteristic>
+            <characteristic name="BS" typeId="6c5a-df71-fefa-2ee3">4</characteristic>
+            <characteristic name="S" typeId="02ba-082e-e385-1ede">8</characteristic>
+            <characteristic name="Front" typeId="0d00-68d8-0535-e898">13</characteristic>
+            <characteristic name="Side" typeId="cb92-5809-d327-6981">12</characteristic>
+            <characteristic name="Rear" typeId="8fa4-6e34-29c4-d8c6">12</characteristic>
+            <characteristic name="I" typeId="91b3-4335-71bf-3fa9">2</characteristic>
+            <characteristic name="A" typeId="d54a-56a6-68c5-ae72">3</characteristic>
+            <characteristic name="HP" typeId="2490-aa2f-f5db-6070">7</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="0b76-f798-f8c1-0d47" name="Night Vision" hidden="false" targetId="683e-b4f2-f032-d31b" type="rule"/>
+        <infoLink id="b7be-0884-f011-c7a5" name="Overtaxed Reactor" hidden="false" targetId="5f22-e7a4-4141-ee2e" type="rule"/>
+      </infoLinks>
+      <selectionEntries>
+        <selectionEntry id="2862-f27b-74c7-3c4a" name="Arm Mounted Lightning Cannon" publicationId="bde1-6db1-163b-3b76" page="113" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6348-74c7-6d67-5c4c" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9385-242e-f76e-9bd9" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="21dc-1e79-a5c5-93e2" name="Blast" hidden="false" targetId="1d9a-73ef-5f4f-8bd8" type="rule"/>
+            <infoLink id="16e2-6f4c-9c45-f241" name="Exoshock (X)" hidden="false" targetId="69ca-318a-b47a-7a3c" type="rule">
+              <modifiers>
+                <modifier type="set" field="name" value="Exoshock (4+)"/>
+              </modifiers>
+            </infoLink>
+            <infoLink id="da5a-4413-59dc-2597" name="Rending (X)" hidden="false" targetId="0ac9-fab7-aef3-de1d" type="rule">
+              <modifiers>
+                <modifier type="set" field="name" value="Rending (4+)"/>
+              </modifiers>
+            </infoLink>
+            <infoLink id="bda2-e514-d07f-3714" name="Shred" hidden="false" targetId="5e7e-1628-8174-6f2c" type="rule"/>
+            <infoLink id="b360-0b23-65fc-e416" name="Lightning Cannon " publicationId="bde1-6db1-163b-3b76" page="113" hidden="false" targetId="119e-f108-83fe-d0e3" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="bb2a-a002-5ae0-ca20" name="May exchange its Arm Mounted Reaper Chainsword for:" hidden="false" collective="false" import="true" defaultSelectionEntryId="ef68-af42-7a21-12c8">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8547-d39a-c7cb-0364" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a685-0627-455e-f741" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="ef68-af42-7a21-12c8" name="Reaper Chainsword" hidden="false" collective="false" import="true" targetId="2164-1725-d032-ed49" type="selectionEntry"/>
+            <entryLink id="8259-c004-3c44-3013" name="Siege Claw with In-Built Irad-Cleanser" hidden="false" collective="false" import="true" targetId="6a06-cbf5-fbbf-85fe" type="selectionEntry">
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="9282-230f-ed8e-61f3" name="Hull (Front) Mounted Phased Plasma-Fusil" hidden="false" collective="false" import="true" defaultSelectionEntryId="98dd-c918-4cd9-bb74">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="16eb-d4c5-e5d7-c2bf" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9362-8078-871c-8abb" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="98dd-c918-4cd9-bb74" name="Phased Plasma-Fusil" hidden="false" collective="false" import="true" targetId="17c6-afe9-c5da-d9b6" type="selectionEntry"/>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="385.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="c21c-3c14-2d2e-4bc0" name="Knight Moirax Talon" publicationId="bde1-6db1-163b-3b76" page="50" hidden="false" collective="false" import="true" type="unit">
+      <categoryLinks>
+        <categoryLink id="b385-2704-464e-ad3c" name="Line Sub-type:" hidden="false" targetId="6399-5c65-7833-1025" primary="false"/>
+        <categoryLink id="5c31-2a0a-2abf-0d40" name="Skirmish Sub-type:" hidden="false" targetId="59a4-7b61-600a-c457" primary="false"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="b399-3555-ba3b-f5e5" name="Knight Moirax" publicationId="bde1-6db1-163b-3b76" page="50" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="606b-d886-6cee-e5a7" type="min"/>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="392d-3abd-a673-335d" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="f7ac-ccea-89fb-73b1" name="Knight Moirax" publicationId="bde1-6db1-163b-3b76" page="50" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName="Unit">
+              <characteristics>
+                <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Armiger</characteristic>
+                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">8</characteristic>
+                <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
+                <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
+                <characteristic name="S" typeId="e478-41d4-a092-48a8">7</characteristic>
+                <characteristic name="T" typeId="c32b-5fdd-3fbe-9b1f">7</characteristic>
+                <characteristic name="W" typeId="57ee-1126-32a9-5672">6</characteristic>
+                <characteristic name="I" typeId="62d3-22d7-2d49-52dc">4</characteristic>
+                <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">3</characteristic>
+                <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">8</characteristic>
+                <characteristic name="Save" typeId="e593-6b3c-f169-04f0">3+</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="ec18-9798-fc0b-3b79" name="Greuso Protocol" publicationId="bde1-6db1-163b-3b76" page="105" hidden="false" typeId="90b9-7fab-87db-aed3" typeName="Reactions">
+              <characteristics>
+                <characteristic name="Description" typeId="c627-4637-8de5-65fb">This Advanced Reaction may be made whenever an enemy unit declares a Charge targeting a friendly unit with the Automata Unit Type or Knight Unit Sub-type which is within 12&quot; of another friendly unit that includes at least one model with the Greuso Protocol special rule and is not itself locked in combat. The unit with the Greuso Protocol special rule may make a Shooting Attack, targeting the unit that triggered this Reaction and following all the usual rules for Shooting Attacks. A unit that makes a Shooting Attack as part of a Greuso Protocol Reaction may not make any attacks indirectly (without line of sight) including weapons with the Barrage special rule or other weapons or special rules that otherwise ignore line of sight, and Vehicles may only fire Defensive Weapons. Template weapons used as part of a Greuso Protocol Reaction use the Wall of Death rule instead of firing normally. The unit targeted by the Greuso Protocol Reaction may not take Cover Saves against Wounds inflicted as part of that Reaction.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="d873-2839-b082-c5f0" name="Greuso Protocol" publicationId="bde1-6db1-163b-3b76" page="105" hidden="false">
+              <description>A unit that includes one or more models with this special rule may make use of the Greuso Protocol Advanced Reaction.</description>
+            </rule>
+          </rules>
+          <infoLinks>
+            <infoLink id="cc02-c2c1-8d85-e1af" name="Armiger Unit-Type" hidden="false" targetId="53f7-6b93-cc7a-b976" type="rule"/>
+            <infoLink id="4cba-fcd3-c4d9-d8af" name="Stubborn" hidden="false" targetId="7989-1f2c-a43d-82ae" type="rule"/>
+            <infoLink id="e000-7857-3986-8b0e" name="Fleet (X)" hidden="false" targetId="ddc9-0b4b-78da-bbd2" type="rule">
+              <modifiers>
+                <modifier type="set" field="name" value="Fleet (2)"/>
+              </modifiers>
+            </infoLink>
+            <infoLink id="196a-55c1-60d7-e3f5" name="Move Through Cover" hidden="false" targetId="2b6f-bfec-759e-1746" type="rule"/>
+            <infoLink id="6162-7615-565a-e57c" name="Armiger and Moirax Talons" hidden="false" targetId="d840-fbd0-352e-b33e" type="rule"/>
+          </infoLinks>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="549e-6e01-3698-1119" name="May exchange its Volkite Veuglaire for:" hidden="false" collective="false" import="true" defaultSelectionEntryId="f3e6-3c6a-b16a-b315">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ed29-5ff9-df5a-98b9" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f977-a05f-c8e2-ba49" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="ecd9-64ae-6831-f404" name="Siege Claw with In-Built Irad-Cleanser" hidden="false" collective="false" import="true" targetId="6a06-cbf5-fbbf-85fe" type="selectionEntry"/>
+                <entryLink id="de13-606e-bef6-c278" name="Lightning Lock" hidden="false" collective="false" import="true" targetId="dd74-951d-8540-5ea1" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="d6ae-f960-f172-c268" name="Conversion Beam Cannon" hidden="false" collective="false" import="true" targetId="5775-0d94-8e13-8c1f" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="9458-88e6-1e21-da97" name="Graviton Pulsar" hidden="false" collective="false" import="true" targetId="115a-86e7-896f-b872" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="f3e6-3c6a-b16a-b315" name="Volkite Veuglaire" hidden="false" collective="false" import="true" targetId="0dd0-0edf-9526-cc6b" type="selectionEntry"/>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="baaf-db9c-aefa-a012" name="May exchange its Siege Claw with In-Built Irad-Cleanser for:" hidden="false" collective="false" import="true" defaultSelectionEntryId="70ed-6afd-c6b0-cc99">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="55ab-eb2c-6453-fe96" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8e7b-6dd3-6fb8-4d68" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="70ed-6afd-c6b0-cc99" name="Siege Claw with In-Built Irad-Cleanser" hidden="false" collective="false" import="true" targetId="6a06-cbf5-fbbf-85fe" type="selectionEntry"/>
+                <entryLink id="aa8f-258e-a5fc-7820" name="Lightning Lock" hidden="false" collective="false" import="true" targetId="dd74-951d-8540-5ea1" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="3025-41a5-9c0a-f6bc" name="Conversion Beam Cannon" hidden="false" collective="false" import="true" targetId="5775-0d94-8e13-8c1f" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="e852-f687-c6d6-5d72" name="Graviton Pulsar" hidden="false" collective="false" import="true" targetId="115a-86e7-896f-b872" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="7f2f-c8b7-ff9a-9c4c" name="Volkite Veuglaire" hidden="false" collective="false" import="true" targetId="0dd0-0edf-9526-cc6b" type="selectionEntry"/>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks>
+            <entryLink id="0698-ed86-1c46-276c" name="Ionic Deflector" hidden="false" collective="false" import="true" targetId="c587-8d02-aaba-ce19" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2ae6-6ea3-b4cf-1fb3" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5cd4-3a8b-6c75-f75f" type="max"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="3b2f-2c81-f35b-3501" name="Rad Furnace" hidden="false" collective="false" import="true" targetId="18da-a26c-bdd4-8a5f" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8fb4-db59-42c6-e3d2" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9d2d-517a-5dc4-f059" type="max"/>
+              </constraints>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="200.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
       <costs>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
       </costs>


### PR DESCRIPTION
More Mechy Updates (just Elites and HQ to finish) then maybe some tidy up such as adding 

Added units (things with a space before are SE's added within the unit as they are unique to that unit) Ordinatus Aktaeus
 Aktaeus Class Seismic Excavator Macro-Drill
 Terrestrial Disregard
Ordinatus Ulator
 Ordinatus Dispersion Shield
 Sonic Destructor
Mechanicum Acastus Knight Asterius
Mechanicum Knight Atrapos
Mechanicum Knight Styrix
Mechanicum Knight Magaera
Knight Moirax Talon
 Volkite Veuglaire
 Graviton Pulsar
Krios Squadron
Karacnos Assault Tank
Myrmidon Destructor Host
Vultarax Stratos-Automata
 Stratos thrusters
Ursarax
Arlatax
 Light Autocannon
Scyllax Guardian-Automata Maniple
 Scyllax Combat Array
Thallax Cohort
Adsecularis Tech-thralls Covenant

ADDED SE's for 
Lucifex
Incunabulan jet pack
Utan Jump Booster
Graviton imploder
Photon thruster
Rad furnace
Las-Lock
Prehensile Dataspike
Irradiation engine 
Graviton Imploder
Conversion Beamer
Close Combat Weapon (This would probably be better in GST instead of Mech Library though)