### PR TITLE
The Last Mech??? Unless there are errors or new units

### DIFF
--- a/2022 - Mech Library.cat
+++ b/2022 - Mech Library.cat
@@ -3258,6 +3258,9 @@ Invulnerable Saves granted by a mag-inverter shield do not stack with other Invu
                       </constraints>
                     </entryLink>
                   </entryLinks>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                  </costs>
                 </selectionEntry>
               </selectionEntries>
             </selectionEntryGroup>
@@ -4929,6 +4932,9 @@ A unit composed entirely of models with Utan jump boosters may not Run. During R
           </characteristics>
         </profile>
       </profiles>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="4cc0-c7df-7157-6bf0" name="Volkite Incinerator" publicationId="bde1-6db1-163b-3b76" page=" &amp; 123" hidden="false" collective="false" import="true" type="upgrade">
       <selectionEntries>
@@ -4950,6 +4956,9 @@ A unit composed entirely of models with Utan jump boosters may not Run. During R
           <infoLinks>
             <infoLink id="2bca-f8d1-dc31-245a" name="Deflagrate" hidden="false" targetId="60bc-f79a-67ae-be4f" type="rule"/>
           </infoLinks>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+          </costs>
         </selectionEntry>
         <selectionEntry id="9149-00e8-dd49-c213" name="Volkite incinerator (Melee)" hidden="false" collective="true" import="true" type="upgrade">
           <constraints>
@@ -4974,8 +4983,14 @@ A unit composed entirely of models with Utan jump boosters may not Run. During R
           <infoLinks>
             <infoLink id="e4db-a990-aa36-e516" name="Instant Death" hidden="false" targetId="9e96-fff1-b916-d9a3" type="rule"/>
           </infoLinks>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+          </costs>
         </selectionEntry>
       </selectionEntries>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="9033-c395-43b3-5612" name="Arc Scourge" publicationId="bde1-6db1-163b-3b76" page="120" hidden="false" collective="false" import="true" type="upgrade">
       <profiles>
@@ -5000,6 +5015,9 @@ A unit composed entirely of models with Utan jump boosters may not Run. During R
           </modifiers>
         </infoLink>
       </infoLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="9978-8a9e-ab4b-5e0f" name="Light Autocannon" publicationId="bde1-6db1-163b-3b76" page="114" hidden="false" collective="false" import="true" type="upgrade">
       <profiles>
@@ -5012,6 +5030,9 @@ A unit composed entirely of models with Utan jump boosters may not Run. During R
           </characteristics>
         </profile>
       </profiles>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="3d50-2f85-06ff-6aee" name="Close Combat Weapon" hidden="false" collective="false" import="true" type="upgrade">
       <profiles>
@@ -5024,6 +5045,24 @@ A unit composed entirely of models with Utan jump boosters may not Run. During R
           </characteristics>
         </profile>
       </profiles>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="654d-be88-b0a8-7ae5" name="Laspistol" publicationId="bde1-6db1-163b-3b76" page="117" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="a0ca-3d2e-5151-b9c7" name="Laspistol" publicationId="bde1-6db1-163b-3b76" page="117" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="95ba-cda7-b831-6066">12&quot;</characteristic>
+            <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">3</characteristic>
+            <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">-</characteristic>
+            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Pistol 1</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
     </selectionEntry>
   </sharedSelectionEntries>
   <sharedSelectionEntryGroups>
@@ -5380,6 +5419,14 @@ When deployed onto the battlefield (either at the start of the battle or when ar
     </rule>
     <rule id="50f4-db05-3e45-467f" name="Djinn-Sight" publicationId="bde1-6db1-163b-3b76" page="104" hidden="false">
       <description>When making Shooting Attacks, djinn-sight reduces the benefits of any Cover Save the target unit has by -2 (a 4+ becoming a 6+, a 5+ being ignored entirely, and so on). Additionally, Infiltrators may not be set up within 24&quot; of units with this special rule, regardless of line of sight.</description>
+    </rule>
+    <rule id="a686-026f-6674-102e" name="Guardian Unit Sub-type" publicationId="bde1-6db1-163b-3b76" page="91" hidden="false">
+      <description>• Units including models with the Guardian Unit Sub-type may Embark freely upon models with the Transport Unit Sub-type and within Buildings and Fortifications as if they had the Infantry Type, even if their Unit Type would normally restrict this.
+• Units including models with the Guardian Unit Sub-type may be joined by friendly models with the Character Unit Sub-type or Independent Character special rule, and when they are joined in this manner may make Reactions, even if their Unit Type would normally restrict this.
+• If a unit contains any models with the Guardian Unit Sub-type as well as one or more models with the Character Unit Sub-type, any Wounds which would be allocated to the Character (even those caused by the Precision Strikes (X) or Sniper special rules) may instead be allocated to a model with the Guardian Unit Sub-type first.
+• Unless they are joined by a friendly Character, all models with the Guardian Unit Sub-type suffer the following provisions:
+-	Reduce their Movement Characteristic by -2 and may not Run.
+-	Reduce their Initiative Characteristic to 1.</description>
     </rule>
   </sharedRules>
   <sharedProfiles>

--- a/2022 - Mechanicum.cat
+++ b/2022 - Mechanicum.cat
@@ -9,48 +9,48 @@
         <categoryLink id="e8be-9a28-67c2-ab93" name="New CategoryLink" hidden="false" targetId="e90d-e5a8-f42d-da84" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="12ef-d6e7-3e43-41f7" name="Archmagos Prime (Placeholder)" hidden="false" collective="false" import="true" targetId="d0f2-ee39-450c-39db" type="selectionEntry">
+    <entryLink id="12ef-d6e7-3e43-41f7" name="Archmagos Prime" hidden="false" collective="false" import="true" targetId="d0f2-ee39-450c-39db" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="b654-9601-210e-2023" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="ed2f-e502-9c88-ef9e" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="943e-3900-7eb5-e5ab" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="c24f-27c9-1759-4427" name="Archmagos Prime on Abeyant (Placeholder)" hidden="false" collective="false" import="true" targetId="3821-7503-6139-3054" type="selectionEntry">
+    <entryLink id="c24f-27c9-1759-4427" name="Archmagos Prime on Abeyant" hidden="false" collective="false" import="true" targetId="3821-7503-6139-3054" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="7fc8-bff9-1ce8-4ab5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="fec0-6e63-9264-bfd2" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="4592-5ca2-9c47-09ba" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="850d-b62e-8f76-b1be" name="Magos Dominus (Placeholder)" hidden="false" collective="false" import="true" targetId="2dcd-d6c5-9f57-0084" type="selectionEntry">
+    <entryLink id="850d-b62e-8f76-b1be" name="Magos Dominus" hidden="false" collective="false" import="true" targetId="2dcd-d6c5-9f57-0084" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="5b02-7a0e-57ce-4c30" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="3984-61d8-2f84-c437" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="ce21-60e8-7612-3909" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="2f3b-dd15-7f5e-9cf7" name="Magos Dominus on Abeyant (Placeholder)" hidden="false" collective="false" import="true" targetId="ed8b-48de-1e04-fa9d" type="selectionEntry">
+    <entryLink id="2f3b-dd15-7f5e-9cf7" name="Magos Dominus on Abeyant" hidden="false" collective="false" import="true" targetId="ed8b-48de-1e04-fa9d" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="071e-1aff-6f80-5a67" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="44e7-ba3a-da35-d5fc" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="ae9b-7528-7813-39d2" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="140c-306c-d09d-265f" name="Calleb Decima Invictus (Placeholder)" hidden="true" collective="false" import="true" targetId="a204-6b74-3aeb-0231" type="selectionEntry">
+    <entryLink id="140c-306c-d09d-265f" name="Calleb Decima Invictus" hidden="true" collective="false" import="true" targetId="a204-6b74-3aeb-0231" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="58b5-6803-6799-0aa9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="3d6b-6612-cc33-5f72" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="ae5d-99ed-bca3-5c51" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="eb03-59c6-97aa-8f6b" name="Tech-Priest Auxilia (Placeholder)" hidden="false" collective="false" import="true" targetId="0eae-0c52-1087-a3b0" type="selectionEntry">
+    <entryLink id="eb03-59c6-97aa-8f6b" name="Tech-Priest Auxilia" hidden="false" collective="false" import="true" targetId="0eae-0c52-1087-a3b0" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="0e6d-0458-4a4d-ca4d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="5ba2-c0ac-fb56-e190" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="d629-dd69-e689-c38a" name="Arcuitor Magisterium (Placeholder)" hidden="false" collective="false" import="true" targetId="6f33-657c-a1b4-710e" type="selectionEntry">
+    <entryLink id="d629-dd69-e689-c38a" name="Arcuitor Magisterium" hidden="false" collective="false" import="true" targetId="6f33-657c-a1b4-710e" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
@@ -63,63 +63,63 @@
         <categoryLink id="0c0f-9a1e-4050-56d4" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="4f46-e279-a2c2-df18" name="Myrmidon Secutor Host (Placeholder)" hidden="false" collective="false" import="true" targetId="1869-2d16-d825-04c3" type="selectionEntry">
+    <entryLink id="4f46-e279-a2c2-df18" name="Myrmidon Secutor Host" hidden="false" collective="false" import="true" targetId="1869-2d16-d825-04c3" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="8567-d030-d756-4c6a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="e0af-3ec1-6313-926e" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="c06a-da74-71b7-fee1" name="Adsecularis Tech-thralls Covenant (Placeholder)" hidden="false" collective="false" import="true" targetId="bc2c-076a-209b-f121" type="selectionEntry">
+    <entryLink id="c06a-da74-71b7-fee1" name="Adsecularis Tech-thralls Covenant" hidden="false" collective="false" import="true" targetId="bc2c-076a-209b-f121" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="b03f-214f-f4e8-8de8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="e761-63e9-40c4-57ff" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="9bef-dc92-297a-da86" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="123c-8d49-5eb2-8e19" name="Thallax Cohort (Placeholder)" hidden="false" collective="false" import="true" targetId="25c8-3e0f-e22d-a7eb" type="selectionEntry">
+    <entryLink id="123c-8d49-5eb2-8e19" name="Thallax Cohort" hidden="false" collective="false" import="true" targetId="25c8-3e0f-e22d-a7eb" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="670f-cf2a-d36d-be6e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="eb58-ed23-c958-3d96" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="02de-e1ca-567c-d897" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="88d1-a0a6-3637-5bf8" name="Scyllax Guardian-Automata Maniple (Placeholder)" hidden="false" collective="false" import="true" targetId="57ab-2409-6707-b967" type="selectionEntry">
+    <entryLink id="88d1-a0a6-3637-5bf8" name="Scyllax Guardian-Automata Maniple" hidden="false" collective="false" import="true" targetId="57ab-2409-6707-b967" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="6658-9df3-d4ac-70d7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="f1b8-f9a4-e1fb-c21f" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="de1b-2a5f-b271-fd61" name="Arlatax Battle-Automata Maniple (Placeholder)" hidden="false" collective="false" import="true" targetId="b178-7d35-136f-d305" type="selectionEntry">
+    <entryLink id="de1b-2a5f-b271-fd61" name="Arlatax Battle-Automata Maniple" hidden="false" collective="false" import="true" targetId="b178-7d35-136f-d305" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="b0c1-fb4e-652e-7630" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="fa0b-cfcd-a68a-1c73" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="a722-3efe-7ccb-6242" name="Ursarax Cohort (Placeholder)" hidden="false" collective="false" import="true" targetId="0750-2aed-2d36-8a82" type="selectionEntry">
+    <entryLink id="a722-3efe-7ccb-6242" name="Ursarax Cohort" hidden="false" collective="false" import="true" targetId="0750-2aed-2d36-8a82" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="d453-d437-1236-00c0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="9ca5-73ce-baf3-ecf1" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="b790-b6dc-b904-118c" name="Vultarax Stratos-Automata Squadron (Placeholder)" hidden="false" collective="false" import="true" targetId="0e08-6b7e-8fff-1f02" type="selectionEntry">
+    <entryLink id="b790-b6dc-b904-118c" name="Vultarax Stratos-Automata Squadron" hidden="false" collective="false" import="true" targetId="0e08-6b7e-8fff-1f02" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="76a8-0091-e9f9-e5e2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="ef35-36e0-2fc3-f8c7" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="6558-9557-4654-31fc" name="Myrmidon Destructor Host (Placeholder)" hidden="false" collective="false" import="true" targetId="356f-a88b-1d13-3700" type="selectionEntry">
+    <entryLink id="6558-9557-4654-31fc" name="Myrmidon Destructor Host" hidden="false" collective="false" import="true" targetId="356f-a88b-1d13-3700" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="23e1-8fa1-49c1-1d77" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="66c0-0a59-046b-249b" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="4467-970e-236e-6118" name="Karacnos Assault Tank (Placeholder)" hidden="false" collective="false" import="true" targetId="8920-3184-2455-1834" type="selectionEntry">
+    <entryLink id="4467-970e-236e-6118" name="Karacnos Assault Tank" hidden="false" collective="false" import="true" targetId="8920-3184-2455-1834" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="3691-ade8-41f9-ecf2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="1e5d-4224-528c-7cba" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="30bc-6d27-6a7b-5d02" name="Krios Squadron (Placeholder)" hidden="false" collective="false" import="true" targetId="ce87-68e2-0134-3c84" type="selectionEntry">
+    <entryLink id="30bc-6d27-6a7b-5d02" name="Krios Squadron" hidden="false" collective="false" import="true" targetId="ce87-68e2-0134-3c84" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="90f5-b210-0447-2356" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="4b9e-daec-dd50-1582" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
@@ -167,7 +167,7 @@
         <categoryLink id="3331-9a71-e131-6128" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="6a07-9580-9c41-dbc6" name="Archmagos Anacharis Scoria (Placeholder)" hidden="true" collective="false" import="true" targetId="2185-5fd1-2e59-b467" type="selectionEntry">
+    <entryLink id="6a07-9580-9c41-dbc6" name="Archmagos Anacharis Scoria" hidden="true" collective="false" import="true" targetId="2185-5fd1-2e59-b467" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="1bfa-3de2-bf04-16db" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="d3aa-2699-4210-25dd" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
@@ -191,6 +191,7 @@
       <categoryLinks>
         <categoryLink id="b52a-0f4e-b317-2bcd" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="12ad-c3f3-cdb7-1735" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="63cb-4eca-61e7-11af" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="2394-56b3-7592-01ae" name="Domitar Battle-Automata Maniple" hidden="false" collective="false" import="true" targetId="1a1b-fa35-a6a2-ca78" type="selectionEntry">
@@ -212,7 +213,7 @@
         <categoryLink id="22c6-2c40-c433-b524" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="0d52-bf5d-15d6-0470" name="Tech-Priest Auxilia (Placeholder)" hidden="true" collective="false" import="true" targetId="0eae-0c52-1087-a3b0" type="selectionEntry">
+    <entryLink id="0d52-bf5d-15d6-0470" name="Tech-Priest Auxilia" hidden="true" collective="false" import="true" targetId="0eae-0c52-1087-a3b0" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
@@ -223,9 +224,10 @@
       <categoryLinks>
         <categoryLink id="22e8-b76e-e559-5ac5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="093d-3993-8774-9f21" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="2e88-4d17-543b-453e" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="a311-28b2-65d1-193d" name="Arcuitor Magisterium (Placeholder)" hidden="true" collective="false" import="true" targetId="6f33-657c-a1b4-710e" type="selectionEntry">
+    <entryLink id="a311-28b2-65d1-193d" name="Arcuitor Magisterium" hidden="true" collective="false" import="true" targetId="6f33-657c-a1b4-710e" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditionGroups>
@@ -241,6 +243,7 @@
       <categoryLinks>
         <categoryLink id="ac20-54eb-277f-85ca" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="a52f-f980-0f7d-36c3" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="cd51-74f1-04ca-2248" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="d1c5-ff4b-1a9e-2a92" name="Thanatar Siege-automata Maniple" hidden="true" collective="false" import="true" targetId="2903-fef6-e839-368b" type="selectionEntry">
@@ -256,7 +259,7 @@
         <categoryLink id="db76-cda6-0690-9f5c" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="3ca2-40e2-1b7e-b0b3" name="Myrmidon Secutor Host (Placeholder)" hidden="true" collective="false" import="true" targetId="1869-2d16-d825-04c3" type="selectionEntry">
+    <entryLink id="3ca2-40e2-1b7e-b0b3" name="Myrmidon Secutor Host" hidden="true" collective="false" import="true" targetId="1869-2d16-d825-04c3" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
@@ -267,9 +270,10 @@
       <categoryLinks>
         <categoryLink id="e4bc-e382-e2f4-1151" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="6609-996b-bd48-3075" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="44d3-3b8a-f672-7fb4" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="001b-6e55-0b99-c015" name="Myrmidon Destructor Host (Placeholder)" hidden="true" collective="false" import="true" targetId="356f-a88b-1d13-3700" type="selectionEntry">
+    <entryLink id="001b-6e55-0b99-c015" name="Myrmidon Destructor Host" hidden="true" collective="false" import="true" targetId="356f-a88b-1d13-3700" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
@@ -284,12 +288,7 @@
     </entryLink>
   </entryLinks>
   <sharedSelectionEntries>
-    <selectionEntry id="7c8d-b21a-1f72-7e22" name="Upgrade Points (Placeholders)" hidden="false" collective="false" import="true" type="upgrade">
-      <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="1.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="d0f2-ee39-450c-39db" name="Archmagos Prime (Placeholder)" publicationId="bde1-6db1-163b-3b76" page="20" hidden="false" collective="false" import="true" type="unit">
+    <selectionEntry id="d0f2-ee39-450c-39db" name="Archmagos Prime" publicationId="bde1-6db1-163b-3b76" page="20" hidden="false" collective="false" import="true" type="unit">
       <constraints>
         <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7627-04e3-89f2-e14f" type="max"/>
       </constraints>
@@ -327,6 +326,20 @@
           </characteristics>
         </profile>
       </profiles>
+      <infoLinks>
+        <infoLink id="a1f3-3354-d23f-f046" name="Battlesmith (X)" hidden="false" targetId="5d57-4d02-1e36-4a82" type="rule">
+          <modifiers>
+            <modifier type="set" field="name" value="Battlesmith (4+)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="34de-d754-4304-039e" name="Firing Protocols (X)" hidden="false" targetId="32a3-f599-5c92-2945" type="rule">
+          <modifiers>
+            <modifier type="set" field="name" value="Firing Protocols (3)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="3e68-edb3-e82b-bcbb" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule"/>
+        <infoLink id="16f9-27ca-ca47-1d1e" name="Stubborn" hidden="false" targetId="7989-1f2c-a43d-82ae" type="rule"/>
+      </infoLinks>
       <categoryLinks>
         <categoryLink id="fc8b-7c82-9965-120f" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
         <categoryLink id="699b-4a76-ee6f-f722" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
@@ -413,6 +426,235 @@
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
+        <selectionEntryGroup id="2ab1-bffc-d310-dee2" name="May take any of the following options:" hidden="false" collective="false" import="true">
+          <selectionEntries>
+            <selectionEntry id="100c-29a9-e126-e082" name="Master-craft one weapon" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0da6-a6e0-8fbb-627e" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="0eee-3c76-6a5a-b60f" name="Master-crafted" hidden="false" targetId="6de0-55b0-bf21-48b9" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <entryLinks>
+            <entryLink id="3808-81b7-4bf1-9f60" name="Augury Scanner" hidden="false" collective="false" import="true" targetId="67ee-7338-3b74-04b4" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f02d-1a77-6483-eeb0" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="530a-00b3-54f5-fbe7" name="Meltabombs" hidden="false" collective="false" import="true" targetId="b9dd-3b21-f3f8-78e3" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d618-15e1-1d37-32c0" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="56c5-62e1-c683-fc95" name="Rad Grenades" hidden="false" collective="false" import="true" targetId="1b0b-3dfc-9521-b27e" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e197-afc7-fb60-e8c2" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="b28f-41d5-7caa-ba47" name="Cyber-Familiar" hidden="false" collective="false" import="true" targetId="6c85-4601-cf58-7b35" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c70e-7d76-4524-2796" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="fd00-143b-56bb-caf8" name="May exchange either their Volkite Serpenta and/or Power Weapon each for one of the following options:" hidden="false" collective="false" import="true" defaultSelectionEntryId="bd58-fc10-2ae8-611e">
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="52c9-2f1c-800c-a0ab" type="min"/>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="78b7-42b5-c8d0-8c79" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="bd58-fc10-2ae8-611e" name="Volkite Serpenta" hidden="false" collective="false" import="true" targetId="d535-1da8-290d-69a6" type="selectionEntry"/>
+            <entryLink id="7b9a-a5a9-9da0-06a1" name="Power Sword" hidden="false" collective="false" import="true" targetId="a3cd-aa97-a148-2309" type="selectionEntry"/>
+            <entryLink id="a7d3-874b-cb5c-8898" name="Power Maul" hidden="false" collective="false" import="true" targetId="0df4-c67e-cf64-82e0" type="selectionEntry"/>
+            <entryLink id="e287-31ff-1cdb-274e" name="Power Axe" hidden="false" collective="false" import="true" targetId="c066-2ace-f68c-e440" type="selectionEntry"/>
+            <entryLink id="6c14-de51-6afc-2b64" name="Power Lance" hidden="false" collective="false" import="true" targetId="a4c8-c8ff-87f2-1ac9" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="3767-8bda-7444-b0ce" value="0.0"/>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3767-8bda-7444-b0ce" type="min"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="87d1-fe9f-990f-652c" name="Archaeotech Pistol" hidden="false" collective="false" import="true" targetId="c22a-ed4d-af68-bf00" type="selectionEntry">
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="ff67-6414-40cc-5aa3" name="Lucifex" hidden="false" collective="false" import="true" targetId="71cf-978d-0444-a3f1" type="selectionEntry">
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="b8dc-3cb9-2692-a2df" name="Maxima Bolter" hidden="false" collective="false" import="true" targetId="1d3e-1b60-d133-ea0d" type="selectionEntry">
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="3ff1-c2e7-0dd8-5d8a" name="Photon Gauntlet" hidden="false" collective="false" import="true" targetId="e825-c60e-e6c3-60f0" type="selectionEntry">
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="be9f-af48-eb9c-5b3c" name="Plasma Pistol" hidden="false" collective="false" import="true" targetId="717f-cf0a-1593-4bd8" type="selectionEntry">
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="b095-e29e-c105-bdd8" name="Power Fist" hidden="false" collective="false" import="true" targetId="768d-b89b-7328-d749" type="selectionEntry">
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="6ee5-c22a-e1c3-ff15" name="Corposant Stave" hidden="false" collective="false" import="true" targetId="cfc3-0ca2-ebdc-e6b0" type="selectionEntry">
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="d40d-149e-7a43-2510" name="Chainfist" hidden="false" collective="false" import="true" targetId="7347-c5b1-5da3-a78f" type="selectionEntry">
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="c104-ece0-9f82-c9cf" name="Paragon Blade" hidden="false" collective="false" import="true" targetId="2ab9-0e45-405e-056b" type="selectionEntry">
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="de1b-c169-e406-509d" name="May take one of the following options:" hidden="false" collective="false" import="true">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="75da-4222-d7e5-ba25" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="a5f2-4694-f699-fd16" name="Servo-Arm" hidden="false" collective="false" import="true" targetId="4168-fc85-8912-7188" type="selectionEntry">
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="a186-7ee1-b717-10f4" name="Incunabulan Jet Pack" hidden="false" collective="false" import="true" targetId="9faf-7242-dc40-c3e5" type="selectionEntry">
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="a1a0-135e-7b69-5882" name="Conversion Beamer" hidden="false" collective="false" import="true" targetId="2397-a3fd-81e6-4ced" type="selectionEntry">
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="2ef4-9107-2995-d88e" name="Graviton Imploder" hidden="false" collective="false" import="true" targetId="c651-d95e-6aa9-c3de" type="selectionEntry">
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="8aa5-6d46-faa4-de37" name="Machinator Array" hidden="false" collective="false" import="true" targetId="66f5-697c-605c-f1bb" type="selectionEntry">
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="9b84-f467-8b83-1476" name="Machinator Array with Prehensile Data-Spike" hidden="true" collective="false" import="true" targetId="3104-9879-3dcd-2bbb" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="hidden" value="false">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5e62-8d7e-a487-0490" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="35.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="a160-c7ca-210b-6b2e" name="Servo-Arm with Prehensile Data-Spike" hidden="true" collective="false" import="true" targetId="981f-5ffe-b686-0491" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="hidden" value="false">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5e62-8d7e-a487-0490" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="2725-d5f8-44c1-d795" name="May take one of the following additional weapon options (an Archmagos Prime with the Myrmidax Order of High Techno-arcana may takeup to two selections from the list instead, but may not select a rad furnace):" hidden="false" collective="false" import="true">
+          <modifiers>
+            <modifier type="increment" field="dca2-7358-f3f2-3dc5" value="1.0">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8305-5ac6-f395-e570" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dca2-7358-f3f2-3dc5" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="036b-7d7a-b439-77ef" name="Rotor Cannon" hidden="false" collective="false" import="true" targetId="5ce3-3aa5-3f5e-9ead" type="selectionEntry">
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="8e17-9d26-e061-c3eb" name="Graviton Gun" hidden="false" collective="false" import="true" targetId="5303-5a3e-de51-1707" type="selectionEntry">
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="da4a-e7d1-3ffe-82aa" name="Meltagun" hidden="false" collective="false" import="true" targetId="4ebd-57e0-3560-e568" type="selectionEntry">
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="a8b1-7de1-cf57-cc0e" name="Irad-Cleanser" hidden="false" collective="false" import="true" targetId="b3c5-237f-e1d2-d9f8" type="selectionEntry">
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="504b-3e65-4742-7853" name="Phased Plasma-Fusil" hidden="false" collective="false" import="true" targetId="17c6-afe9-c5da-d9b6" type="selectionEntry">
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="9326-8db2-fe47-c839" name="Photon Thruster" hidden="false" collective="false" import="true" targetId="3519-b118-7c6e-2343" type="selectionEntry">
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="30.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="196a-5910-71d1-f566" name="Rad Furnace" hidden="false" collective="false" import="true" targetId="18da-a26c-bdd4-8a5f" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="eae2-4a71-6ba3-547c" value="0.0">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8305-5ac6-f395-e570" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eae2-4a71-6ba3-547c" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="30.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
         <entryLink id="34f8-3711-2e5b-5bad" name="Warlord" hidden="false" collective="false" import="true" targetId="0176-56a3-d590-b103" type="selectionEntry">
@@ -427,15 +669,26 @@
             <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ff1b-f9d7-b417-c057" type="min"/>
           </constraints>
         </entryLink>
-        <entryLink id="fe5d-5729-e3c2-771e" name="Upgrade Points (Placeholders)" hidden="false" collective="false" import="true" targetId="7c8d-b21a-1f72-7e22" type="selectionEntry"/>
         <entryLink id="4417-2a5d-c0ec-dd84" name="Orders of High Techno-arcana" hidden="false" collective="false" import="true" targetId="c36b-a6a2-9cb2-b090" type="selectionEntryGroup"/>
         <entryLink id="3ed3-cc97-d116-35df" name="Feudal Hierarchy" hidden="false" collective="false" import="true" targetId="27ff-3ae1-5cb6-774b" type="selectionEntry"/>
+        <entryLink id="7fa1-908e-c53e-8fcb" name="Mechanicum Protectiva" hidden="false" collective="false" import="true" targetId="7908-9b34-c5bb-21c2" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f1b6-784c-0df6-f37a" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b032-baff-b790-6d40" type="min"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="bb43-f15c-90e4-ba94" name="Cortex Controller" hidden="false" collective="false" import="true" targetId="2fda-455f-d34d-97e0" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="159a-931b-278b-2e19" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6e9b-73f4-15d3-f3b3" type="max"/>
+          </constraints>
+        </entryLink>
       </entryLinks>
       <costs>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="155.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="3821-7503-6139-3054" name="Archmagos Prime on Abeyant (Placeholder)" publicationId="bde1-6db1-163b-3b76" page="22" hidden="false" collective="false" import="true" type="unit">
+    <selectionEntry id="3821-7503-6139-3054" name="Archmagos Prime on Abeyant" publicationId="bde1-6db1-163b-3b76" page="22" hidden="false" collective="false" import="true" type="unit">
       <constraints>
         <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3a42-ed80-41ab-7cb1" type="max"/>
       </constraints>
@@ -468,6 +721,15 @@
           </characteristics>
         </profile>
       </profiles>
+      <infoLinks>
+        <infoLink id="02f4-4735-b3fc-dd82" name="Battlesmith (X)" hidden="false" targetId="5d57-4d02-1e36-4a82" type="rule">
+          <modifiers>
+            <modifier type="set" field="name" value="Battlesmith (4+)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="7e8b-641d-fb93-4424" name="Pride of Place" hidden="false" targetId="f83c-9442-8102-5da4" type="rule"/>
+        <infoLink id="310c-f07b-6e82-263c" name="Stubborn" hidden="false" targetId="7989-1f2c-a43d-82ae" type="rule"/>
+      </infoLinks>
       <categoryLinks>
         <categoryLink id="8bf8-9627-3e73-b8bc" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
         <categoryLink id="6a96-9d2f-a329-7562" name="Monstrous Sub-type:" hidden="false" targetId="7d95-f9d1-440a-67bd" primary="false"/>
@@ -554,9 +816,207 @@
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
+        <selectionEntryGroup id="b1be-d5bb-2751-7b63" name="May exchange either their Volkite Serpenta and/or Power Weapon each for one of the following options:" hidden="false" collective="false" import="true" defaultSelectionEntryId="7676-9e72-ebf6-5df9">
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fdf9-bd60-0935-0abe" type="min"/>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a43b-ea96-afa5-5e94" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="7676-9e72-ebf6-5df9" name="Volkite Serpenta" hidden="false" collective="false" import="true" targetId="d535-1da8-290d-69a6" type="selectionEntry"/>
+            <entryLink id="b64f-43d7-9750-d15f" name="Power Sword" hidden="false" collective="false" import="true" targetId="a3cd-aa97-a148-2309" type="selectionEntry"/>
+            <entryLink id="7086-4055-3b52-39a2" name="Power Maul" hidden="false" collective="false" import="true" targetId="0df4-c67e-cf64-82e0" type="selectionEntry"/>
+            <entryLink id="c1f0-6592-242a-1f6a" name="Power Axe" hidden="false" collective="false" import="true" targetId="c066-2ace-f68c-e440" type="selectionEntry"/>
+            <entryLink id="c782-73cf-613d-4d72" name="Power Lance" hidden="false" collective="false" import="true" targetId="a4c8-c8ff-87f2-1ac9" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="1c61-cdf7-7cbe-9074" value="0.0"/>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1c61-cdf7-7cbe-9074" type="min"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="254a-e864-526d-8981" name="Archaeotech Pistol" hidden="false" collective="false" import="true" targetId="c22a-ed4d-af68-bf00" type="selectionEntry">
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="2c80-743a-104e-24a0" name="Lucifex" hidden="false" collective="false" import="true" targetId="71cf-978d-0444-a3f1" type="selectionEntry">
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="2c9b-5cf7-dc2a-fb0e" name="Maxima Bolter" hidden="false" collective="false" import="true" targetId="1d3e-1b60-d133-ea0d" type="selectionEntry">
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="8f9f-5c4d-03c5-7f60" name="Photon Gauntlet" hidden="false" collective="false" import="true" targetId="e825-c60e-e6c3-60f0" type="selectionEntry">
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="92c3-e436-d6b7-4fb3" name="Plasma Pistol" hidden="false" collective="false" import="true" targetId="717f-cf0a-1593-4bd8" type="selectionEntry">
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="2aa8-1044-0584-87f6" name="Power Fist" hidden="false" collective="false" import="true" targetId="768d-b89b-7328-d749" type="selectionEntry">
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="6f84-1056-7c7f-d991" name="Corposant Stave" hidden="false" collective="false" import="true" targetId="cfc3-0ca2-ebdc-e6b0" type="selectionEntry">
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="c964-5f69-6863-8796" name="Chainfist" hidden="false" collective="false" import="true" targetId="7347-c5b1-5da3-a78f" type="selectionEntry">
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="5237-1cb3-4860-0422" name="Paragon Blade" hidden="false" collective="false" import="true" targetId="2ab9-0e45-405e-056b" type="selectionEntry">
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="7a33-fa4c-6c53-b688" name="May take any of the following options:" hidden="false" collective="false" import="true">
+          <selectionEntries>
+            <selectionEntry id="bb8c-9755-e7bc-a6b0" name="Master-craft one weapon" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a892-6259-2975-3ae6" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="736b-9f63-ff30-86ad" name="Master-crafted" hidden="false" targetId="6de0-55b0-bf21-48b9" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <entryLinks>
+            <entryLink id="152d-2ab8-a897-94c5" name="Augury Scanner" hidden="false" collective="false" import="true" targetId="67ee-7338-3b74-04b4" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d2d0-8918-bb0e-a95e" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="f8a6-7fcc-04d9-c4b0" name="Rad Grenades" hidden="false" collective="false" import="true" targetId="1b0b-3dfc-9521-b27e" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="593f-a1a6-929b-63b4" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="a979-5559-cc7f-d5a1" name="Cyber-Familiar" hidden="false" collective="false" import="true" targetId="6c85-4601-cf58-7b35" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1324-5167-9a3e-4e4c" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="55ef-5df8-75d9-4b82" name="May take one of the following additional weapon options" hidden="false" collective="false" import="true">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2e68-ba87-c740-c567" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="9766-3754-e8db-9103" name="Rotor Cannon" hidden="false" collective="false" import="true" targetId="5ce3-3aa5-3f5e-9ead" type="selectionEntry">
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="fb44-a97f-9af4-209a" name="Graviton Gun" hidden="false" collective="false" import="true" targetId="5303-5a3e-de51-1707" type="selectionEntry">
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="d766-3752-8734-1392" name="Meltagun" hidden="false" collective="false" import="true" targetId="4ebd-57e0-3560-e568" type="selectionEntry">
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="0f07-69dc-43a1-2bd3" name="Irad-Cleanser" hidden="false" collective="false" import="true" targetId="b3c5-237f-e1d2-d9f8" type="selectionEntry">
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="06eb-d933-9408-5288" name="Phased Plasma-Fusil" hidden="false" collective="false" import="true" targetId="17c6-afe9-c5da-d9b6" type="selectionEntry">
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="79bd-3cb6-ac30-3eca" name="Photon Thruster" hidden="false" collective="false" import="true" targetId="3519-b118-7c6e-2343" type="selectionEntry">
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="30.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="e1b8-2f4f-0232-079b" name="Rad Furnace" hidden="false" collective="false" import="true" targetId="18da-a26c-bdd4-8a5f" type="selectionEntry">
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="30.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="82bc-a087-e43e-efaf" name="May take one of the following options:" hidden="false" collective="false" import="true">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fe7a-0e7d-8bf9-9a3e" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="fab3-4f9f-1fb0-c456" name="Servo-Arm" hidden="false" collective="false" import="true" targetId="4168-fc85-8912-7188" type="selectionEntry">
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="ce73-4a18-f345-e7ad" name="Conversion Beamer" hidden="false" collective="false" import="true" targetId="2397-a3fd-81e6-4ced" type="selectionEntry">
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="5c04-4d16-8f43-1e52" name="Graviton Imploder" hidden="false" collective="false" import="true" targetId="c651-d95e-6aa9-c3de" type="selectionEntry">
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="be98-0352-563e-1d5d" name="Machinator Array" hidden="false" collective="false" import="true" targetId="66f5-697c-605c-f1bb" type="selectionEntry">
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="a8c1-1dd4-0a83-1f05" name="Machinator Array with Prehensile Data-Spike" hidden="true" collective="false" import="true" targetId="3104-9879-3dcd-2bbb" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="hidden" value="false">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5e62-8d7e-a487-0490" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="35.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="fe87-affb-34f9-6ce2" name="Servo-Arm with Prehensile Data-Spike" hidden="true" collective="false" import="true" targetId="981f-5ffe-b686-0491" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="hidden" value="false">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5e62-8d7e-a487-0490" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="11bd-b0d7-ac49-5e45" name="Upgrade Points (Placeholders)" hidden="false" collective="false" import="true" targetId="7c8d-b21a-1f72-7e22" type="selectionEntry"/>
         <entryLink id="080a-3d66-7fa3-b65d" name="Warlord" hidden="false" collective="false" import="true" targetId="0176-56a3-d590-b103" type="selectionEntry">
           <modifiers>
             <modifier type="set" field="a96c-007d-083d-b58c" value="1.0">
@@ -571,41 +1031,454 @@
         </entryLink>
         <entryLink id="51ec-4169-13a5-abe4" name="Orders of High Techno-arcana" hidden="false" collective="false" import="true" targetId="c36b-a6a2-9cb2-b090" type="selectionEntryGroup"/>
         <entryLink id="a990-eb17-4c30-6fbb" name="Feudal Hierarchy" hidden="false" collective="false" import="true" targetId="27ff-3ae1-5cb6-774b" type="selectionEntry"/>
+        <entryLink id="811b-c29f-e0c8-6a52" name="Cortex Controller" hidden="false" collective="false" import="true" targetId="2fda-455f-d34d-97e0" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0cee-cd20-154d-f271" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="db6e-8cea-4870-0d0a" type="max"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="b442-7d58-bb76-f51e" name="Mechanicum Protectiva" hidden="false" collective="false" import="true" targetId="7908-9b34-c5bb-21c2" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1296-db0c-63c4-2b7e" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="55dd-6deb-fe92-120a" type="min"/>
+          </constraints>
+        </entryLink>
       </entryLinks>
       <costs>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="185.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="2dcd-d6c5-9f57-0084" name="Magos Dominus (Placeholder)" publicationId="bde1-6db1-163b-3b76" page="24" hidden="false" collective="false" import="true" type="unit">
+    <selectionEntry id="2dcd-d6c5-9f57-0084" name="Magos Dominus" publicationId="bde1-6db1-163b-3b76" page="24" hidden="false" collective="false" import="true" type="unit">
+      <profiles>
+        <profile id="b636-8df8-c56f-7569" name="Magos Dominus" publicationId="bde1-6db1-163b-3b76" page="24" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName="Unit">
+          <characteristics>
+            <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Character, Cybertheurgist, Heavy)</characteristic>
+            <characteristic name="Move" typeId="893e-2d76-8f04-44e5">6</characteristic>
+            <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">3</characteristic>
+            <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
+            <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
+            <characteristic name="T" typeId="c32b-5fdd-3fbe-9b1f">4</characteristic>
+            <characteristic name="W" typeId="57ee-1126-32a9-5672">2</characteristic>
+            <characteristic name="I" typeId="62d3-22d7-2d49-52dc">3</characteristic>
+            <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">2</characteristic>
+            <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">9</characteristic>
+            <characteristic name="Save" typeId="e593-6b3c-f169-04f0">3+</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="cd09-e27a-d227-f39f" name="Battlesmith (X)" hidden="false" targetId="5d57-4d02-1e36-4a82" type="rule">
+          <modifiers>
+            <modifier type="set" field="name" value="Battlesmith (5+)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="eb00-4ffc-f96a-06b0" name="Feel No Pain (X)" hidden="false" targetId="ec46-ff29-32e0-c2aa" type="rule">
+          <modifiers>
+            <modifier type="set" field="name" value="Feel No Pain (5+)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="c3f2-adf6-4d29-7721" name="Firing Protocols (X)" hidden="false" targetId="32a3-f599-5c92-2945" type="rule">
+          <modifiers>
+            <modifier type="set" field="name" value="Firing Protocols (2)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="1916-22d6-38ab-bc36" name="Patris Cybernetica" hidden="false" targetId="0893-4bd0-d5a1-14db" type="rule"/>
+        <infoLink id="765f-164a-9ff3-2cc3" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule"/>
+        <infoLink id="033a-d8cc-ac49-b72a" name="Stubborn" hidden="false" targetId="7989-1f2c-a43d-82ae" type="rule"/>
+      </infoLinks>
       <categoryLinks>
         <categoryLink id="4312-d152-9e2a-c653" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
         <categoryLink id="176d-fff6-f157-330a" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="a16c-e7f6-08fc-a357" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
       </categoryLinks>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="0cae-ba4f-f97c-5f0f" name="May take any of the following options:" hidden="false" collective="false" import="true">
+          <selectionEntries>
+            <selectionEntry id="e1e2-af22-d6ef-70ba" name="Master-craft one weapon" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="61b1-6c41-3933-2ccf" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="a701-4f62-64f9-e8f5" name="Master-crafted" hidden="false" targetId="6de0-55b0-bf21-48b9" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <entryLinks>
+            <entryLink id="3b7c-c29d-0daf-0e7f" name="Augury Scanner" hidden="false" collective="false" import="true" targetId="67ee-7338-3b74-04b4" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e469-3528-9fcf-1724" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="5815-e56d-afaf-3c87" name="Meltabombs" hidden="false" collective="false" import="true" targetId="b9dd-3b21-f3f8-78e3" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d608-aa1c-1f01-1c8b" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="9205-f0ef-7065-c528" name="Cyber-Familiar" hidden="false" collective="false" import="true" targetId="6c85-4601-cf58-7b35" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="db9d-3e64-f2bc-059d" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="9e37-aa1a-d8f8-97b0" name="May take one of the following options:" hidden="false" collective="false" import="true">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8dd8-6e8f-09f4-18c2" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="c644-f92a-7039-30cc" name="Servo-Arm" hidden="false" collective="false" import="true" targetId="4168-fc85-8912-7188" type="selectionEntry">
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="6966-8ea8-5c96-b1d0" name="Conversion Beamer" hidden="false" collective="false" import="true" targetId="2397-a3fd-81e6-4ced" type="selectionEntry">
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="5a87-fe4d-d6a5-8d48" name="Machinator Array" hidden="false" collective="false" import="true" targetId="66f5-697c-605c-f1bb" type="selectionEntry">
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="bc5c-bf13-7bde-22c7" name="Machinator Array with Prehensile Data-Spike" hidden="true" collective="false" import="true" targetId="3104-9879-3dcd-2bbb" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="hidden" value="false">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5e62-8d7e-a487-0490" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="35.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="1f61-15d5-365c-3ccd" name="Servo-Arm with Prehensile Data-Spike" hidden="true" collective="false" import="true" targetId="981f-5ffe-b686-0491" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="hidden" value="false">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5e62-8d7e-a487-0490" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="07cb-052a-a389-2db5" name="May take one of the following additional weapons:" hidden="false" collective="false" import="true">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="db2d-bafe-77b4-32bf" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="b656-20dd-c851-4b23" name="Rotor Cannon" hidden="false" collective="false" import="true" targetId="5ce3-3aa5-3f5e-9ead" type="selectionEntry">
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="0c1e-ba9c-8b45-9cea" name="Graviton Gun" hidden="false" collective="false" import="true" targetId="5303-5a3e-de51-1707" type="selectionEntry">
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="a9dc-0a8d-8f59-7f7a" name="Meltagun" hidden="false" collective="false" import="true" targetId="4ebd-57e0-3560-e568" type="selectionEntry">
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="1b44-85f4-f9d7-7245" name="Irad-Cleanser" hidden="false" collective="false" import="true" targetId="b3c5-237f-e1d2-d9f8" type="selectionEntry">
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="86ec-c70b-7363-de95" name="Phased Plasma-Fusil" hidden="false" collective="false" import="true" targetId="17c6-afe9-c5da-d9b6" type="selectionEntry">
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="5eac-96c2-9be9-9349" name="Photon Thruster" hidden="false" collective="false" import="true" targetId="3519-b118-7c6e-2343" type="selectionEntry">
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="30.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="88bf-f37a-6479-adf8" name="May exchange their Laspistol for one of the following options:" hidden="false" collective="false" import="true" defaultSelectionEntryId="981c-c968-b91e-0a9e">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0f3e-6d36-faed-cb2f" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f3bb-4274-41c3-6949" type="min"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="1876-6947-aa0c-110c" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="e5ae-6872-37aa-8600" type="selectionEntry">
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="1.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="3b6c-f4cc-9db1-59b7" name="Volkite Serpenta" hidden="false" collective="false" import="true" targetId="d535-1da8-290d-69a6" type="selectionEntry">
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="e931-8a4e-359b-d903" name="Archaeotech Pistol" hidden="false" collective="false" import="true" targetId="c22a-ed4d-af68-bf00" type="selectionEntry">
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="a4ef-0e71-688f-5ba3" name="Photon Gauntlet" hidden="false" collective="false" import="true" targetId="e825-c60e-e6c3-60f0" type="selectionEntry">
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="9b4e-4e43-a497-5b0e" name="Plasma Pistol" hidden="false" collective="false" import="true" targetId="717f-cf0a-1593-4bd8" type="selectionEntry">
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="981c-c968-b91e-0a9e" name="Laspistol" hidden="false" collective="false" import="true" targetId="654d-be88-b0a8-7ae5" type="selectionEntry"/>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="9ac7-6b44-4ac9-6d3d" name="Cybertheurgic Arcana" hidden="false" collective="false" import="true">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="74ec-d2b0-fc99-36e1" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="86ee-8c42-c7c0-4e3f" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="767b-91c0-8f1c-e9c5" name="Artificia Machina" hidden="false" collective="false" import="true" targetId="51ed-f978-9a5e-1e04" type="selectionEntry"/>
+            <entryLink id="050c-b30a-233d-e4cb" name="Ephemera Incursus" hidden="false" collective="false" import="true" targetId="12fc-d4d8-d36c-6f14" type="selectionEntry"/>
+            <entryLink id="7041-0cdf-8fea-965d" name="Artificia Cybernetica" hidden="false" collective="false" import="true" targetId="d342-dbdb-33ec-5191" type="selectionEntry"/>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="a63a-9dfe-ee64-913c" name="Upgrade Points (Placeholders)" hidden="false" collective="false" import="true" targetId="7c8d-b21a-1f72-7e22" type="selectionEntry"/>
         <entryLink id="9dcc-9b17-198f-5691" name="Warlord" hidden="false" collective="false" import="true" targetId="0176-56a3-d590-b103" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="75.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="ed8b-48de-1e04-fa9d" name="Magos Dominus on Abeyant (Placeholder)" publicationId="bde1-6db1-163b-3b76" page="25" hidden="false" collective="false" import="true" type="unit">
+    <selectionEntry id="ed8b-48de-1e04-fa9d" name="Magos Dominus on Abeyant" publicationId="bde1-6db1-163b-3b76" page="25" hidden="false" collective="false" import="true" type="unit">
+      <profiles>
+        <profile id="8d75-6ac8-0f42-4345" name="Magos Dominus on Abeyant" publicationId="bde1-6db1-163b-3b76" page="24" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName="Unit">
+          <characteristics>
+            <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Character, Monstrous, Antigrav, Cybertheurgist, Heavy)</characteristic>
+            <characteristic name="Move" typeId="893e-2d76-8f04-44e5">6</characteristic>
+            <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">3</characteristic>
+            <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
+            <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
+            <characteristic name="T" typeId="c32b-5fdd-3fbe-9b1f">5</characteristic>
+            <characteristic name="W" typeId="57ee-1126-32a9-5672">4</characteristic>
+            <characteristic name="I" typeId="62d3-22d7-2d49-52dc">3</characteristic>
+            <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">2</characteristic>
+            <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">9</characteristic>
+            <characteristic name="Save" typeId="e593-6b3c-f169-04f0">3+</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="8185-97ed-9f04-61f6" name="Battlesmith (X)" hidden="false" targetId="5d57-4d02-1e36-4a82" type="rule">
+          <modifiers>
+            <modifier type="set" field="name" value="Battlesmith (5+)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="e197-1071-6e36-82e1" name="Feel No Pain (X)" hidden="false" targetId="ec46-ff29-32e0-c2aa" type="rule">
+          <modifiers>
+            <modifier type="set" field="name" value="Feel No Pain (5+)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="454d-0a38-bcde-faa1" name="Stubborn" hidden="false" targetId="7989-1f2c-a43d-82ae" type="rule"/>
+        <infoLink id="73b1-9db2-87ee-a964" name="Patris Cybernetica" hidden="false" targetId="0893-4bd0-d5a1-14db" type="rule"/>
+        <infoLink id="64c8-70e7-2021-4bd2" name="Pride of Place" hidden="false" targetId="f83c-9442-8102-5da4" type="rule"/>
+      </infoLinks>
       <categoryLinks>
         <categoryLink id="7d92-0210-bdb9-cd3a" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
         <categoryLink id="8595-f4c5-ba1d-69b5" name="Monstrous Sub-type:" hidden="false" targetId="7d95-f9d1-440a-67bd" primary="false"/>
         <categoryLink id="f75f-bd69-3fb1-c37d" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="ad3f-ad1c-6a50-2d8c" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
       </categoryLinks>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="14fc-6747-0f45-1075" name="May take one of the following options:" hidden="false" collective="false" import="true">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ecad-acb6-1e7e-28d2" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="914e-c2ba-1d9a-2db7" name="Servo-Arm" hidden="false" collective="false" import="true" targetId="4168-fc85-8912-7188" type="selectionEntry">
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="502c-2de8-f086-1bfc" name="Conversion Beamer" hidden="false" collective="false" import="true" targetId="2397-a3fd-81e6-4ced" type="selectionEntry">
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="2dc9-7252-f6ab-2f7c" name="Machinator Array" hidden="false" collective="false" import="true" targetId="66f5-697c-605c-f1bb" type="selectionEntry">
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="7bc1-9f83-8e67-cecc" name="Machinator Array with Prehensile Data-Spike" hidden="true" collective="false" import="true" targetId="3104-9879-3dcd-2bbb" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="hidden" value="false">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5e62-8d7e-a487-0490" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="35.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="aab8-5a79-df9b-401a" name="Servo-Arm with Prehensile Data-Spike" hidden="true" collective="false" import="true" targetId="981f-5ffe-b686-0491" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="hidden" value="false">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5e62-8d7e-a487-0490" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="a234-2d6b-393d-c045" name="Cybertheurgic Arcana" hidden="false" collective="false" import="true">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0592-ad40-c996-6594" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7fe1-72a5-d584-a0fe" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="0892-e3e3-7a9a-309f" name="Artificia Machina" hidden="false" collective="false" import="true" targetId="51ed-f978-9a5e-1e04" type="selectionEntry"/>
+            <entryLink id="64d4-bc50-895e-7d89" name="Ephemera Incursus" hidden="false" collective="false" import="true" targetId="12fc-d4d8-d36c-6f14" type="selectionEntry"/>
+            <entryLink id="4d56-318b-d15f-132c" name="Artificia Cybernetica" hidden="false" collective="false" import="true" targetId="d342-dbdb-33ec-5191" type="selectionEntry"/>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="324e-9521-e7be-98ea" name="May exchange their Laspistol for one of the following options:" hidden="false" collective="false" import="true" defaultSelectionEntryId="42e1-da12-b81b-62b6">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b870-95a4-bb72-4407" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="825b-b40c-e694-9165" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="9cc1-7c63-4fb2-7a5c" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="e5ae-6872-37aa-8600" type="selectionEntry">
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="1.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="9bf3-577a-76ef-8a2c" name="Volkite Serpenta" hidden="false" collective="false" import="true" targetId="d535-1da8-290d-69a6" type="selectionEntry">
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="6f5f-42c8-0d4a-3aa1" name="Archaeotech Pistol" hidden="false" collective="false" import="true" targetId="c22a-ed4d-af68-bf00" type="selectionEntry">
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="9f47-8004-c36f-27de" name="Photon Gauntlet" hidden="false" collective="false" import="true" targetId="e825-c60e-e6c3-60f0" type="selectionEntry">
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="42bd-c6a0-37f0-8e8c" name="Plasma Pistol" hidden="false" collective="false" import="true" targetId="717f-cf0a-1593-4bd8" type="selectionEntry">
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="42e1-da12-b81b-62b6" name="Laspistol" hidden="false" collective="false" import="true" targetId="654d-be88-b0a8-7ae5" type="selectionEntry"/>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="1432-b02b-4019-658f" name="May take any of the following options:" hidden="false" collective="false" import="true">
+          <selectionEntries>
+            <selectionEntry id="56ab-1c30-0ef7-d31c" name="Master-craft one weapon" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6fea-5e26-9ca7-3474" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="022d-2305-d7d7-baf4" name="Master-crafted" hidden="false" targetId="6de0-55b0-bf21-48b9" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <entryLinks>
+            <entryLink id="6be0-69cd-0e74-2d94" name="Augury Scanner" hidden="false" collective="false" import="true" targetId="67ee-7338-3b74-04b4" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0dce-8e00-af8f-2065" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="953b-1b84-93b8-797e" name="Cyber-Familiar" hidden="false" collective="false" import="true" targetId="6c85-4601-cf58-7b35" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e73f-1d2f-5a4a-aed8" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="5d60-e2e4-b3cb-0865" name="May take one of the following additional weapons:" hidden="false" collective="false" import="true">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4dc1-5f3b-1df1-95eb" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="0a08-3511-5834-63cb" name="Rotor Cannon" hidden="false" collective="false" import="true" targetId="5ce3-3aa5-3f5e-9ead" type="selectionEntry">
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="8c75-ab05-2b9a-d66f" name="Graviton Gun" hidden="false" collective="false" import="true" targetId="5303-5a3e-de51-1707" type="selectionEntry">
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="befd-817b-3b94-b17e" name="Meltagun" hidden="false" collective="false" import="true" targetId="4ebd-57e0-3560-e568" type="selectionEntry">
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="c0a3-0dc2-623c-50a4" name="Irad-Cleanser" hidden="false" collective="false" import="true" targetId="b3c5-237f-e1d2-d9f8" type="selectionEntry">
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="b0c1-20e8-292f-9ac5" name="Phased Plasma-Fusil" hidden="false" collective="false" import="true" targetId="17c6-afe9-c5da-d9b6" type="selectionEntry">
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="f016-2977-4184-bcfe" name="Photon Thruster" hidden="false" collective="false" import="true" targetId="3519-b118-7c6e-2343" type="selectionEntry">
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="30.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="1380-c529-afc1-fec4" name="Upgrade Points (Placeholders)" hidden="false" collective="false" import="true" targetId="7c8d-b21a-1f72-7e22" type="selectionEntry"/>
         <entryLink id="fc61-b732-41ab-b1b8" name="Warlord" hidden="false" collective="false" import="true" targetId="0176-56a3-d590-b103" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="105.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="a204-6b74-3aeb-0231" name="Calleb Decima Invictus (Placeholder)" publicationId="bde1-6db1-163b-3b76" page="26" hidden="false" collective="false" import="true" type="unit">
+    <selectionEntry id="a204-6b74-3aeb-0231" name="Calleb Decima Invictus" publicationId="bde1-6db1-163b-3b76" page="26" hidden="false" collective="false" import="true" type="unit">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
@@ -616,9 +1489,106 @@
       <constraints>
         <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d0ac-bc16-01cb-aa14" type="max"/>
       </constraints>
+      <profiles>
+        <profile id="1811-37b4-b2a0-829c" name="Calleb Decima Invictus" publicationId="bde1-6db1-163b-3b76" page="26" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName="Unit">
+          <characteristics>
+            <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Character, Cybertheurgist, Unique)</characteristic>
+            <characteristic name="Move" typeId="893e-2d76-8f04-44e5">6</characteristic>
+            <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
+            <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
+            <characteristic name="S" typeId="e478-41d4-a092-48a8">5</characteristic>
+            <characteristic name="T" typeId="c32b-5fdd-3fbe-9b1f">5</characteristic>
+            <characteristic name="W" typeId="57ee-1126-32a9-5672">3</characteristic>
+            <characteristic name="I" typeId="62d3-22d7-2d49-52dc">4</characteristic>
+            <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">2</characteristic>
+            <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">10</characteristic>
+            <characteristic name="Save" typeId="e593-6b3c-f169-04f0">3+</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules>
+        <rule id="cf28-db85-769d-2701" name="Walker in Ruin" publicationId="bde1-6db1-163b-3b76" page="26" hidden="false">
+          <description>Calleb Decima Invictus and any friendly units that have at least one model within 6&quot; of Caleb Decima Invictus have the Move Through Cover special rule.</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="b83b-3aee-eed6-01e2" name="Battle-Hardened (X)" hidden="false" targetId="5c3b-ed0b-4ad0-d547" type="rule">
+          <modifiers>
+            <modifier type="set" field="name" value="Battle-hardened (1)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="abee-78aa-4d9b-3847" name="Battlesmith (X)" hidden="false" targetId="5d57-4d02-1e36-4a82" type="rule">
+          <modifiers>
+            <modifier type="set" field="name" value="Battlesmith (4+)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="21da-022f-3a0f-3cf1" name="Fearless" hidden="false" targetId="b48c-d7e1-2a83-2f5b" type="rule"/>
+        <infoLink id="7808-58b8-8d3c-d8b8" name="Hatred (X)" hidden="false" targetId="dc0b-fe69-6b71-e0a4" type="rule">
+          <modifiers>
+            <modifier type="set" field="name" value="Hatred (Traitors)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="8c95-27f9-f737-52a5" name="Ignores Cover" hidden="false" targetId="fdb5-59e2-c446-1cbc" type="rule"/>
+        <infoLink id="60af-fa01-2305-b839" name="Loyalist" hidden="false" targetId="d1de-a45d-2b9b-c878" type="rule"/>
+        <infoLink id="098e-2ef2-1fa5-eed2" name="Precision Strikes (X)" hidden="false" targetId="2206-8497-8fe1-e973" type="rule">
+          <modifiers>
+            <modifier type="set" field="name" value="Precision Strikes (5+)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="0843-5047-7d1d-6d53" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule"/>
+        <infoLink id="5133-b3fc-c20b-e5cc" name="Sunder" hidden="false" targetId="20e2-75cf-bc16-cd8f" type="rule"/>
+        <infoLink id="1f09-40fd-1890-e17a" name="Wrecker" hidden="false" targetId="ba77-a802-55df-da67" type="rule"/>
+      </infoLinks>
       <categoryLinks>
         <categoryLink id="4870-4291-805f-07db" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
       </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="f20a-630b-4b7d-6fe9" name="Master-crafted Power Axe" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ddb1-f90c-18ea-6610" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1021-5ad5-5018-c13e" type="min"/>
+          </constraints>
+          <profiles>
+            <profile id="1d6b-be45-654f-9e2c" name="Master-crafted Power Axe" page="" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+              <characteristics>
+                <characteristic name="Range" typeId="95ba-cda7-b831-6066">-</characteristic>
+                <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">+1</characteristic>
+                <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">2</characteristic>
+                <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Melee, Unwieldy, Master-crafted</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <infoLinks>
+            <infoLink id="66d6-c902-fc3c-7a38" name="Unwieldy" hidden="false" targetId="1570-c21a-881f-8b8a" type="rule"/>
+            <infoLink id="b8c3-3097-a731-a3c3" name="Master-crafted" hidden="false" targetId="6de0-55b0-bf21-48b9" type="rule"/>
+          </infoLinks>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="aa34-16f9-bb8d-e98e" name="Master-crafted Bolt Pistol" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0489-3dde-e0c3-3d86" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ed2d-62ee-624c-6c2e" type="min"/>
+          </constraints>
+          <profiles>
+            <profile id="be17-1994-4a60-cafd" name="Master-crafted Bolt Pistol" page="" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+              <characteristics>
+                <characteristic name="Range" typeId="95ba-cda7-b831-6066">12&quot;</characteristic>
+                <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">4</characteristic>
+                <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">5</characteristic>
+                <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Pistol 1, Master-crafted</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <infoLinks>
+            <infoLink id="0ccd-7b5c-fa80-3dd1" name="Master-crafted" hidden="false" targetId="6de0-55b0-bf21-48b9" type="rule"/>
+          </infoLinks>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
       <selectionEntryGroups>
         <selectionEntryGroup id="0ad9-b637-48ef-d9ca" name="Guardian Retinue" hidden="false" collective="false" import="true">
           <constraints>
@@ -631,107 +1601,227 @@
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="f0bb-1603-401f-ad2a" name="Upgrade Points (Placeholders)" hidden="false" collective="false" import="true" targetId="7c8d-b21a-1f72-7e22" type="selectionEntry"/>
         <entryLink id="bc40-d9d2-9a73-a9e6" name="Warlord" hidden="false" collective="false" import="true" targetId="0176-56a3-d590-b103" type="selectionEntry"/>
         <entryLink id="d123-3dad-767a-3dab" name="Feudal Hierarchy" hidden="false" collective="false" import="true" targetId="27ff-3ae1-5cb6-774b" type="selectionEntry"/>
+        <entryLink id="a765-9860-600e-d0bb" name="Artificia Reductor" hidden="false" collective="false" import="true" targetId="b627-88f0-ee8c-c43c" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7a56-d0d5-5eb8-f068" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a10c-c18c-bfe2-03fe" type="max"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="ead9-ac24-4613-ed94" name="Power Axe" hidden="false" collective="false" import="true" targetId="c066-2ace-f68c-e440" type="selectionEntry"/>
+        <entryLink id="e3cc-237d-79ba-ae91" name="Mechanicum Protectiva" hidden="false" collective="false" import="true" targetId="7908-9b34-c5bb-21c2" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="67ab-7ebc-91a3-81e7" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ea7c-f2e6-d87d-acf4" type="min"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="4ccf-73e6-b18b-9b23" name="Machinator Array" hidden="false" collective="false" import="true" targetId="66f5-697c-605c-f1bb" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1645-c264-5922-93f9" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="634b-eaa4-043e-2366" type="min"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="9309-21bf-6f4c-8be1" name="Meltabombs" hidden="false" collective="false" import="true" targetId="b9dd-3b21-f3f8-78e3" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f37d-5e00-8f65-eac9" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="87ea-10c8-64cd-88b6" type="max"/>
+          </constraints>
+        </entryLink>
       </entryLinks>
       <costs>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="200.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="0eae-0c52-1087-a3b0" name="Tech-Priest Auxilia (Placeholder)" publicationId="bde1-6db1-163b-3b76" page="28" hidden="false" collective="false" import="true" type="unit">
+    <selectionEntry id="0eae-0c52-1087-a3b0" name="Tech-Priest Auxilia" publicationId="bde1-6db1-163b-3b76" page="28" hidden="false" collective="false" import="true" type="unit">
+      <categoryLinks>
+        <categoryLink id="0f49-7308-c6f1-e967" name="Line Sub-type:" hidden="false" targetId="6399-5c65-7833-1025" primary="false"/>
+      </categoryLinks>
       <selectionEntries>
         <selectionEntry id="d015-cea7-196a-9f4c" name="Tech-Priest" publicationId="bde1-6db1-163b-3b76" page="28" hidden="false" collective="false" import="true" type="model">
+          <modifiers>
+            <modifier type="set" field="name" value="Magos Auxilia">
+              <conditions>
+                <condition field="selections" scope="d015-cea7-196a-9f4c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="78ee-741f-83eb-e2ca" type="equalTo"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="57a1-ae47-ff1b-36e4">
+              <conditions>
+                <condition field="selections" scope="d015-cea7-196a-9f4c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="78ee-741f-83eb-e2ca" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9b4a-a1f4-d598-6560" type="min"/>
             <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="64d9-295f-21ea-27d9" type="max"/>
           </constraints>
+          <rules>
+            <rule id="5438-ef32-6502-5b9d" name="Techno-Arcana" hidden="false">
+              <description>Each Tech-Priest Auxilia unit must choose one of the following Techno-arcana. Only one selection may be made per Tech-Priest Auxilia unit. The Techno-arcana applies to the entire unit, providing it with additional special rules and wargear at no additional cost unless noted:</description>
+            </rule>
+          </rules>
+          <infoLinks>
+            <infoLink id="a05f-2480-a5ad-7241" name="Battlesmith (X)" hidden="false" targetId="5d57-4d02-1e36-4a82" type="rule"/>
+            <infoLink id="6fee-56ad-7222-f038" name="Stubborn" hidden="false" targetId="7989-1f2c-a43d-82ae" type="rule"/>
+          </infoLinks>
+          <categoryLinks>
+            <categoryLink id="02be-cd76-9a50-d755" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
+            <categoryLink id="03b4-892e-1b2f-2071" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+          </categoryLinks>
           <selectionEntryGroups>
-            <selectionEntryGroup id="00db-3638-6000-b067" name="Techno-Arcana" publicationId="bde1-6db1-163b-3b76" page="29" hidden="false" collective="false" import="true">
+            <selectionEntryGroup id="7fed-0d9f-2849-b801" name="Tech-Priest or Magos Auxilia" hidden="false" collective="false" import="true" defaultSelectionEntryId="abdc-96ec-d4d8-7779">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="99b2-12de-3b94-b707" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="18fd-06bd-5c73-1019" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="34bf-3bfb-6a90-aa60" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6e20-2dcb-6b16-b34b" type="min"/>
               </constraints>
               <selectionEntries>
-                <selectionEntry id="42f9-e690-11a6-4b1a" name="Enginseer" publicationId="bde1-6db1-163b-3b76" page="29" hidden="false" collective="false" import="true" type="upgrade">
-                  <modifiers>
-                    <modifier type="set" field="a71b-2300-5eb8-03dc" value="1.0">
-                      <conditionGroups>
-                        <conditionGroup type="and">
-                          <conditions>
-                            <condition field="selections" scope="primary-category" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9b5d-fac7-799b-d7e7" type="instanceOf"/>
-                            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1247-a94b-070d-2a7b" type="greaterThan"/>
-                          </conditions>
-                        </conditionGroup>
-                      </conditionGroups>
-                    </modifier>
-                  </modifiers>
+                <selectionEntry id="78ee-741f-83eb-e2ca" name="Magos Auxilia" publicationId="bde1-6db1-163b-3b76" page="28" hidden="false" collective="false" import="true" type="upgrade">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a71b-2300-5eb8-03dc" type="min"/>
+                    <constraint field="selections" scope="0eae-0c52-1087-a3b0" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="780f-1302-0f9d-de30" type="max"/>
                   </constraints>
-                  <rules>
-                    <rule id="ca01-10d0-a753-6fa2" name="Enginseer" publicationId="bde1-6db1-163b-3b76" page="29" hidden="false">
-                      <description>Tech-Priests and Magos Auxilia in the unit are each equipped with a servo-arm. While the unit contains any number of Servo-automata, Tech-Priests and Magos Auxilia in the unit improve their Battlesmith (X) special rule to Battlesmith (4+). </description>
-                    </rule>
-                  </rules>
+                  <profiles>
+                    <profile id="ab01-892f-3910-5254" name="Magos Auxilia" publicationId="bde1-6db1-163b-3b76" page="28" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName="Unit">
+                      <characteristics>
+                        <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Character, Cybertheurgist, Line)</characteristic>
+                        <characteristic name="Move" typeId="893e-2d76-8f04-44e5">6</characteristic>
+                        <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">3</characteristic>
+                        <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
+                        <characteristic name="S" typeId="e478-41d4-a092-48a8">3</characteristic>
+                        <characteristic name="T" typeId="c32b-5fdd-3fbe-9b1f">4</characteristic>
+                        <characteristic name="W" typeId="57ee-1126-32a9-5672">2</characteristic>
+                        <characteristic name="I" typeId="62d3-22d7-2d49-52dc">3</characteristic>
+                        <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">2</characteristic>
+                        <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">8</characteristic>
+                        <characteristic name="Save" typeId="e593-6b3c-f169-04f0">3+</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0"/>
                   </costs>
                 </selectionEntry>
-                <selectionEntry id="94f3-8a54-ed2e-5cfb" name="Lachrimallus" publicationId="bde1-6db1-163b-3b76" page="29" hidden="false" collective="false" import="true" type="upgrade">
-                  <rules>
-                    <rule id="3452-6b13-669c-e68c" name="Lachrimallus" publicationId="bde1-6db1-163b-3b76" page="29" hidden="false">
-                      <description>Tech-Priests, Magos Auxilia and Servo-automata in the unit have the Feel No Pain (5+) special rule. Friendly Adsecularis Tech-thrall units with at least one model within 6&quot; of one or more Tech-Priest or Magos Auxilia with this special rule add +1 to their Feel No Pain Damage Mitigation rolls or the Feel No Pain (6+) special rule if they do not already possess the Feel No Pain (X) special rule. </description>
-                    </rule>
-                  </rules>
-                  <infoLinks>
-                    <infoLink id="64bc-bbee-5358-be8a" name="Feel No Pain (X)" hidden="false" targetId="ec46-ff29-32e0-c2aa" type="rule"/>
-                  </infoLinks>
-                  <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
-                  </costs>
-                </selectionEntry>
-                <selectionEntry id="0749-4e5b-1bf4-a4ab" name="Reductor" publicationId="bde1-6db1-163b-3b76" page="29" hidden="false" collective="false" import="true" type="upgrade">
-                  <rules>
-                    <rule id="dbfc-425c-3aa6-9123" name="Reductor" publicationId="bde1-6db1-163b-3b76" page="29" hidden="false">
-                      <description>Tech-Priests and Magos Auxilia in the unit are each equipped with a servo-arm, and all models in the unit gain the Sunder and Wrecker special rules. Magos Auxilia may exchange their servo-arm for either a conversion beamer or graviton imploder for +25 points each. </description>
-                    </rule>
-                  </rules>
-                  <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
-                  </costs>
-                </selectionEntry>
-                <selectionEntry id="757a-cd91-e5f1-b5f7" name="Interfector" hidden="true" collective="false" import="true" type="upgrade">
-                  <modifiers>
-                    <modifier type="set" field="hidden" value="false">
-                      <conditions>
-                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5e62-8d7e-a487-0490" type="greaterThan"/>
-                      </conditions>
-                    </modifier>
-                  </modifiers>
-                  <rules>
-                    <rule id="7043-476d-533c-93a2" name="Interfector" publicationId="bde1-6db1-163b-3b76" page="100" hidden="false">
-                      <description>Tech-Priests and Magos Auxilia in the unit are each equipped with a prehensile data-spike. In addition, models in the unit gain the Scout special rule.</description>
-                    </rule>
-                  </rules>
-                  <infoLinks>
-                    <infoLink id="522d-e3ed-7ce3-92fe" name="Scout" hidden="false" targetId="aacf-9a7e-982d-b793" type="rule"/>
-                  </infoLinks>
-                  <entryLinks>
-                    <entryLink id="6a15-2014-925e-8d4c" name=" Prehensile Data-Spike" hidden="false" collective="true" import="true" targetId="2a20-c068-3230-ad17" type="selectionEntry">
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0e2e-79f2-0021-77f3" type="min"/>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ce85-1432-520f-0da3" type="max"/>
-                      </constraints>
-                    </entryLink>
-                  </entryLinks>
-                  <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
-                  </costs>
+                <selectionEntry id="abdc-96ec-d4d8-7779" name="Tech-Priest" publicationId="bde1-6db1-163b-3b76" page="28" hidden="false" collective="false" import="true" type="upgrade">
+                  <profiles>
+                    <profile id="f6a2-9e5e-87ec-9e42" name="Tech-Priest" publicationId="bde1-6db1-163b-3b76" page="28" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName="Unit">
+                      <characteristics>
+                        <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Character, Line)</characteristic>
+                        <characteristic name="Move" typeId="893e-2d76-8f04-44e5">6</characteristic>
+                        <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">3</characteristic>
+                        <characteristic name="BS" typeId="74ae-c840-0036-d244">3</characteristic>
+                        <characteristic name="S" typeId="e478-41d4-a092-48a8">3</characteristic>
+                        <characteristic name="T" typeId="c32b-5fdd-3fbe-9b1f">3</characteristic>
+                        <characteristic name="W" typeId="57ee-1126-32a9-5672">1</characteristic>
+                        <characteristic name="I" typeId="62d3-22d7-2d49-52dc">3</characteristic>
+                        <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">1</characteristic>
+                        <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">7</characteristic>
+                        <characteristic name="Save" typeId="e593-6b3c-f169-04f0">4+</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
                 </selectionEntry>
               </selectionEntries>
             </selectionEntryGroup>
+            <selectionEntryGroup id="7dcc-a442-8a48-ce9c" name="Any Tech-Priest or Magos Auxilia may take:" hidden="false" collective="false" import="true">
+              <entryLinks>
+                <entryLink id="9dc3-ae61-e67b-67f7" name="Cyber-Familiar" hidden="false" collective="false" import="true" targetId="6c85-4601-cf58-7b35" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2dfa-cafc-11db-92c0" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="4d0f-6be4-bbf0-132d" name="Meltabombs" hidden="false" collective="false" import="true" targetId="b9dd-3b21-f3f8-78e3" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a4f3-b197-d995-ce89" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                  </costs>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="9f58-5665-bdfc-e87d" name="Any Tech-Priest or Magos Auxilia may take any of the following:" hidden="false" collective="false" import="true">
+              <entryLinks>
+                <entryLink id="002a-4074-9e84-5233" name="Augury Scanner" hidden="false" collective="false" import="true" targetId="67ee-7338-3b74-04b4" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b07c-e8bd-618c-2e1b" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="5666-1037-8298-6747" name="Nuncio-Vox" hidden="false" collective="false" import="true" targetId="005e-aae6-ddac-bb45" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="55ff-544c-9c38-ff0a" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="3674-2b2c-337f-4a57" name="Volkite Charger" hidden="false" collective="false" import="true" targetId="6f6e-ad55-e093-6503" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9d64-1099-d3d3-30b4" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="d018-ed38-0c35-31f7" name="Cortex Controller" hidden="false" collective="false" import="true" targetId="2fda-455f-d34d-97e0" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="726b-aded-2d5f-23e0" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="3e3d-7fb9-40c7-a736" name="Graviton Gun" hidden="false" collective="false" import="true" targetId="5303-5a3e-de51-1707" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ca75-a960-f531-0c7b" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                  </costs>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="5e74-2f72-d7ab-653b" name="Cybertheurgic Arcana" hidden="true" collective="false" import="true">
+              <modifiers>
+                <modifier type="set" field="3802-56a6-c690-6dbb" value="1.0">
+                  <conditions>
+                    <condition field="selections" scope="d015-cea7-196a-9f4c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="78ee-741f-83eb-e2ca" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="set" field="hidden" value="false">
+                  <conditions>
+                    <condition field="selections" scope="d015-cea7-196a-9f4c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="78ee-741f-83eb-e2ca" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3802-56a6-c690-6dbb" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="df39-d29a-30eb-2dd8" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="9a8a-bcda-9600-142d" name="Artificia Machina" hidden="false" collective="false" import="true" targetId="51ed-f978-9a5e-1e04" type="selectionEntry"/>
+                <entryLink id="659a-8ca9-a97f-4500" name="Artificia Cybernetica" hidden="false" collective="false" import="true" targetId="d342-dbdb-33ec-5191" type="selectionEntry"/>
+              </entryLinks>
+            </selectionEntryGroup>
           </selectionEntryGroups>
+          <entryLinks>
+            <entryLink id="9a7c-0f68-a192-a96d" name="Laspistol" hidden="false" collective="false" import="true" targetId="654d-be88-b0a8-7ae5" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="608e-d607-f60f-7128" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="03a7-fb23-8a38-3a3e" type="min"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="6e5f-7dde-4dcd-2546" name="Power Axe" hidden="false" collective="false" import="true" targetId="c066-2ace-f68c-e440" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5c76-1331-6466-5f98" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8003-704b-9ba6-5aa0" type="min"/>
+              </constraints>
+            </entryLink>
+          </entryLinks>
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0"/>
           </costs>
@@ -741,6 +1831,56 @@
             <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dd84-bb8b-5578-5764" type="min"/>
             <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="18ba-9e62-836e-b6b0" type="max"/>
           </constraints>
+          <infoLinks>
+            <infoLink id="3c59-e74f-f057-b248" name="Guardian Unit Sub-type" hidden="false" targetId="a686-026f-6674-102e" type="rule"/>
+          </infoLinks>
+          <categoryLinks>
+            <categoryLink id="0811-7d31-715c-ef42" name="Automata Unit-type:" hidden="false" targetId="d8ab-8e21-e193-63ba" primary="false"/>
+          </categoryLinks>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="5d44-26bf-c747-c100" name="Any Servo-automata may take one of the following:" hidden="false" collective="false" import="true">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="81df-f71a-10c5-9f8f" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="cc24-2832-1818-9f68" name="Servo-Arm" hidden="false" collective="false" import="true" targetId="4168-fc85-8912-7188" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="2a95-daed-dc3c-7e60" name="Las-lock" hidden="false" collective="false" import="true" targetId="6491-5e10-ba7e-e0d3" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="80e8-84cc-99a2-a23a" name="Flamer" hidden="false" collective="false" import="true" targetId="9f41-82e2-90f6-973a" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="1882-9209-4abb-578b" name="Maxima Bolter" hidden="false" collective="false" import="true" targetId="1d3e-1b60-d133-ea0d" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="6b91-0073-6b3d-edb2" name="Rotor Cannon" hidden="false" collective="false" import="true" targetId="5ce3-3aa5-3f5e-9ead" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="b116-5cd8-3645-c626" name="Heavy Bolter" hidden="false" collective="false" import="true" targetId="07fd-c24a-9235-4206" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="d039-99a4-595e-8f59" name="Multi-Melta" hidden="false" collective="false" import="true" targetId="9332-3834-cf3a-56b4" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0"/>
+                  </costs>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
           </costs>
@@ -755,15 +1895,99 @@
             <entryLink id="f117-68df-5af9-d08f" name="Triaros Armoured Conveyor " hidden="false" collective="false" import="true" targetId="2484-a122-76a2-b142" type="selectionEntry"/>
           </entryLinks>
         </selectionEntryGroup>
+        <selectionEntryGroup id="3809-6add-1c91-5262" name="Techno-Arcana (for all Tech-Priests and Magos Auxilia in unit)" publicationId="bde1-6db1-163b-3b76" page="29" hidden="false" collective="false" import="true">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e98b-7996-cc00-90a9" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fed7-9d92-a96f-1bbc" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="df96-3b30-f3c7-43ff" name="Enginseer" publicationId="bde1-6db1-163b-3b76" page="29" hidden="false" collective="false" import="true" type="upgrade">
+              <modifiers>
+                <modifier type="set" field="2eb8-febc-b82d-9a36" value="1.0">
+                  <conditionGroups>
+                    <conditionGroup type="and">
+                      <conditions>
+                        <condition field="selections" scope="primary-category" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9b5d-fac7-799b-d7e7" type="instanceOf"/>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1247-a94b-070d-2a7b" type="greaterThan"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2eb8-febc-b82d-9a36" type="min"/>
+              </constraints>
+              <rules>
+                <rule id="4e97-739a-16b0-f2d6" name="Enginseer" publicationId="bde1-6db1-163b-3b76" page="29" hidden="false">
+                  <description>Tech-Priests and Magos Auxilia in the unit are each equipped with a servo-arm. While the unit contains any number of Servo-automata, Tech-Priests and Magos Auxilia in the unit improve their Battlesmith (X) special rule to Battlesmith (4+). </description>
+                </rule>
+              </rules>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="4f03-e19e-7327-89cd" name="Lachrimallus" publicationId="bde1-6db1-163b-3b76" page="29" hidden="false" collective="false" import="true" type="upgrade">
+              <rules>
+                <rule id="c533-6e23-37cb-e47f" name="Lachrimallus" publicationId="bde1-6db1-163b-3b76" page="29" hidden="false">
+                  <description>Tech-Priests, Magos Auxilia and Servo-automata in the unit have the Feel No Pain (5+) special rule. Friendly Adsecularis Tech-thrall units with at least one model within 6&quot; of one or more Tech-Priest or Magos Auxilia with this special rule add +1 to their Feel No Pain Damage Mitigation rolls or the Feel No Pain (6+) special rule if they do not already possess the Feel No Pain (X) special rule. </description>
+                </rule>
+              </rules>
+              <infoLinks>
+                <infoLink id="2454-b3ab-1a9c-a3d7" name="Feel No Pain (X)" hidden="false" targetId="ec46-ff29-32e0-c2aa" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="eb4f-558c-b2a5-f60a" name="Reductor" publicationId="bde1-6db1-163b-3b76" page="29" hidden="false" collective="false" import="true" type="upgrade">
+              <rules>
+                <rule id="f428-4adb-1218-2667" name="Reductor" publicationId="bde1-6db1-163b-3b76" page="29" hidden="false">
+                  <description>Tech-Priests and Magos Auxilia in the unit are each equipped with a servo-arm, and all models in the unit gain the Sunder and Wrecker special rules. Magos Auxilia may exchange their servo-arm for either a conversion beamer or graviton imploder for +25 points each. </description>
+                </rule>
+              </rules>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="d8a9-8d49-0ed1-846d" name="Interfector" hidden="true" collective="false" import="true" type="upgrade">
+              <modifiers>
+                <modifier type="set" field="hidden" value="false">
+                  <conditions>
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5e62-8d7e-a487-0490" type="greaterThan"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <rules>
+                <rule id="51ee-b3cf-a842-91cf" name="Interfector" publicationId="bde1-6db1-163b-3b76" page="100" hidden="false">
+                  <description>Tech-Priests and Magos Auxilia in the unit are each equipped with a prehensile data-spike. In addition, models in the unit gain the Scout special rule.</description>
+                </rule>
+              </rules>
+              <infoLinks>
+                <infoLink id="b24e-8666-57e5-dc15" name="Scout" hidden="false" targetId="aacf-9a7e-982d-b793" type="rule"/>
+              </infoLinks>
+              <entryLinks>
+                <entryLink id="bde0-5da1-1d3c-d193" name="Prehensile Data-Spike" hidden="false" collective="false" import="true" targetId="2a20-c068-3230-ad17" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bb6c-cf51-4f39-2db8" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4857-be38-0009-a549" type="max"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
       </selectionEntryGroups>
-      <entryLinks>
-        <entryLink id="c7e8-32ad-5c86-c1b7" name="Upgrade Points (Placeholders)" hidden="false" collective="false" import="true" targetId="7c8d-b21a-1f72-7e22" type="selectionEntry"/>
-      </entryLinks>
       <costs>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="6f33-657c-a1b4-710e" name="Arcuitor Magisterium (Placeholder)" publicationId="bde1-6db1-163b-3b76" page="30" hidden="true" collective="false" import="true" type="unit">
+    <selectionEntry id="6f33-657c-a1b4-710e" name="Arcuitor Magisterium" publicationId="bde1-6db1-163b-3b76" page="30" hidden="true" collective="false" import="true" type="unit">
+      <constraints>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ef15-f533-382e-0663" type="max"/>
+      </constraints>
       <selectionEntries>
         <selectionEntry id="b9e8-8c2b-084c-1952" name="Arcuitor" publicationId="bde1-6db1-163b-3b76" page="30" hidden="false" collective="false" import="true" type="model">
           <modifiers>
@@ -778,13 +2002,156 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b335-3906-c30c-81d8" type="max"/>
           </constraints>
           <rules>
-            <rule id="6957-b5ed-1429-1231" name="Court of Executioners" publicationId="bde1-6db1-163b-3b76" page="100" hidden="false">
+            <rule id="6957-b5ed-1429-1231" name="Court of Executioners" publicationId="bde1-6db1-163b-3b76" page="100" hidden="true">
+              <modifiers>
+                <modifier type="set" field="hidden" value="false">
+                  <conditions>
+                    <condition field="selections" scope="primary-category" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4f85-eb33-30c9-8f51" type="instanceOf"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
               <description>A unit with this special rule may include up to two additional Arcuitor Magisterium for 110 points each. When deployed onto the battlefield (either at the start of the battle or when arriving from Reserves), all models with this special rule in a unit must be deployed within unit coherency, but afterwards operate independently and are not treated as a unit.</description>
             </rule>
           </rules>
           <infoLinks>
-            <infoLink id="f23f-5b3c-2874-6306" name="Scout" hidden="false" targetId="aacf-9a7e-982d-b793" type="rule"/>
+            <infoLink id="f23f-5b3c-2874-6306" name="Scout" hidden="true" targetId="aacf-9a7e-982d-b793" type="rule">
+              <modifiers>
+                <modifier type="set" field="hidden" value="false">
+                  <conditions>
+                    <condition field="selections" scope="primary-category" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4f85-eb33-30c9-8f51" type="instanceOf"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+            </infoLink>
+            <infoLink id="0d7d-6377-b79d-db6c" name="Battlesmith (X)" hidden="false" targetId="5d57-4d02-1e36-4a82" type="rule">
+              <modifiers>
+                <modifier type="set" field="name" value="Battlesmith (5+)"/>
+              </modifiers>
+            </infoLink>
+            <infoLink id="0a45-7de7-bb27-3637" name="Feel No Pain (X)" hidden="false" targetId="ec46-ff29-32e0-c2aa" type="rule">
+              <modifiers>
+                <modifier type="set" field="name" value="Feel No Pain (5+)"/>
+              </modifiers>
+            </infoLink>
+            <infoLink id="032b-cf8f-03da-33d3" name="Firing Protocols (X)" hidden="false" targetId="32a3-f599-5c92-2945" type="rule">
+              <modifiers>
+                <modifier type="set" field="name" value="Firing Protocols (2)"/>
+              </modifiers>
+            </infoLink>
+            <infoLink id="2945-923d-610e-feb6" name="Loyalist" hidden="false" targetId="d1de-a45d-2b9b-c878" type="rule"/>
+            <infoLink id="a799-4434-8eeb-074f" name="Monster Hunter" hidden="false" targetId="118d-58ce-8611-ab15" type="rule"/>
+            <infoLink id="79de-fa71-1277-d87a" name="Precision Strikes (X)" hidden="false" targetId="2206-8497-8fe1-e973" type="rule">
+              <modifiers>
+                <modifier type="set" field="name" value="Precision Strikes (5+)"/>
+              </modifiers>
+            </infoLink>
           </infoLinks>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="189e-6465-c640-54b1" name="May take a:" hidden="false" collective="false" import="true">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b8aa-ab07-98f3-8d2d" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="e33b-49f7-9319-a3e7" name="Servo-Arm" hidden="false" collective="false" import="true" targetId="4168-fc85-8912-7188" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="2114-247d-5598-f773" name="Machinator Array" hidden="false" collective="false" import="true" targetId="66f5-697c-605c-f1bb" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="93c3-4585-3cf4-698e" name="Machinator Array with Prehensile Data-Spike" hidden="true" collective="false" import="true" targetId="3104-9879-3dcd-2bbb" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="false">
+                      <conditions>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5e62-8d7e-a487-0490" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="35.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="2335-99fb-7829-666b" name="Servo-Arm with Prehensile Data-Spike" hidden="true" collective="false" import="true" targetId="981f-5ffe-b686-0491" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="false">
+                      <conditions>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5e62-8d7e-a487-0490" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0"/>
+                  </costs>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="2463-1498-2f57-cf6e" name="May exchange their Corposant Stave for a:" hidden="false" collective="false" import="true" defaultSelectionEntryId="f9fa-b361-09ab-c9de">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a575-4fe2-baa3-96de" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0c6c-b2b0-7743-00da" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="f9fa-b361-09ab-c9de" name="Corposant Stave" hidden="false" collective="false" import="true" targetId="cfc3-0ca2-ebdc-e6b0" type="selectionEntry"/>
+                <entryLink id="502a-aa8e-1d98-61b2" name="Paragon Blade" hidden="false" collective="false" import="true" targetId="2ab9-0e45-405e-056b" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                  </costs>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="9d2b-4794-279e-3f3e" name="May take one of the following additional ranged weapons:" hidden="false" collective="false" import="true">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b136-5645-8465-ae64" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="5db6-aaa4-1755-12e1" name="Phased Plasma-Fusil" hidden="false" collective="false" import="true" targetId="17c6-afe9-c5da-d9b6" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="66f5-b876-a0e1-6d62" name="Photon Thruster" hidden="false" collective="false" import="true" targetId="3519-b118-7c6e-2343" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0"/>
+                  </costs>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks>
+            <entryLink id="ff37-9067-bceb-f46b" name="Archaeotech Pistol" hidden="false" collective="false" import="true" targetId="c22a-ed4d-af68-bf00" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="01fd-1441-a4c0-bd0b" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="286f-3399-eba1-c4e5" type="max"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="7b63-59d2-013f-c606" name="Mechanicum Protectiva" hidden="false" collective="false" import="true" targetId="7908-9b34-c5bb-21c2" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4a1d-9da7-c2ce-dd02" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e1ea-97e2-26c8-dd02" type="max"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="2fae-5abc-d660-6dc1" name="Cortex Controller" hidden="false" collective="false" import="true" targetId="2fda-455f-d34d-97e0" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5033-8b6a-61fa-e882" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fa12-d1d2-ba15-b42f" type="max"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="6c5a-ce4b-ca68-4fae" name="Krak Grenades" hidden="false" collective="false" import="true" targetId="99df-2421-acf7-a5ad" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8f12-bad6-8a57-2699" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ff5e-0202-5278-4ab3" type="max"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="7402-b678-a397-fdb9" name="Frag Grenades" hidden="false" collective="false" import="true" targetId="cf9c-327b-3449-00d7" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bf3d-41ab-4a19-23e6" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8f44-b852-7ca4-fbe7" type="max"/>
+              </constraints>
+            </entryLink>
+          </entryLinks>
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="110.0"/>
           </costs>
@@ -824,20 +2191,36 @@ This unit may be upgraded freely as described in their profile, though they may 
           </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
-      <entryLinks>
-        <entryLink id="c52b-c6b0-8dc4-9546" name="Upgrade Points (Placeholders)" hidden="false" collective="false" import="true" targetId="7c8d-b21a-1f72-7e22" type="selectionEntry"/>
-      </entryLinks>
       <costs>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="-25.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="1869-2d16-d825-04c3" name="Myrmidon Secutor Host (Placeholder)" publicationId="bde1-6db1-163b-3b76" page="32" hidden="false" collective="false" import="true" type="unit">
+    <selectionEntry id="1869-2d16-d825-04c3" name="Myrmidon Secutor Host" publicationId="bde1-6db1-163b-3b76" page="32" hidden="false" collective="false" import="true" type="unit">
       <selectionEntries>
         <selectionEntry id="33d3-7ec5-ef32-38ca" name=" Myrmidon Secutors" publicationId="bde1-6db1-163b-3b76" page="32" hidden="false" collective="false" import="true" type="model">
           <constraints>
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="48f7-6092-3c6d-3a16" type="min"/>
             <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="aee4-231d-6ac1-8467" type="max"/>
           </constraints>
+          <infoLinks>
+            <infoLink id="d5e4-4fce-ff6f-c3db" name="Bulky (X)" hidden="false" targetId="676c-7b75-4b6f-9405" type="rule">
+              <modifiers>
+                <modifier type="set" field="name" value="Bulky (3)"/>
+              </modifiers>
+            </infoLink>
+            <infoLink id="8c12-6aae-9385-6627" name="Firing Protocols (X)" hidden="false" targetId="32a3-f599-5c92-2945" type="rule">
+              <modifiers>
+                <modifier type="set" field="name" value="Firing Protocols (2)"/>
+              </modifiers>
+            </infoLink>
+            <infoLink id="0f1f-b7f3-db4f-6075" name="Hatred (X)" hidden="false" targetId="dc0b-fe69-6b71-e0a4" type="rule">
+              <modifiers>
+                <modifier type="set" field="name" value="Hatred (Everything)"/>
+              </modifiers>
+            </infoLink>
+            <infoLink id="fa07-af10-e558-a86d" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule"/>
+            <infoLink id="46b6-af34-2f57-6a5b" name="Stubborn" hidden="false" targetId="7989-1f2c-a43d-82ae" type="rule"/>
+          </infoLinks>
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="45.0"/>
           </costs>
@@ -847,6 +2230,44 @@ This unit may be upgraded freely as described in their profile, though they may 
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d461-f1e0-eb5c-7928" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="aeb2-03a0-f333-7ca3" type="max"/>
           </constraints>
+          <infoLinks>
+            <infoLink id="b22a-de1c-aa2e-01ec" name="Bulky (X)" hidden="false" targetId="676c-7b75-4b6f-9405" type="rule">
+              <modifiers>
+                <modifier type="set" field="name" value="Bulky (3)"/>
+              </modifiers>
+            </infoLink>
+            <infoLink id="f73f-04cb-fab9-48d4" name="Firing Protocols (X)" hidden="false" targetId="32a3-f599-5c92-2945" type="rule">
+              <modifiers>
+                <modifier type="set" field="name" value="Firing Protocols (2)"/>
+              </modifiers>
+            </infoLink>
+            <infoLink id="5962-03de-e01e-113d" name="Hatred (X)" hidden="false" targetId="dc0b-fe69-6b71-e0a4" type="rule">
+              <modifiers>
+                <modifier type="set" field="name" value="Hatred (Everything)"/>
+              </modifiers>
+            </infoLink>
+            <infoLink id="78c6-35f2-0bfb-0825" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule"/>
+            <infoLink id="917f-2330-5f93-f4ad" name="Stubborn" hidden="false" targetId="7989-1f2c-a43d-82ae" type="rule"/>
+          </infoLinks>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="df78-6567-879f-c96a" name="Myrmidon Axe" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4201-7b7a-6f4a-0ce4" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b739-2de4-0852-2ef9" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="e9e9-8999-c74a-6036" name="Myrmidon Axe" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+              <characteristics>
+                <characteristic name="Range" typeId="95ba-cda7-b831-6066"/>
+                <characteristic name="Strength" typeId="24d9-b8e1-a355-2458"/>
+                <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d"/>
+                <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9"/>
+              </characteristics>
+            </profile>
+          </profiles>
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
           </costs>
@@ -858,12 +2279,69 @@ This unit may be upgraded freely as described in their profile, though they may 
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="68da-211e-c364-ca1a" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="20c7-f1d5-9f93-8f14" name="Triaros Armoured Conveyor " hidden="false" collective="false" import="true" targetId="2484-a122-76a2-b142" type="selectionEntry"/>
+            <entryLink id="20c7-f1d5-9f93-8f14" name="Triaros Armoured Conveyor " hidden="false" collective="false" import="true" targetId="2484-a122-76a2-b142" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="1869-2d16-d825-04c3" value="6.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="greaterThan"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="469b-dfe3-1bf7-25f5" name="Any model in the unit may exchange either or both of their Maxima bolters for:" hidden="false" collective="false" import="true" defaultSelectionEntryId="a0c8-ef0f-8dd8-2436">
+          <modifiers>
+            <modifier type="increment" field="90a0-346e-c6a2-1307" value="2.0">
+              <repeats>
+                <repeat field="selections" scope="1869-2d16-d825-04c3" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+            <modifier type="increment" field="f957-3998-befe-4e33" value="2.0">
+              <repeats>
+                <repeat field="selections" scope="1869-2d16-d825-04c3" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+            <modifier type="decrement" field="f957-3998-befe-4e33" value="6.0"/>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f957-3998-befe-4e33" type="min"/>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="90a0-346e-c6a2-1307" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="a0c8-ef0f-8dd8-2436" name="Maxima Bolter" hidden="false" collective="false" import="true" targetId="1d3e-1b60-d133-ea0d" type="selectionEntry"/>
+            <entryLink id="1ce9-93a4-ea75-55b9" name="Volkite Charger" hidden="false" collective="false" import="true" targetId="6f6e-ad55-e093-6503" type="selectionEntry"/>
+            <entryLink id="4ee1-9ccc-acde-97c3" name="Graviton Gun" hidden="false" collective="false" import="true" targetId="5303-5a3e-de51-1707" type="selectionEntry">
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="0aed-ef35-dff7-3fbd" name="Irad-Cleanser" hidden="false" collective="false" import="true" targetId="b3c5-237f-e1d2-d9f8" type="selectionEntry">
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="cebd-f1c6-ae9c-ad75" name="Phased Plasma-Fusil" hidden="false" collective="false" import="true" targetId="17c6-afe9-c5da-d9b6" type="selectionEntry">
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+              </costs>
+            </entryLink>
           </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="5b32-0575-e909-3adc" name="Upgrade Points (Placeholders)" hidden="false" collective="false" import="true" targetId="7c8d-b21a-1f72-7e22" type="selectionEntry"/>
+        <entryLink id="619f-ba66-4afb-1454" name="Refractor Field" hidden="false" collective="false" import="true" targetId="a06a-55a5-070b-1d0e" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="65c2-df22-2c8e-ebc6" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4558-e37e-904e-f076" type="max"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="8ac3-d0ae-e50f-bf64" name="Frag Grenades" hidden="false" collective="false" import="true" targetId="cf9c-327b-3449-00d7" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="17c7-7dfb-92f0-c60a" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8088-dde2-242d-02e4" type="max"/>
+          </constraints>
+        </entryLink>
       </entryLinks>
       <costs>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="60.0"/>
@@ -1155,21 +2633,12 @@ This unit may be upgraded freely as described in their profile, though they may 
               </characteristics>
             </profile>
           </profiles>
-          <rules>
-            <rule id="9185-e0fe-fb16-d9bb" name="Guardian Unit Sub-type" publicationId="bde1-6db1-163b-3b76" page="91" hidden="false">
-              <description>• Units including models with the Guardian Unit Sub-type may Embark freely upon models with the Transport Unit Sub-type and within Buildings and Fortifications as if they had the Infantry Type, even if their Unit Type would normally restrict this.
-• Units including models with the Guardian Unit Sub-type may be joined by friendly models with the Character Unit Sub-type or Independent Character special rule, and when they are joined in this manner may make Reactions, even if their Unit Type would normally restrict this.
-• If a unit contains any models with the Guardian Unit Sub-type as well as one or more models with the Character Unit Sub-type, any Wounds which would be allocated to the Character (even those caused by the Precision Strikes (X) or Sniper special rules) may instead be allocated to a model with the Guardian Unit Sub-type first.
-• Unless they are joined by a friendly Character, all models with the Guardian Unit Sub-type suffer the following provisions:
--	Reduce their Movement Characteristic by -2 and may not Run.
--	Reduce their Initiative Characteristic to 1.</description>
-            </rule>
-          </rules>
           <infoLinks>
             <infoLink id="4679-fa2e-bafa-55c3" name="Move Through Cover" hidden="false" targetId="2b6f-bfec-759e-1746" type="rule"/>
             <infoLink id="0c41-d591-8f11-140c" name="Night Vision" hidden="false" targetId="683e-b4f2-f032-d31b" type="rule"/>
             <infoLink id="5099-7f9f-41b6-aa8a" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule"/>
             <infoLink id="d084-a195-c74d-1901" name="Support Squad" hidden="false" targetId="768e-56d6-ca52-24ae" type="rule"/>
+            <infoLink id="5ed7-a250-aea1-1c1b" name="Guardian Unit Sub-type" hidden="false" targetId="a686-026f-6674-102e" type="rule"/>
           </infoLinks>
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0"/>
@@ -2324,7 +3793,7 @@ At the beginning of each of the controlling player’s Shooting phases for the r
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="800.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="2185-5fd1-2e59-b467" name="Archmagos Anacharis Scoria (Placeholder)" publicationId="bde1-6db1-163b-3b76" page="62" hidden="false" collective="false" import="true" type="unit">
+    <selectionEntry id="2185-5fd1-2e59-b467" name="Archmagos Anacharis Scoria" publicationId="bde1-6db1-163b-3b76" page="62" hidden="false" collective="false" import="true" type="unit">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
@@ -2335,20 +3804,159 @@ At the beginning of each of the controlling player’s Shooting phases for the r
       <constraints>
         <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8445-7f9a-b431-cd6c" type="max"/>
       </constraints>
+      <profiles>
+        <profile id="9bab-26aa-a73d-50e5" name="Archmagos Anacharis Scoria" publicationId="bde1-6db1-163b-3b76" page="62" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName="Unit">
+          <characteristics>
+            <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Monstrous, Heavy, Unique, Cybertheurgist)</characteristic>
+            <characteristic name="Move" typeId="893e-2d76-8f04-44e5">9</characteristic>
+            <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">5</characteristic>
+            <characteristic name="BS" typeId="74ae-c840-0036-d244">5</characteristic>
+            <characteristic name="S" typeId="e478-41d4-a092-48a8">5</characteristic>
+            <characteristic name="T" typeId="c32b-5fdd-3fbe-9b1f">7</characteristic>
+            <characteristic name="W" typeId="57ee-1126-32a9-5672">7</characteristic>
+            <characteristic name="I" typeId="62d3-22d7-2d49-52dc">5</characteristic>
+            <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">4</characteristic>
+            <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">10</characteristic>
+            <characteristic name="Save" typeId="e593-6b3c-f169-04f0">2+</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="8fc7-be6a-33b2-8ec5" name="Forbidden Protocols" publicationId="bde1-6db1-163b-3b76" page="62" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
+          <characteristics>
+            <characteristic name="Text" typeId="c68e-2cda-b67b-baca">Any friendly units made up entirely of models with the Automata Unit Type that have at least one model within 6&quot; of this Warlord may make Reactions, ignoring the usual restriction in the Automata Unit Type. In addition, an army whose Warlord has this Trait may make an additional Reaction in the Movement phase as long as Anacharis Scoria has not been
+removed as a casualty.�</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules>
+        <rule id="9d8c-1ee2-4e7c-70c3" name="Archmagos Anacharis Scoria" hidden="false"/>
+        <rule id="94ad-dd9a-c902-2f99" name="Rites of the Beast" publicationId="bde1-6db1-163b-3b76" page="63" hidden="false">
+          <description>Anacharis Scoria has the Artificia Machina, Artificia Cybernetica, and Ephemera Incursus Cybertheurgic Arcana, and has all Rites and weapons that are part of those Arcana.</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="0b1c-2ad2-7337-b78f" name="Adamantium Will (X+)" hidden="false" targetId="4380-44a5-f01a-d964" type="rule"/>
+        <infoLink id="ba28-ab7f-71e0-4aa8" name="Battlesmith (X)" hidden="false" targetId="5d57-4d02-1e36-4a82" type="rule"/>
+        <infoLink id="5024-4c05-644f-2031" name="Eternal Warrior" hidden="false" targetId="000b-fe96-31f8-c0ad" type="rule"/>
+        <infoLink id="38b5-f285-16ac-9f4a" name="Fear (X)" hidden="false" targetId="21f6-7842-df5c-d2e7" type="rule"/>
+        <infoLink id="ad1d-bb37-41e5-8b3e" name="Firing Protocols (X)" hidden="false" targetId="32a3-f599-5c92-2945" type="rule"/>
+        <infoLink id="b47d-4e14-ffb2-4aec" name="It Will Not Die (X)" hidden="false" targetId="2784-d0be-a4e2-890f" type="rule"/>
+        <infoLink id="204f-2d12-b48e-4f4c" name="Move Through Cover" hidden="false" targetId="2b6f-bfec-759e-1746" type="rule"/>
+        <infoLink id="e5d8-c080-adcd-3c9b" name="Patris Cybernetica" hidden="false" targetId="0893-4bd0-d5a1-14db" type="rule"/>
+        <infoLink id="4e05-29af-baba-ee5a" name="Pride of Place" hidden="false" targetId="f83c-9442-8102-5da4" type="rule"/>
+        <infoLink id="96e9-3018-859e-8010" name="Traitor" hidden="false" targetId="eff2-8b0e-21da-2f0d" type="rule"/>
+      </infoLinks>
       <categoryLinks>
         <categoryLink id="35ea-4280-934d-b8e0" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
         <categoryLink id="b65c-4e4f-9056-3390" name="Monstrous Sub-type:" hidden="false" targetId="7d95-f9d1-440a-67bd" primary="false"/>
         <categoryLink id="1048-d3fc-35af-c693" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="75ce-3f3b-dc4a-ecad" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
       </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="493a-5efa-8772-b9c9" name="The Vodian Sceptre" publicationId="bde1-6db1-163b-3b76" page="63" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eb0b-a6d4-4600-7ff1" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="93a0-3057-b5ec-d09a" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="b3c7-8648-7397-5971" name="The Vodian Sceptre" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+              <characteristics>
+                <characteristic name="Range" typeId="95ba-cda7-b831-6066">-</characteristic>
+                <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">+2</characteristic>
+                <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">2</characteristic>
+                <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Melee, Two-handed, Armourbane (Melee), Exoshock (4+), Murderous Strike (5+)</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <infoLinks>
+            <infoLink id="a092-e42d-2ede-4d9c" name="Two-handed" hidden="false" targetId="4c23-e863-a569-7617" type="rule"/>
+            <infoLink id="fe8e-66bf-ae69-3428" name="Armourbane (X)" hidden="false" targetId="cb59-f920-f071-7cd4" type="rule">
+              <modifiers>
+                <modifier type="set" field="name" value="Armourbane (Melee)"/>
+              </modifiers>
+            </infoLink>
+            <infoLink id="acfd-bb16-bd9d-879d" name="Exoshock (X)" hidden="false" targetId="69ca-318a-b47a-7a3c" type="rule">
+              <modifiers>
+                <modifier type="set" field="name" value="Exoshock (4+)"/>
+              </modifiers>
+            </infoLink>
+            <infoLink id="8db4-ca3c-54bd-10de" name="Murderous Strike (X)" hidden="false" targetId="93b9-1454-0e7c-42ae" type="rule">
+              <modifiers>
+                <modifier type="set" field="name" value="Murderous Strike (5+)"/>
+              </modifiers>
+            </infoLink>
+          </infoLinks>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="ba3d-94b3-3823-4d39" name="Cybertheurgic Arcana" hidden="false" collective="false" import="true">
+          <entryLinks>
+            <entryLink id="363b-da90-3afa-4e61" name="Artificia Machina" hidden="false" collective="false" import="true" targetId="51ed-f978-9a5e-1e04" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0bd5-c10a-f965-2bc8" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9a53-9339-5784-ff1d" type="max"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="fdbe-d076-f5c3-c974" name="Ephemera Incursus" hidden="false" collective="false" import="true" targetId="12fc-d4d8-d36c-6f14" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a58d-03c7-3217-b9af" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="af75-20f7-9720-9dc9" type="max"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="a59f-bd5b-c0d9-d0d3" name="Artificia Cybernetica" hidden="false" collective="false" import="true" targetId="d342-dbdb-33ec-5191" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4fdc-a3bf-0ae0-d689" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5cb3-4382-a369-b2fb" type="max"/>
+              </constraints>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="acc5-93d9-18f8-008f" name="Upgrade Points (Placeholders)" hidden="false" collective="false" import="true" targetId="7c8d-b21a-1f72-7e22" type="selectionEntry"/>
         <entryLink id="8fca-c03a-73a7-e888" name="Warlord" hidden="false" collective="false" import="true" targetId="0176-56a3-d590-b103" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1b6d-6b67-f0eb-d494" type="min"/>
           </constraints>
         </entryLink>
         <entryLink id="d607-72a9-d945-8779" name="Feudal Hierarchy" hidden="false" collective="false" import="true" targetId="27ff-3ae1-5cb6-774b" type="selectionEntry"/>
+        <entryLink id="151d-1345-5eb1-41d6" name="Machinator Array" hidden="false" collective="false" import="true" targetId="66f5-697c-605c-f1bb" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ee0d-a165-a8e4-d6fc" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="06d1-a244-797f-37c3" type="max"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="a47e-8273-6cb7-a57f" name="Archaeotech Pistol" hidden="false" collective="false" import="true" targetId="c22a-ed4d-af68-bf00" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="91c5-b073-807a-6d0d" type="max"/>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="03e6-bc76-beec-030c" type="min"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="c91f-c5a3-5df9-92d0" name="Photon Thruster" hidden="false" collective="false" import="true" targetId="3519-b118-7c6e-2343" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2333-8f12-762f-4e26" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c2e2-7016-3215-c2b9" type="min"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="f66f-ce13-620c-93ca" name="Mechanicum Protectiva" hidden="false" collective="false" import="true" targetId="7908-9b34-c5bb-21c2" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="aeef-c9ce-980c-5a99" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a676-0a7f-ae7a-19c9" type="min"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="971f-cf77-fcb3-be85" name="Cortex Controller" hidden="false" collective="false" import="true" targetId="2fda-455f-d34d-97e0" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b5bd-629f-a0d7-ff54" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="442b-80b0-31a5-27a1" type="min"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="1135-baa7-7b70-e427" name="Cyber-Familiar" hidden="false" collective="false" import="true" targetId="6c85-4601-cf58-7b35" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b8c5-dfb5-90c7-efd6" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cafa-2894-d0bb-70ca" type="min"/>
+          </constraints>
+        </entryLink>
       </entryLinks>
       <costs>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="365.0"/>
@@ -2813,6 +4421,44 @@ At the beginning of each of the controlling player’s Shooting phases for the r
           </costs>
         </selectionEntry>
       </selectionEntries>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="3104-9879-3dcd-2bbb" name="Machinator Array with Prehensile Data-Spike" hidden="false" collective="false" import="true" type="upgrade">
+      <entryLinks>
+        <entryLink id="9469-1545-e561-5bdd" name="Machinator Array" hidden="false" collective="false" import="true" targetId="66f5-697c-605c-f1bb" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6ce3-1e04-2766-1a8c" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="00be-ae80-b22c-aac8" type="min"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="9fa1-4a61-d1db-aed1" name="Prehensile Data-Spike" hidden="false" collective="false" import="true" targetId="2a20-c068-3230-ad17" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="276a-7a0b-8d52-3357" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5c2d-0670-b76a-8dca" type="min"/>
+          </constraints>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="981f-5ffe-b686-0491" name="Servo-Arm with Prehensile Data-Spike" hidden="false" collective="false" import="true" type="upgrade">
+      <entryLinks>
+        <entryLink id="4565-f55b-604f-7685" name="Prehensile Data-Spike" hidden="false" collective="false" import="true" targetId="2a20-c068-3230-ad17" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="83f8-415d-1372-4ce3" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="743e-f41d-93c2-9152" type="min"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="04e2-73b8-1807-7df9" name="Servo-Arm" hidden="false" collective="false" import="true" targetId="4168-fc85-8912-7188" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="435c-9e65-5aea-d0d9" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fb1a-0397-635e-7360" type="max"/>
+          </constraints>
+        </entryLink>
+      </entryLinks>
       <costs>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
       </costs>


### PR DESCRIPTION
Finished off by adding in all the remaining HQ and Elite choices and gear from previous pull request. This should complete Mech, knights and titans in full.

Added - Laspistol (though probably should be switched to GST with Combat weapon as well)

Added - Guardian automata subtype rule

Complete - Archmagos Prime
Complete - Archmagos Prime on Abyant
Complete - Magos Dominus
Complete - Magos Dominus on Abyant
Complete - Calleb Decima Invictus
Complete - Tech-Priest Auxilia
Complete - Arcuitor Magisterium
Complete - Myrmidon Secutor Host
Complete - Scoria
