### PR TITLE
RoW prepping

### DIFF
--- a/2022 - Horus Heresy.gst
+++ b/2022 - Horus Heresy.gst
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<gameSystem id="28d4-bd2e-4858-ece6" name="(HH V2) Horus Heresy (2022)" revision="17" battleScribeVersion="2.03" xmlns="http://www.battlescribe.net/schema/gameSystemSchema">
+<gameSystem id="28d4-bd2e-4858-ece6" name="(HH V2) Horus Heresy (2022)" revision="18" battleScribeVersion="2.03" xmlns="http://www.battlescribe.net/schema/gameSystemSchema">
   <publications>
     <publication id="e77a-823a-da94-16b9" name="Warhammer: The Horus Heresy - Age of Darkness Rulebook" shortName="Main Rules" publicationDate="June 18th, 2022"/>
     <publication id="817a-6288-e016-7469" name="Liber Astartes – Loyalist Legiones Astartes Army Book" shortName="LA - Loyalist" publicationDate="June 18th, 2022"/>
@@ -239,6 +239,20 @@ During Reactions made in any Phase, a unit equipped with Jump PAcks may not acti
     <categoryEntry id="0a04-abac-c606-2d48" name="Compulsory Lord of War:" hidden="false"/>
     <categoryEntry id="1b67-8d3b-283a-1488" name="Compulsory Fortification:" hidden="false"/>
     <categoryEntry id="9231-183c-b97b-63f9" name="Heavy" hidden="false">
+      <modifiers>
+        <modifier type="set" field="fd31-bf22-2243-ccc7" value="0.0">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="force" value="-1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="fd31-bf22-2243-ccc7" type="max"/>
+      </constraints>
       <rules>
         <rule id="79ce-8870-0b12-79ab" name="Heavy Sub-type" publicationId="e77a-823a-da94-16b9" page="197" hidden="false">
           <description>• A unit that includes only models with the Heavy subtype may re-roll failed Armour Saves against Template and Blast weapons.
@@ -265,6 +279,9 @@ During Reactions made in any Phase, a unit equipped with Jump PAcks may not acti
       </infoLinks>
     </categoryEntry>
     <categoryEntry id="4280-4963-02b5-e31d" name="Dreadnought Unit-type:" hidden="false">
+      <constraints>
+        <constraint field="selections" scope="force" value="-1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a524-3855-be3c-a633" type="max"/>
+      </constraints>
       <rules>
         <rule id="ab7d-c74d-a976-2540" name="Dreadnought Unit-type" publicationId="e77a-823a-da94-16b9" page="195" hidden="false">
           <description>• Successful Wounds scored by attacks with the Poisoned or Fleshbane special rules must be re-rolled against models of the Dreadnought Unit Type.
@@ -441,6 +458,39 @@ In addition, when a Fast Vehicle moves, it may choose to move at Flat-out:</desc
         </rule>
       </rules>
     </categoryEntry>
+    <categoryEntry id="a335-d5b0-79b6-8117" name="Non-Flying Vehicle" hidden="false">
+      <modifiers>
+        <modifier type="set" field="d6c9-9c3d-647f-eabc" value="0.0">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="force" value="-1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d6c9-9c3d-647f-eabc" type="max"/>
+      </constraints>
+    </categoryEntry>
+    <categoryEntry id="6d0b-fe0e-911e-486f" name="Non-Flying/Fast/Skimmer Vehicle" hidden="false">
+      <modifiers>
+        <modifier type="set" field="b0ca-ca8a-f177-7ba1" value="0.0">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="force" value="-1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b0ca-ca8a-f177-7ba1" type="max"/>
+      </constraints>
+    </categoryEntry>
+    <categoryEntry id="d82b-1980-74f8-5dac" name="Allied Detachment" hidden="false"/>
   </categoryEntries>
   <forceEntries>
     <forceEntry id="d926-652f-8436-30ce" name="Crusade Force Organisation Chart" hidden="false">
@@ -470,16 +520,56 @@ In addition, when a Fast Vehicle moves, it may choose to move at Flat-out:</desc
           </constraints>
         </categoryLink>
         <categoryLink id="75a1-25b0-df4d-9930" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="false">
+          <modifiers>
+            <modifier type="set" field="5474-d2f8-4d1d-66be" value="1.0">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4ca1-b02c-e2c7-5f09" type="equalTo"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
           <constraints>
             <constraint field="selections" scope="force" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="5474-d2f8-4d1d-66be" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="0662-8301-1a87-5c23" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="false">
+          <modifiers>
+            <modifier type="set" field="5c70-e3f3-a942-3e71" value="1.0">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4ca1-b02c-e2c7-5f09" type="equalTo"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
           <constraints>
             <constraint field="selections" scope="force" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="5c70-e3f3-a942-3e71" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="9271-24df-a8f3-4a99" name="Fortification:" hidden="false" targetId="a24f-12d8-36c1-f477" primary="false">
+          <modifiers>
+            <modifier type="set" field="1a78-0551-84cc-20b0" value="0.0">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1977-49f2-7910-f177" type="equalTo"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo"/>
+                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4ca1-b02c-e2c7-5f09" type="equalTo"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ccb7-6c5c-76ce-5b77" type="equalTo"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
           <constraints>
             <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1a78-0551-84cc-20b0" type="max"/>
           </constraints>
@@ -507,6 +597,17 @@ In addition, when a Fast Vehicle moves, it may choose to move at Flat-out:</desc
           </constraints>
         </categoryLink>
         <categoryLink id="db9f-30b3-e5db-3e0f" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="false">
+          <modifiers>
+            <modifier type="set" field="1c0d-0ff5-e468-703c" value="0.0">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
           <constraints>
             <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1c0d-0ff5-e468-703c" type="max"/>
           </constraints>
@@ -570,6 +671,24 @@ In addition, when a Fast Vehicle moves, it may choose to move at Flat-out:</desc
           </constraints>
         </categoryLink>
         <categoryLink id="b5a1-9980-4945-e1aa" name="Rite of War:" hidden="false" targetId="d494-e450-d4aa-579a" primary="false"/>
+        <categoryLink id="a276-296f-d1ff-e8b8" name="Allied Detachment" hidden="false" targetId="d82b-1980-74f8-5dac" primary="false">
+          <modifiers>
+            <modifier type="set" field="6b4c-542e-a6b9-fa0a" value="0.0">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4ca1-b02c-e2c7-5f09" type="equalTo"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7b03-4662-4303-03f5" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="15a8-6197-ea7a-84eb" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6b4c-542e-a6b9-fa0a" type="max"/>
+          </constraints>
+        </categoryLink>
       </categoryLinks>
     </forceEntry>
   </forceEntries>
@@ -600,6 +719,13 @@ In addition, when a Fast Vehicle moves, it may choose to move at Flat-out:</desc
       </costs>
     </selectionEntry>
     <selectionEntry id="15dd-ba85-599e-d215" name="Expanded Army List Profiles:" hidden="false" collective="false" import="true" type="upgrade">
+      <modifiers>
+        <modifier type="set" field="9b27-8da6-1ace-a81d" value="0.0">
+          <conditions>
+            <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d4f2-6da5-b6de-06ec" type="instanceOf"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <constraints>
         <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9b27-8da6-1ace-a81d" type="min"/>
         <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e555-35cf-f840-e444" type="max"/>
@@ -630,6 +756,11 @@ In addition, when a Fast Vehicle moves, it may choose to move at Flat-out:</desc
     <entryLink id="427d-eb8e-dbbd-87a2" name="Defence Line" hidden="false" collective="false" import="true" targetId="ea91-0572-393c-e925" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="86ff-083e-ce6d-8284" name="New CategoryLink" hidden="false" targetId="a24f-12d8-36c1-f477" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="ad63-7783-8500-e19f" name="Allied Detachment" hidden="false" collective="false" import="true" targetId="0fc8-91be-dcf4-1513" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="9fb6-1837-1414-95a7" name="New CategoryLink" hidden="false" targetId="d82b-1980-74f8-5dac" primary="true"/>
       </categoryLinks>
     </entryLink>
   </entryLinks>
@@ -5961,6 +6092,20 @@ In addition, a model with the Paragon of Metal special rule may not be targeted 
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
       </costs>
     </selectionEntry>
+    <selectionEntry id="0fc8-91be-dcf4-1513" name="Allied Detachment" hidden="false" collective="false" import="true" type="upgrade">
+      <modifiers>
+        <modifier type="set" field="1191-ed3c-422f-51b0" value="1.0">
+          <conditions>
+            <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d4f2-6da5-b6de-06ec" type="instanceOf"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="fb55-4121-bfb2-3348" type="max"/>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ba40-62e6-2111-e938" type="max"/>
+        <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1191-ed3c-422f-51b0" type="min"/>
+      </constraints>
+    </selectionEntry>
   </sharedSelectionEntries>
   <sharedSelectionEntryGroups>
     <selectionEntryGroup id="4a48-4935-246d-0c2e" name="Legion" hidden="false" collective="false" import="true">
@@ -7865,6 +8010,16 @@ Limitations
           </costs>
         </selectionEntry>
         <selectionEntry id="4ca1-b02c-e2c7-5f09" name="Pride Of The Legion" publicationId="a716-c1c4-7b26-8424" page="100" hidden="false" collective="false" import="true" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="4a27-2341-3537-9937" value="0.0">
+              <conditions>
+                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d4f2-6da5-b6de-06ec" type="instanceOf"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4a27-2341-3537-9937" type="max"/>
+          </constraints>
           <rules>
             <rule id="3cb1-9be8-c256-7909" name="Pride Of The Legion" publicationId="a716-c1c4-7b26-8424" page="100" hidden="false">
               <description>Effects
@@ -7904,6 +8059,16 @@ Limitations
           </costs>
         </selectionEntry>
         <selectionEntry id="ccb7-6c5c-76ce-5b77" name="Armoured Spearhead" publicationId="a716-c1c4-7b26-8424" page="102" hidden="false" collective="false" import="true" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="cfb9-4307-47d9-4bbb" value="0.0">
+              <conditions>
+                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d4f2-6da5-b6de-06ec" type="instanceOf"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cfb9-4307-47d9-4bbb" type="max"/>
+          </constraints>
           <rules>
             <rule id="a1d0-0e6a-db7e-bbcd" name="Armoured Spearhead" publicationId="a716-c1c4-7b26-8424" page="102" hidden="false">
               <description>Effects
@@ -7942,6 +8107,16 @@ Limitations
           </costs>
         </selectionEntry>
         <selectionEntry id="b5b7-3410-a8e5-95a6" name="Fury Of The Ancients" publicationId="a716-c1c4-7b26-8424" page="103" hidden="false" collective="false" import="true" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="ef62-47b5-4c55-7c8b" value="0.0">
+              <conditions>
+                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d4f2-6da5-b6de-06ec" type="instanceOf"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ef62-47b5-4c55-7c8b" type="max"/>
+          </constraints>
           <rules>
             <rule id="9329-1a60-d5b6-b939" name="Fury Of The Ancients" hidden="false">
               <description>Effects


### PR DESCRIPTION
### **GST**

Added "max -1 in force" to "Heavy" in Catagory Entries.
Added an "OR" modifier to Heavy Catagory
Added "set max -1 to 0 if equal to 1 of Recon Company in force" under the OR

Added to Fortification under Crusade Force Org Chart a "Set Max 1 selection in Force to 0"
Added an "OR" modifier to Fortification under "Set Max 1 selection in Force to 0"
Added "set max 1 to 0 if equal to 1 of Recon Company in force" under the OR
Added "set max 1 to 0 if equal to 1 of Angel's Wrath in force" under the OR
Added "set max 1 to 0 if equal to 1 of Sky-Huner Phalanx in force" under the OR
Added "set max 1 to 0 if equal to 1 of Drop Pod Assault in force" under the OR
Added "set max 1 to 0 if equal to 1 of Pride of the Legion in force" under the OR
Added "set max 1 to 0 if equal to 1 of Underworld Assault in force" under the OR
Added "set max 1 to 0 if equal to 1 of Armoured Spearhead in force" under the OR
Added "set max 1 to 0 if equal to 1 of Fury of the Ancients in force" under the OR

Added "Non-Flying Vehicle" Category
Added "max -1 in force" to "Non-Flying Vehicle" in Catagory Entry.
Added an "OR" modifier to Non-Flying Vehicle under "max -1 in force"
Added "set max 1 to 0 if equal to 1 of Angel's Wrath in force" under the OR

Added "Non-Flying/Fast/Skimmer Vehicle" Catagory
Added "max -1 in force" to "Non-Flying/Fast/Skimmer Vehicle" in Catagory Entry.
Added an "OR" modifier to Non-Flying/Fast/Skimmer Vehicle under "max -1 in force"
Added "set max 1 to 0 if equal to 1 of Sky-Huner Phalanx in force" under the OR

Added "max -1 in force" to "Dreadnought" in Catagory Entries.
Added an "OR" modifier to Dreadnought Catagory under "max -1 in force"
Added "set max -1 to 0 if equal to 1 of Sky-Huner Phalanx in force" under the OR

Added Allied Detachment Catagory Entry
Added Allied Detachment to Allied Detachment
Added SE for Allied Detachment with constraits and modifier.
Added a Root for Allied Detachment
Added Set Max 1 in roster to 0
Added an "OR" modifier to Allied Detachment
Added "set max 1 to 0 if equal to 1 of Pride of the Legion Roster" under the OR

Added to Fast Attack inside Crusade FoC - Set Max 3 selections in force to 1
Added an "OR" modifier under "max 3 in force to 1"
Added "set max 3 to 1 if equal to 1 of Pride of the Legion" under the OR

Added to Heavy Support inside Crusade FoC - Set Max 3 selections in force to 1
Added an "OR" modifier under "max 3 in force to 1"
Added "set max 3 to 1 if equal to 1 of Pride of the Legion" under the OR

Added Max 1 selection in parent to Pride of the Legion
Added Set max 1 to 0 if Ancester instance of allied detachment

Added Max 1 selection in parent to Armoured Spearhead
Added Set max 1 to 0 if Ancester instance of allied detachment

Added modifier to Lords of War "Set Max 1 selection in Force to 0"
Added an "OR" modifier to Lords of War under "Set Max 1 selection in Force to 0"
Added "set max 1 to 0 if equal to 1 of Fury of the Ancients in force" under the OR

Added Max 1 selection in parent to Fury of the Ancients
Added Set max 1 to 0 if Ancester instance of allied detachment

### **TO DO** 
Mostly needing to be editing LA or Legion Cats.
Give access to RoW to legions.

**Recon Company**
Recon and Scouts need “Support Squad” set hidden & add compulsory Troops
Add Legion Seekers Root for Troops (not compulsory troops)
Maybe “Hide” all units with “Heavy” for convenience of users
Remove Compulsory for  Assault, Breacher, Despoiler, Recon, Tactical, Grey Stalker, Grey Slayer (and any other legion compulsory troop).

**Angel's Wrath**
Add Storm Eagle DT to all units able to take Rhino and hide rhino
Add Non-Flying Vehicle category to all non-flying vehicles.
**IMPOSSIBLE TO DO!** All infantry without jump packs need to be on a flying transport

**Sky-Huner Phalanx**
Sky-hunters and Proteus Land Speeders need Root for Troops & add compulsory Troops
Add Line category to Sky-hunters 
Add Non-Flying/Fast/Skimmer Vehicle category to all non-flying vehicles.
**IMPOSSIBLE TO DO!** All infantry must be embarked upon a model with both flyer and transport sub-type. Though could be made that vehicles like Land Raiders, Rhinos, Spartans and other ground dedicated transports are hidden from dedicated transports as well.

**Drop Pod Assault**
Add Legion Drop-pods and Dreadclaw Drop-pods DT to all units able to take Rhino or Land Raider, then and hide rhino and Land Raider.
Limit Dreadnought type units to Max 1 and make either Dreadclaw or Dreadnought Drop-pod compulsory.

**Pride of the Legion**
Add Root for Veterans, Cata Termy, Tart Termy for Troops (But do not add compulsory – See below)
Add tickbox to Veterans, Cata Termy, Tart Termy with a max based on how many compulsories the FoC has which if ticked gives them “Line” and “Compulsory Troops” only if ticked.
Add Root for any Elite Termy to make Troops (can add compulsory troop to these)

**Underworld Assault**
Add Termite Assault Drill DT to all units able to take Rhino and hide rhino. Termite Assault Drill needs a Root for Fast Attack and Heavy support
**IMPOSSIBLE TO DO!** All units in a Detachment using this Rite of War that begin play on the battlefield and not in Reserve, gain the Stubborn special rule until the end of the turn in which any units assigned to a Subterranean Assault (see page 101) are deployed onto the battlefield.
**IMPOSSIBLE TO DO!** All Infantry units that do not have a version of the Bulky (X) special rule in a Detachment using this Rite of War must begin the battle Embarked on a Legion Termite Assault Drill.
**IMPOSSIBLE TO DO!** Any models selected as part of a Detachment using this Rite of War that are not Legion Termite Assault Drills, or Embarked on a Legion Termite Assault Drill, may not be placed into Reserve and cannot take part in any alternative deployments (such as Deep Strike Assaults or Flanking Assaults).

**Armoured Spearhead**
Add Land Raider Carrier DT to all units able to take Rhino
Add Root for Predator squads as Troops (and add compulsory troop)
Add Root for Sicaran Squadrons squads as Elites
Add Master of Armour SE and Root as HQ (and compulsory HQ) which links to single Pred or Sicaran which must take Master of Armour Warlord trait. If taken must be Warlord (as a result hide Primarchs and other characters which must be the warlord as well).
**IMPOSSIBLE TO DO!** All units in a Detachment using this Rite of War with the Infantry Type must begin the battle Embarked upon a model with the Transport Sub-type; any Infantry models in a Detachment using this Rite of War, both those deployed on the battlefield and in Reserves, that are not Embarked upon a model with the Transport Subtype at the beginning of the controlling player’s first turn must be removed as casualties.
**May need to work out how to implement** “Detachment using this Rite of War may not include any models with a Movement Characteristic of 0 or ‘-’.”

**Bretren of Iron**
Add Root for Castellax Battle-automata Maniples as non-compulsory troops
Add Root for Vorax Battleautomata Maniple as non-Compulsory Fast Attack
Add Root for Domitar Battle-automata Maniples as non-Compulsory Elites
Add Root for Thanatar Siege-automata Maniple (with Max 1 in force or a single Thanatar) as non-Compulsory Heavy Support
Add option for Legion Techmarine to take cortex controller at +20 points
**Need to work out how to implement** A Detachment using this Rite of War may not have more units that include one or more models with the Automata Unit Type than the total number of units it includes that do not include any models with the Automata Unit Type.
**Need to work out how to implement** At least one model with a cortex controller must be included in the Detachment for every three models with the Automata Unit Type in the Detachment. Add in Paragon of Metal a Max 0 modifier if this RoW is taken. Set min 1 Forge Lord Legiones Consularis upgrade for this RoW

**Fury of the Ancients**
Add Root for Contemptor Dreadnought Talons may be taken as Troops choices (and Compulsory Troops).
Add tickbox to Legion Contemptor Dreadnought Talons a max based on how many compulsories the FoC has which if ticked gives them “Line” and “Compulsory Troops” only if ticked.
Add Venerable Ancient SE and Root as HQ (and compulsory HQ) which links to single Contemptor (+30pts) which must take Venerable Ancient Warlord trait. If taken must be Warlord (as a result hide Primarchs and other characters which must be the warlord as well).
Remove Compulsory for  Assault, Breacher, Despoiler, Recon, Tactical, Grey Stalker, Grey Slayer (and any other legion compulsory troop).
Hide all consul’s apart from Forge Lord, Legion Primus Medicae & Legion Mortificator.
Add a “Non-Dreadnought FA” hidden SE (can be done in LA file) with max 1 in Force non-dreadnought Fast Attack to be added to all Fast attack choices. Have it set with Max 1 in parent, Min 0 in parent inside of SE. Then Min 0 set to 1 if Fury of the Ancients RoW.
Add a “Non-Dreadnought HS” hidden SE (can be done in LA file) with max 1 in Force non-dreadnought Heavy Support to be added to all Heavy Support choices. Have it set with Max 1 in parent, Min 0 in parent inside of SE. Then Min 0 set to 1 if Fury of the Ancients RoW.