### PR TITLE
Row stuff and categories

### DIFF
--- a/2022 - Horus Heresy.gst
+++ b/2022 - Horus Heresy.gst
@@ -502,6 +502,7 @@ In addition, when a Fast Vehicle moves, it may choose to move at Flat-out:</desc
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="fa4b-a703-9dbf-bb6a" type="max"/>
           </constraints>
         </categoryLink>
+        <categoryLink id="4240-0870-e7ec-839e" name="Rite of Warzz:" hidden="false" targetId="d494-e450-d4aa-579a" primary="false"/>
         <categoryLink id="cb59-2a42-9e16-fbe7" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="false">
           <constraints>
             <constraint field="selections" scope="force" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1db1-1803-cee1-86cb" type="max"/>
@@ -622,7 +623,6 @@ In addition, when a Fast Vehicle moves, it may choose to move at Flat-out:</desc
             <constraint field="selections" scope="force" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8810-8109-85db-93e4" type="min"/>
           </constraints>
         </categoryLink>
-        <categoryLink id="4240-0870-e7ec-839e" name="Rite of War:" hidden="false" targetId="d494-e450-d4aa-579a" primary="false"/>
       </categoryLinks>
     </forceEntry>
     <forceEntry id="d4f2-6da5-b6de-06ec" name="Allied Detachment" hidden="false">
@@ -6105,6 +6105,9 @@ In addition, a model with the Paragon of Metal special rule may not be targeted 
         <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ba40-62e6-2111-e938" type="max"/>
         <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1191-ed3c-422f-51b0" type="min"/>
       </constraints>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
     </selectionEntry>
   </sharedSelectionEntries>
   <sharedSelectionEntryGroups>
@@ -7937,6 +7940,9 @@ An army whose Warlord has this Trait counts any Allied Detachment that has any v
       </selectionEntryGroups>
     </selectionEntryGroup>
     <selectionEntryGroup id="cf3e-1d75-6f91-651f" name="Rites of War (Text Only / Work in Progress)" publicationId="a716-c1c4-7b26-8424" page="" hidden="false" collective="false" import="true">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="797b-0bd6-8cbf-f25a" type="max"/>
+      </constraints>
       <selectionEntries>
         <selectionEntry id="dbde-0e4f-0b5a-43d2" name="Recon Company" publicationId="a716-c1c4-7b26-8424" page="97" hidden="false" collective="false" import="true" type="upgrade">
           <rules>

--- a/2022 - LA - Alpha Legion.cat
+++ b/2022 - LA - Alpha Legion.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="9c06-1c61-d01d-8445" name="LA - XX: Alpha Legion" revision="22" battleScribeVersion="2.03" authorName="Alphalas" authorContact="BSData Developers Discord" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="18" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="9c06-1c61-d01d-8445" name="LA - XX: Alpha Legion" revision="23" battleScribeVersion="2.03" authorName="Alphalas" authorContact="BSData Developers Discord" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="18" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <categoryEntries>
     <categoryEntry id="2275-5253-2421-7383" name="Rewards of Trechery" hidden="false">
       <constraints>
@@ -45,32 +45,38 @@
       <categoryLinks>
         <categoryLink id="007a-4705-5f7a-695b" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="69ff-87ed-3c34-3742" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
+        <categoryLink id="c597-72fd-c1c9-39ff" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="8bd1-2ebe-9806-2c7a" name="Alpharius" hidden="false" collective="false" import="true" targetId="e56e-40d5-e362-0e1c" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="3a48-ebd5-979a-ab0e" name="New CategoryLink" hidden="false" targetId="ad5f-31db-8bc7-5c46" primary="true"/>
+        <categoryLink id="b56c-b87b-07a2-6437" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="d7e9-6d99-675b-0a20" name="Armillus Dynat" hidden="false" collective="false" import="true" targetId="42af-ab98-e733-dc01" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="dd12-09e4-7e98-1293" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="3732-e871-9e0b-7235" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
+        <categoryLink id="b2da-e306-a467-d325" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="9515-498a-82b3-893b" name="Exodus" hidden="false" collective="false" import="true" targetId="f912-9416-39ea-b3fc" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="2c9a-c549-943f-5cd4" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="9b6f-0ee4-663a-93da" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="886e-415e-5ab8-3190" name="Headhunter Kill Team" hidden="false" collective="false" import="true" targetId="70e6-ace3-8feb-1ddc" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="8616-35c3-c887-a64c" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="c995-fa87-2f17-b073" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="d20f-c0b6-43bd-93a0" name="Lernaean Terminator Squad" hidden="false" collective="false" import="true" targetId="6161-d387-f086-0958" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="46d2-e42c-5804-d2d4" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="1a05-3dc3-65de-89f6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="3249-0974-fb92-4e6b" name="Contemptor-Incaendius Dreadnought" hidden="true" collective="false" import="true" targetId="090c-5656-0180-16c8" type="selectionEntry">
@@ -84,6 +90,7 @@
       <categoryLinks>
         <categoryLink id="c05e-35d3-2f58-ee87" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
         <categoryLink id="85bf-5c39-d77e-de7e" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
+        <categoryLink id="0322-dc48-e060-7882" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="fef9-8f33-d164-6c07" name="Dawnbreaker Cohort" hidden="true" collective="false" import="true" targetId="3c67-35da-d64a-f22b" type="selectionEntry">
@@ -97,6 +104,7 @@
       <categoryLinks>
         <categoryLink id="a8ff-df82-9b34-d336" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="2a5f-6671-1cd0-8824" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
+        <categoryLink id="7f2a-7de5-1140-d4c1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="5a11-ffcb-138c-07af" name="The Angel&apos;s Tears" hidden="true" collective="false" import="true" targetId="dda1-0fcf-0245-6c10" type="selectionEntry">
@@ -110,6 +118,7 @@
       <categoryLinks>
         <categoryLink id="04c0-2b59-6737-2841" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="4cb8-a680-b384-2e82" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
+        <categoryLink id="209d-5586-1f70-fda7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="4ebf-55c4-fb59-569d" name="Dreadwing Interemptor Squad" hidden="true" collective="false" import="true" targetId="3008-e8ed-9e97-71c9" type="selectionEntry">
@@ -123,6 +132,7 @@
       <categoryLinks>
         <categoryLink id="b3ad-92e7-3dcd-b644" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="ea34-926e-6a09-afe1" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
+        <categoryLink id="ae94-21c7-e1d1-a2fc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="4d98-c46c-40f7-b5f4" name="Firewing Enigmatus Cabal" hidden="true" collective="false" import="true" targetId="3731-e0df-bd0c-a33e" type="selectionEntry">
@@ -136,6 +146,7 @@
       <categoryLinks>
         <categoryLink id="46a9-0c8d-202d-f470" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
         <categoryLink id="1cb0-db62-d7b8-96fb" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="4bac-0e00-a20e-b1bb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="948c-2c74-497e-47e8" name="Excindio Battle-automata" hidden="true" collective="false" import="true" targetId="cf23-fd3a-15a0-7347" type="selectionEntry">
@@ -149,6 +160,7 @@
       <categoryLinks>
         <categoryLink id="6141-22f3-bbe6-e74f" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
         <categoryLink id="1aa8-88aa-6181-ff4c" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
+        <categoryLink id="e183-a5aa-1334-af65" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="3d59-14ba-095f-f402" name="Inner Circle Knights Cenobium" hidden="true" collective="false" import="true" targetId="9946-61c0-3656-36dd" type="selectionEntry">
@@ -162,6 +174,7 @@
       <categoryLinks>
         <categoryLink id="10d9-0cba-6158-32a9" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="f31f-785e-2f52-2ebc" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
+        <categoryLink id="ecd5-a8eb-ac46-efaa" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="853d-6ff7-293a-3474" name="Inner Circle Knights Cenobium - Order of the Broken Claws" hidden="true" collective="false" import="true" targetId="b9ad-ab3e-437e-c373" type="selectionEntry">
@@ -175,6 +188,7 @@
       <categoryLinks>
         <categoryLink id="41da-54c7-c6c3-4991" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="b730-a050-02af-16d5" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
+        <categoryLink id="6522-92fe-75aa-77a4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="1193-4e5a-ab65-f739" name="Mortus Poisoner Squad" hidden="true" collective="false" import="true" targetId="dd7b-fe21-cf53-0ebc" type="selectionEntry">
@@ -188,6 +202,7 @@
       <categoryLinks>
         <categoryLink id="b9f4-db55-fe6d-94b2" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="2c47-5afd-2dc9-7b56" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
+        <categoryLink id="3cca-372c-6f4e-a10e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="241d-6c1a-dfe4-5b69" name="Grave Warden Terminator Squad" hidden="true" collective="false" import="true" targetId="be32-77c9-fe55-7dc0" type="selectionEntry">
@@ -201,6 +216,7 @@
       <categoryLinks>
         <categoryLink id="16e5-e6f3-635f-6251" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
         <categoryLink id="c1e3-bbfd-225e-5ab3" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
+        <categoryLink id="60eb-e7a6-75c2-be95" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="26ab-aed8-c986-17d5" name="Kakophoni Squad" hidden="true" collective="false" import="true" targetId="8359-c463-9cde-4f21" type="selectionEntry">
@@ -211,6 +227,11 @@
           </conditions>
         </modifier>
       </modifiers>
+      <categoryLinks>
+        <categoryLink id="e90b-c3e4-96a6-40d7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="cba5-d0a7-9735-c282" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
+        <categoryLink id="a921-1b20-3242-bd7a" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+      </categoryLinks>
     </entryLink>
     <entryLink id="027a-256b-f351-75f5" name="Palatine Blade Squad" hidden="true" collective="false" import="true" targetId="fa86-f7a5-0062-a205" type="selectionEntry">
       <modifiers>
@@ -220,6 +241,11 @@
           </conditions>
         </modifier>
       </modifiers>
+      <categoryLinks>
+        <categoryLink id="980f-cfcf-c294-e804" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="a7f9-b7c1-8756-f9ea" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="0df2-e5ac-30c0-562a" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
+      </categoryLinks>
     </entryLink>
     <entryLink id="c326-cb15-c3dd-3f9c" name="Phoenix Terminator Squad" hidden="true" collective="false" import="true" targetId="5b08-65c1-cc45-1b91" type="selectionEntry">
       <modifiers>
@@ -229,6 +255,11 @@
           </conditions>
         </modifier>
       </modifiers>
+      <categoryLinks>
+        <categoryLink id="a77e-592b-fe68-b614" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="3e22-e8a9-32e5-c9ca" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="e8d2-9f63-b325-32c0" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
+      </categoryLinks>
     </entryLink>
     <entryLink id="4dbb-34a4-fdd2-0cbf" name="Sun Killer Squad" hidden="true" collective="false" import="true" targetId="cce2-fd03-ac17-88e4" type="selectionEntry">
       <modifiers>
@@ -238,6 +269,10 @@
           </conditions>
         </modifier>
       </modifiers>
+      <categoryLinks>
+        <categoryLink id="731f-fd34-3855-df4a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="9f80-c46b-5b87-06fc" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+      </categoryLinks>
     </entryLink>
     <entryLink id="0830-4929-8091-746a" name="Huscarl Squad" hidden="true" collective="false" import="true" targetId="4420-5ce0-beb7-cb5e" type="selectionEntry">
       <modifiers>
@@ -250,6 +285,7 @@
       <categoryLinks>
         <categoryLink id="6c1e-4c9e-e3bd-1ed1" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="85c5-b06d-1d39-aad0" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
+        <categoryLink id="b485-56bf-6221-dd06" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="0457-3563-1aab-ece5" name="Templar Brethren" hidden="true" collective="false" import="true" targetId="6f69-665c-3199-77aa" type="selectionEntry">
@@ -263,6 +299,7 @@
       <categoryLinks>
         <categoryLink id="bae3-e5c1-dfc6-dc12" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="274f-7764-d62a-c30a" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
+        <categoryLink id="7001-3855-b64e-05b4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="e31e-95d0-222e-589c" name="Phalanx Warder Squad" hidden="true" collective="false" import="true" targetId="19ce-b8dc-dd40-fee9" type="selectionEntry">
@@ -276,6 +313,7 @@
       <categoryLinks>
         <categoryLink id="08d9-f6ed-b8dd-e10c" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
         <categoryLink id="a4fa-28fa-2625-6b6e" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
+        <categoryLink id="94ac-87ca-a047-7f37" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="c427-5adb-5425-5ab9" name="Gorgon Terminator Squad" hidden="true" collective="false" import="true" targetId="ea50-6315-7a52-f560" type="selectionEntry">
@@ -288,8 +326,8 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="e9fb-2b4f-655a-82db" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="b6ff-7cb7-13c3-ade3" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
         <categoryLink id="90cd-cd1d-07cb-c23b" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
+        <categoryLink id="4e70-99fb-415a-a938" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="dac8-a583-c05d-6c22" name="Medusan Immortal Squad" hidden="true" collective="false" import="true" targetId="f9e4-0da2-5049-df81" type="selectionEntry">
@@ -302,8 +340,8 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="ae0e-4cf9-c6f7-c1a2" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="bed1-a653-73a8-4680" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
         <categoryLink id="a82b-8ee2-5f4e-826f" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
+        <categoryLink id="1461-85ec-945e-5e31" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="84af-f180-93a9-b4e6" name="Iron Circle Maniple" hidden="true" collective="false" import="true" targetId="a6e3-baab-45b9-7fea" type="selectionEntry">
@@ -316,8 +354,8 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="475a-4d51-e6b1-b353" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="8fbf-49ab-198c-04a8" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
         <categoryLink id="9758-f439-2d9f-f6c0" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
+        <categoryLink id="443f-534b-ca5c-39ec" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="21ea-86f3-aab1-a0cc" name="Tyrant Siege Terminator Squad" hidden="true" collective="false" import="true" targetId="795a-5698-a1bc-6ec6" type="selectionEntry">
@@ -331,6 +369,7 @@
       <categoryLinks>
         <categoryLink id="8d21-c340-4539-6209" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
         <categoryLink id="8daf-d124-9b5c-e0c1" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
+        <categoryLink id="c6fd-e694-7395-20f2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="f48c-ea6c-0fbc-598a" name="Dominator Cohort" hidden="true" collective="false" import="true" targetId="1bfa-2413-beb9-5f32" type="selectionEntry">
@@ -344,6 +383,7 @@
       <categoryLinks>
         <categoryLink id="f056-f0c1-ad40-6834" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="54f4-39a6-c4fc-c33e" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
+        <categoryLink id="fe1a-584c-173e-87f3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="c4d9-2b32-325e-9c4f" name="Iron Havocs" hidden="true" collective="false" import="true" targetId="d355-5488-1277-fabf" type="selectionEntry">
@@ -357,6 +397,7 @@
       <categoryLinks>
         <categoryLink id="6eb4-905f-5c57-cf57" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
         <categoryLink id="68dc-de7f-8ab8-838d" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
+        <categoryLink id="3166-a82f-5b57-1c5e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="3291-aa2f-0e9e-017f" name="Atramentar Squad" hidden="true" collective="false" import="true" targetId="12d3-9df0-4118-997f" type="selectionEntry">
@@ -370,6 +411,7 @@
       <categoryLinks>
         <categoryLink id="c435-91dd-cb19-23ed" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="cdf9-f163-9e6d-1243" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
+        <categoryLink id="4ee3-79a9-4706-6791" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="30e5-1996-ad7f-1cb8" name="Terror Squad" hidden="true" collective="false" import="true" targetId="53ce-6dc9-aa69-fbaa" type="selectionEntry">
@@ -383,6 +425,7 @@
       <categoryLinks>
         <categoryLink id="1f0a-5ac7-30de-45e8" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="ae02-dcb6-4b6e-f03e" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
+        <categoryLink id="127b-1f7c-f850-d939" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="0303-9efb-a46c-9e35" name="Night Raptor Squad" hidden="true" collective="false" import="true" targetId="9bb8-8fe4-11c1-9e50" type="selectionEntry">
@@ -396,6 +439,7 @@
       <categoryLinks>
         <categoryLink id="a09d-624d-b66c-4f59" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="1175-0a3e-b135-13f0" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
+        <categoryLink id="aebc-435f-a0b7-79c3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="522b-84dd-0422-1ca5" name="Contekar Terminator Squad" hidden="true" collective="false" import="true" targetId="837e-c3ca-437e-dfbf" type="selectionEntry">
@@ -409,6 +453,7 @@
       <categoryLinks>
         <categoryLink id="57a2-7099-cbed-ecc4" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="d02b-01a8-c88c-266f" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
+        <categoryLink id="aa49-0b17-af19-2871" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="3449-42bd-723e-8f58" name="Dark Furies" hidden="true" collective="false" import="true" targetId="58f4-3d8d-f243-6e5d" type="selectionEntry">
@@ -422,6 +467,7 @@
       <categoryLinks>
         <categoryLink id="97b1-3f08-d172-8a15" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
         <categoryLink id="90c2-8531-b18d-b9b9" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
+        <categoryLink id="a1a6-0507-e958-2599" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="61aa-3233-8f98-7243" name="Mor Deythan Squad" hidden="true" collective="false" import="true" targetId="c268-08ac-5b90-d034" type="selectionEntry">
@@ -435,6 +481,7 @@
       <categoryLinks>
         <categoryLink id="0d35-e913-d462-7066" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="6267-16c3-3f0c-d3ce" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
+        <categoryLink id="af87-08f0-109f-d6c5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="2563-d825-3a1f-556a" name="Deliverers Squad" hidden="true" collective="false" import="true" targetId="5d1d-8348-ed95-d366" type="selectionEntry">
@@ -448,6 +495,7 @@
       <categoryLinks>
         <categoryLink id="95ea-2552-bc04-8f45" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="8610-0a32-a51b-1666" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
+        <categoryLink id="e8ef-534c-a9ca-b1e6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="9c8e-6562-6c4b-5687" name="Firedrake Terminator Squad" hidden="true" collective="false" import="true" targetId="6775-8379-8d6b-9614" type="selectionEntry">
@@ -461,6 +509,7 @@
       <categoryLinks>
         <categoryLink id="5fe0-ce32-6415-3d27" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="b2d4-8fb2-d07a-d9d1" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
+        <categoryLink id="2b5a-3212-0e2c-4b35" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="2982-0553-c877-9b8c" name="Pyroclast Squad" hidden="true" collective="false" import="true" targetId="71fe-d3bc-b7f9-75ca" type="selectionEntry">
@@ -474,6 +523,7 @@
       <categoryLinks>
         <categoryLink id="fe9d-d416-66cc-3840" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="5bbd-91c1-a792-d250" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
+        <categoryLink id="5dcd-cef6-8861-fba9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="e30f-252c-9d00-eb3a" name="Deathsworn Pack" hidden="true" collective="false" import="true" targetId="3fa0-d6ed-981b-e361" type="selectionEntry">
@@ -487,6 +537,7 @@
       <categoryLinks>
         <categoryLink id="ab26-ddb6-3918-328e" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="6b1d-a72a-6eae-d530" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
+        <categoryLink id="ad6f-009a-e3fd-03f3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="1d61-9489-044c-4d84" name="Chieftain Squad" hidden="true" collective="false" import="true" targetId="0c73-9141-d1b4-6a40" type="selectionEntry">
@@ -500,6 +551,7 @@
       <categoryLinks>
         <categoryLink id="aa05-6f88-816e-bfda" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="387c-5bef-8480-79fa" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
+        <categoryLink id="e42f-2919-31ba-66ed" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="3762-6cfd-39ef-1a13" name="Justaerin Terminator Squad" hidden="true" collective="false" import="true" targetId="c45d-ade3-6b28-68a2" type="selectionEntry">
@@ -513,6 +565,7 @@
       <categoryLinks>
         <categoryLink id="a321-0fd1-53f5-1756" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="75fd-7486-ed31-b419" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
+        <categoryLink id="d328-4b4c-55b5-63bf" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="38cc-adf2-fed4-85be" name="Reaver Aggressor Squad" hidden="true" collective="false" import="true" targetId="af3a-334f-152f-d55f" type="selectionEntry">
@@ -526,6 +579,7 @@
       <categoryLinks>
         <categoryLink id="e5a7-c6bf-98d1-b1f7" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="5f5b-f5e8-7f86-eb96" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
+        <categoryLink id="441b-6620-46c3-d0b1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="4ed2-aeff-41a0-466f" name="Reaver Attack Squad" hidden="true" collective="false" import="true" targetId="8b29-bf2a-a814-5642" type="selectionEntry">
@@ -539,6 +593,7 @@
       <categoryLinks>
         <categoryLink id="6400-720a-7c91-b8c6" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="dcf6-53ba-4274-e748" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
+        <categoryLink id="6da8-2162-e41c-9dbb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="7666-52aa-d0d6-05f9" name="Varagyr Wolf Guard Terminator Squad" hidden="true" collective="false" import="true" targetId="9359-61a5-fcdb-c28e" type="selectionEntry">
@@ -552,6 +607,7 @@
       <categoryLinks>
         <categoryLink id="13ca-19e6-fa4c-59a3" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="226f-9aa6-780b-aac9" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
+        <categoryLink id="98c7-72db-c50a-e9e5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="d7de-2fe2-d8a3-0134" name="Grey Slayer Pack" hidden="true" collective="false" import="true" targetId="4bbf-f3df-7b18-4a49" type="selectionEntry">
@@ -560,6 +616,16 @@
           <conditions>
             <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4916-965e-8339-44f6" type="greaterThan"/>
           </conditions>
+        </modifier>
+        <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
@@ -575,11 +641,22 @@
             <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4916-965e-8339-44f6" type="greaterThan"/>
           </conditions>
         </modifier>
+        <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
       </modifiers>
       <categoryLinks>
         <categoryLink id="dc7c-154a-28ef-62cc" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
         <categoryLink id="9e6c-a4a4-973d-f93f" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="90e3-ff3c-3b76-d42c" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
+        <categoryLink id="26c4-7af8-ab43-8177" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="d7db-4065-219f-32fe" name="Jorlund Hunter Pack" hidden="true" collective="false" import="true" targetId="fcc8-bc3c-e443-eb3f" type="selectionEntry">
@@ -593,6 +670,7 @@
       <categoryLinks>
         <categoryLink id="8fc2-00bd-c7a6-0cca" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
         <categoryLink id="c1c1-f2a0-d7a8-8a2f" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="73b5-a699-f247-c096" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="59b0-23da-b88c-698b" name="Ammitara Occult Intercession Cabal" hidden="true" collective="false" import="true" targetId="d3ad-275c-e22b-a28f" type="selectionEntry">
@@ -606,6 +684,7 @@
       <categoryLinks>
         <categoryLink id="8cce-74a0-825f-76b2" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
         <categoryLink id="fcea-6b0f-9886-453f" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
+        <categoryLink id="0f28-156d-4624-4fb8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="87d8-139a-0e23-da54" name="Castellax-Achea Automata" hidden="true" collective="false" import="true" targetId="95cb-9366-295e-f10d" type="selectionEntry">
@@ -619,6 +698,7 @@
       <categoryLinks>
         <categoryLink id="10b6-efe8-eb05-1122" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="8493-2d60-abcf-0341" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
+        <categoryLink id="b10b-27e3-45a1-93c1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="6cc5-b7ae-1d59-c024" name="Khenetai Occult Cabal" hidden="true" collective="false" import="true" targetId="faa7-27d5-2ee2-5d58" type="selectionEntry">
@@ -632,6 +712,7 @@
       <categoryLinks>
         <categoryLink id="43b6-e5db-d065-4c3d" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="3e9e-aa2d-e31b-82b4" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
+        <categoryLink id="985b-042a-6c7f-3d8b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="7471-4aa8-40a3-ba58" name="Sekhmet Terminator Cabal" hidden="true" collective="false" import="true" targetId="dda2-bdd0-3ced-b427" type="selectionEntry">
@@ -645,6 +726,7 @@
       <categoryLinks>
         <categoryLink id="e9db-b17f-ef90-49c9" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="9881-969b-bd71-6e33" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
+        <categoryLink id="b75b-ced4-7c8c-82ee" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="9e0a-dda3-e372-0548" name="Fulmentarus Terminator Squad" hidden="true" collective="false" import="true" targetId="7fb0-6302-d46f-029d" type="selectionEntry">
@@ -658,6 +740,7 @@
       <categoryLinks>
         <categoryLink id="4b53-0b13-f50e-bd04" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="4e61-2ef8-09c5-342f" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
+        <categoryLink id="6ef7-3e18-5801-0c99" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="ffee-e152-1467-4bed" name="Invictarus Suzerain Squad" hidden="true" collective="false" import="true" targetId="ed63-e872-9410-a4b5" type="selectionEntry">
@@ -671,6 +754,7 @@
       <categoryLinks>
         <categoryLink id="6081-3aef-69a9-0723" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="46a6-2a49-b309-965a" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
+        <categoryLink id="6a44-ef13-acf2-cef6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="f900-3681-c641-0842" name="Locutarus Storm Squad" hidden="true" collective="false" import="true" targetId="314d-f363-fb52-743a" type="selectionEntry">
@@ -684,6 +768,7 @@
       <categoryLinks>
         <categoryLink id="10ca-0f92-db85-de6f" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
         <categoryLink id="4582-1241-6135-f55c" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
+        <categoryLink id="3be9-a405-a78b-a1d3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="35c9-cc7b-a14e-a4c7" name="Nemesis Destroyer Squad" hidden="true" collective="false" import="true" targetId="32d1-29a6-9023-142c" type="selectionEntry">
@@ -697,6 +782,7 @@
       <categoryLinks>
         <categoryLink id="8576-3c18-b764-3bf9" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="b291-e267-0c5b-6b07" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
+        <categoryLink id="ecf9-b782-cdec-0f89" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="dbed-4afc-faad-50c6" name="Praetorian Breacher Squad" hidden="true" collective="false" import="true" targetId="7587-35cc-01f6-b5d2" type="selectionEntry">
@@ -710,6 +796,7 @@
       <categoryLinks>
         <categoryLink id="b90f-7fe3-220d-b301" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="2601-513b-bf12-ee56" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
+        <categoryLink id="3d0a-44a8-dd1c-1167" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="ab1f-ce36-7a3a-e274" name="Golden Keshig Squadron" hidden="true" collective="false" import="true" targetId="1d55-faa7-caa5-a132" type="selectionEntry">
@@ -723,6 +810,7 @@
       <categoryLinks>
         <categoryLink id="2abe-d220-2c83-214a" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="8957-dd47-1e4a-f19e" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
+        <categoryLink id="101d-e6ef-d933-ef24" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="7aa6-6013-0a0a-ea52" name="Ebon Keshig Cohort" hidden="true" collective="false" import="true" targetId="eb44-e977-2ce5-b239" type="selectionEntry">
@@ -733,6 +821,11 @@
           </conditions>
         </modifier>
       </modifiers>
+      <categoryLinks>
+        <categoryLink id="99d9-1f22-45d6-01e2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="2d51-411b-c502-acaf" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
+        <categoryLink id="375c-755b-17a9-1232" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+      </categoryLinks>
     </entryLink>
     <entryLink id="336e-3223-67ce-912c" name="Kyzagan Assualt Speeder Squadron" hidden="true" collective="false" import="true" targetId="e37e-09ea-50c6-2daa" type="selectionEntry">
       <modifiers>
@@ -745,9 +838,10 @@
       <categoryLinks>
         <categoryLink id="3e18-b878-223f-289e" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
         <categoryLink id="1538-9081-32fa-c24b" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
+        <categoryLink id="6de1-d44e-3b0c-d4b5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="034d-cae7-d430-71a5" name="Dark Sons of Death " hidden="true" collective="false" import="true" targetId="4372-ad51-04a6-97ce" type="selectionEntry">
+    <entryLink id="034d-cae7-d430-71a5" name="Dark Sons of Death" hidden="true" collective="false" import="true" targetId="4372-ad51-04a6-97ce" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
@@ -758,6 +852,7 @@
       <categoryLinks>
         <categoryLink id="806e-73fd-00f3-b1ca" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="55ad-798d-1f21-7563" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
+        <categoryLink id="1c7f-0bda-93a9-fd09" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="00c2-d209-94ce-05ad" name="Falcon&apos;s Claws" hidden="true" collective="false" import="true" targetId="c598-7fda-13d0-7523" type="selectionEntry">
@@ -771,6 +866,7 @@
       <categoryLinks>
         <categoryLink id="89aa-08cc-1ad3-9073" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
         <categoryLink id="6cef-29a8-2dba-b29a" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
+        <categoryLink id="c6fd-0435-662e-908d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="b16e-245e-993e-37a4" name="Ashen Circle" hidden="true" collective="false" import="true" targetId="f4e7-a798-a322-dc10" type="selectionEntry">
@@ -784,6 +880,7 @@
       <categoryLinks>
         <categoryLink id="b1a0-b911-73a6-3f52" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="399f-5ed8-9211-f7be" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
+        <categoryLink id="9503-23d5-fc66-cea2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="54d0-9a88-bfb3-dce5" name="Mhara Gal Dreadnought" hidden="true" collective="false" import="true" targetId="5254-5c76-10d4-c909" type="selectionEntry">
@@ -797,6 +894,7 @@
       <categoryLinks>
         <categoryLink id="581b-17a1-da13-5fea" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="7f2e-7d15-717b-90a6" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
+        <categoryLink id="99e6-38c3-c771-151d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="1ffe-18a3-a1e0-fae5" name="Gal Vorbak Squad" hidden="true" collective="false" import="true" targetId="be3a-5acc-b4bd-8621" type="selectionEntry">
@@ -810,6 +908,7 @@
       <categoryLinks>
         <categoryLink id="6af3-1969-4705-0fb1" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="91af-e352-f10a-b59a" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
+        <categoryLink id="c519-c47d-546b-3000" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="e2e9-3770-5b79-8838" name="Rampager Squad" hidden="true" collective="false" import="true" targetId="2fb9-74a8-43b0-dd00" type="selectionEntry">
@@ -823,6 +922,7 @@
       <categoryLinks>
         <categoryLink id="d168-2562-e83e-8e9b" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="2eb1-2e57-dbbc-957b" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
+        <categoryLink id="ce2b-fc21-8058-7388" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="62ad-e646-2deb-0a06" name="Red Butchers" hidden="true" collective="false" import="true" targetId="1987-2aa5-929b-979e" type="selectionEntry">
@@ -836,6 +936,7 @@
       <categoryLinks>
         <categoryLink id="bab1-bf37-f813-87b0" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="7d89-c6b5-084b-5ed7" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
+        <categoryLink id="dc77-206a-860a-db65" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="5613-923b-06e3-3d91" name="Red Hand Destroyer Assault Squad" hidden="true" collective="false" import="true" targetId="7a04-bc44-70bb-cb98" type="selectionEntry">
@@ -849,6 +950,7 @@
       <categoryLinks>
         <categoryLink id="6601-3a00-9ee4-d330" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="822c-7e6e-04bd-e562" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
+        <categoryLink id="ca87-f80f-b302-cabb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="f1f4-2076-9174-8149" name="Contemptor-Osiron Dreadnought Talon" hidden="true" collective="false" import="true" targetId="eef1-0f91-a59f-b3e2" type="selectionEntry">
@@ -859,6 +961,11 @@
           </conditions>
         </modifier>
       </modifiers>
+      <categoryLinks>
+        <categoryLink id="87af-6bfa-d646-4441" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="b0ef-c961-5f21-627a" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
+        <categoryLink id="7618-a59b-753f-2ff8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+      </categoryLinks>
     </entryLink>
     <entryLink id="9e61-f556-1d53-d498" name="Apothecarion Detachment" hidden="false" collective="false" import="true" targetId="81df-ffd4-a32b-b4a1" type="selectionEntry">
       <infoLinks>
@@ -879,6 +986,18 @@
       </categoryLinks>
     </entryLink>
     <entryLink id="c7fd-2e08-2272-d83f" name="Assault Squad" hidden="false" collective="false" import="true" targetId="a8e9-70e1-b8bc-8ee2" type="selectionEntry">
+      <modifiers>
+        <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <infoLinks>
         <infoLink id="468f-7e9d-716d-0ac7" name="Legiones Astartes (Alpha Legion) " hidden="false" targetId="2a9e-be1f-d6c1-0ec4" type="rule"/>
       </infoLinks>
@@ -889,6 +1008,18 @@
       </categoryLinks>
     </entryLink>
     <entryLink id="ba5e-59d7-8e8d-4b06" name="Breacher Squad" hidden="false" collective="false" import="true" targetId="ad97-c090-fa67-696f" type="selectionEntry">
+      <modifiers>
+        <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <infoLinks>
         <infoLink id="0b1f-3eed-1a8f-872c" name="Legiones Astartes (Alpha Legion) " hidden="false" targetId="2a9e-be1f-d6c1-0ec4" type="rule"/>
       </infoLinks>
@@ -1015,7 +1146,6 @@
       </infoLinks>
       <categoryLinks>
         <categoryLink id="465a-0540-9d96-9b21" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="813e-a907-e676-8a17" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="f188-747b-4d2b-bdd1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -1029,6 +1159,18 @@
       </categoryLinks>
     </entryLink>
     <entryLink id="01e8-be04-bdd2-6a50" name="Despoiler Squad" hidden="false" collective="false" import="true" targetId="4357-930e-165a-a6e3" type="selectionEntry">
+      <modifiers>
+        <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <infoLinks>
         <infoLink id="1968-da98-d100-a1f4" name="Legiones Astartes (Alpha Legion) " hidden="false" targetId="2a9e-be1f-d6c1-0ec4" type="rule"/>
       </infoLinks>
@@ -1053,7 +1195,7 @@
       </infoLinks>
       <categoryLinks>
         <categoryLink id="cef2-18eb-734e-6d0d" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="bf76-40ab-ae33-3ee0" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+        <categoryLink id="0010-2076-4f3e-165e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="f799-0fc7-f087-844e" name="Falchion" hidden="false" collective="false" import="true" targetId="1fe8-7386-9509-d2d8" type="selectionEntry">
@@ -1062,6 +1204,7 @@
       </infoLinks>
       <categoryLinks>
         <categoryLink id="2389-24f4-9d13-9a44" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="5503-3e99-e4b4-df79" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="3906-77b6-552a-adc4" name="Fellblade" hidden="false" collective="false" import="true" targetId="9c3c-f15a-9a1f-c0d0" type="selectionEntry">
@@ -1070,6 +1213,7 @@
       </infoLinks>
       <categoryLinks>
         <categoryLink id="565c-e27f-51f5-4b95" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="1914-e8b5-82ae-864b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="f4bf-f90d-88b7-0c56" name="Fire Raptor Gunship" hidden="false" collective="false" import="true" targetId="f6e1-24e2-fbdb-c5ef" type="selectionEntry">
@@ -1078,7 +1222,6 @@
       </infoLinks>
       <categoryLinks>
         <categoryLink id="25c3-58f6-2ac5-b0d2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="fcc3-ad61-2284-893a" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="6d2e-63c1-dd57-5d95" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
       </categoryLinks>
     </entryLink>
@@ -1088,6 +1231,7 @@
       </infoLinks>
       <categoryLinks>
         <categoryLink id="5406-c9ce-e2c9-a4d1" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="f030-3b2c-6218-0c72" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="c0f4-4dc2-9fdd-be0c" name="Heavy Support Squad" hidden="false" collective="false" import="true" targetId="bac9-5389-e2e7-0b1f" type="selectionEntry">
@@ -1168,6 +1312,7 @@
       </infoLinks>
       <categoryLinks>
         <categoryLink id="ba81-942b-bbf9-4f78" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="4d24-ccb8-1b76-b671" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="cbe2-ac9a-15e5-3fbc" name="Mortalis Destroyer Squad" hidden="false" collective="false" import="true" targetId="dbd4-930e-e003-9449" type="selectionEntry">
@@ -1204,6 +1349,7 @@
       <categoryLinks>
         <categoryLink id="d45f-0474-619c-5755" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="5d7e-a9d1-64bd-3af8" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
+        <categoryLink id="f5d0-5bc0-9608-900b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
       <entryLinks>
         <entryLink id="a14e-0eae-a869-3ba7" name="Retinue" hidden="false" collective="false" import="true" targetId="09f9-933c-a88e-6e38" type="selectionEntryGroup"/>
@@ -1266,6 +1412,13 @@
       </categoryLinks>
     </entryLink>
     <entryLink id="e447-df88-7247-6ef4" name="Reconnaissance Squad" hidden="false" collective="false" import="true" targetId="6db7-6e88-877e-35ca" type="selectionEntry">
+      <modifiers>
+        <modifier type="add" field="category" value="8f42-a824-fb5f-8fea">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <infoLinks>
         <infoLink id="26c8-0314-43f3-b070" name="Legiones Astartes (Alpha Legion) " hidden="false" targetId="2a9e-be1f-d6c1-0ec4" type="rule"/>
       </infoLinks>
@@ -1293,6 +1446,13 @@
       </categoryLinks>
     </entryLink>
     <entryLink id="d8cb-af69-e634-2557" name="Scout Squad" hidden="false" collective="false" import="true" targetId="9b10-b657-a65a-9d60" type="selectionEntry">
+      <modifiers>
+        <modifier type="add" field="category" value="8f42-a824-fb5f-8fea">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <infoLinks>
         <infoLink id="8163-f41a-4e99-cc59" name="Legiones Astartes (Alpha Legion) " hidden="false" targetId="2a9e-be1f-d6c1-0ec4" type="rule"/>
       </infoLinks>
@@ -1325,7 +1485,6 @@
       </infoLinks>
       <categoryLinks>
         <categoryLink id="237a-bba3-bee8-24ac" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="1424-fbf6-7d22-06a2" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="04cc-6610-9b41-bda9" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
       </categoryLinks>
     </entryLink>
@@ -1344,7 +1503,6 @@
       </infoLinks>
       <categoryLinks>
         <categoryLink id="cf26-daa7-1824-ee30" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="41c4-10ad-6b84-87d2" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="6e5b-2b5c-fb44-50f4" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
       </categoryLinks>
     </entryLink>
@@ -1372,6 +1530,7 @@
       </infoLinks>
       <categoryLinks>
         <categoryLink id="74eb-b246-f3f8-a5b5" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="c7bf-2362-70b8-7583" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="e713-408d-a46b-1944" name="Storm Eagle Gunship" hidden="false" collective="false" import="true" targetId="8aa5-ff31-7de7-19d4" type="selectionEntry">
@@ -1380,10 +1539,22 @@
       </infoLinks>
       <categoryLinks>
         <categoryLink id="900f-1539-5d72-2a13" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="e3a8-03e6-7372-ec7c" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+        <categoryLink id="9730-fda0-ef8c-8700" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="de2d-9a98-f9d0-8376" name="Tactical Squad" hidden="false" collective="false" import="true" targetId="aa72-63e4-bc60-4611" type="selectionEntry">
+      <modifiers>
+        <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <infoLinks>
         <infoLink id="72c4-65ad-3793-d9b3" name="Legiones Astartes (Alpha Legion) " hidden="false" targetId="2a9e-be1f-d6c1-0ec4" type="rule"/>
       </infoLinks>
@@ -1427,7 +1598,6 @@
       <categoryLinks>
         <categoryLink id="9a1a-b5ea-a356-1928" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="ca5e-2cb8-913e-76fb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="0cd5-4e44-90a6-74c5" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="a563-4ed7-87d2-1d4f" name="Thunderhawk Gunship" hidden="false" collective="false" import="true" targetId="8754-3a4f-213b-bdc0" type="selectionEntry">
@@ -1436,6 +1606,7 @@
       </infoLinks>
       <categoryLinks>
         <categoryLink id="3e96-2675-f739-a789" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="c4ba-fcb8-eba6-a607" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="90af-930f-182e-8518" name="Typhon Squadron" hidden="false" collective="false" import="true" targetId="d06a-3087-af13-ca95" type="selectionEntry">
@@ -1444,6 +1615,7 @@
       </infoLinks>
       <categoryLinks>
         <categoryLink id="b16d-4e2f-0edb-62fe" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="907b-8694-3c99-f1cb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="87a8-6884-e508-2395" name="Veteran Squad" hidden="false" collective="false" import="true" targetId="a423-7dd8-3f1b-3e28" type="selectionEntry">
@@ -1496,7 +1668,6 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="38ca-f056-7e0e-c830" name="Bombard Sub-type:" hidden="false" targetId="d5df-57ac-8f3c-097b" primary="false"/>
         <categoryLink id="8381-c5f9-8f07-4351" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
         <categoryLink id="c080-5197-cd1f-2bc1" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
       </categoryLinks>
@@ -1549,7 +1720,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="0541-6ca5-0619-0ed5" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="e6b9-b856-9e96-7966" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+        <categoryLink id="4129-8f1e-5ca4-31fb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="ba21-eab2-432a-2475" name="Legion Banehammer" hidden="true" collective="false" import="true" targetId="1240-c71c-3a60-cf20" type="selectionEntry">
@@ -1562,7 +1733,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="254f-c967-42b0-45ad" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="6522-fce0-cbc7-fb47" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+        <categoryLink id="d73e-276b-60b5-0787" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="b161-b776-8ce7-6245" name="Legion Macharius Heavy Tank Squadron" hidden="false" collective="false" import="true" targetId="36ed-ca59-0d95-d85c" type="selectionEntry">
@@ -1627,7 +1798,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="c62d-e194-4ecd-f184" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="4c46-a2a5-efa5-4b9e" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+        <categoryLink id="c4b6-a051-631e-785e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="603b-327b-e62d-67a6" name="Legion Stormlord" hidden="true" collective="false" import="true" targetId="0887-0f66-2c7e-a5ba" type="selectionEntry">
@@ -1640,7 +1811,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="5208-ba63-5fcd-d472" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="e78c-c306-f57d-b8b1" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+        <categoryLink id="6446-51bb-9f89-8e52" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="35aa-70ad-086e-39f0" name="Legion Stormsword" hidden="true" collective="false" import="true" targetId="8e67-8f84-730c-2778" type="selectionEntry">
@@ -1653,7 +1824,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="e4df-7194-e569-cc65" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="67d5-a9cc-9fe8-5ef4" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+        <categoryLink id="9b1a-4f40-03fe-2954" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="c5a2-61b9-4bcc-db25" name="Medusa Squadron" hidden="true" collective="false" import="true" targetId="24c8-5f6a-d48a-27b7" type="selectionEntry">
@@ -1665,9 +1836,8 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="56cd-a4fd-288a-bf74" name="Bombard Sub-type:" hidden="false" targetId="d5df-57ac-8f3c-097b" primary="false"/>
         <categoryLink id="942a-1229-6cb6-c01d" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="fd3e-8817-0b34-f91b" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
+        <categoryLink id="470c-9306-46e2-6c8b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="51bb-8682-066b-c838" name="Nathaniel Garro" hidden="false" collective="false" import="true" targetId="0583-258d-f0a0-2170" type="selectionEntry">
@@ -1718,7 +1888,6 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="b1e5-9c15-8a4f-7683" name="Artillery Sub-type:" hidden="false" targetId="6f99-c178-6f9d-fb63" primary="false"/>
         <categoryLink id="7d32-2e6b-d728-b40d" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
         <categoryLink id="68b9-cfa2-d75c-8c87" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
@@ -1734,7 +1903,6 @@
       <categoryLinks>
         <categoryLink id="f2f7-4c19-87c9-a916" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="94cb-c54d-d366-cc58" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="7659-1f98-4982-ca18" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="2e0a-2e35-22a8-b267" name="Thunderbolt Fighter" hidden="false" collective="false" import="true" targetId="5d24-1e9a-ad9d-95ca" type="selectionEntry">
@@ -1773,8 +1941,23 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="118c-b263-a228-d93d" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="e273-c1c0-9708-8ee6" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
-        <categoryLink id="7549-e22d-68a0-8185" name="Bombard Sub-type:" hidden="false" targetId="d5df-57ac-8f3c-097b" primary="false"/>
+        <categoryLink id="1061-00eb-1be3-3844" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="29b7-efb2-b00c-31b5" name="Seeker Squad" hidden="true" collective="false" import="false" targetId="58e6-f9cc-4c46-e258" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <infoLinks>
+        <infoLink id="c832-c1c8-6e9f-15b8" name="Legiones Astartes (Alpha Legion) " hidden="false" targetId="2a9e-be1f-d6c1-0ec4" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="9458-1032-5c85-0b99" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="3e95-ab10-bf35-f965" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
       </categoryLinks>
     </entryLink>
   </entryLinks>
@@ -1803,6 +1986,7 @@
       <categoryLinks>
         <categoryLink id="86bf-d7af-033d-7bc5" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="38f4-15f0-cef1-6eed" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+        <categoryLink id="d9d8-ed91-7e24-1a00" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="215d-b8b6-0c32-188b" name="Harrower" publicationId="09c5-eeae-f398-b653" page="338" hidden="false" collective="false" import="true" type="model">
@@ -2153,6 +2337,7 @@
       <categoryLinks>
         <categoryLink id="53f7-5d61-294f-9b80" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="bb2c-c74f-2106-5acc" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="f843-2674-b0ea-6b16" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="fc1f-0089-4c16-d538" name="The Instrument" publicationId="09c5-eeae-f398-b653" page="341" hidden="false" collective="false" import="true" type="upgrade">
@@ -2284,6 +2469,7 @@
       <categoryLinks>
         <categoryLink id="a10b-7811-b811-52e6" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="0374-00b9-d878-2d9b" name="Skirmish Sub-type:" hidden="false" targetId="59a4-7b61-600a-c457" primary="false"/>
+        <categoryLink id="924c-38c1-a729-0f0b" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="e0e7-2496-e912-61f5" name="Headhunter Prime" hidden="false" collective="false" import="true" type="upgrade">
@@ -2847,6 +3033,11 @@
           </modifiers>
         </infoLink>
       </infoLinks>
+      <categoryLinks>
+        <categoryLink id="0162-1ffa-9d07-6d83" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="abbd-7422-7468-daf9" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="8359-b586-6975-bb16" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
+      </categoryLinks>
       <selectionEntries>
         <selectionEntry id="86b8-39b0-0c18-216a" name="The Prince and the Prophet" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
@@ -2997,6 +3188,9 @@
         <infoLink id="c6e1-4a83-447d-e63d" name="Crusader" hidden="false" targetId="c705-0829-75f6-a785" type="rule"/>
         <infoLink id="f032-2a44-d3a9-a905" name="Legiones Astartes (Alpha Legion) " hidden="false" targetId="2a9e-be1f-d6c1-0ec4" type="rule"/>
       </infoLinks>
+      <categoryLinks>
+        <categoryLink id="f996-05bf-ded5-1995" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
+      </categoryLinks>
       <selectionEntries>
         <selectionEntry id="c60e-92ed-d696-b0b9" name="The Hydra&apos;s Spite" publicationId="09c5-eeae-f398-b653" page="337" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>

--- a/2022 - LA - Alpha Legion.cat
+++ b/2022 - LA - Alpha Legion.cat
@@ -3190,6 +3190,7 @@
       </infoLinks>
       <categoryLinks>
         <categoryLink id="f996-05bf-ded5-1995" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
+        <categoryLink id="3719-acf7-a932-2783" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="c60e-92ed-d696-b0b9" name="The Hydra&apos;s Spite" publicationId="09c5-eeae-f398-b653" page="337" hidden="false" collective="false" import="true" type="upgrade">

--- a/2022 - LA - Blood Angels.cat
+++ b/2022 - LA - Blood Angels.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="cd4d-8765-5387-8409" name="LA -  IX: Blood Angels" revision="20" battleScribeVersion="2.03" authorName="Jon K &quot;Alphalas&quot;" authorContact="Twitter: Alphalas_ Discord: Alphalas#8789" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="18" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="cd4d-8765-5387-8409" name="LA -  IX: Blood Angels" revision="21" battleScribeVersion="2.03" authorName="Jon K &quot;Alphalas&quot;" authorContact="Twitter: Alphalas_ Discord: Alphalas#8789" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="18" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entryLinks>
     <entryLink id="1900-3f09-f47b-bed2" name="Praetor" hidden="false" collective="false" import="false" targetId="03be-5d55-d05a-771d" type="selectionEntry">
       <infoLinks>
@@ -8,6 +8,7 @@
       <categoryLinks>
         <categoryLink id="7e95-886f-ed9d-3000" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="4180-caf6-d0dc-7347" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
+        <categoryLink id="6422-8dc7-7934-be6e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
       <entryLinks>
         <entryLink id="0493-4e5d-281f-d4f2" name="Retinue" hidden="false" collective="false" import="true" targetId="6307-ed53-0ac4-0212" type="selectionEntryGroup"/>
@@ -25,21 +26,25 @@
       <categoryLinks>
         <categoryLink id="9ebe-3513-9ab7-69db" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="3357-5e6d-c437-5295" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
+        <categoryLink id="8eb8-b5f6-a13e-e6a7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="201c-1876-1343-82bd" name="Contemptor-Incaendius Dreadnought" hidden="false" collective="false" import="false" targetId="090c-5656-0180-16c8" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="f0c3-dea6-a3b3-8814" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="94a0-f009-d095-0a13" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="c1af-e2cc-99eb-9c5b" name="Crimson Paladins" hidden="false" collective="false" import="false" targetId="33fe-9683-bde5-95ca" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="b2fb-57e6-76d1-b70e" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="99ad-3f89-2b00-ceea" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="f425-f617-0a7a-ce2b" name="Dawnbreaker Cohort" hidden="false" collective="false" import="false" targetId="3c67-35da-d64a-f22b" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="2138-4038-c520-9323" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="06d6-2550-bdf0-d9fd" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="6593-806e-c67a-1797" name="Dominion Zephon" hidden="false" collective="false" import="false" targetId="98d4-555a-6911-7c1a" type="selectionEntry">
@@ -53,6 +58,7 @@
       <categoryLinks>
         <categoryLink id="66b1-54b1-9b38-8d89" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="805e-3ba0-5df2-fb4d" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
+        <categoryLink id="4cf4-9b23-0677-86f5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="8a1e-4de2-5a75-956f" name="Judicar Aster Crohne" hidden="false" collective="false" import="false" targetId="8dba-83cd-4922-bc63" type="selectionEntry">
@@ -71,9 +77,10 @@
       <categoryLinks>
         <categoryLink id="fc0b-2d5b-6e2b-a661" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="18df-f052-5edd-948c" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
+        <categoryLink id="50a0-d65b-9aed-4040" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="6c34-54c1-2c55-e6dc" name="Sanguinius" hidden="false" collective="false" import="false" targetId="2c54-82c1-c1e4-3aee" type="selectionEntry">
+    <entryLink id="6c34-54c1-2c55-e6dc" name="Sanguinius (PLACEHOLDER)" hidden="false" collective="false" import="false" targetId="2c54-82c1-c1e4-3aee" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
@@ -83,11 +90,13 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="9dac-939c-1711-76ba" name="New CategoryLink" hidden="false" targetId="ad5f-31db-8bc7-5c46" primary="true"/>
+        <categoryLink id="b565-cac7-63e5-fb44" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="d781-5311-119f-a8e2" name="The Angel&apos;s Tears" hidden="false" collective="false" import="false" targetId="dda1-0fcf-0245-6c10" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="bd40-3a9c-fc64-acc2" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="f2df-62ef-c931-765a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="41ff-7a92-f8e9-0631" name="  IX: Blood Angels" hidden="false" collective="false" import="false" targetId="296e-301e-3ce1-1c15" type="selectionEntry">
@@ -118,6 +127,18 @@
       </categoryLinks>
     </entryLink>
     <entryLink id="1b28-4298-99cc-0ca7" name="Assault Squad" hidden="false" collective="false" import="false" targetId="a8e9-70e1-b8bc-8ee2" type="selectionEntry">
+      <modifiers>
+        <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <infoLinks>
         <infoLink id="ac37-d988-8cf2-97c7" name="Legiones Astartes (Blood Angels) " hidden="false" targetId="b0d1-ccab-8708-500f" type="rule"/>
       </infoLinks>
@@ -128,6 +149,18 @@
       </categoryLinks>
     </entryLink>
     <entryLink id="67a5-c32f-598e-5dd6" name="Breacher Squad" hidden="false" collective="false" import="false" targetId="ad97-c090-fa67-696f" type="selectionEntry">
+      <modifiers>
+        <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <infoLinks>
         <infoLink id="ec06-3f39-1691-76a9" name="Legiones Astartes (Blood Angels) " hidden="false" targetId="b0d1-ccab-8708-500f" type="rule"/>
       </infoLinks>
@@ -227,7 +260,6 @@
       </infoLinks>
       <categoryLinks>
         <categoryLink id="5f44-f33b-db1e-5ebd" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="2d75-af91-0fcb-c0d4" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="b559-18f7-4a13-234a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -241,6 +273,18 @@
       </categoryLinks>
     </entryLink>
     <entryLink id="9c32-38e5-c57f-baf8" name="Despoiler Squad" hidden="false" collective="false" import="false" targetId="4357-930e-165a-a6e3" type="selectionEntry">
+      <modifiers>
+        <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <infoLinks>
         <infoLink id="a2df-5b85-7f0b-aeef" name="Legiones Astartes (Blood Angels) " hidden="false" targetId="b0d1-ccab-8708-500f" type="rule"/>
       </infoLinks>
@@ -265,7 +309,7 @@
       </infoLinks>
       <categoryLinks>
         <categoryLink id="405e-623e-e5f6-2e54" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="e9cd-c1cf-8412-b289" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+        <categoryLink id="8ec3-ff6b-9c00-3dbf" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="58cf-9f01-9289-7af6" name="Falchion" hidden="false" collective="false" import="false" targetId="1fe8-7386-9509-d2d8" type="selectionEntry">
@@ -274,6 +318,7 @@
       </infoLinks>
       <categoryLinks>
         <categoryLink id="c418-712f-cb83-6081" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="6a07-32b8-f6b3-4081" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="1aa1-77c1-ba59-e7a5" name="Fellblade" hidden="false" collective="false" import="false" targetId="9c3c-f15a-9a1f-c0d0" type="selectionEntry">
@@ -282,6 +327,7 @@
       </infoLinks>
       <categoryLinks>
         <categoryLink id="e57f-8fdf-b790-5b9b" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="8e2d-c855-646b-2848" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="738b-6376-1b98-5956" name="Fire Raptor Gunship" hidden="false" collective="false" import="false" targetId="f6e1-24e2-fbdb-c5ef" type="selectionEntry">
@@ -290,7 +336,6 @@
       </infoLinks>
       <categoryLinks>
         <categoryLink id="f951-f918-a1ac-dc74" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="dadb-fb80-03ff-9d5a" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="06b9-5ea1-1f78-1049" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
       </categoryLinks>
     </entryLink>
@@ -300,6 +345,7 @@
       </infoLinks>
       <categoryLinks>
         <categoryLink id="b108-7524-fe41-5c36" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="77b3-59ff-faed-23e9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="e969-bad1-eb73-d543" name="Heavy Support Squad" hidden="false" collective="false" import="false" targetId="bac9-5389-e2e7-0b1f" type="selectionEntry">
@@ -380,6 +426,7 @@
       </infoLinks>
       <categoryLinks>
         <categoryLink id="d93a-3e12-f0ae-b242" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="77f6-c777-0825-3e90" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="b8e9-4e46-d433-1722" name="Mortalis Destroyer Squad" hidden="false" collective="false" import="false" targetId="dbd4-930e-e003-9449" type="selectionEntry">
@@ -465,6 +512,13 @@
       </categoryLinks>
     </entryLink>
     <entryLink id="cef7-8b15-720f-e55d" name="Reconnaissance Squad" hidden="false" collective="false" import="false" targetId="6db7-6e88-877e-35ca" type="selectionEntry">
+      <modifiers>
+        <modifier type="add" field="category" value="8f42-a824-fb5f-8fea">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <infoLinks>
         <infoLink id="5fe0-e759-0488-8cca" name="Legiones Astartes (Blood Angels) " hidden="false" targetId="b0d1-ccab-8708-500f" type="rule"/>
       </infoLinks>
@@ -492,6 +546,13 @@
       </categoryLinks>
     </entryLink>
     <entryLink id="d885-c84a-004e-1434" name="Scout Squad" hidden="false" collective="false" import="false" targetId="9b10-b657-a65a-9d60" type="selectionEntry">
+      <modifiers>
+        <modifier type="add" field="category" value="8f42-a824-fb5f-8fea">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <infoLinks>
         <infoLink id="0359-d754-640f-7d24" name="Legiones Astartes (Blood Angels) " hidden="false" targetId="b0d1-ccab-8708-500f" type="rule"/>
       </infoLinks>
@@ -524,7 +585,6 @@
       </infoLinks>
       <categoryLinks>
         <categoryLink id="bbe9-ebf7-c4e6-3bb4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="9a6c-c58e-47c1-c407" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="ffef-47f1-e988-cbc3" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
       </categoryLinks>
     </entryLink>
@@ -543,7 +603,6 @@
       </infoLinks>
       <categoryLinks>
         <categoryLink id="0e58-2594-6fd2-9fae" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="5b57-7cdc-77e2-7de5" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="2ad4-a091-c130-7799" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
       </categoryLinks>
     </entryLink>
@@ -571,6 +630,7 @@
       </infoLinks>
       <categoryLinks>
         <categoryLink id="ccf0-4bc5-277b-e5d8" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="6c34-cc3f-dd1b-1da1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="a430-f532-d7d8-276a" name="Spatha Attack Bike Squadron" hidden="false" collective="false" import="false" targetId="4d72-1cc1-8bee-aa88" type="selectionEntry">
@@ -595,10 +655,22 @@
       </infoLinks>
       <categoryLinks>
         <categoryLink id="cd4e-563c-c3d0-976d" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="22f1-21b2-59c8-c723" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+        <categoryLink id="57f6-7d87-301a-d4ed" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="beb7-833b-89c7-4aab" name="Tactical Squad" hidden="false" collective="false" import="false" targetId="aa72-63e4-bc60-4611" type="selectionEntry">
+      <modifiers>
+        <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <infoLinks>
         <infoLink id="1eed-78fe-5ff2-2dda" name="Legiones Astartes (Blood Angels) " hidden="false" targetId="b0d1-ccab-8708-500f" type="rule"/>
       </infoLinks>
@@ -642,7 +714,6 @@
       <categoryLinks>
         <categoryLink id="fc24-2561-23c0-9059" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="0cdb-7ad9-7fdb-bf27" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="ad76-8e01-5adb-4e22" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="7a5f-a4fb-fd86-4bea" name="Thunderhawk Gunship" hidden="false" collective="false" import="false" targetId="8754-3a4f-213b-bdc0" type="selectionEntry">
@@ -651,6 +722,7 @@
       </infoLinks>
       <categoryLinks>
         <categoryLink id="3f74-b023-3ed2-c979" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="0ee4-bda5-11cb-aa51" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="a96a-a2dc-9779-a11b" name="Typhon Squadron" hidden="false" collective="false" import="false" targetId="d06a-3087-af13-ca95" type="selectionEntry">
@@ -659,6 +731,7 @@
       </infoLinks>
       <categoryLinks>
         <categoryLink id="1546-6bfb-093e-b8b6" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="fde9-03d1-3c38-f038" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="d423-6885-77d4-a9e8" name="Veteran Squad" hidden="false" collective="false" import="false" targetId="a423-7dd8-3f1b-3e28" type="selectionEntry">
@@ -727,9 +800,8 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="8422-016a-fa93-d755" name="Bombard Sub-type:" hidden="false" targetId="d5df-57ac-8f3c-097b" primary="false"/>
         <categoryLink id="7454-91f1-ef94-7a1c" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="bcbf-f02e-f688-b374" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
+        <categoryLink id="f525-25a7-b7df-8d89" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="6345-583c-e6eb-e61a" name="Caestus Assault Ram" hidden="false" collective="false" import="false" targetId="67b6-3d17-3b16-a94d" type="selectionEntry">
@@ -780,7 +852,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="594e-df51-101c-4496" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="c556-4bf0-e752-e51b" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+        <categoryLink id="994b-0f52-09e3-7ab5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="28bf-e158-9205-494d" name="Legion Banehammer" hidden="true" collective="false" import="false" targetId="1240-c71c-3a60-cf20" type="selectionEntry">
@@ -793,7 +865,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="b643-60a0-36e6-66de" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="280f-f96d-28e5-4455" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+        <categoryLink id="8496-e2df-38b1-0780" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="8031-0852-bdc2-5b72" name="Legion Macharius Heavy Tank Squadron" hidden="false" collective="false" import="false" targetId="36ed-ca59-0d95-d85c" type="selectionEntry">
@@ -858,7 +930,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="d3a9-19d9-3bdb-2f60" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="e9f6-5bb1-e2fc-12e3" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+        <categoryLink id="09f7-0027-87d6-9265" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="0522-a1a3-a74c-bcb8" name="Legion Stormlord" hidden="true" collective="false" import="false" targetId="0887-0f66-2c7e-a5ba" type="selectionEntry">
@@ -871,7 +943,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="3c3b-639a-bf12-417d" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="8de7-ca4d-15ec-217d" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+        <categoryLink id="3d66-84b4-6a2f-7e29" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="c496-acde-83ad-3224" name="Legion Stormsword" hidden="true" collective="false" import="false" targetId="8e67-8f84-730c-2778" type="selectionEntry">
@@ -884,7 +956,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="0280-378c-022d-4f16" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="34ce-f708-fd31-c90d" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+        <categoryLink id="99c6-4d38-c321-2686" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="8ed8-4298-c820-c3ad" name="Medusa Squadron" hidden="true" collective="false" import="false" targetId="24c8-5f6a-d48a-27b7" type="selectionEntry">
@@ -896,7 +968,6 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="07cb-3927-e326-ff12" name="Bombard Sub-type:" hidden="false" targetId="d5df-57ac-8f3c-097b" primary="false"/>
         <categoryLink id="19f0-b993-32a3-16b3" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
         <categoryLink id="2be3-a0a9-72a5-1330" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
       </categoryLinks>
@@ -936,7 +1007,6 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="c675-2e9b-6dfb-2b0e" name="Artillery Sub-type:" hidden="false" targetId="6f99-c178-6f9d-fb63" primary="false"/>
         <categoryLink id="55e2-34c8-cda4-cd62" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
         <categoryLink id="50f4-97e6-6ce1-5168" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
@@ -952,7 +1022,6 @@
       <categoryLinks>
         <categoryLink id="f8ea-d6f4-97c5-f7d0" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="009a-c793-7a3f-f754" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="9dc3-07ad-e293-92ba" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="fb54-b05d-5f33-db94" name="Thunderbolt Fighter" hidden="false" collective="false" import="false" targetId="5d24-1e9a-ad9d-95ca" type="selectionEntry">
@@ -992,7 +1061,22 @@
       <categoryLinks>
         <categoryLink id="3d34-2949-190c-ef3a" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
         <categoryLink id="9990-9b4f-df96-71b1" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
-        <categoryLink id="681b-253e-6ba3-bfb0" name="Bombard Sub-type:" hidden="false" targetId="d5df-57ac-8f3c-097b" primary="false"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="c2aa-0d69-c2d0-2edd" name="Seeker Squad" hidden="true" collective="false" import="false" targetId="58e6-f9cc-4c46-e258" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <infoLinks>
+        <infoLink id="12f5-1878-2199-7a2a" name="Legiones Astartes (Blood Angels) " hidden="false" targetId="b0d1-ccab-8708-500f" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="5b34-686b-1a34-09a0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="13fd-081f-8aff-ec40" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
       </categoryLinks>
     </entryLink>
   </entryLinks>
@@ -1243,7 +1327,6 @@ Sanguinius may still Run on a turn when his wings have been activated. When maki
       <categoryLinks>
         <categoryLink id="21ac-518e-b688-7692" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="5bf7-7060-f4e9-3862" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
-        <categoryLink id="4987-c258-3ee9-7079" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="38d1-09b6-7e6d-9833" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
       </categoryLinks>
       <selectionEntries>
@@ -1565,7 +1648,6 @@ Sanguinius may still Run on a turn when his wings have been activated. When maki
       <categoryLinks>
         <categoryLink id="22af-8bdb-ac49-af08" name="Dreadnought Unit-type:" hidden="false" targetId="4280-4963-02b5-e31d" primary="false"/>
         <categoryLink id="8f2a-d33d-1b36-8cb0" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="54cd-45a1-895c-e9a0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="862e-307d-4c73-4992" name="Incaedius booster pack" hidden="false" collective="false" import="true" type="upgrade">
@@ -2134,6 +2216,7 @@ Those models also gain the Feel No Pain (5+) special rule when locked in combat 
         <categoryLink id="31ae-7034-a2db-dc40" name="Independant Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
         <categoryLink id="feba-d345-0dbc-faa9" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="8059-18d2-a192-f6bd" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="9f7b-e6db-ff1f-ad62" name="Jump Infantry:" hidden="false" targetId="eee8-3c7c-2762-e33e" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="cae6-5863-3f61-2a37" name="Lament and Grief (PLACEHOLDER)" hidden="false" collective="false" import="true" type="upgrade">
@@ -2282,6 +2365,7 @@ Those models also gain the Feel No Pain (5+) special rule when locked in combat 
             <categoryLink id="c36e-bb39-8df0-74e2" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
             <categoryLink id="b4d7-4ed5-a971-32a5" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
             <categoryLink id="191b-abdd-c10c-0657" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
+            <categoryLink id="3f8c-7a78-380b-d895" name="Jump Infantry:" hidden="false" targetId="eee8-3c7c-2762-e33e" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="cc0f-26fa-472e-ae51" name="The Arch-Erelim may exchange their chainsword for:" hidden="false" collective="false" import="true" defaultSelectionEntryId="01b2-db36-8e0b-cd59">
@@ -2638,7 +2722,7 @@ Those models also gain the Feel No Pain (5+) special rule when locked in combat 
       <categoryLinks>
         <categoryLink id="ea81-014b-635d-47bb" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="8925-58cb-6e34-0c0c" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="fe06-2eba-9dca-6733" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="680f-d029-6ed2-3bf6" name="Jump Infantry:" hidden="false" targetId="eee8-3c7c-2762-e33e" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="e958-de95-0a5b-de1f" name="Dawnbreaker Champion" hidden="false" collective="false" import="true" type="model">

--- a/2022 - LA - Dark Angels.cat
+++ b/2022 - LA - Dark Angels.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="ee5e-198e-1b19-4b9f" name="LA -   I: Dark Angels" revision="10" battleScribeVersion="2.03" authorName="revivedtitan" authorContact="BSData Developers Discord" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="17" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="ee5e-198e-1b19-4b9f" name="LA -   I: Dark Angels" revision="12" battleScribeVersion="2.03" authorName="revivedtitan" authorContact="BSData Developers Discord" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="18" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entryLinks>
     <entryLink id="7653-8041-8d1c-c872" name="Dreadwing Interemptor Squad" hidden="false" collective="false" import="false" targetId="3008-e8ed-9e97-71c9" type="selectionEntry">
       <categoryLinks>
@@ -164,6 +164,28 @@
       </categoryLinks>
     </entryLink>
     <entryLink id="db79-8bda-3f20-3087" name="Assault Squad" hidden="false" collective="false" import="false" targetId="a8e9-70e1-b8bc-8ee2" type="selectionEntry">
+      <modifiers>
+        <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+        <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <infoLinks>
         <infoLink id="665c-c1a4-6e87-710e" name="Legiones Astartes (Dark Angels)" hidden="false" targetId="513e-0647-996a-6229" type="rule"/>
       </infoLinks>
@@ -174,6 +196,28 @@
       </categoryLinks>
     </entryLink>
     <entryLink id="39db-3517-48bb-514a" name="Breacher Squad" hidden="false" collective="false" import="false" targetId="ad97-c090-fa67-696f" type="selectionEntry">
+      <modifiers>
+        <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+        <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <infoLinks>
         <infoLink id="749f-807b-966e-dbb0" name="Legiones Astartes (Dark Angels)" hidden="false" targetId="513e-0647-996a-6229" type="rule"/>
       </infoLinks>
@@ -330,7 +374,6 @@
       </infoLinks>
       <categoryLinks>
         <categoryLink id="a979-6641-5f2b-8cfc" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="12cc-21a0-97df-d006" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="e162-0d4b-7615-902f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -344,6 +387,28 @@
       </categoryLinks>
     </entryLink>
     <entryLink id="add1-33dc-1d02-c0d6" name="Despoiler Squad" hidden="false" collective="false" import="false" targetId="4357-930e-165a-a6e3" type="selectionEntry">
+      <modifiers>
+        <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+        <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <infoLinks>
         <infoLink id="89f2-2a16-c748-4312" name="Legiones Astartes (Dark Angels)" hidden="false" targetId="513e-0647-996a-6229" type="rule"/>
       </infoLinks>
@@ -368,7 +433,7 @@
       </infoLinks>
       <categoryLinks>
         <categoryLink id="2b26-3803-a23a-87d0" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="82fa-7a3b-a671-7329" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+        <categoryLink id="5442-09cb-6083-fc96" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="b7a0-fedc-e0a4-7a45" name="Falchion" hidden="false" collective="false" import="false" targetId="1fe8-7386-9509-d2d8" type="selectionEntry">
@@ -377,6 +442,7 @@
       </infoLinks>
       <categoryLinks>
         <categoryLink id="4e04-baff-3d25-4703" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="b2f0-3641-09a8-fa69" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="7922-2c4d-b936-b55b" name="Fellblade" hidden="false" collective="false" import="false" targetId="9c3c-f15a-9a1f-c0d0" type="selectionEntry">
@@ -385,6 +451,7 @@
       </infoLinks>
       <categoryLinks>
         <categoryLink id="3950-15b1-cc51-437d" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="e6c6-43e5-6c90-5f0b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="34a3-a9a9-d139-a0e9" name="Fire Raptor Gunship" hidden="false" collective="false" import="false" targetId="f6e1-24e2-fbdb-c5ef" type="selectionEntry">
@@ -393,7 +460,6 @@
       </infoLinks>
       <categoryLinks>
         <categoryLink id="220e-c996-8040-c965" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="ae13-ecf5-49f2-f085" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="f9c7-ecfb-5110-387f" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
       </categoryLinks>
     </entryLink>
@@ -403,6 +469,7 @@
       </infoLinks>
       <categoryLinks>
         <categoryLink id="d081-da98-04e1-afc0" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="cf0c-1f34-8c79-4d59" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="9f14-6ec4-3e9b-3812" name="Heavy Support Squad" hidden="false" collective="false" import="false" targetId="bac9-5389-e2e7-0b1f" type="selectionEntry">
@@ -492,6 +559,7 @@
       </infoLinks>
       <categoryLinks>
         <categoryLink id="0240-a7e6-50a5-8f7d" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="108b-aacd-baf5-6594" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="7150-94b2-a5fd-ecc8" name="Mortalis Destroyer Squad" hidden="false" collective="false" import="false" targetId="dbd4-930e-e003-9449" type="selectionEntry">
@@ -528,6 +596,7 @@
       <categoryLinks>
         <categoryLink id="fb23-8b6b-0611-ed86" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="eb5d-715f-63b5-af5e" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
+        <categoryLink id="5c7e-a83d-2108-1c5e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
       <entryLinks>
         <entryLink id="d4ac-24af-d933-2f2c" name="Retinue" hidden="false" collective="false" import="true" targetId="66e9-e8f8-5eb6-1cf6" type="selectionEntryGroup"/>
@@ -590,6 +659,13 @@
       </categoryLinks>
     </entryLink>
     <entryLink id="364f-8f20-ff7c-1755" name="Reconnaissance Squad" hidden="false" collective="false" import="false" targetId="6db7-6e88-877e-35ca" type="selectionEntry">
+      <modifiers>
+        <modifier type="add" field="category" value="8f42-a824-fb5f-8fea">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <infoLinks>
         <infoLink id="7701-0404-5ea8-905f" name="Legiones Astartes (Dark Angels)" hidden="false" targetId="513e-0647-996a-6229" type="rule"/>
       </infoLinks>
@@ -617,6 +693,13 @@
       </categoryLinks>
     </entryLink>
     <entryLink id="9f04-cc5c-38b2-5ccc" name="Scout Squad" hidden="false" collective="false" import="false" targetId="9b10-b657-a65a-9d60" type="selectionEntry">
+      <modifiers>
+        <modifier type="add" field="category" value="8f42-a824-fb5f-8fea">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <infoLinks>
         <infoLink id="f004-9af4-39f4-575f" name="Legiones Astartes (Dark Angels)" hidden="false" targetId="513e-0647-996a-6229" type="rule"/>
       </infoLinks>
@@ -649,7 +732,6 @@
       </infoLinks>
       <categoryLinks>
         <categoryLink id="f7fd-029d-98de-8d09" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="a0a1-e1f6-0857-abb9" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="4b7f-6969-0c0d-dab1" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
       </categoryLinks>
     </entryLink>
@@ -668,7 +750,6 @@
       </infoLinks>
       <categoryLinks>
         <categoryLink id="e4c8-a63c-9b21-d3c2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="b68a-79dc-9f1d-79c2" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="0243-9ea0-53a6-8c37" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
       </categoryLinks>
     </entryLink>
@@ -696,6 +777,7 @@
       </infoLinks>
       <categoryLinks>
         <categoryLink id="db9b-9ea5-b949-851d" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="3b6d-2eb9-4ecc-17ba" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="0f6b-7f4f-71ff-c667" name="Spatha Attack Bike Squadron" hidden="false" collective="false" import="false" targetId="4d72-1cc1-8bee-aa88" type="selectionEntry">
@@ -720,10 +802,32 @@
       </infoLinks>
       <categoryLinks>
         <categoryLink id="c9f3-ba68-aba9-9632" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="df7f-5cea-220c-41ea" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+        <categoryLink id="f362-c81c-0949-cd49" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="9fb0-76df-cdd9-ff22" name="Tactical Squad" hidden="false" collective="false" import="false" targetId="aa72-63e4-bc60-4611" type="selectionEntry">
+      <modifiers>
+        <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+        <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <infoLinks>
         <infoLink id="611c-bbaa-1f97-db57" name="Legiones Astartes (Dark Angels)" hidden="false" targetId="513e-0647-996a-6229" type="rule"/>
       </infoLinks>
@@ -767,7 +871,6 @@
       <categoryLinks>
         <categoryLink id="203c-456b-22b5-c12f" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="2f3b-bb86-38b1-732b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="7b5b-1747-6e7a-5360" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="1431-cf29-f3a6-9a24" name="Terminator Tartaros Squad" hidden="false" collective="false" import="false" targetId="1a8e-0ded-a4dc-2b4e" type="selectionEntry">
@@ -777,7 +880,6 @@
       <categoryLinks>
         <categoryLink id="b955-1f0b-01c0-2e69" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="29d6-efb7-4f96-7083" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="bb2e-f61f-9019-388a" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="182d-f4ed-5866-691d" name="Thunderhawk Gunship" hidden="false" collective="false" import="false" targetId="8754-3a4f-213b-bdc0" type="selectionEntry">
@@ -786,6 +888,7 @@
       </infoLinks>
       <categoryLinks>
         <categoryLink id="a6fe-90d6-4d99-f75b" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="2ee3-ef14-7158-09e2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="1987-c23d-e533-d50c" name="Typhon Squadron" hidden="false" collective="false" import="false" targetId="d06a-3087-af13-ca95" type="selectionEntry">
@@ -794,6 +897,7 @@
       </infoLinks>
       <categoryLinks>
         <categoryLink id="7c4f-41f5-015f-9d08" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="b574-8088-0962-d845" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="a6bc-c982-26bf-7caf" name="Veteran Squad" hidden="false" collective="false" import="false" targetId="a423-7dd8-3f1b-3e28" type="selectionEntry">
@@ -824,6 +928,22 @@
         <categoryLink id="a8e5-a7dd-01fc-e2e6" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
       </categoryLinks>
     </entryLink>
+    <entryLink id="5f4f-a0b7-1ea3-a1cf" name="Seeker Squad" hidden="true" collective="false" import="false" targetId="58e6-f9cc-4c46-e258" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <infoLinks>
+        <infoLink id="7c67-f9c4-207f-3ebf" name="Legiones Astartes (Dark Angels)" hidden="false" targetId="513e-0647-996a-6229" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="d8ac-ff1f-014d-5042" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="9382-ceeb-671a-8173" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+      </categoryLinks>
+    </entryLink>
   </entryLinks>
   <sharedSelectionEntries>
     <selectionEntry id="4097-b2b4-d9da-da99" name="Corswain" hidden="false" collective="false" import="true" type="unit">
@@ -832,6 +952,8 @@
       </constraints>
       <categoryLinks>
         <categoryLink id="dada-97ba-b9da-7a55" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="e21c-e91f-1504-340b" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
+        <categoryLink id="4c67-e0ac-3d2b-391a" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="0fec-c66f-9639-612f" name="Corswain" hidden="false" collective="false" import="true" type="model">
@@ -1266,6 +1388,7 @@
       <categoryLinks>
         <categoryLink id="6efd-8f1a-fc43-564f" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="41dc-2f36-d265-13b9" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+        <categoryLink id="4a74-0b7b-e4f1-ac5d" name="Cybertheurgist" hidden="false" targetId="57a1-ae47-ff1b-36e4" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="f512-ae27-71ee-88f1" name="4) Dedicated Transport:" hidden="false" collective="false" import="true">
@@ -1462,6 +1585,7 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d111-f381-1b07-a587" type="max"/>
           </constraints>
         </entryLink>
+        <entryLink id="42cc-cf88-b137-d2de" name="Animatus Excindor (Cybertheurgic Weapon)" hidden="false" collective="false" import="true" targetId="caa2-99d2-b7a0-21b7" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="350.0"/>
@@ -1751,6 +1875,7 @@ Selenite Shard-bolt Pistol</description>
       <categoryLinks>
         <categoryLink id="3a4b-b4f9-aeeb-da68" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="8c89-c8a4-6609-6878" name="Jump Infantry:" hidden="false" targetId="eee8-3c7c-2762-e33e" primary="false"/>
+        <categoryLink id="1edd-14b2-f178-4fba" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="9549-9717-b59c-3f41" name="Firewing Enigmatii" publicationId="817a-6288-e016-7469" page="52" hidden="false" collective="false" import="true" type="model">
@@ -1926,6 +2051,7 @@ Selenite Shard-bolt Pistol</description>
         <categoryLink id="ef49-f8a7-3bda-0fba" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
         <categoryLink id="2dec-96ad-9237-42f0" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="21de-4e57-9f08-b389" name="Terminators:" hidden="false" targetId="bab3-f50d-3e5f-2f78" primary="false"/>
+        <categoryLink id="4708-b98d-9e99-73eb" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="902d-a2c3-bd20-dbf1" name="Holguin" publicationId="d0df-7166-5cd3-89fd" page="47" hidden="false" collective="false" import="true" type="model">
@@ -2738,6 +2864,9 @@ special rule.</description>
       <categoryLinks>
         <categoryLink id="2601-e1ee-e7fc-4791" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="ee1c-afee-f2c8-3259" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="7596-3e24-f641-1552" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
+        <categoryLink id="2687-f1d9-6b82-5dc4" name="Terminators:" hidden="false" targetId="bab3-f50d-3e5f-2f78" primary="false"/>
+        <categoryLink id="ffb0-fffb-d657-d8f2" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="3f28-07ff-77b7-bd25" name="Regalia of the Shattered Sceptre" hidden="false" collective="false" import="true" type="upgrade">
@@ -2863,6 +2992,13 @@ special rule.</description>
       </costs>
     </selectionEntry>
     <selectionEntry id="a9b5-ef4c-31db-4104" name="Deathwing Companion Detachment" publicationId="817a-6288-e016-7469" page="164" hidden="true" collective="false" import="true" type="unit">
+      <modifiers>
+        <modifier type="add" field="category" value="eee8-3c7c-2762-e33e">
+          <conditions>
+            <condition field="selections" scope="a9b5-ef4c-31db-4104" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a298-8584-70ed-18ce" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <rules>
         <rule id="a2d3-7903-d187-909f" name="Deathwing Retinue" publicationId="817a-6288-e016-7469" page="165" hidden="true">
           <description>A Deathwing Companion Detachment my only be selected as part of a Detachment that includes at least one model with both the Master of the Legion and the Legiones Astartes (Dark Angels) special rules. A unit selected in this manner is considered a &apos;Retinue Squad&apos; and the model with both the Master of the Legion and Legiones Astartes (Dark Angels) special rules is reffered to as the Retinue Squad&apos;s Leader for the purposes of this special rule (if the Detachment includes more than one eligible Leader then the controlling player selects one as the unit&apos;s Leader). The Retinue squad does not use up a Force Organization slot and is considered part of the same unit as the model selected as its Leader. The Retinue Squad must be deployed with the model selected as its Leader deployed as part of the unit and the Leader may not voluntarily leave the Retinue Squad during play. A Deathwing Companion Detachment may not be selected as part of an army without a Leader.</description>
@@ -3486,6 +3622,7 @@ Legion and Legiones Astartes (Dark Angels) special rules is referred to as the r
       <categoryLinks>
         <categoryLink id="1685-35af-8fdd-ad14" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="f047-d090-eb49-7696" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="1489-93f7-05f0-75c3" name="Terminators:" hidden="false" targetId="bab3-f50d-3e5f-2f78" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="bf35-1f7a-dba1-a5a1" name="Deathwing Tartaros Companion" publicationId="d0df-7166-5cd3-89fd" page="48" hidden="false" collective="false" import="true" type="model">

--- a/2022 - LA - Dark Angels.cat
+++ b/2022 - LA - Dark Angels.cat
@@ -2607,6 +2607,7 @@ special rule.</description>
       </constraints>
       <categoryLinks>
         <categoryLink id="1159-e4ba-1ed9-3218" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="f149-e20a-bc3b-9a43" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="ea6d-8560-75cc-fbca" name="Lion El&apos;Jonson" hidden="false" collective="false" import="true" type="model">
@@ -3037,6 +3038,9 @@ special rule.</description>
               </characteristics>
             </profile>
           </profiles>
+          <categoryLinks>
+            <categoryLink id="5386-ddf5-eca5-316a" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
+          </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="3bc5-2913-e35c-5675" name="May exchange its Calibanite warblade for:" hidden="false" collective="false" import="true" defaultSelectionEntryId="2b2c-26e0-deb2-9d9b">
               <constraints>
@@ -3360,8 +3364,7 @@ special rule.</description>
             </profile>
           </profiles>
           <categoryLinks>
-            <categoryLink id="4d09-a6f6-8547-54d1" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
-            <categoryLink id="9cd7-8d3d-c80a-a37a" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+            <categoryLink id="0fd9-666f-e9e3-f3ca" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="9f78-55c5-f254-bc7f" name="May take a:" hidden="false" collective="false" import="true">
@@ -3485,10 +3488,6 @@ special rule.</description>
               </characteristics>
             </profile>
           </profiles>
-          <categoryLinks>
-            <categoryLink id="3711-7295-f46d-ba99" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
-            <categoryLink id="249e-9be6-5115-ee2e" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-          </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="bbe6-3947-266e-94e0" name="2) May exchange his combi-bolter for:" hidden="false" collective="false" import="true" defaultSelectionEntryId="3c0c-f416-4292-e257">
               <modifiers>
@@ -3743,7 +3742,7 @@ Legion and Legiones Astartes (Dark Angels) special rules is referred to as the r
           <profiles>
             <profile id="5ca6-3723-6f32-af59" name="Deathwing Tartaros Oathbearer" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
               <characteristics>
-                <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Heavy, Character, Deathwing)</characteristic>
+                <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Character, Deathwing)</characteristic>
                 <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
                 <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">5</characteristic>
                 <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
@@ -3757,6 +3756,9 @@ Legion and Legiones Astartes (Dark Angels) special rules is referred to as the r
               </characteristics>
             </profile>
           </profiles>
+          <categoryLinks>
+            <categoryLink id="78d1-af37-64f4-55f6" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
+          </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="240b-051a-8626-4d01" name="May take a:" hidden="false" collective="false" import="true">
               <entryLinks>

--- a/2022 - LA - Death Guard.cat
+++ b/2022 - LA - Death Guard.cat
@@ -1135,8 +1135,8 @@
         <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="031f-3c06-53e7-0ee3" type="max"/>
       </constraints>
       <categoryLinks>
-        <categoryLink id="f5cf-6334-3b84-32dd" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
-        <categoryLink id="27a7-61f5-eb70-36be" name="Primarch:" hidden="false" targetId="ad5f-31db-8bc7-5c46" primary="false"/>
+        <categoryLink id="b149-05d4-2f7b-a3bd" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="4055-f3db-da41-c441" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="4106-fc7b-3756-ae9a" name="Mortarion" hidden="false" collective="false" import="true" type="model">
@@ -2036,6 +2036,7 @@ If this option is used then Mortarion is removed from the battlefield, leaving a
         <categoryLink id="58d0-40f3-bf65-136f" name="Siege Breaker:" hidden="false" targetId="8247-54dc-9194-948f" primary="false"/>
         <categoryLink id="0a04-abf8-2e59-99ae" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
         <categoryLink id="076e-8fde-df99-a46e" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+        <categoryLink id="9919-bd28-8a44-115d" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="dd03-bdde-aa4c-d15d" name="Defiant" hidden="false" collective="false" import="true" type="upgrade">

--- a/2022 - LA - Death Guard.cat
+++ b/2022 - LA - Death Guard.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="d228-55e8-b58c-1b77" name="LA -  XIV: Death Guard" revision="9" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="17" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="d228-55e8-b58c-1b77" name="LA -  XIV: Death Guard" revision="10" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="18" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entryLinks>
     <entryLink id="fb89-32c1-bdc5-2e3d" name="Mortarion" hidden="false" collective="false" import="false" targetId="7427-bdfa-c359-ebb8" type="selectionEntry">
       <modifiers>
@@ -10,7 +10,6 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="1cd5-97ad-9b89-5d10" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="false"/>
         <categoryLink id="44be-4e1f-6984-02f2" name="New CategoryLink" hidden="false" targetId="ad5f-31db-8bc7-5c46" primary="true"/>
         <categoryLink id="edd2-1a56-37a4-4b58" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
@@ -108,6 +107,18 @@
       </categoryLinks>
     </entryLink>
     <entryLink id="7dd0-94d5-4727-58ee" name="Assault Squad" hidden="false" collective="false" import="false" targetId="a8e9-70e1-b8bc-8ee2" type="selectionEntry">
+      <modifiers>
+        <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="3ba4-6f75-b11f-5ac3" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="4746-1ae6-ff31-80e5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
@@ -136,12 +147,23 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="2ae0-0e06-247f-ad7c" name="Bombard Sub-type:" hidden="false" targetId="d5df-57ac-8f3c-097b" primary="false"/>
         <categoryLink id="e639-48f5-49aa-ff9a" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
         <categoryLink id="e870-5e18-c785-c323" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="e814-78ae-e106-ac52" name="Breacher Squad" hidden="false" collective="false" import="false" targetId="ad97-c090-fa67-696f" type="selectionEntry">
+      <modifiers>
+        <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="777e-d175-06f6-89bf" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="d303-2916-45fd-fba5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
@@ -264,7 +286,6 @@
     <entryLink id="7194-5a5e-656b-17ff" name="Damocles Command Rhino" hidden="false" collective="false" import="false" targetId="e337-8239-5e92-7f5f" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="edb5-a892-57aa-baf5" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="ff8d-784c-3576-c2c9" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="4d1c-5482-4ab8-89d2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -281,6 +302,18 @@
       </categoryLinks>
     </entryLink>
     <entryLink id="938a-6fc6-b597-2112" name="Despoiler Squad" hidden="false" collective="false" import="false" targetId="4357-930e-165a-a6e3" type="selectionEntry">
+      <modifiers>
+        <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="5a74-10d2-56b2-767b" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="1483-ddc4-dd74-487d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
@@ -296,29 +329,31 @@
     <entryLink id="31a6-4f5c-b6b9-1e82" name="Dreadclaw Drop Pod" hidden="false" collective="false" import="false" targetId="bbe8-818d-3068-d79c" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="8229-ea7a-f6fa-54ee" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="72e0-c125-be7a-72de" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+        <categoryLink id="5aa1-1743-6028-ca5b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="85a0-ff11-6e9a-c5cd" name="Falchion" hidden="false" collective="false" import="false" targetId="1fe8-7386-9509-d2d8" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="ded9-d2d7-03f4-e8a6" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="e350-66f1-029c-72cd" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="f598-6f7d-54d2-5dd4" name="Fellblade" hidden="false" collective="false" import="false" targetId="9c3c-f15a-9a1f-c0d0" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="0d4c-07fb-8ff6-6b48" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="301c-3185-56ef-dd73" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="a968-0378-9216-a941" name="Fire Raptor Gunship" hidden="false" collective="false" import="false" targetId="f6e1-24e2-fbdb-c5ef" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="c561-0f53-9f05-16f1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="4414-e08c-1e60-3d9a" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="a52a-182e-48b4-551f" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="8569-3903-fbf1-b0d9" name="Glaive" hidden="false" collective="false" import="false" targetId="04e0-f69f-f759-b0b3" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="eccf-478b-daa1-42c1" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="db42-0b07-fe22-0866" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="a260-1302-3355-5a51" name="Heavy Support Squad" hidden="false" collective="false" import="false" targetId="bac9-5389-e2e7-0b1f" type="selectionEntry">
@@ -385,7 +420,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="87ee-97b2-4b16-839b" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="bc5c-b800-38a8-f974" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+        <categoryLink id="112d-983a-9242-0823" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="fe98-dcea-59fc-82e3" name="Legion Banehammer" hidden="true" collective="false" import="false" targetId="1240-c71c-3a60-cf20" type="selectionEntry">
@@ -398,7 +433,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="7cef-e262-b55d-12f8" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="79d4-361f-c490-d5d1" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+        <categoryLink id="f754-036a-01ff-b739" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="4bcd-21dd-c6ab-7eca" name="Legion Macharius Heavy Tank Squadron" hidden="false" collective="false" import="false" targetId="36ed-ca59-0d95-d85c" type="selectionEntry">
@@ -463,7 +498,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="63f9-13a1-64fc-1b60" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="8a29-a78a-1abc-0601" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+        <categoryLink id="d47f-030d-7433-7049" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="7987-d97a-08b6-680c" name="Legion Stormlord" hidden="true" collective="false" import="false" targetId="0887-0f66-2c7e-a5ba" type="selectionEntry">
@@ -476,7 +511,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="5592-15ea-e76f-ddea" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="b5a3-2df4-12db-ea0a" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+        <categoryLink id="5609-eb08-b5ae-2252" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="d35e-0701-4192-aab3" name="Legion Stormsword" hidden="true" collective="false" import="false" targetId="8e67-8f84-730c-2778" type="selectionEntry">
@@ -489,7 +524,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="b428-9b1a-3de9-dd66" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="f57d-7e6b-2179-8a28" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+        <categoryLink id="c0a9-71fd-f964-6050" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="d27d-e3be-c85a-467b" name="Leviathan Dreadnought Talon" hidden="false" collective="false" import="false" targetId="c2a7-9e2c-fc65-1b78" type="selectionEntry">
@@ -501,6 +536,7 @@
     <entryLink id="cedf-4f4f-8ec1-9097" name="Mastodon" hidden="false" collective="false" import="false" targetId="7f24-2b72-9128-5330" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="328a-99f2-094c-b390" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="c760-bd0b-3cdc-6f46" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="50b4-e9f5-dcf5-80bc" name="Medusa Squadron" hidden="true" collective="false" import="false" targetId="24c8-5f6a-d48a-27b7" type="selectionEntry">
@@ -512,9 +548,8 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="e637-d3d5-8e87-d234" name="Bombard Sub-type:" hidden="false" targetId="d5df-57ac-8f3c-097b" primary="false"/>
         <categoryLink id="032b-5892-7749-6517" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="499c-d1e9-e2f2-ad04" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
+        <categoryLink id="0eac-7019-e1a1-938f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="4280-e7f6-3922-360f" name="Mortalis Destroyer Squad" hidden="false" collective="false" import="false" targetId="dbd4-930e-e003-9449" type="selectionEntry">
@@ -613,6 +648,13 @@
       </categoryLinks>
     </entryLink>
     <entryLink id="4d50-a28a-15f0-6b9d" name="Reconnaissance Squad" hidden="false" collective="false" import="false" targetId="6db7-6e88-877e-35ca" type="selectionEntry">
+      <modifiers>
+        <modifier type="add" field="category" value="8f42-a824-fb5f-8fea">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="4bdc-6119-8f9e-b739" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="b61a-d21e-6d85-f70f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
@@ -631,6 +673,13 @@
       </categoryLinks>
     </entryLink>
     <entryLink id="c59d-949c-def6-156e" name="Scout Squad" hidden="false" collective="false" import="false" targetId="9b10-b657-a65a-9d60" type="selectionEntry">
+      <modifiers>
+        <modifier type="add" field="category" value="8f42-a824-fb5f-8fea">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="d466-ef14-1aab-e266" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="6a89-799f-bae4-e727" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
@@ -651,7 +700,6 @@
     <entryLink id="b29b-b6d8-64b0-ad57" name="Sicaran Omega Squadron" hidden="false" collective="false" import="false" targetId="c88b-fe44-34a3-97e1" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="d296-0a74-7adc-eb37" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="1010-0eb1-12d9-9750" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="a92f-c63a-674d-5d6b" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
       </categoryLinks>
     </entryLink>
@@ -664,7 +712,6 @@
     <entryLink id="7ab5-27ee-8c1c-bddb" name="Sicaran Squadron" hidden="false" collective="false" import="false" targetId="706a-9532-f06d-00ed" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="1f52-0793-b77f-aa71" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="d8af-5aad-ff03-2e9c" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="86a8-2a5a-5e1d-febe" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
       </categoryLinks>
     </entryLink>
@@ -683,6 +730,7 @@
     <entryLink id="30bd-085b-0e7c-39a9" name="Sokar Stormbird" hidden="false" collective="false" import="false" targetId="f403-630f-71ae-5a7d" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="12ca-5aa1-a90d-9538" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="0f02-6375-6c11-8faf" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="5aef-8d2d-c34d-25d0" name="Spatha Attack Bike Squadron" hidden="false" collective="false" import="false" targetId="4d72-1cc1-8bee-aa88" type="selectionEntry">
@@ -701,10 +749,22 @@
     <entryLink id="aa0c-2200-bdf0-90bd" name="Storm Eagle Gunship" hidden="false" collective="false" import="false" targetId="8aa5-ff31-7de7-19d4" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="7c72-0819-aaaa-1f8d" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="ef16-be36-b8d6-4605" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+        <categoryLink id="76a1-db25-00dd-0ea7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="9fb8-08f8-9024-1015" name="Tactical Squad" hidden="false" collective="false" import="false" targetId="aa72-63e4-bc60-4611" type="selectionEntry">
+      <modifiers>
+        <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="eee7-ecc7-788c-23d2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="75b4-c3de-bc9b-f5a7" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
@@ -726,7 +786,6 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="77f9-4451-bc36-def4" name="Artillery Sub-type:" hidden="false" targetId="6f99-c178-6f9d-fb63" primary="false"/>
         <categoryLink id="c86f-456b-ea6d-1574" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
         <categoryLink id="f21a-83be-767a-b735" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
@@ -754,14 +813,12 @@
       <categoryLinks>
         <categoryLink id="379f-423c-1b26-4af6" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="3992-b442-e809-5dde" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="1cea-e7d3-21cd-498c" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="83ae-538e-57d9-ce01" name="Terminator Tartaros Squad" hidden="false" collective="false" import="false" targetId="1a8e-0ded-a4dc-2b4e" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="6ac3-58f6-2662-ac7d" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="659b-6e8c-97c7-1bfc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="d191-128e-840d-2001" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="6c25-69a3-62eb-3f42" name="Thunderbolt Fighter" hidden="false" collective="false" import="false" targetId="5d24-1e9a-ad9d-95ca" type="selectionEntry">
@@ -780,6 +837,7 @@
     <entryLink id="2792-ab38-fd66-fe12" name="Thunderhawk Gunship" hidden="false" collective="false" import="false" targetId="8754-3a4f-213b-bdc0" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="964b-f758-9f21-90d9" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="51b0-bdd5-5105-8150" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="a70f-fc8b-42cd-5f02" name="Tylos Rubio" hidden="false" collective="false" import="false" targetId="56bf-2c6d-a0fa-a145" type="selectionEntry">
@@ -798,6 +856,7 @@
     <entryLink id="c92c-4514-d7bb-0cd9" name="Typhon Squadron" hidden="false" collective="false" import="false" targetId="d06a-3087-af13-ca95" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="16dc-aa80-44ee-dbb6" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="f718-09c7-8831-44ff" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="8883-a80c-8cd9-bb29" name="Veteran Squad" hidden="false" collective="false" import="false" targetId="a423-7dd8-3f1b-3e28" type="selectionEntry">
@@ -824,7 +883,6 @@
       <categoryLinks>
         <categoryLink id="1ae1-84be-5e69-aba1" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
         <categoryLink id="c011-6399-c0a5-d6f3" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
-        <categoryLink id="c68d-c6b3-2514-be6a" name="Bombard Sub-type:" hidden="false" targetId="d5df-57ac-8f3c-097b" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="85f4-6e9a-4797-7534" name="Xiphon Interceptor" hidden="false" collective="false" import="false" targetId="596b-5478-e079-59ab" type="selectionEntry">
@@ -842,6 +900,23 @@
     <entryLink id="bf98-3ce4-bbae-27f4" name="Deathshroud Terminator Squad" hidden="false" collective="false" import="true" targetId="7669-a6c0-7f86-e641" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="b426-11a9-a374-dc73" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true"/>
+        <categoryLink id="9101-b7e1-a69a-8690" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="1f21-083f-ed75-5d38" name="Seeker Squad" hidden="true" collective="false" import="false" targetId="58e6-f9cc-4c46-e258" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <infoLinks>
+        <infoLink id="bfa3-df31-9e63-694f" name="Legiones Astartes (Death Guard) " hidden="false" targetId="48a9-493f-e255-5070" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="3756-dc59-4b6f-1d17" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="6628-588b-3f5f-005f" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
       </categoryLinks>
     </entryLink>
   </entryLinks>
@@ -855,6 +930,9 @@
         <categoryLink id="33f7-f2cd-2c9b-34cb" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="8177-1aab-8a85-3acc" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
         <categoryLink id="e01c-ad05-c3de-4026" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
+        <categoryLink id="2f7a-f3e1-0ebe-7f53" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+        <categoryLink id="043c-bb03-e878-0086" name="Psyker:" hidden="false" targetId="6e0c-29ba-a445-8321" primary="false"/>
+        <categoryLink id="8ef4-70d2-ba35-70b9" name="Terminators:" hidden="false" targetId="bab3-f50d-3e5f-2f78" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="598d-9b12-2059-e804" name="Calas Typhon" hidden="false" collective="false" import="true" type="model">
@@ -1237,6 +1315,11 @@ If this option is used then Mortarion is removed from the battlefield, leaving a
         <infoLink id="4f41-d770-ace8-28d9" name="Stubborn" hidden="false" targetId="7989-1f2c-a43d-82ae" type="rule"/>
         <infoLink id="4a9d-1f85-27d1-18c0" name="Legiones Astartes (Death Guard) " hidden="false" targetId="48a9-493f-e255-5070" type="rule"/>
       </infoLinks>
+      <categoryLinks>
+        <categoryLink id="8781-fa3a-a2f2-bfea" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="dfa4-63db-3a8e-a198" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+        <categoryLink id="4ee0-168f-36f7-496d" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+      </categoryLinks>
       <selectionEntries>
         <selectionEntry id="277b-5aad-6264-93e1" name="Mortus Poisoner" hidden="false" collective="false" import="true" type="model">
           <constraints>
@@ -1544,6 +1627,7 @@ If this option is used then Mortarion is removed from the battlefield, leaving a
         <categoryLink id="ca31-c0b0-1723-d85a" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
         <categoryLink id="4b86-b5c5-f3e9-3f35" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="0fe4-702f-0f7f-805c" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="51c7-b78d-5c3b-7ebd" name="Terminators:" hidden="false" targetId="bab3-f50d-3e5f-2f78" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="ef11-6c72-ed0c-3518" name="Chem-master" hidden="false" collective="false" import="true" type="model">
@@ -1793,8 +1877,10 @@ If this option is used then Mortarion is removed from the battlefield, leaving a
         <infoLink id="355a-310f-4c86-d4dd" name="Bitter Duty" hidden="false" targetId="d1b8-31da-c53c-4fe2" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="1434-d662-bade-7356" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
         <categoryLink id="d376-a6bd-3afa-18db" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
+        <categoryLink id="09dd-97f2-3578-0b77" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="c14e-e1ca-7d1e-8ba9" name="Psyker:" hidden="false" targetId="6e0c-29ba-a445-8321" primary="false"/>
+        <categoryLink id="3ab9-09ca-d35c-7778" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="82e1-3fe4-d8a1-63c5" name="The Revenant&apos;s Aegis" hidden="false" collective="false" import="true" type="upgrade">
@@ -1948,7 +2034,8 @@ If this option is used then Mortarion is removed from the battlefield, leaving a
       </infoLinks>
       <categoryLinks>
         <categoryLink id="58d0-40f3-bf65-136f" name="Siege Breaker:" hidden="false" targetId="8247-54dc-9194-948f" primary="false"/>
-        <categoryLink id="f32f-bec4-e5d0-acc0" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
+        <categoryLink id="0a04-abf8-2e59-99ae" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
+        <categoryLink id="076e-8fde-df99-a46e" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="dd03-bdde-aa4c-d15d" name="Defiant" hidden="false" collective="false" import="true" type="upgrade">
@@ -2071,6 +2158,11 @@ If this option is used then Mortarion is removed from the battlefield, leaving a
         <infoLink id="e88f-fb18-7c1d-6db6" name="Legiones Astartes (Death Guard) " hidden="false" targetId="48a9-493f-e255-5070" type="rule"/>
         <infoLink id="0325-99f5-52bf-4a56" name="Chosen Warriors" hidden="false" targetId="13d1-9270-6539-08ed" type="rule"/>
       </infoLinks>
+      <categoryLinks>
+        <categoryLink id="d4f9-501e-a4fa-3f6f" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="63ee-4b93-4160-2bd7" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="9aa5-47d6-a6d0-cc9a" name="Terminators:" hidden="false" targetId="bab3-f50d-3e5f-2f78" primary="false"/>
+      </categoryLinks>
       <selectionEntries>
         <selectionEntry id="1dce-0343-5e1c-eac8" name="Deathshroud" hidden="false" collective="false" import="true" type="model">
           <constraints>

--- a/2022 - LA - Emperor's Children.cat
+++ b/2022 - LA - Emperor's Children.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="72ba-61c2-37ad-c785" name="LA -   III: Emperor&apos;s Children" revision="7" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="17" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="72ba-61c2-37ad-c785" name="LA -   III: Emperor&apos;s Children" revision="8" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="18" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entryLinks>
     <entryLink id="b36e-8c73-fe83-f087" name="   III: Emperor&apos;s Children" hidden="false" collective="false" import="false" targetId="3edc-a1b9-6dc6-b1ea" type="selectionEntry">
       <constraints>
@@ -21,6 +21,7 @@
       <categoryLinks>
         <categoryLink id="8198-4bd3-2445-7a2b" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="9304-b442-49fe-fa71" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
+        <categoryLink id="1574-a84f-21ef-30ad" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="31b0-fad0-cbb6-491d" name="Captain Saul Tarvitz" hidden="true" collective="false" import="false" targetId="a91c-719f-4abf-1598" type="selectionEntry">
@@ -34,6 +35,7 @@
       <categoryLinks>
         <categoryLink id="ae2e-66fe-3c38-c0c2" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="c295-161b-a153-5e23" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
+        <categoryLink id="c818-c8fe-e1d4-843d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="d159-e0c0-f0a4-c8c9" name="Fulgrim" hidden="true" collective="false" import="false" targetId="0de5-8b3c-74a0-858e" type="selectionEntry">
@@ -46,6 +48,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="d1b1-8747-b31c-93ba" name="New CategoryLink" hidden="false" targetId="ad5f-31db-8bc7-5c46" primary="true"/>
+        <categoryLink id="d25a-accf-b6de-facb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="3e78-22f5-fc51-3a6e" name="Kakophoni Squad" hidden="true" collective="false" import="false" targetId="8359-c463-9cde-4f21" type="selectionEntry">
@@ -58,6 +61,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="76ab-3f7a-43b7-7b98" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="89c1-4a2a-ad42-8b4b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="ec64-4532-a15d-ad6b" name="Lord Commander Eidolon" hidden="true" collective="false" import="false" targetId="ac90-d090-9a21-60c4" type="selectionEntry">
@@ -71,16 +75,19 @@
       <categoryLinks>
         <categoryLink id="d7b4-0c11-69c4-0790" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="dafb-5fbd-1def-b788" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
+        <categoryLink id="92b5-0c2e-6efd-c525" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="b704-91be-c88e-763e" name="Palatine Blade Squad" hidden="false" collective="false" import="false" targetId="fa86-f7a5-0062-a205" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="8bd4-b59d-9966-f4a9" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="1e32-b5d5-15b6-759c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="d901-03b2-b27a-d793" name="Phoenix Terminator Squad" hidden="false" collective="false" import="false" targetId="5b08-65c1-cc45-1b91" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="0f06-08b1-9de3-dac5" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="1823-c289-362f-ce97" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="9e33-b30a-861d-c0f8" name="Rylanor the Unyielding" hidden="true" collective="false" import="false" targetId="281b-1950-5c15-de68" type="selectionEntry">
@@ -98,6 +105,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="f813-02a8-90f1-a6fe" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="3a40-1d8f-dc1d-d52b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="abb4-2af9-15c8-2c3d" name="Sun Killer Squad" hidden="true" collective="false" import="false" targetId="cce2-fd03-ac17-88e4" type="selectionEntry">
@@ -110,6 +118,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="2a6f-aeba-536a-ffb8" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="806c-e31c-d83d-3c70" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="ecec-6831-34d9-b21b" name="Apothecarion Detachment" hidden="false" collective="false" import="false" targetId="81df-ffd4-a32b-b4a1" type="selectionEntry">
@@ -125,6 +134,18 @@
       </categoryLinks>
     </entryLink>
     <entryLink id="bc27-da9a-8975-4051" name="Assault Squad" hidden="false" collective="false" import="false" targetId="a8e9-70e1-b8bc-8ee2" type="selectionEntry">
+      <modifiers>
+        <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="e265-dc69-cf9e-dfd1" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="a097-5047-4d84-c63c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
@@ -153,12 +174,23 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="8504-7083-733b-d86f" name="Bombard Sub-type:" hidden="false" targetId="d5df-57ac-8f3c-097b" primary="false"/>
         <categoryLink id="a369-b028-93d3-eb98" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="f82c-bc61-d87d-8fb6" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
+        <categoryLink id="cf5e-6ae2-11e7-6095" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="df1d-3151-9c34-afe5" name="Breacher Squad" hidden="false" collective="false" import="false" targetId="ad97-c090-fa67-696f" type="selectionEntry">
+      <modifiers>
+        <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="e909-39c8-2194-b6c4" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="f4a3-a75b-4b04-f430" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
@@ -281,7 +313,6 @@
     <entryLink id="99df-a04f-4d15-5a7e" name="Damocles Command Rhino" hidden="false" collective="false" import="false" targetId="e337-8239-5e92-7f5f" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="fd0b-4621-f89d-45d8" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="fe4e-dc53-0390-331e" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="9620-d2d4-92c5-d07c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -298,6 +329,18 @@
       </categoryLinks>
     </entryLink>
     <entryLink id="5ea2-d146-b89a-1217" name="Despoiler Squad" hidden="false" collective="false" import="false" targetId="4357-930e-165a-a6e3" type="selectionEntry">
+      <modifiers>
+        <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="1b95-ff6c-67b0-c7ad" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="c262-93f6-ca05-c025" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
@@ -313,23 +356,24 @@
     <entryLink id="4dc9-f18b-b18b-f6d3" name="Dreadclaw Drop Pod" hidden="false" collective="false" import="false" targetId="bbe8-818d-3068-d79c" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="2d13-ffdb-29f7-e4a7" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="3afd-3c25-3934-aef5" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+        <categoryLink id="9a18-8c66-d7de-ad37" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="62a4-c5e2-9494-6380" name="Falchion" hidden="false" collective="false" import="false" targetId="1fe8-7386-9509-d2d8" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="2fac-3433-337f-4d72" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="d6f6-a4ff-3034-b9ec" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="5cee-0919-6a27-0ccf" name="Fellblade" hidden="false" collective="false" import="false" targetId="9c3c-f15a-9a1f-c0d0" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="222d-9743-0408-bb10" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="29f5-d0f2-8a8a-0fe3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="05f1-c29f-3faf-0409" name="Fire Raptor Gunship" hidden="false" collective="false" import="false" targetId="f6e1-24e2-fbdb-c5ef" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="44a5-670e-0902-1e0e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="e418-c455-246c-f7aa" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="a254-25c1-de02-297a" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
       </categoryLinks>
     </entryLink>
@@ -397,7 +441,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="92f0-68f1-5c99-bdf0" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="13bb-43c5-b6d8-bd31" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+        <categoryLink id="fdd2-07fd-90c5-c24f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="5efd-b2d6-c765-311b" name="Legion Banehammer" hidden="true" collective="false" import="false" targetId="1240-c71c-3a60-cf20" type="selectionEntry">
@@ -410,7 +454,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="8cb5-b39f-f07c-774b" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="6013-92ec-c78e-80ee" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+        <categoryLink id="4f51-ed25-7d81-08de" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="4a59-da44-7080-da44" name="Legion Macharius Heavy Tank Squadron" hidden="false" collective="false" import="false" targetId="36ed-ca59-0d95-d85c" type="selectionEntry">
@@ -475,7 +519,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="8805-361f-9647-e6d4" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="aaeb-eeb5-496e-e9b3" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+        <categoryLink id="bc51-0762-b627-0d4e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="1933-c2cc-0886-f7e2" name="Legion Stormlord" hidden="true" collective="false" import="false" targetId="0887-0f66-2c7e-a5ba" type="selectionEntry">
@@ -488,7 +532,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="37c3-a142-92f4-1170" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="704b-b9ad-954b-1078" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+        <categoryLink id="3c1c-b046-f211-4c53" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="002d-a997-d2a0-cf6d" name="Legion Stormsword" hidden="true" collective="false" import="false" targetId="8e67-8f84-730c-2778" type="selectionEntry">
@@ -501,7 +545,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="9890-d166-91b2-8bed" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="c42d-ed39-6804-5bef" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+        <categoryLink id="0799-5eb4-c25a-5a2f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="abc6-e8e1-4066-68e1" name="Leviathan Dreadnought Talon" hidden="false" collective="false" import="false" targetId="c2a7-9e2c-fc65-1b78" type="selectionEntry">
@@ -513,6 +557,7 @@
     <entryLink id="cebd-8215-51aa-f6a2" name="Mastodon" hidden="false" collective="false" import="false" targetId="7f24-2b72-9128-5330" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="8f51-adaf-bf3f-4e0e" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="7906-9273-349e-89ff" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="5079-8467-4b74-5a1c" name="Medusa Squadron" hidden="true" collective="false" import="false" targetId="24c8-5f6a-d48a-27b7" type="selectionEntry">
@@ -524,9 +569,8 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="ceb4-7b8b-717f-82ff" name="Bombard Sub-type:" hidden="false" targetId="d5df-57ac-8f3c-097b" primary="false"/>
         <categoryLink id="7868-8b04-94ef-2461" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="0e1b-f773-152c-3e25" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
+        <categoryLink id="0ba1-8d30-54d6-3cb1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="59f3-7771-84d0-8948" name="Mortalis Destroyer Squad" hidden="false" collective="false" import="false" targetId="dbd4-930e-e003-9449" type="selectionEntry">
@@ -625,6 +669,13 @@
       </categoryLinks>
     </entryLink>
     <entryLink id="b4b5-8ef8-904c-2768" name="Reconnaissance Squad" hidden="false" collective="false" import="false" targetId="6db7-6e88-877e-35ca" type="selectionEntry">
+      <modifiers>
+        <modifier type="add" field="category" value="8f42-a824-fb5f-8fea">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="9869-1c47-5445-e654" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="0981-4cd0-3389-f45b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
@@ -643,6 +694,13 @@
       </categoryLinks>
     </entryLink>
     <entryLink id="1314-96d9-9d30-b56c" name="Scout Squad" hidden="false" collective="false" import="false" targetId="9b10-b657-a65a-9d60" type="selectionEntry">
+      <modifiers>
+        <modifier type="add" field="category" value="8f42-a824-fb5f-8fea">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="06d9-2af2-98f7-362c" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="5da1-72e3-144b-d4e0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
@@ -663,7 +721,6 @@
     <entryLink id="4f12-7a28-7980-97e4" name="Sicaran Omega Squadron" hidden="false" collective="false" import="false" targetId="c88b-fe44-34a3-97e1" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="1e8d-8b50-9ba7-1ce2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="ed1a-856a-8280-4bd3" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="29bb-14af-bfb8-79c4" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
       </categoryLinks>
     </entryLink>
@@ -676,7 +733,6 @@
     <entryLink id="3194-1cd7-f371-ca9a" name="Sicaran Squadron" hidden="false" collective="false" import="false" targetId="706a-9532-f06d-00ed" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="93e6-2990-b830-1499" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="56e4-5951-dc44-327e" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="789c-808f-4b13-7144" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
       </categoryLinks>
     </entryLink>
@@ -695,6 +751,7 @@
     <entryLink id="1019-efcf-1548-2a00" name="Sokar Stormbird" hidden="false" collective="false" import="false" targetId="f403-630f-71ae-5a7d" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="e6d0-e337-9c95-5aaf" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="23de-4dec-ea47-3059" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="6488-1f35-b482-fc83" name="Spatha Attack Bike Squadron" hidden="false" collective="false" import="false" targetId="4d72-1cc1-8bee-aa88" type="selectionEntry">
@@ -713,10 +770,22 @@
     <entryLink id="7e61-c663-30d1-9acb" name="Storm Eagle Gunship" hidden="false" collective="false" import="false" targetId="8aa5-ff31-7de7-19d4" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="8efd-44c6-f9bd-bfc1" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="2f29-caa0-b8d2-cd78" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+        <categoryLink id="72bf-4dae-911f-bb8d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="3e94-aa5e-e44b-1dc1" name="Tactical Squad" hidden="false" collective="false" import="false" targetId="aa72-63e4-bc60-4611" type="selectionEntry">
+      <modifiers>
+        <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="14cd-5061-2107-8ac5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="8017-c625-0639-a56d" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
@@ -738,7 +807,6 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="30a0-d649-3a95-e742" name="Artillery Sub-type:" hidden="false" targetId="6f99-c178-6f9d-fb63" primary="false"/>
         <categoryLink id="9c21-edaf-e5c3-e45d" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
         <categoryLink id="5d5f-46a8-dc0b-24f4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
@@ -766,14 +834,12 @@
       <categoryLinks>
         <categoryLink id="ee85-ab1f-b425-2e48" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="b582-7a4b-38fc-578b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="1980-8ed5-89dd-cda5" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="1a8f-9850-89eb-d7ad" name="Terminator Tartaros Squad" hidden="false" collective="false" import="false" targetId="1a8e-0ded-a4dc-2b4e" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="a3d8-c9fd-6174-b118" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="5c34-a726-4adb-8777" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="1ac4-0124-a320-06fc" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="6aba-c558-f194-e782" name="Thunderbolt Fighter" hidden="false" collective="false" import="false" targetId="5d24-1e9a-ad9d-95ca" type="selectionEntry">
@@ -792,6 +858,7 @@
     <entryLink id="764c-66f2-5272-cd99" name="Thunderhawk Gunship" hidden="false" collective="false" import="false" targetId="8754-3a4f-213b-bdc0" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="7260-967c-9552-04c0" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="bd6c-21dd-9930-6294" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="dcff-a922-ec9f-0762" name="Tylos Rubio" hidden="false" collective="false" import="false" targetId="56bf-2c6d-a0fa-a145" type="selectionEntry">
@@ -810,6 +877,7 @@
     <entryLink id="4e08-db14-2499-3405" name="Typhon Squadron" hidden="false" collective="false" import="false" targetId="d06a-3087-af13-ca95" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="c116-21a1-7d9d-b98d" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="9845-aca4-b259-fc4d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="a333-c071-34ec-5b04" name="Veteran Squad" hidden="false" collective="false" import="false" targetId="a423-7dd8-3f1b-3e28" type="selectionEntry">
@@ -835,14 +903,29 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="3bf8-f40b-a517-f72b" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="4d0a-831a-4188-67f5" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
-        <categoryLink id="df06-fa5f-fff4-e8ed" name="Bombard Sub-type:" hidden="false" targetId="d5df-57ac-8f3c-097b" primary="false"/>
+        <categoryLink id="b244-00bc-1a32-581d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="5980-4afe-fe25-4687" name="Xiphon Interceptor" hidden="false" collective="false" import="false" targetId="596b-5478-e079-59ab" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="3b8e-c92f-dcca-d33b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="d698-5c0f-4ee6-b3f7" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="b6d1-068e-7afa-6204" name="Seeker Squad" hidden="true" collective="false" import="false" targetId="58e6-f9cc-4c46-e258" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <infoLinks>
+        <infoLink id="c06e-df8f-83fe-158d" name="Legiones Astartes (Emperor&apos;s Children) " hidden="false" targetId="4a36-8b9d-6b6c-51e1" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="77d3-cc99-0a9a-f5c3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="ed4a-30c1-c4d7-221b" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
       </categoryLinks>
     </entryLink>
   </entryLinks>
@@ -853,6 +936,7 @@
       </constraints>
       <categoryLinks>
         <categoryLink id="f617-3901-e330-116d" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="63e2-604e-8ad8-2949" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="7350-db6b-c492-06cf" name="Firebrand" hidden="false" collective="false" import="true" type="upgrade">
@@ -1053,6 +1137,7 @@ Sire of the Emperor’s Children - All friendly models with the Legiones Astarte
       <categoryLinks>
         <categoryLink id="99d4-024f-39b9-f2dd" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="5042-adc1-b6a6-33c7" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="f095-c7f1-6d36-0bf8" name="Terminators:" hidden="false" targetId="bab3-f50d-3e5f-2f78" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="8782-15de-1f8e-d858" name="Phoenix Champion" hidden="false" collective="false" import="true" type="model">
@@ -1614,6 +1699,7 @@ Sire of the Emperor’s Children - All friendly models with the Legiones Astarte
       <categoryLinks>
         <categoryLink id="b7e4-e6dd-51b7-6cdb" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="846d-5f51-c454-c2fc" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="abb6-d43c-caa7-4751" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="e845-5008-a4fe-b8b9" name="Lord Commander Eidolon" hidden="false" collective="false" import="true" type="model">
@@ -1773,7 +1859,8 @@ Sire of the Emperor’s Children - All friendly models with the Legiones Astarte
       </constraints>
       <categoryLinks>
         <categoryLink id="097f-3ba4-1906-564b" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="9e20-1c70-e2d9-ccd7" name="Legion Consularis:" hidden="false" targetId="4171-e276-e90d-b8e5" primary="false"/>
+        <categoryLink id="d99b-5d8e-d60b-0feb" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
+        <categoryLink id="5ce7-8211-fce9-9cc1" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="b99f-1483-2853-ccaa" name="Captain Saul Tarvitz" hidden="false" collective="false" import="true" type="upgrade">
@@ -1937,6 +2024,7 @@ If any of these are true then Captain Saul Tarvitz and any friendly units with a
       <categoryLinks>
         <categoryLink id="881f-052e-58c5-49de" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="8d21-e2d9-7847-b808" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="3c42-b8b4-f9e4-1f13" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="240f-c893-3999-b339" name="Captain Lucius" hidden="false" collective="false" import="true" type="upgrade">

--- a/2022 - LA - Emperor's Children.cat
+++ b/2022 - LA - Emperor's Children.cat
@@ -2254,6 +2254,7 @@ Captain Lucius is engaged in a Challenge all friendly models in the same combat 
       </infoLinks>
       <categoryLinks>
         <categoryLink id="7acc-1ab8-5189-f03c" name="Dreadnought Unit-type:" hidden="false" targetId="4280-4963-02b5-e31d" primary="false"/>
+        <categoryLink id="0a18-eece-0831-f72d" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
       </categoryLinks>
       <entryLinks>
         <entryLink id="53b4-68bd-0941-24e4" name="Atomantic Deflector" hidden="false" collective="false" import="true" targetId="38fb-9a0b-edef-a497" type="selectionEntry">

--- a/2022 - LA - Imperial Fists.cat
+++ b/2022 - LA - Imperial Fists.cat
@@ -1464,6 +1464,7 @@
         <categoryLink id="93db-ffc9-0558-73e6" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="e823-f428-97c9-b5d7" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="0d9a-8f4f-0ec8-6ebc" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
+        <categoryLink id="7668-e167-087e-ec1a" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="194d-69e1-55b6-8453" name="Alexis Polux" hidden="false" collective="false" import="true" type="model">
@@ -1581,6 +1582,7 @@
         <categoryLink id="7d2a-1492-8056-3083" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="f860-72fd-d93c-1290" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="7b95-8b9b-38c1-f8fb" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
+        <categoryLink id="1715-31a2-3ed9-4522" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="0a3e-c822-cc8c-3bef" name="Fafnir Rann" hidden="false" collective="false" import="true" type="model">
@@ -2481,6 +2483,7 @@ Both weapons are counted as ‘Power’ weapons for those rules that affect such
       <categoryLinks>
         <categoryLink id="0926-4bcb-7263-d6a1" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
         <categoryLink id="9de5-657e-8970-390d" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
+        <categoryLink id="4ee5-2ad3-9806-aa1c" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="d982-313d-0d97-d831" name="Wing Weapon Options" hidden="false" collective="false" import="true" defaultSelectionEntryId="0127-b935-d076-9419">

--- a/2022 - LA - Imperial Fists.cat
+++ b/2022 - LA - Imperial Fists.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="8866-00ec-715f-f21a" name="LA -   VII: Imperial Fists" revision="8" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="17" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="8866-00ec-715f-f21a" name="LA -   VII: Imperial Fists" revision="10" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="18" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entryLinks>
     <entryLink id="b3e4-1487-4ab7-7515" name="Alexis Polux " hidden="false" collective="false" import="false" targetId="9229-b4f9-2213-9672" type="selectionEntry">
       <modifiers>
@@ -12,6 +12,7 @@
       <categoryLinks>
         <categoryLink id="ee0f-2bd2-436f-ec16" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="2c32-d871-9f89-6b91" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="8d13-d219-2715-ad2a" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="f3a4-1d62-0904-18c5" name="Fafnir Rann" hidden="false" collective="false" import="false" targetId="d483-8c34-3bcb-f1d5" type="selectionEntry">
@@ -25,6 +26,7 @@
       <categoryLinks>
         <categoryLink id="74f0-6109-ed78-2945" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="d3ba-a5cd-59f7-f99a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="e598-efd8-ee80-b4c1" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="a7ed-633f-9b24-83bb" name="Phalanx Warder Squad" hidden="false" collective="false" import="false" targetId="19ce-b8dc-dd40-fee9" type="selectionEntry">
@@ -44,6 +46,7 @@
       <categoryLinks>
         <categoryLink id="3ef3-f102-3e71-37b5" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="c59c-4b7b-a872-41e7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="f613-1e6d-5e72-52bb" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="c1a0-4e23-bb48-8b6b" name="Templar Brethren" hidden="false" collective="false" import="false" targetId="6f69-665c-3199-77aa" type="selectionEntry">
@@ -118,6 +121,18 @@
       </categoryLinks>
     </entryLink>
     <entryLink id="6445-0f74-57d7-7267" name="Assault Squad" hidden="false" collective="false" import="false" targetId="a8e9-70e1-b8bc-8ee2" type="selectionEntry">
+      <modifiers>
+        <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="b5bd-4049-731e-cc49" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="ad85-f23a-72a7-0218" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
@@ -146,12 +161,23 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="1154-2cd1-76cf-5d30" name="Bombard Sub-type:" hidden="false" targetId="d5df-57ac-8f3c-097b" primary="false"/>
         <categoryLink id="3662-1e31-c505-a363" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="d30f-ea35-c242-a35c" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
+        <categoryLink id="30ec-959e-9485-83a4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="16b5-ada1-0377-a933" name="Breacher Squad" hidden="false" collective="false" import="false" targetId="ad97-c090-fa67-696f" type="selectionEntry">
+      <modifiers>
+        <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="d622-65cd-95c1-3848" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="5cfe-9890-b315-b4b9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
@@ -274,7 +300,6 @@
     <entryLink id="eb10-8d4b-c2c7-17d4" name="Damocles Command Rhino" hidden="false" collective="false" import="false" targetId="e337-8239-5e92-7f5f" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="f81e-a92f-6c7e-0980" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="b931-406c-5283-8445" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="d6da-13e2-7a4d-60b7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -291,6 +316,18 @@
       </categoryLinks>
     </entryLink>
     <entryLink id="5a18-11c5-5201-77d0" name="Despoiler Squad" hidden="false" collective="false" import="false" targetId="4357-930e-165a-a6e3" type="selectionEntry">
+      <modifiers>
+        <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="d73b-a407-0131-92bc" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="1262-cf57-7c1b-575d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
@@ -306,29 +343,31 @@
     <entryLink id="6f9b-b823-db02-749d" name="Dreadclaw Drop Pod" hidden="false" collective="false" import="false" targetId="bbe8-818d-3068-d79c" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="e78a-5a31-04d0-9a38" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="9f7b-238e-0169-6183" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+        <categoryLink id="9caf-b166-6e85-3fa0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="f5a3-cf20-d280-0d62" name="Falchion" hidden="false" collective="false" import="false" targetId="1fe8-7386-9509-d2d8" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="034a-b657-4331-482a" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="9694-8b06-6b72-c761" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="8fec-45d2-8c3b-1d40" name="Fellblade" hidden="false" collective="false" import="false" targetId="9c3c-f15a-9a1f-c0d0" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="3def-9e3f-93ca-c5b9" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="2a23-c511-c2b3-e449" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="318d-0ca8-920b-a155" name="Fire Raptor Gunship" hidden="false" collective="false" import="false" targetId="f6e1-24e2-fbdb-c5ef" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="61eb-6a78-045e-c729" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="f42f-ea8b-9802-5880" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="74ec-ad61-504f-2e4d" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="85df-adb9-8692-6b35" name="Glaive" hidden="false" collective="false" import="false" targetId="04e0-f69f-f759-b0b3" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="f0c9-2840-406c-dade" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="7f9a-3d07-b4b1-0118" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="d49d-b769-a7a1-105f" name="Heavy Support Squad" hidden="false" collective="false" import="false" targetId="bac9-5389-e2e7-0b1f" type="selectionEntry">
@@ -395,7 +434,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="4200-ff67-8196-c3eb" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="ec09-5564-c134-c01d" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+        <categoryLink id="3a2d-e60e-f5a7-1c72" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="6764-be36-2434-9807" name="Legion Banehammer" hidden="true" collective="false" import="false" targetId="1240-c71c-3a60-cf20" type="selectionEntry">
@@ -408,7 +447,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="58c8-bd18-3008-2861" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="ec66-4db2-9db8-9f53" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+        <categoryLink id="5f81-3d66-2dbe-752a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="6460-302a-4edf-0f8f" name="Legion Macharius Heavy Tank Squadron" hidden="false" collective="false" import="false" targetId="36ed-ca59-0d95-d85c" type="selectionEntry">
@@ -473,7 +512,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="8887-4fb0-f50f-71d1" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="7881-d136-4a11-a9c5" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+        <categoryLink id="a13c-a5f2-c61b-37cb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="3161-18f3-4ff5-565e" name="Legion Stormlord" hidden="true" collective="false" import="false" targetId="0887-0f66-2c7e-a5ba" type="selectionEntry">
@@ -486,7 +525,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="208a-c842-a3e5-0cbf" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="ece8-e87b-05f3-8fdd" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+        <categoryLink id="3200-21ec-16c3-05fb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="8612-8de9-0d49-bc1c" name="Legion Stormsword" hidden="true" collective="false" import="false" targetId="8e67-8f84-730c-2778" type="selectionEntry">
@@ -499,7 +538,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="8375-b2bc-b21f-6d62" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="f834-5003-9424-c26e" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+        <categoryLink id="76a9-9067-c558-8050" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="89f4-ec64-18e3-834a" name="Leviathan Dreadnought Talon" hidden="false" collective="false" import="false" targetId="c2a7-9e2c-fc65-1b78" type="selectionEntry">
@@ -511,6 +550,7 @@
     <entryLink id="2c48-417f-2d9f-607f" name="Mastodon" hidden="false" collective="false" import="false" targetId="7f24-2b72-9128-5330" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="2134-480f-42c0-e0c3" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="4da0-e85b-d624-c95e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="a598-c2dd-0f71-f45b" name="Medusa Squadron" hidden="true" collective="false" import="false" targetId="24c8-5f6a-d48a-27b7" type="selectionEntry">
@@ -522,7 +562,6 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="a46a-0cbd-6063-706f" name="Bombard Sub-type:" hidden="false" targetId="d5df-57ac-8f3c-097b" primary="false"/>
         <categoryLink id="f2be-a5a7-541e-bc2d" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
         <categoryLink id="76de-e849-aa9e-2613" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
       </categoryLinks>
@@ -623,6 +662,13 @@
       </categoryLinks>
     </entryLink>
     <entryLink id="f01d-877f-a918-e097" name="Reconnaissance Squad" hidden="false" collective="false" import="false" targetId="6db7-6e88-877e-35ca" type="selectionEntry">
+      <modifiers>
+        <modifier type="add" field="category" value="8f42-a824-fb5f-8fea">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="6fec-c224-577a-bfc7" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="f065-e895-8376-0868" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
@@ -641,6 +687,13 @@
       </categoryLinks>
     </entryLink>
     <entryLink id="1509-08ef-cef0-45d5" name="Scout Squad" hidden="false" collective="false" import="false" targetId="9b10-b657-a65a-9d60" type="selectionEntry">
+      <modifiers>
+        <modifier type="add" field="category" value="8f42-a824-fb5f-8fea">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="e443-4e9a-afd7-75a1" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="b36a-c596-6ac7-7ac4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
@@ -661,7 +714,6 @@
     <entryLink id="7f98-4826-a1f8-3a6b" name="Sicaran Omega Squadron" hidden="false" collective="false" import="false" targetId="c88b-fe44-34a3-97e1" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="d776-6199-79a7-f820" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="1d04-20d5-92a5-f747" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="1277-e55b-20f5-2be4" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
       </categoryLinks>
     </entryLink>
@@ -674,7 +726,6 @@
     <entryLink id="d567-0a28-d590-0504" name="Sicaran Squadron" hidden="false" collective="false" import="false" targetId="706a-9532-f06d-00ed" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="6ca1-2a3b-ce97-7411" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="bd83-7b9c-6910-2d04" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="00f5-daec-ffef-ce45" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
       </categoryLinks>
     </entryLink>
@@ -693,6 +744,7 @@
     <entryLink id="a1da-a30a-5185-b804" name="Sokar Stormbird" hidden="false" collective="false" import="false" targetId="f403-630f-71ae-5a7d" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="9296-e8c7-5a57-f74e" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="7990-cb8e-74c7-972b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="533f-92c6-3c3c-191c" name="Spatha Attack Bike Squadron" hidden="false" collective="false" import="false" targetId="4d72-1cc1-8bee-aa88" type="selectionEntry">
@@ -711,10 +763,22 @@
     <entryLink id="85ce-3361-689f-de0b" name="Storm Eagle Gunship" hidden="false" collective="false" import="false" targetId="8aa5-ff31-7de7-19d4" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="0962-9fe8-d952-237b" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="dc4e-bfca-09b7-c926" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+        <categoryLink id="c8f8-89e0-e77a-aa29" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="b8ca-7fc3-9885-442f" name="Tactical Squad" hidden="false" collective="false" import="false" targetId="aa72-63e4-bc60-4611" type="selectionEntry">
+      <modifiers>
+        <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="c53e-35fb-7409-d6cd" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="c562-f87b-3a3f-c2b7" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
@@ -736,7 +800,6 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="0bf5-ba06-eb2b-cc0a" name="Artillery Sub-type:" hidden="false" targetId="6f99-c178-6f9d-fb63" primary="false"/>
         <categoryLink id="9454-6a20-9086-a0ba" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
         <categoryLink id="bc38-316f-be80-ff7e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
@@ -771,7 +834,6 @@
       <categoryLinks>
         <categoryLink id="e6cc-2e9d-4c89-6eba" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="9972-607b-a844-41da" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="df0e-846e-fcbc-7b1d" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="4766-17f6-e613-f831" name="Thunderbolt Fighter" hidden="false" collective="false" import="false" targetId="5d24-1e9a-ad9d-95ca" type="selectionEntry">
@@ -790,6 +852,7 @@
     <entryLink id="4f6c-a6a0-471a-d91e" name="Thunderhawk Gunship" hidden="false" collective="false" import="false" targetId="8754-3a4f-213b-bdc0" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="f4f2-f5c1-852f-f2f4" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="43c7-06a5-8c7b-85af" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="cbb7-653a-6657-251a" name="Tylos Rubio" hidden="false" collective="false" import="false" targetId="56bf-2c6d-a0fa-a145" type="selectionEntry">
@@ -808,6 +871,7 @@
     <entryLink id="3c84-63cb-339a-9eea" name="Typhon Squadron" hidden="false" collective="false" import="false" targetId="d06a-3087-af13-ca95" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="90d1-4dee-1f65-1a45" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="40bf-4f06-7c14-b8b4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="b3ed-cd72-c764-20a7" name="Veteran Squad" hidden="false" collective="false" import="false" targetId="a423-7dd8-3f1b-3e28" type="selectionEntry">
@@ -833,14 +897,29 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="eb54-3f93-c551-aa64" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="30b5-c4bd-4322-b067" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
-        <categoryLink id="e45d-f6ce-9eb6-5b39" name="Bombard Sub-type:" hidden="false" targetId="d5df-57ac-8f3c-097b" primary="false"/>
+        <categoryLink id="28f3-6735-3fe8-5daa" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="4b12-b17a-86c7-960a" name="Xiphon Interceptor" hidden="false" collective="false" import="false" targetId="596b-5478-e079-59ab" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="0fab-a641-0aca-93c3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="b99b-a19a-14d8-3e9f" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="da28-3e90-f9bb-ac33" name="Seeker Squad" hidden="true" collective="false" import="false" targetId="58e6-f9cc-4c46-e258" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <infoLinks>
+        <infoLink id="1097-dea9-335d-5945" name="Legiones Astartes (Imperial Fists)" hidden="false" targetId="e876-4f8f-a30f-8b22" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="8247-71b0-fc82-30a0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="3c7e-b112-2089-7e60" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
       </categoryLinks>
     </entryLink>
   </entryLinks>
@@ -1220,6 +1299,7 @@
       <categoryLinks>
         <categoryLink id="0f9a-794e-6027-b9cf" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="e5a6-f3dc-73de-2bdb" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="8937-ca79-5a50-90fb" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="3825-ece6-4a69-41cb" name="Sigismund" hidden="false" collective="false" import="true" type="model">
@@ -1383,6 +1463,7 @@
       <categoryLinks>
         <categoryLink id="93db-ffc9-0558-73e6" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="e823-f428-97c9-b5d7" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="0d9a-8f4f-0ec8-6ebc" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="194d-69e1-55b6-8453" name="Alexis Polux" hidden="false" collective="false" import="true" type="model">
@@ -1499,6 +1580,7 @@
       <categoryLinks>
         <categoryLink id="7d2a-1492-8056-3083" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="f860-72fd-d93c-1290" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="7b95-8b9b-38c1-f8fb" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="0a3e-c822-cc8c-3bef" name="Fafnir Rann" hidden="false" collective="false" import="true" type="model">
@@ -1919,6 +2001,10 @@ Both weapons are counted as ‘Power’ weapons for those rules that affect such
       <infoLinks>
         <infoLink id="7f1a-b7fb-507c-ea29" name="Legiones Astartes (Imperial Fists)" hidden="false" targetId="e876-4f8f-a30f-8b22" type="rule"/>
       </infoLinks>
+      <categoryLinks>
+        <categoryLink id="c043-4561-4769-2322" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
+        <categoryLink id="0895-b881-212f-b491" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+      </categoryLinks>
       <selectionEntries>
         <selectionEntry id="7518-46a4-31f2-3033" name="Rogal Dorn" hidden="false" collective="false" import="true" type="model">
           <profiles>
@@ -2086,6 +2172,12 @@ Both weapons are counted as ‘Power’ weapons for those rules that affect such
         </infoLink>
         <infoLink id="1b54-dd41-0d20-8ea4" name="Deep Strike" hidden="false" targetId="f1e1-986f-c783-ca9e" type="rule"/>
       </infoLinks>
+      <categoryLinks>
+        <categoryLink id="9c2c-a3a7-f173-2fd3" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+        <categoryLink id="1611-1fbf-b28d-082b" name="Terminators:" hidden="false" targetId="bab3-f50d-3e5f-2f78" primary="false"/>
+        <categoryLink id="7d8a-f02e-04ca-e7e6" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="c04e-d6da-5531-7c3a" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+      </categoryLinks>
       <selectionEntries>
         <selectionEntry id="3702-7bd5-26f0-d56e" name="Huscarl-master" hidden="false" collective="false" import="true" type="model">
           <constraints>
@@ -2386,6 +2478,10 @@ Both weapons are counted as ‘Power’ weapons for those rules that affect such
         </infoLink>
         <infoLink id="2e8b-f617-0766-bb4e" name="Transport Bay" hidden="false" targetId="0662-8b8d-38e8-60f8" type="rule"/>
       </infoLinks>
+      <categoryLinks>
+        <categoryLink id="0926-4bcb-7263-d6a1" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+        <categoryLink id="9de5-657e-8970-390d" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
+      </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="d982-313d-0d97-d831" name="Wing Weapon Options" hidden="false" collective="false" import="true" defaultSelectionEntryId="0127-b935-d076-9419">
           <constraints>

--- a/2022 - LA - Iron Hands.cat
+++ b/2022 - LA - Iron Hands.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="b73e-125f-db29-17f2" name="LA -  X: Iron Hands" revision="8" battleScribeVersion="2.03" authorName="Figjam Bohica" authorContact="BSData Developers Discord" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="17" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="b73e-125f-db29-17f2" name="LA -  X: Iron Hands" revision="9" battleScribeVersion="2.03" authorName="Figjam Bohica" authorContact="BSData Developers Discord" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="18" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entryLinks>
     <entryLink id="6107-168e-198e-2e94" name="  X: Iron Hands" hidden="false" collective="false" import="false" targetId="bfc9-c99c-bf8a-3917" type="selectionEntry">
       <constraints>
@@ -39,21 +39,18 @@
       <categoryLinks>
         <categoryLink id="4352-3cd4-e3da-54fa" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="5628-344a-7f03-95bf" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="a6cc-0043-82f4-20f4" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="e1ce-d9b7-2ea1-760b" name="Medusan Immortal Squad" hidden="false" collective="false" import="false" targetId="f9e4-0da2-5049-df81" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="028c-19b9-ccdf-9229" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="3f2e-25c7-b685-51db" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="01ed-67ea-cdc1-b2e2" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="de83-37e7-9228-0b81" name="Gorgon Terminator Squad" hidden="false" collective="false" import="false" targetId="ea50-6315-7a52-f560" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="26b1-401b-c49d-a163" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="0ac3-4093-1c72-a6c2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="e78f-9b56-5432-ae85" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="acbb-d53d-6be7-eef8" name="Ferrus Manus" hidden="false" collective="false" import="false" targetId="554b-1024-a345-0d14" type="selectionEntry">
@@ -67,7 +64,6 @@
       <categoryLinks>
         <categoryLink id="84ec-691d-8d75-7998" name="New CategoryLink" hidden="false" targetId="ad5f-31db-8bc7-5c46" primary="true"/>
         <categoryLink id="4198-15b1-372c-89c8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="cfaa-df97-506a-12e7" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="2dbc-c2bc-600f-0c06" name="Apothecarion Detachment" hidden="false" collective="false" import="false" targetId="81df-ffd4-a32b-b4a1" type="selectionEntry">
@@ -83,6 +79,18 @@
       </categoryLinks>
     </entryLink>
     <entryLink id="75b9-a14d-71c6-c1c3" name="Assault Squad" hidden="false" collective="false" import="false" targetId="a8e9-70e1-b8bc-8ee2" type="selectionEntry">
+      <modifiers>
+        <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="531a-be7b-d57c-54bc" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="a743-76f5-596b-b2f4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
@@ -111,12 +119,23 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="1c2c-b39d-a574-e0c1" name="Bombard Sub-type:" hidden="false" targetId="d5df-57ac-8f3c-097b" primary="false"/>
         <categoryLink id="1b48-5870-0014-271a" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="4838-5f74-0a1c-bf9e" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
+        <categoryLink id="b204-d1e3-78bc-448e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="ccd5-7195-3de9-39e4" name="Breacher Squad" hidden="false" collective="false" import="false" targetId="ad97-c090-fa67-696f" type="selectionEntry">
+      <modifiers>
+        <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="0c09-eed2-c6ce-455f" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="0116-7fce-ff42-fe7f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
@@ -239,7 +258,6 @@
     <entryLink id="441c-ddc8-3d17-9db6" name="Damocles Command Rhino" hidden="false" collective="false" import="false" targetId="e337-8239-5e92-7f5f" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="f918-fd61-e41a-e9c0" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="5e9b-f6bd-5996-f08c" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="4e42-ca8c-97e0-6ea6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -256,6 +274,18 @@
       </categoryLinks>
     </entryLink>
     <entryLink id="2395-c646-99b6-1777" name="Despoiler Squad" hidden="false" collective="false" import="false" targetId="4357-930e-165a-a6e3" type="selectionEntry">
+      <modifiers>
+        <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="c780-1b7a-0929-5223" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="0366-c15a-ffdc-62de" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
@@ -271,29 +301,31 @@
     <entryLink id="19a2-1290-e7e5-8e08" name="Dreadclaw Drop Pod" hidden="false" collective="false" import="false" targetId="bbe8-818d-3068-d79c" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="417b-dbb5-bec6-e1f0" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="894b-25bd-7ae8-a300" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+        <categoryLink id="f936-0064-b47d-0555" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="071e-77a5-ee6a-a920" name="Falchion" hidden="false" collective="false" import="false" targetId="1fe8-7386-9509-d2d8" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="7abd-e634-26fb-60a3" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="cc55-492f-0300-bd31" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="7576-7c97-0d6f-0e29" name="Fellblade" hidden="false" collective="false" import="false" targetId="9c3c-f15a-9a1f-c0d0" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="2e4c-2f9a-b6c3-1443" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="9456-af88-1cb7-c951" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="6f34-4910-1f0d-135d" name="Fire Raptor Gunship" hidden="false" collective="false" import="false" targetId="f6e1-24e2-fbdb-c5ef" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="b1eb-06fb-765d-08d3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="0293-1474-ec56-1264" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="abec-5c83-73e2-5418" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="68f5-4813-a2bd-e9aa" name="Glaive" hidden="false" collective="false" import="false" targetId="04e0-f69f-f759-b0b3" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="ba17-bb90-131c-570a" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="2b60-d0f8-a4ac-43ce" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="ad5a-8d7b-66ac-b648" name="Heavy Support Squad" hidden="false" collective="false" import="false" targetId="bac9-5389-e2e7-0b1f" type="selectionEntry">
@@ -360,7 +392,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="38eb-f183-e981-92d8" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="63d0-16c1-9888-1654" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+        <categoryLink id="162b-4449-21f6-ff6f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="72a7-17b3-fff3-1c5a" name="Legion Banehammer" hidden="true" collective="false" import="false" targetId="1240-c71c-3a60-cf20" type="selectionEntry">
@@ -373,7 +405,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="77f7-6263-51a4-0ba6" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="e9cb-da42-1d3d-0f5e" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+        <categoryLink id="cc9a-f0ce-ddf7-4b31" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="d710-dc61-52f2-c32e" name="Legion Macharius Heavy Tank Squadron" hidden="false" collective="false" import="false" targetId="36ed-ca59-0d95-d85c" type="selectionEntry">
@@ -438,7 +470,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="f6e1-a675-3d27-e26f" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="1ddf-892f-0230-a11c" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+        <categoryLink id="788b-d547-1eae-1d0f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="8e2e-97f0-d89f-9855" name="Legion Stormlord" hidden="true" collective="false" import="false" targetId="0887-0f66-2c7e-a5ba" type="selectionEntry">
@@ -451,7 +483,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="1fc4-e84a-3234-08b3" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="c68a-87f8-3a26-6860" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+        <categoryLink id="80b6-4b14-2f4f-f57a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="f78e-acbe-e0ef-3f9a" name="Legion Stormsword" hidden="true" collective="false" import="false" targetId="8e67-8f84-730c-2778" type="selectionEntry">
@@ -464,7 +496,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="2fdf-1912-95e9-2a15" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="b899-0590-5110-bcb2" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+        <categoryLink id="be83-2df4-f1c2-e45f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="798e-c8c7-1a7c-795a" name="Leviathan Dreadnought Talon" hidden="false" collective="false" import="false" targetId="c2a7-9e2c-fc65-1b78" type="selectionEntry">
@@ -476,6 +508,7 @@
     <entryLink id="163e-01af-2fd1-1c45" name="Mastodon" hidden="false" collective="false" import="false" targetId="7f24-2b72-9128-5330" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="087c-966b-e42a-22cd" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="371a-2b24-a9d6-1166" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="1364-f4c8-53dc-2f0b" name="Medusa Squadron" hidden="true" collective="false" import="false" targetId="24c8-5f6a-d48a-27b7" type="selectionEntry">
@@ -487,9 +520,8 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="3f52-c6c6-4e49-fead" name="Bombard Sub-type:" hidden="false" targetId="d5df-57ac-8f3c-097b" primary="false"/>
         <categoryLink id="959d-19e4-ec90-7ec8" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="af04-903d-f121-0bf4" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
+        <categoryLink id="8bd9-79cd-330f-49e0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="f1a5-3987-25ff-8129" name="Mortalis Destroyer Squad" hidden="false" collective="false" import="false" targetId="dbd4-930e-e003-9449" type="selectionEntry">
@@ -588,6 +620,13 @@
       </categoryLinks>
     </entryLink>
     <entryLink id="eb63-a37e-895d-9a79" name="Reconnaissance Squad" hidden="false" collective="false" import="false" targetId="6db7-6e88-877e-35ca" type="selectionEntry">
+      <modifiers>
+        <modifier type="add" field="category" value="8f42-a824-fb5f-8fea">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="5cc7-810b-0d3e-63dc" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="f6e0-5868-53b2-5d5e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
@@ -606,6 +645,13 @@
       </categoryLinks>
     </entryLink>
     <entryLink id="477f-108c-303a-fc0b" name="Scout Squad" hidden="false" collective="false" import="false" targetId="9b10-b657-a65a-9d60" type="selectionEntry">
+      <modifiers>
+        <modifier type="add" field="category" value="8f42-a824-fb5f-8fea">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="afdb-e293-67c7-4748" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="aaee-7ce8-137e-a5df" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
@@ -626,7 +672,6 @@
     <entryLink id="be5f-a69e-5831-c359" name="Sicaran Omega Squadron" hidden="false" collective="false" import="false" targetId="c88b-fe44-34a3-97e1" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="afd9-5c5c-db16-996f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="9ab6-4ab2-a05c-3730" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="7e8c-7024-3a84-4378" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
       </categoryLinks>
     </entryLink>
@@ -639,7 +684,6 @@
     <entryLink id="be5b-081f-76e6-2f75" name="Sicaran Squadron" hidden="false" collective="false" import="false" targetId="706a-9532-f06d-00ed" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="fc36-b4d6-0bcd-4518" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="8f89-2b72-a5c0-f656" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="f681-f9b9-80e8-316a" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
       </categoryLinks>
     </entryLink>
@@ -658,6 +702,7 @@
     <entryLink id="4713-5110-f8f9-269e" name="Sokar Stormbird" hidden="false" collective="false" import="false" targetId="f403-630f-71ae-5a7d" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="ee31-00d9-9130-cce6" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="6350-3358-7460-b373" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="31e7-41bc-dac7-267c" name="Spatha Attack Bike Squadron" hidden="false" collective="false" import="false" targetId="4d72-1cc1-8bee-aa88" type="selectionEntry">
@@ -676,10 +721,22 @@
     <entryLink id="5944-cb4e-8d33-7d57" name="Storm Eagle Gunship" hidden="false" collective="false" import="false" targetId="8aa5-ff31-7de7-19d4" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="dbbf-7484-4f53-9da7" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="562e-c292-ffe7-b3ba" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+        <categoryLink id="b3bc-a9ec-3e00-79be" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="591d-7932-3aa6-5aaa" name="Tactical Squad" hidden="false" collective="false" import="false" targetId="aa72-63e4-bc60-4611" type="selectionEntry">
+      <modifiers>
+        <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="9f8c-79f2-ce3f-2934" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="bcf3-01d8-1987-9cee" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
@@ -701,7 +758,6 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="bace-e3f9-545c-5856" name="Artillery Sub-type:" hidden="false" targetId="6f99-c178-6f9d-fb63" primary="false"/>
         <categoryLink id="6b29-deb4-4c36-3517" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
         <categoryLink id="34c0-9279-1cb8-3620" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
@@ -729,14 +785,12 @@
       <categoryLinks>
         <categoryLink id="6441-874e-5580-ee68" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="4900-7ae1-3710-27fa" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="8aaf-45bf-4bae-ca60" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="4882-f7c6-bb2a-1149" name="Terminator Tartaros Squad" hidden="false" collective="false" import="false" targetId="1a8e-0ded-a4dc-2b4e" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="fecf-acab-f5c9-18e2" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="1c8a-b4be-4122-6e09" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="32ef-dbd8-1b17-20d1" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="f50d-3ded-be21-4dfd" name="Thunderbolt Fighter" hidden="false" collective="false" import="false" targetId="5d24-1e9a-ad9d-95ca" type="selectionEntry">
@@ -755,6 +809,7 @@
     <entryLink id="6cc4-b71c-19d3-fbf9" name="Thunderhawk Gunship" hidden="false" collective="false" import="false" targetId="8754-3a4f-213b-bdc0" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="96a5-968a-66d4-b487" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="e156-5f36-9d0f-4a9a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="0d04-7fb4-1b16-4e46" name="Tylos Rubio" hidden="false" collective="false" import="false" targetId="56bf-2c6d-a0fa-a145" type="selectionEntry">
@@ -798,14 +853,29 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="8722-856a-826c-84b3" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="5f64-ab72-5e81-c07a" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
-        <categoryLink id="f868-f851-e20d-aed2" name="Bombard Sub-type:" hidden="false" targetId="d5df-57ac-8f3c-097b" primary="false"/>
+        <categoryLink id="efaf-72c1-6376-af2f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="52be-3800-aa3f-3077" name="Xiphon Interceptor" hidden="false" collective="false" import="false" targetId="596b-5478-e079-59ab" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="0ffe-2e1c-a8bc-7023" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="2a69-e3df-9913-6f1b" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="bcea-53b5-c7b1-4233" name="Seeker Squad" hidden="true" collective="false" import="false" targetId="58e6-f9cc-4c46-e258" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <infoLinks>
+        <infoLink id="b9e9-3d4a-f9e7-b8c6" name="Legiones Astartes (Iron Hands) " hidden="false" targetId="2e45-4b61-44fb-260b" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="7df1-c6fb-ca38-bb32" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="56d9-39b6-a7b5-9b38" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
       </categoryLinks>
     </entryLink>
   </entryLinks>
@@ -827,9 +897,10 @@
         <infoLink id="db91-3a2e-46b5-3998" name="Stubborn" hidden="false" targetId="7989-1f2c-a43d-82ae" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="61d4-5e58-36c9-9f32" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="false"/>
         <categoryLink id="9593-8dda-915e-8ef4" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
         <categoryLink id="0de3-d934-b836-a40c" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="5df3-9231-c29a-5bf6" name="Terminators:" hidden="false" targetId="bab3-f50d-3e5f-2f78" primary="false"/>
+        <categoryLink id="9bfa-f05f-d04f-e983" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="175c-be5a-9f30-7a03" name="Gorgon Hammerbearer" hidden="false" collective="false" import="true" type="model">
@@ -1155,7 +1226,9 @@
         <infoLink id="68c9-ea5b-8dbf-55ce" name="Stubborn" hidden="false" targetId="7989-1f2c-a43d-82ae" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="1bd4-40cb-dd60-a550" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="false"/>
+        <categoryLink id="922a-9c91-509f-36fd" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="b0a0-c02f-f97d-8b78" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+        <categoryLink id="221e-a4f5-b097-1747" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="c831-444b-9325-de3b" name="Immortal Sergeant" hidden="false" collective="false" import="true" type="model">
@@ -1567,7 +1640,8 @@
         <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="bbac-3de7-7dbd-15c1" type="max"/>
       </constraints>
       <categoryLinks>
-        <categoryLink id="e1e5-95e5-40c2-6e26" name="New CategoryLink" hidden="false" targetId="ad5f-31db-8bc7-5c46" primary="false"/>
+        <categoryLink id="ea33-c875-88be-d428" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
+        <categoryLink id="9014-262a-9067-0e59" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="6b2c-960f-6914-2c01" name="Ferrus Manus" hidden="false" collective="false" import="true" type="upgrade">
@@ -1731,9 +1805,9 @@
         <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9e96-f78b-5bbc-f13d" type="max"/>
       </constraints>
       <categoryLinks>
-        <categoryLink id="e549-4739-d1b7-8507" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="false"/>
         <categoryLink id="f1af-c02b-85f4-4611" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
-        <categoryLink id="e07c-741f-a596-fad1" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
+        <categoryLink id="4cb3-dd41-3d7c-685e" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="d41e-871d-300d-cb4b" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="9aef-f396-b30d-8cd0" name="Iron Father Autek Mor" hidden="false" collective="false" import="true" type="upgrade">
@@ -1894,7 +1968,9 @@
         <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7b9a-32a2-58e0-b6dc" type="max"/>
       </constraints>
       <categoryLinks>
-        <categoryLink id="0a37-199d-ac29-af4a" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="false"/>
+        <categoryLink id="66f5-3b86-bd2f-710f" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
+        <categoryLink id="b22b-21c0-8c4b-d804" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="87be-a40d-63fe-1eed" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="94ef-185a-f5bc-cc1c" name="Shadrak Meduson" hidden="false" collective="false" import="true" type="upgrade">

--- a/2022 - LA - Iron Warriors.cat
+++ b/2022 - LA - Iron Warriors.cat
@@ -1082,6 +1082,7 @@
       </constraints>
       <categoryLinks>
         <categoryLink id="652f-8767-983f-8259" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
+        <categoryLink id="2cb8-f4af-7359-ee4e" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="877c-1463-cab0-6661" name="Forgebreaker Desecrated" hidden="false" collective="false" import="true" type="upgrade">
@@ -1935,6 +1936,7 @@
       <categoryLinks>
         <categoryLink id="139a-249d-4c38-650d" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="cf0b-835c-75dd-6527" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+        <categoryLink id="733c-2fe4-e40d-c3e4" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="e241-8547-5f25-6bb1" name="Turret Mounted volcano cannon" hidden="false" collective="false" import="true" type="upgrade">

--- a/2022 - LA - Iron Warriors.cat
+++ b/2022 - LA - Iron Warriors.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="2ee4-57ed-db44-8a63" name="LA -   IV: Iron Warriors" revision="10" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="17" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="2ee4-57ed-db44-8a63" name="LA -   IV: Iron Warriors" revision="11" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="18" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entryLinks>
     <entryLink id="fe10-3104-0252-96de" name="Nârik Dreygur" hidden="false" collective="false" import="false" targetId="ac97-c8ce-16ba-9c49" type="selectionEntry">
       <modifiers>
@@ -31,7 +31,6 @@
       <categoryLinks>
         <categoryLink id="4fe3-7aed-a86d-e3a9" name="New CategoryLink" hidden="false" targetId="ad5f-31db-8bc7-5c46" primary="true"/>
         <categoryLink id="23ea-8f2f-28bd-c663" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="a42a-0125-6bda-676f" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="ede1-9c07-8401-67f9" name="Iron Havocs" hidden="false" collective="false" import="false" targetId="d355-5488-1277-fabf" type="selectionEntry">
@@ -145,6 +144,18 @@
       </categoryLinks>
     </entryLink>
     <entryLink id="19a9-0c79-2acf-5beb" name="Assault Squad" hidden="false" collective="false" import="false" targetId="a8e9-70e1-b8bc-8ee2" type="selectionEntry">
+      <modifiers>
+        <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="2ca9-a2a3-04f2-9611" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="b70b-5b20-bed2-cf21" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
@@ -173,12 +184,23 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="64c0-0187-9bbf-ef7a" name="Bombard Sub-type:" hidden="false" targetId="d5df-57ac-8f3c-097b" primary="false"/>
         <categoryLink id="e472-3b9d-e1bc-74e5" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="e3f7-0d36-34e4-299c" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
+        <categoryLink id="ed2f-76c6-c5a0-105d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="be21-9e50-1c3c-5076" name="Breacher Squad" hidden="false" collective="false" import="false" targetId="ad97-c090-fa67-696f" type="selectionEntry">
+      <modifiers>
+        <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="f471-f8fd-d5ec-2e28" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="ca2d-8576-e9a5-fe1a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
@@ -283,7 +305,6 @@
     <entryLink id="a2de-2601-7341-a58b" name="Damocles Command Rhino" hidden="false" collective="false" import="false" targetId="e337-8239-5e92-7f5f" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="65f2-4d62-ce1b-3938" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="7d5a-90f2-a185-add6" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="bf48-2199-1971-a440" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -300,6 +321,18 @@
       </categoryLinks>
     </entryLink>
     <entryLink id="23f0-1740-f4e4-005f" name="Despoiler Squad" hidden="false" collective="false" import="false" targetId="4357-930e-165a-a6e3" type="selectionEntry">
+      <modifiers>
+        <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="d565-e231-c7cc-dad0" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="4b41-2860-b73b-36b7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
@@ -315,29 +348,31 @@
     <entryLink id="5b47-f6af-d9f3-aa17" name="Dreadclaw Drop Pod" hidden="false" collective="false" import="false" targetId="bbe8-818d-3068-d79c" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="2d28-f74d-c6f9-6cc4" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="5e48-46ef-4c09-4120" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+        <categoryLink id="f8a4-8649-246a-d43b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="9eea-4f38-15d8-709e" name="Falchion" hidden="false" collective="false" import="false" targetId="1fe8-7386-9509-d2d8" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="732a-bf0a-fbe1-9072" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="83bb-470a-9752-3909" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="f138-3e9f-27d9-1894" name="Fellblade" hidden="false" collective="false" import="false" targetId="9c3c-f15a-9a1f-c0d0" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="b553-99bf-fd84-7042" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="33bd-daa1-1ac6-4a9c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="d6fe-9fe8-2d16-f05f" name="Fire Raptor Gunship" hidden="false" collective="false" import="false" targetId="f6e1-24e2-fbdb-c5ef" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="aa30-6175-bdf1-274a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="74e5-ae86-2f66-587e" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="e1ee-7f3d-2738-2557" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="c54a-98be-4c8c-b986" name="Glaive" hidden="false" collective="false" import="false" targetId="04e0-f69f-f759-b0b3" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="e923-aded-8787-05b6" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="fec6-e8c2-5fb3-8a6c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="c4be-f1d2-b4e4-2368" name="Heavy Support Squad" hidden="false" collective="false" import="false" targetId="bac9-5389-e2e7-0b1f" type="selectionEntry">
@@ -404,7 +439,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="5837-c1ba-6a20-0a63" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="192f-827c-e95b-a9b9" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+        <categoryLink id="0622-1da0-fee5-a3fd" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="8532-6414-3304-df12" name="Legion Banehammer" hidden="true" collective="false" import="false" targetId="1240-c71c-3a60-cf20" type="selectionEntry">
@@ -417,7 +452,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="7e41-3a91-4a34-d57e" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="4317-e00f-c631-29d4" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+        <categoryLink id="566e-f42e-68ed-faac" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="d3dc-d845-cc2a-0034" name="Legion Macharius Heavy Tank Squadron" hidden="false" collective="false" import="false" targetId="36ed-ca59-0d95-d85c" type="selectionEntry">
@@ -482,7 +517,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="47dc-9d14-6804-12b7" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="8286-4ac9-b673-18f1" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+        <categoryLink id="588d-1e81-0f6c-e8e5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="8f8b-c900-6eff-a33c" name="Legion Stormlord" hidden="true" collective="false" import="false" targetId="0887-0f66-2c7e-a5ba" type="selectionEntry">
@@ -495,7 +530,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="64f5-ae24-51c5-8606" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="30f2-2e53-c872-b99d" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+        <categoryLink id="7162-1b0c-26c3-9628" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="fdde-30f4-4c3f-a916" name="Legion Stormsword" hidden="true" collective="false" import="false" targetId="8e67-8f84-730c-2778" type="selectionEntry">
@@ -508,7 +543,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="9242-b8ad-53af-00f8" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="e2d7-3cdb-a744-b5ed" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+        <categoryLink id="03ec-a16f-0545-cc14" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="84e0-9ff7-a11d-73d1" name="Leviathan Dreadnought Talon" hidden="false" collective="false" import="false" targetId="c2a7-9e2c-fc65-1b78" type="selectionEntry">
@@ -520,6 +555,7 @@
     <entryLink id="cd78-3a92-039d-5bdd" name="Mastodon" hidden="false" collective="false" import="false" targetId="7f24-2b72-9128-5330" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="7d91-a02d-52b1-693b" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="8c3a-2ab9-03ec-2a68" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="d4a6-50b9-fa28-fd20" name="Medusa Squadron" hidden="true" collective="false" import="false" targetId="24c8-5f6a-d48a-27b7" type="selectionEntry">
@@ -531,9 +567,8 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="b1aa-612a-cf75-a588" name="Bombard Sub-type:" hidden="false" targetId="d5df-57ac-8f3c-097b" primary="false"/>
         <categoryLink id="86d4-1814-46c0-59da" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="bef9-8cb6-d94a-239c" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
+        <categoryLink id="7fe2-380b-8be3-1174" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="f106-f532-e48b-122e" name="Mortalis Destroyer Squad" hidden="false" collective="false" import="false" targetId="dbd4-930e-e003-9449" type="selectionEntry">
@@ -632,6 +667,13 @@
       </categoryLinks>
     </entryLink>
     <entryLink id="e61d-8855-f898-5f38" name="Reconnaissance Squad" hidden="false" collective="false" import="false" targetId="6db7-6e88-877e-35ca" type="selectionEntry">
+      <modifiers>
+        <modifier type="add" field="category" value="8f42-a824-fb5f-8fea">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="18dc-e8d0-2c58-3ea7" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="a958-6d76-bd5c-5319" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
@@ -650,6 +692,13 @@
       </categoryLinks>
     </entryLink>
     <entryLink id="738a-3431-36a7-3fa6" name="Scout Squad" hidden="false" collective="false" import="false" targetId="9b10-b657-a65a-9d60" type="selectionEntry">
+      <modifiers>
+        <modifier type="add" field="category" value="8f42-a824-fb5f-8fea">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="d942-91d3-b543-2ff3" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="dd2a-180a-9293-61c0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
@@ -670,7 +719,6 @@
     <entryLink id="d70d-082d-e74b-c141" name="Sicaran Omega Squadron" hidden="false" collective="false" import="false" targetId="c88b-fe44-34a3-97e1" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="43cf-f743-7a76-a072" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="7610-4511-6e8e-ef89" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="2400-2eb1-7903-8b52" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
       </categoryLinks>
     </entryLink>
@@ -683,7 +731,6 @@
     <entryLink id="4aba-dfc5-b6ac-9881" name="Sicaran Squadron" hidden="false" collective="false" import="false" targetId="706a-9532-f06d-00ed" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="52dc-b8bb-2b06-c9fd" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="fce2-8cb2-c10d-756e" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="163e-54d4-41ea-a209" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
       </categoryLinks>
     </entryLink>
@@ -702,6 +749,7 @@
     <entryLink id="3eb0-83a7-0893-0342" name="Sokar Stormbird" hidden="false" collective="false" import="false" targetId="f403-630f-71ae-5a7d" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="4548-800d-5c39-8db5" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="cc52-554c-d8c4-e9b1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="705d-1e9f-1eda-187b" name="Spatha Attack Bike Squadron" hidden="false" collective="false" import="false" targetId="4d72-1cc1-8bee-aa88" type="selectionEntry">
@@ -720,10 +768,22 @@
     <entryLink id="2cab-599b-7aca-b71e" name="Storm Eagle Gunship" hidden="false" collective="false" import="false" targetId="8aa5-ff31-7de7-19d4" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="c425-6767-1e40-26d8" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="efdf-5f3a-437d-764f" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+        <categoryLink id="4b2f-8cc0-d11a-7882" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="26fc-1f77-f702-8275" name="Tactical Squad" hidden="false" collective="false" import="false" targetId="aa72-63e4-bc60-4611" type="selectionEntry">
+      <modifiers>
+        <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="b977-1383-c399-1c11" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="1304-a4fe-8f32-8c9f" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
@@ -745,7 +805,6 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="92ee-998a-3c59-37a2" name="Artillery Sub-type:" hidden="false" targetId="6f99-c178-6f9d-fb63" primary="false"/>
         <categoryLink id="e126-8e97-6af8-0852" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
         <categoryLink id="048a-6c30-801d-5478" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
@@ -773,14 +832,12 @@
       <categoryLinks>
         <categoryLink id="737d-bdad-c54e-4b3c" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="541d-23ce-1ffa-4d42" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="52bd-888b-28c2-297a" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="3e5f-dbb7-33ac-dca8" name="Terminator Tartaros Squad" hidden="false" collective="false" import="false" targetId="1a8e-0ded-a4dc-2b4e" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="44a0-cf54-18b1-c86d" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="5868-8c0f-c25d-b473" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="de1d-2b97-6251-6a4a" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="925b-bd22-c6b2-b526" name="Thunderbolt Fighter" hidden="false" collective="false" import="false" targetId="5d24-1e9a-ad9d-95ca" type="selectionEntry">
@@ -799,6 +856,7 @@
     <entryLink id="89c8-b555-6b31-0cda" name="Thunderhawk Gunship" hidden="false" collective="false" import="false" targetId="8754-3a4f-213b-bdc0" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="0cac-5c7f-509d-bde7" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="1278-e1b3-11cd-65aa" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="e0bc-1323-236d-3e03" name="Tylos Rubio" hidden="false" collective="false" import="false" targetId="56bf-2c6d-a0fa-a145" type="selectionEntry">
@@ -817,6 +875,7 @@
     <entryLink id="0cb4-9c5d-0a5a-f61f" name="Typhon Squadron" hidden="false" collective="false" import="false" targetId="d06a-3087-af13-ca95" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="55be-f08b-f8d8-0099" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="b874-ec9d-0628-2d42" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="8535-00b2-9aaf-e35c" name="Veteran Squad" hidden="false" collective="false" import="false" targetId="a423-7dd8-3f1b-3e28" type="selectionEntry">
@@ -842,8 +901,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="8d2b-fbad-65f6-0871" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="a74e-0b9a-097f-d36e" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
-        <categoryLink id="5c7a-74fa-05d9-7a16" name="Bombard Sub-type:" hidden="false" targetId="d5df-57ac-8f3c-097b" primary="false"/>
+        <categoryLink id="2c17-401e-40e4-7ec9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="b06e-2d8e-f55f-ec65" name="Xiphon Interceptor" hidden="false" collective="false" import="false" targetId="596b-5478-e079-59ab" type="selectionEntry">
@@ -868,6 +926,22 @@
       <categoryLinks>
         <categoryLink id="1d66-e356-515a-fed0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="b476-6408-a64c-7724" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="6be4-dbc0-31f4-7957" name="Seeker Squad" hidden="true" collective="false" import="false" targetId="58e6-f9cc-4c46-e258" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <infoLinks>
+        <infoLink id="563e-680c-2c8f-b79c" name="Legiones Astartes (Iron Warriors) " hidden="false" targetId="c77b-f3fc-5dc8-1330" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="83b5-f52e-402a-7d7e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="b016-648a-9bf1-8e03" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
       </categoryLinks>
     </entryLink>
   </entryLinks>
@@ -909,6 +983,12 @@
         <infoLink id="1684-2944-0cdd-be4f" name="Legiones Astartes (Iron Warriors) " hidden="false" targetId="c77b-f3fc-5dc8-1330" type="rule"/>
         <infoLink id="939a-42cc-bf7d-57e6" name="Legiones Cybernetica" hidden="false" targetId="a2ef-63a4-3531-db91" type="rule"/>
       </infoLinks>
+      <categoryLinks>
+        <categoryLink id="7837-eff0-6d84-4615" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
+        <categoryLink id="ee56-4096-c582-710a" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="99a3-f200-6427-bcfb" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+        <categoryLink id="3f0c-0709-e9a4-dafd" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+      </categoryLinks>
       <selectionEntries>
         <selectionEntry id="e8e7-72f1-d3e3-e43a" name="Graviton Gauntlet" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
@@ -1000,6 +1080,9 @@
       <constraints>
         <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="448d-767c-67a2-aae4" type="max"/>
       </constraints>
+      <categoryLinks>
+        <categoryLink id="652f-8767-983f-8259" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
+      </categoryLinks>
       <selectionEntries>
         <selectionEntry id="877c-1463-cab0-6661" name="Forgebreaker Desecrated" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
@@ -1184,6 +1267,11 @@
           </modifiers>
         </infoLink>
       </infoLinks>
+      <categoryLinks>
+        <categoryLink id="ee64-c915-d9f8-3b09" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+        <categoryLink id="57e9-d1c5-973b-1aca" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="32ae-ac04-cb33-39c9" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+      </categoryLinks>
       <selectionEntries>
         <selectionEntry id="4cb3-bda9-065c-eed4" name="Iron Havoc" hidden="false" collective="false" import="true" type="model">
           <constraints>
@@ -1240,6 +1328,9 @@
               </characteristics>
             </profile>
           </profiles>
+          <categoryLinks>
+            <categoryLink id="5a36-b0f6-649f-c4f5" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
+          </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="3455-cfff-8f3f-2765" name="May exchange main weapon for:" hidden="false" collective="false" import="true">
               <constraints>
@@ -1527,6 +1618,12 @@
         <infoLink id="3d6b-8698-77f8-dddd" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule"/>
         <infoLink id="7332-ee1c-1ce2-0d4b" name="Legiones Astartes (Iron Warriors) " hidden="false" targetId="c77b-f3fc-5dc8-1330" type="rule"/>
       </infoLinks>
+      <categoryLinks>
+        <categoryLink id="7a42-24a0-f251-742d" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="d025-1500-764b-7cb1" name="Terminators:" hidden="false" targetId="bab3-f50d-3e5f-2f78" primary="false"/>
+        <categoryLink id="1084-a64f-bae5-5999" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+        <categoryLink id="029a-d8b2-d712-01df" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+      </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="b977-01e2-61ff-64bf" name="Dedicated Transport:" hidden="false" collective="false" import="true">
           <constraints>
@@ -1669,6 +1766,9 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e06a-40d1-285b-91fd" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7c57-6f02-5361-ed59" type="max"/>
           </constraints>
+          <categoryLinks>
+            <categoryLink id="1207-e255-854f-7988" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
+          </categoryLinks>
           <selectionEntries>
             <selectionEntry id="941a-cb5c-f6ca-c2f4" name="Siege Master" hidden="false" collective="false" import="true" type="model">
               <profiles>
@@ -1832,6 +1932,10 @@
         <infoLink id="dc59-8af8-089f-dc6b" name="Transport Bay" hidden="false" targetId="0662-8b8d-38e8-60f8" type="rule"/>
         <infoLink id="0c62-e71b-7348-6b5d" name="Legiones Astartes (Iron Warriors) " hidden="false" targetId="c77b-f3fc-5dc8-1330" type="rule"/>
       </infoLinks>
+      <categoryLinks>
+        <categoryLink id="139a-249d-4c38-650d" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
+        <categoryLink id="cf0b-835c-75dd-6527" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+      </categoryLinks>
       <selectionEntries>
         <selectionEntry id="e241-8547-5f25-6bb1" name="Turret Mounted volcano cannon" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
@@ -1961,6 +2065,11 @@
       <infoLinks>
         <infoLink id="a301-b079-3cd3-9d37" name="Legiones Astartes (Iron Warriors) " hidden="false" targetId="c77b-f3fc-5dc8-1330" type="rule"/>
       </infoLinks>
+      <categoryLinks>
+        <categoryLink id="8279-3044-a1e7-7a13" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
+        <categoryLink id="5215-204f-c641-45e8" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="aadf-fc65-d13f-de42" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+      </categoryLinks>
       <selectionEntries>
         <selectionEntry id="046a-5e7e-7b20-3043" name="Kyr Vhalen" hidden="false" collective="false" import="true" type="model">
           <constraints>
@@ -2148,6 +2257,12 @@
         </infoLink>
         <infoLink id="311f-2a92-88cf-ea1f" name="Legiones Astartes (Iron Warriors) " hidden="false" targetId="c77b-f3fc-5dc8-1330" type="rule"/>
       </infoLinks>
+      <categoryLinks>
+        <categoryLink id="1e3b-3776-e033-cd91" name="Terminators:" hidden="false" targetId="bab3-f50d-3e5f-2f78" primary="false"/>
+        <categoryLink id="3cce-4df7-9ff9-c8eb" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="b6c3-bd97-0c98-5440" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
+        <categoryLink id="c0cf-d856-baa2-b2d9" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+      </categoryLinks>
       <selectionEntries>
         <selectionEntry id="9f1e-2af9-7313-02c2" name="Extricator" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
@@ -2272,6 +2387,12 @@
           </modifiers>
         </infoLink>
       </infoLinks>
+      <categoryLinks>
+        <categoryLink id="0be3-3ef2-06d5-513f" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="7d54-110a-f4d0-fbac" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="eb9f-a770-ac11-f3c5" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+        <categoryLink id="2c06-dd4a-568c-f5f3" name="Terminators:" hidden="false" targetId="bab3-f50d-3e5f-2f78" primary="false"/>
+      </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="9d1e-8246-4cef-5387" name="Dominators" hidden="false" collective="false" import="true" defaultSelectionEntryId="3285-cc6e-1b0f-15a9">
           <constraints>

--- a/2022 - LA - Night Lords.cat
+++ b/2022 - LA - Night Lords.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="36dc-14fc-8872-476b" name="LA -   VIII: Night Lords" revision="9" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="17" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="36dc-14fc-8872-476b" name="LA -   VIII: Night Lords" revision="10" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="18" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entryLinks>
     <entryLink id="f491-c7fa-f6d3-917d" name="Contekar Terminator Squad" hidden="false" collective="false" import="false" targetId="837e-c3ca-437e-dfbf" type="selectionEntry">
       <modifiers>
@@ -175,6 +175,18 @@
       </categoryLinks>
     </entryLink>
     <entryLink id="43e2-b2fb-d9d3-4590" name="Assault Squad" hidden="false" collective="false" import="false" targetId="a8e9-70e1-b8bc-8ee2" type="selectionEntry">
+      <modifiers>
+        <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="c2f8-252b-55a0-40af" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="7c51-0be9-3483-90a2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
@@ -203,12 +215,23 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="31fa-39f2-c31e-6696" name="Bombard Sub-type:" hidden="false" targetId="d5df-57ac-8f3c-097b" primary="false"/>
         <categoryLink id="f9ec-02b2-e955-c7c1" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="d3bc-8608-a9b5-1ee1" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
+        <categoryLink id="bd64-ec2f-bc32-1b6f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="eeb6-6f88-48ca-9d74" name="Breacher Squad" hidden="false" collective="false" import="false" targetId="ad97-c090-fa67-696f" type="selectionEntry">
+      <modifiers>
+        <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="3417-8f49-7272-ce18" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="6e19-a1ee-d25b-0123" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
@@ -331,7 +354,6 @@
     <entryLink id="14f8-46c6-5baf-ec66" name="Damocles Command Rhino" hidden="false" collective="false" import="false" targetId="e337-8239-5e92-7f5f" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="bf7b-246b-a0fa-39ea" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="c005-4e23-58f4-85ab" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="e343-0c42-3c25-b45e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -348,6 +370,18 @@
       </categoryLinks>
     </entryLink>
     <entryLink id="8218-b17a-bde2-8383" name="Despoiler Squad" hidden="false" collective="false" import="false" targetId="4357-930e-165a-a6e3" type="selectionEntry">
+      <modifiers>
+        <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="8efe-baba-177d-9872" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="4559-4f5b-d8d9-00ee" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
@@ -363,29 +397,31 @@
     <entryLink id="589e-93e1-3cd7-d79c" name="Dreadclaw Drop Pod" hidden="false" collective="false" import="false" targetId="bbe8-818d-3068-d79c" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="5c0b-fc42-41fa-9172" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="6e9a-82d9-8b61-e02d" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+        <categoryLink id="a085-0029-7499-79a2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="14da-091d-f2bf-4312" name="Falchion" hidden="false" collective="false" import="false" targetId="1fe8-7386-9509-d2d8" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="2f62-7ddb-bf9c-c59b" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="663b-5ce0-a3ca-acf4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="0faa-25ee-9e8d-5462" name="Fellblade" hidden="false" collective="false" import="false" targetId="9c3c-f15a-9a1f-c0d0" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="95dd-60db-f855-6b1c" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="14c8-4ba7-e3c1-8eaf" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="743a-0c64-2289-ce30" name="Fire Raptor Gunship" hidden="false" collective="false" import="false" targetId="f6e1-24e2-fbdb-c5ef" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="4771-7a36-6092-446a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="a0de-5d3e-f1a0-16c6" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="0bbe-97c4-53da-9e28" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="29aa-8bfd-f9d9-4ea1" name="Glaive" hidden="false" collective="false" import="false" targetId="04e0-f69f-f759-b0b3" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="2928-9538-52d5-86ca" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="e969-493e-ce81-1c4f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="8318-eb2b-c28e-4cd0" name="Heavy Support Squad" hidden="false" collective="false" import="false" targetId="bac9-5389-e2e7-0b1f" type="selectionEntry">
@@ -452,7 +488,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="82e7-1141-8911-a3d3" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="5613-2e08-a8c7-c326" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+        <categoryLink id="22b9-19ed-8243-6c9f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="88ee-a5a9-8bc1-d642" name="Legion Banehammer" hidden="true" collective="false" import="false" targetId="1240-c71c-3a60-cf20" type="selectionEntry">
@@ -465,7 +501,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="cbb9-c5cb-a995-11a3" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="d421-74b6-a0ba-4a4e" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+        <categoryLink id="5758-42fa-6483-ad1e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="d3f7-4b68-4620-71c0" name="Legion Macharius Heavy Tank Squadron" hidden="false" collective="false" import="false" targetId="36ed-ca59-0d95-d85c" type="selectionEntry">
@@ -530,7 +566,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="ead6-b9ca-69dc-9e9d" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="8afa-bd88-f1b2-dca1" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+        <categoryLink id="f72f-283a-b30e-5717" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="a964-cde7-e4a6-214f" name="Legion Stormlord" hidden="true" collective="false" import="false" targetId="0887-0f66-2c7e-a5ba" type="selectionEntry">
@@ -543,7 +579,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="2f0c-4e80-0e67-18cb" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="d7e5-03d5-53c8-dfa3" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+        <categoryLink id="b4b6-455d-7034-933f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="50ef-7431-d164-ddc3" name="Legion Stormsword" hidden="true" collective="false" import="false" targetId="8e67-8f84-730c-2778" type="selectionEntry">
@@ -556,7 +592,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="2c88-5bb4-c0a2-b7dc" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="c402-65e8-0197-7169" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+        <categoryLink id="dc15-12fc-5e96-6572" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="c99d-d45c-e6df-c8d5" name="Leviathan Dreadnought Talon" hidden="false" collective="false" import="false" targetId="c2a7-9e2c-fc65-1b78" type="selectionEntry">
@@ -568,6 +604,7 @@
     <entryLink id="77fc-1222-7a9e-e1d0" name="Mastodon" hidden="false" collective="false" import="false" targetId="7f24-2b72-9128-5330" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="96b7-d05f-8520-1933" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="ee6c-4065-b963-db7a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="cb29-6fb3-b99d-62ae" name="Medusa Squadron" hidden="true" collective="false" import="false" targetId="24c8-5f6a-d48a-27b7" type="selectionEntry">
@@ -579,9 +616,8 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="e9af-3279-f2ee-54c9" name="Bombard Sub-type:" hidden="false" targetId="d5df-57ac-8f3c-097b" primary="false"/>
         <categoryLink id="792b-953e-cad5-dbb2" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="3c82-2272-f6d1-bf64" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
+        <categoryLink id="aa0a-9234-c3d8-88d5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="99a3-879d-2980-2285" name="Mortalis Destroyer Squad" hidden="false" collective="false" import="false" targetId="dbd4-930e-e003-9449" type="selectionEntry">
@@ -680,6 +716,13 @@
       </categoryLinks>
     </entryLink>
     <entryLink id="d8cd-1f7f-e904-30f2" name="Reconnaissance Squad" hidden="false" collective="false" import="false" targetId="6db7-6e88-877e-35ca" type="selectionEntry">
+      <modifiers>
+        <modifier type="add" field="category" value="8f42-a824-fb5f-8fea">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="6a7d-054f-1d60-2f03" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="4d42-1cf9-a8f5-6419" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
@@ -698,6 +741,13 @@
       </categoryLinks>
     </entryLink>
     <entryLink id="58e8-a073-7f80-608e" name="Scout Squad" hidden="false" collective="false" import="false" targetId="9b10-b657-a65a-9d60" type="selectionEntry">
+      <modifiers>
+        <modifier type="add" field="category" value="8f42-a824-fb5f-8fea">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="d925-f60a-0175-051e" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="45e9-2190-3f91-a5b4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
@@ -718,7 +768,6 @@
     <entryLink id="a09f-3151-5892-ce0f" name="Sicaran Omega Squadron" hidden="false" collective="false" import="false" targetId="c88b-fe44-34a3-97e1" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="6958-c12e-8f67-8c8c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="12e9-17f8-11f3-5a36" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="f073-82c1-f147-90cf" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
       </categoryLinks>
     </entryLink>
@@ -731,7 +780,6 @@
     <entryLink id="43e2-e234-abfe-1776" name="Sicaran Squadron" hidden="false" collective="false" import="false" targetId="706a-9532-f06d-00ed" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="be3e-2e23-4737-7d29" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="3fd4-bfed-59bc-3536" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="096a-3648-aa71-cad6" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
       </categoryLinks>
     </entryLink>
@@ -750,6 +798,7 @@
     <entryLink id="d52c-f63c-d9c3-731f" name="Sokar Stormbird" hidden="false" collective="false" import="false" targetId="f403-630f-71ae-5a7d" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="29f3-ef3e-b1c1-5976" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="06b1-248d-c5af-2f01" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="7312-5fe5-3530-21c8" name="Spatha Attack Bike Squadron" hidden="false" collective="false" import="false" targetId="4d72-1cc1-8bee-aa88" type="selectionEntry">
@@ -768,10 +817,22 @@
     <entryLink id="733a-b7dc-4703-6144" name="Storm Eagle Gunship" hidden="false" collective="false" import="false" targetId="8aa5-ff31-7de7-19d4" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="897f-9843-57c3-bb5d" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="57d5-5a1a-db2d-c45b" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+        <categoryLink id="ed76-c116-9f18-4446" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="435f-3a9a-898f-829f" name="Tactical Squad" hidden="false" collective="false" import="false" targetId="aa72-63e4-bc60-4611" type="selectionEntry">
+      <modifiers>
+        <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="131a-2c1a-991a-4b31" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="cfe7-c127-804c-7464" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
@@ -793,7 +854,6 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="988e-b5a5-e653-e509" name="Artillery Sub-type:" hidden="false" targetId="6f99-c178-6f9d-fb63" primary="false"/>
         <categoryLink id="6008-9981-ad5d-9281" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
         <categoryLink id="38b3-f3ca-2d28-e0ce" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
@@ -821,14 +881,12 @@
       <categoryLinks>
         <categoryLink id="9c94-977a-d13e-b38b" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="ce84-032d-97dd-f5e0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="8088-7edc-bbbe-31cb" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="b7b4-0041-6e28-3c10" name="Terminator Tartaros Squad" hidden="false" collective="false" import="false" targetId="1a8e-0ded-a4dc-2b4e" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="5c33-bad0-f09d-b782" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="100f-0489-b6cc-9eea" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="ffc9-9ff6-c3ad-3c83" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="0a2f-1481-6fb4-27e9" name="Thunderbolt Fighter" hidden="false" collective="false" import="false" targetId="5d24-1e9a-ad9d-95ca" type="selectionEntry">
@@ -847,6 +905,7 @@
     <entryLink id="80cd-5309-cabd-c861" name="Thunderhawk Gunship" hidden="false" collective="false" import="false" targetId="8754-3a4f-213b-bdc0" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="31f2-04f2-1e04-7f98" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="ba7f-7dad-1594-68da" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="c6e7-5e01-e008-9218" name="Tylos Rubio" hidden="false" collective="false" import="false" targetId="56bf-2c6d-a0fa-a145" type="selectionEntry">
@@ -865,6 +924,7 @@
     <entryLink id="663d-8263-9948-a54c" name="Typhon Squadron" hidden="false" collective="false" import="false" targetId="d06a-3087-af13-ca95" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="8f29-e59c-9f90-4279" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="366f-3c14-f5c3-6a69" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="8462-d44e-1751-a913" name="Veteran Squad" hidden="false" collective="false" import="false" targetId="a423-7dd8-3f1b-3e28" type="selectionEntry">
@@ -890,14 +950,29 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="de27-7454-955e-4652" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="32bf-a634-9cfd-459e" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
-        <categoryLink id="6761-ec1a-b4cd-1555" name="Bombard Sub-type:" hidden="false" targetId="d5df-57ac-8f3c-097b" primary="false"/>
+        <categoryLink id="232f-d991-8115-2ac2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="fc35-9419-bb08-7a4b" name="Xiphon Interceptor" hidden="false" collective="false" import="false" targetId="596b-5478-e079-59ab" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="296b-a648-8319-0bd8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="3abb-d8da-4b54-c7df" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="50e8-9ffd-91ff-0c7b" name="Seeker Squad" hidden="true" collective="false" import="false" targetId="58e6-f9cc-4c46-e258" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <infoLinks>
+        <infoLink id="0fff-a1d4-c68d-08ce" name="Legiones Astartes (Night Lords) " hidden="false" targetId="8280-d4ea-b131-4970" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="7a39-bbf3-4390-4463" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="31ea-3c73-3aa9-6891" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
       </categoryLinks>
     </entryLink>
   </entryLinks>
@@ -909,6 +984,8 @@
       <categoryLinks>
         <categoryLink id="1647-bbf1-c523-59a9" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="cb8a-15df-ffe4-a464" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="9289-d8b0-389a-48bf" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
+        <categoryLink id="a2a9-2111-1212-f029" name="Psyker:" hidden="false" targetId="6e0c-29ba-a445-8321" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="0f6a-a772-4664-ce14" name="Sevatar" hidden="false" collective="false" import="true" type="model">
@@ -1105,6 +1182,10 @@
           </modifiers>
         </infoLink>
       </infoLinks>
+      <categoryLinks>
+        <categoryLink id="45ec-b1d0-a2e1-74b5" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="f894-26fc-995c-2221" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+      </categoryLinks>
       <selectionEntries>
         <selectionEntry id="032a-578d-8f65-22b3" name="Headsman" hidden="false" collective="false" import="true" type="model">
           <constraints>
@@ -1494,6 +1575,11 @@
         </infoLink>
         <infoLink id="5b1f-dbdd-e28e-d28f" name="Night Vision" hidden="false" targetId="683e-b4f2-f032-d31b" type="rule"/>
       </infoLinks>
+      <categoryLinks>
+        <categoryLink id="b113-30d1-8842-415d" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="9fbe-1dcd-30c4-c310" name="Jump Infantry:" hidden="false" targetId="eee8-3c7c-2762-e33e" primary="false"/>
+        <categoryLink id="cfa2-614d-454f-36d8" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+      </categoryLinks>
       <selectionEntries>
         <selectionEntry id="8c9e-a718-9d07-2e08" name="Huntmaster" publicationId="09c5-eeae-f398-b653" hidden="false" collective="false" import="true" type="model">
           <constraints>
@@ -2007,6 +2093,7 @@
       <categoryLinks>
         <categoryLink id="3ecd-9823-e8e4-14f8" name="Psyker:" hidden="false" targetId="6e0c-29ba-a445-8321" primary="false"/>
         <categoryLink id="9bd6-18bb-2ebc-e958" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="9920-bfc8-5c9b-5ffc" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="7cea-1a9a-cee1-7d17" name="Konrad Curze" hidden="false" collective="false" import="true" type="model">
@@ -2161,6 +2248,7 @@ In additon, a Contekar Terminator Squad may be selected as a Retinue Squad in a 
       <categoryLinks>
         <categoryLink id="3aef-1623-40f8-2144" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="0714-07b8-9969-8559" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="8aab-8508-d7d0-37b6" name="Terminators:" hidden="false" targetId="bab3-f50d-3e5f-2f78" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="26f0-ee46-4dbb-2efd" name="Dissident" hidden="false" collective="false" import="true" type="model">
@@ -2185,6 +2273,9 @@ In additon, a Contekar Terminator Squad may be selected as a Retinue Squad in a 
               </characteristics>
             </profile>
           </profiles>
+          <categoryLinks>
+            <categoryLink id="bca6-cd04-8a1f-52fa" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
+          </categoryLinks>
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="65.0"/>
           </costs>
@@ -2310,6 +2401,11 @@ In additon, a Contekar Terminator Squad may be selected as a Retinue Squad in a 
         <infoLink id="e2be-770c-a8d6-3642" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule"/>
         <infoLink id="9783-3fe3-94c2-17fb" name="Deep Strike" hidden="false" targetId="f1e1-986f-c783-ca9e" type="rule"/>
       </infoLinks>
+      <categoryLinks>
+        <categoryLink id="f392-634b-9bb0-06e9" name="Terminators:" hidden="false" targetId="bab3-f50d-3e5f-2f78" primary="false"/>
+        <categoryLink id="68f4-cc55-b1b9-8c1c" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="0368-244a-7061-6fb7" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+      </categoryLinks>
       <selectionEntries>
         <selectionEntry id="228c-e0f5-6a56-aa84" name="Atramentar Trucidor" hidden="false" collective="false" import="true" type="model">
           <constraints>
@@ -2702,6 +2798,11 @@ In additon, a Contekar Terminator Squad may be selected as a Retinue Squad in a 
       <constraints>
         <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ad68-cdd4-e29a-31a7" type="max"/>
       </constraints>
+      <categoryLinks>
+        <categoryLink id="cc1b-8703-8170-fb3d" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
+        <categoryLink id="529d-c6da-a22c-ddf2" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="6af9-fdc8-c956-125c" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+      </categoryLinks>
       <selectionEntries>
         <selectionEntry id="1225-6430-b0ca-bf2a" name="Flaymaster Mawdrym Llansahai" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
@@ -2802,6 +2903,11 @@ Additionally, all models with the Infantry or Cavalry Unit Types in a unit that 
       <constraints>
         <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8690-29d3-a450-6900" type="max"/>
       </constraints>
+      <categoryLinks>
+        <categoryLink id="6344-0186-583a-9fd6" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="a5a8-c39c-e2e1-7e00" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
+        <categoryLink id="170a-9067-b138-78e6" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+      </categoryLinks>
       <selectionEntries>
         <selectionEntry id="0747-85e7-fea1-4526" name="Kheron Ophion of the Kyroptera" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
@@ -2924,6 +3030,11 @@ Additionally, all models with the Infantry or Cavalry Unit Types in a unit that 
       <constraints>
         <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9001-0d6b-08b5-4ae8" type="max"/>
       </constraints>
+      <categoryLinks>
+        <categoryLink id="9c95-019a-6895-f7d2" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
+        <categoryLink id="a5cc-6775-35e2-167c" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="5e08-d8ee-cf56-6118" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+      </categoryLinks>
       <selectionEntries>
         <selectionEntry id="8bdb-96b0-dcb0-9d91" name="Nakrid Thole" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>

--- a/2022 - LA - Raven Guard.cat
+++ b/2022 - LA - Raven Guard.cat
@@ -1056,7 +1056,6 @@
       <categoryLinks>
         <categoryLink id="afca-b635-70d0-d41f" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
         <categoryLink id="d718-986e-82a3-6418" name="Jump Infantry:" hidden="false" targetId="eee8-3c7c-2762-e33e" primary="false"/>
-        <categoryLink id="f790-47c0-39d9-f9a3" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="077f-e8dd-5f24-86e9" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
       </categoryLinks>
       <selectionEntries>

--- a/2022 - LA - Raven Guard.cat
+++ b/2022 - LA - Raven Guard.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="d21e-9c80-a7f8-728c" name="LA - XIX: Raven Guard" revision="6" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="17" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="d21e-9c80-a7f8-728c" name="LA - XIX: Raven Guard" revision="7" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="18" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entryLinks>
     <entryLink id="84cc-e59c-174e-fb25" name="Mor Deythan Squad" hidden="false" collective="false" import="false" targetId="c268-08ac-5b90-d034" type="selectionEntry">
       <categoryLinks>
@@ -88,6 +88,18 @@
       </categoryLinks>
     </entryLink>
     <entryLink id="1d98-08bc-b1c4-e9b3" name="Assault Squad" hidden="false" collective="false" import="false" targetId="a8e9-70e1-b8bc-8ee2" type="selectionEntry">
+      <modifiers>
+        <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="4a13-a002-9199-2b6e" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="d9eb-65c7-f407-5d65" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
@@ -116,12 +128,23 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="024c-6423-5c2c-7363" name="Bombard Sub-type:" hidden="false" targetId="d5df-57ac-8f3c-097b" primary="false"/>
         <categoryLink id="11f0-e8d7-6b29-f95d" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="5855-515e-236f-52bf" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
+        <categoryLink id="82a8-bf4f-4c1a-bbc2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="57d6-9147-79f2-72f9" name="Breacher Squad" hidden="false" collective="false" import="false" targetId="ad97-c090-fa67-696f" type="selectionEntry">
+      <modifiers>
+        <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="11d9-3906-0579-1ac9" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="52e4-858c-d161-746f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
@@ -244,7 +267,6 @@
     <entryLink id="b913-7cbf-afd3-ed83" name="Damocles Command Rhino" hidden="false" collective="false" import="false" targetId="e337-8239-5e92-7f5f" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="acbf-2c66-ae4f-9e81" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="da87-9043-9144-054b" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="f1c2-bf1c-b906-919f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -261,6 +283,18 @@
       </categoryLinks>
     </entryLink>
     <entryLink id="b6ac-386a-c032-bcd6" name="Despoiler Squad" hidden="false" collective="false" import="false" targetId="4357-930e-165a-a6e3" type="selectionEntry">
+      <modifiers>
+        <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="0cf3-02f0-05ae-2d7a" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="974f-073d-e833-6ca6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
@@ -276,29 +310,31 @@
     <entryLink id="dae8-98ab-8ad7-362b" name="Dreadclaw Drop Pod" hidden="false" collective="false" import="false" targetId="bbe8-818d-3068-d79c" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="ac18-eb6c-5cf0-de4d" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="0227-566a-b166-274c" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+        <categoryLink id="7382-3d70-8267-36c9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="2fb9-1d26-2679-13c6" name="Falchion" hidden="false" collective="false" import="false" targetId="1fe8-7386-9509-d2d8" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="c060-58f0-9d44-bfd5" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="ea6e-e5b5-243f-ccbd" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="498e-e241-dced-2a62" name="Fellblade" hidden="false" collective="false" import="false" targetId="9c3c-f15a-9a1f-c0d0" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="088b-338a-e8d5-6be6" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="4a23-7c32-f4a6-84da" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="8f79-c68f-2352-2cdb" name="Fire Raptor Gunship" hidden="false" collective="false" import="false" targetId="f6e1-24e2-fbdb-c5ef" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="68bb-5075-1d33-ee00" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="ddee-13c1-b73d-01e7" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="fa38-9230-3c20-f307" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="772b-3d96-3951-5128" name="Glaive" hidden="false" collective="false" import="false" targetId="04e0-f69f-f759-b0b3" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="d48f-5656-e218-6dcf" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="bfc8-83cc-d935-3f1d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="88b8-c93e-98d1-d299" name="Heavy Support Squad" hidden="false" collective="false" import="false" targetId="bac9-5389-e2e7-0b1f" type="selectionEntry">
@@ -365,7 +401,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="2d71-86dc-43cc-e019" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="3557-227a-d680-ee13" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+        <categoryLink id="e9c4-649c-6888-d69a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="212b-b1c8-03ea-3036" name="Legion Banehammer" hidden="true" collective="false" import="false" targetId="1240-c71c-3a60-cf20" type="selectionEntry">
@@ -378,7 +414,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="aaf9-e673-4b7b-577c" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="5080-67fd-f50e-3743" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+        <categoryLink id="f550-3cdf-db0e-1280" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="2cfd-c944-f062-8f7c" name="Legion Macharius Heavy Tank Squadron" hidden="false" collective="false" import="false" targetId="36ed-ca59-0d95-d85c" type="selectionEntry">
@@ -443,7 +479,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="c9f8-6c11-70bd-322e" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="2562-ec70-fa95-3812" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+        <categoryLink id="1942-1686-a17c-4137" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="5c5c-010c-b80c-0a36" name="Legion Stormlord" hidden="true" collective="false" import="false" targetId="0887-0f66-2c7e-a5ba" type="selectionEntry">
@@ -456,7 +492,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="9fdd-9029-5cb7-83d0" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="5680-0f85-1f57-4863" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+        <categoryLink id="d7a5-09db-56f9-eec4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="9d90-9fd1-630e-69e3" name="Legion Stormsword" hidden="true" collective="false" import="false" targetId="8e67-8f84-730c-2778" type="selectionEntry">
@@ -469,7 +505,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="f9c8-6068-cb85-ed0b" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="4c6d-83a6-d285-1dfe" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+        <categoryLink id="90b7-82e2-8f27-ca4a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="5fa7-b457-7d5c-942f" name="Leviathan Dreadnought Talon" hidden="false" collective="false" import="false" targetId="c2a7-9e2c-fc65-1b78" type="selectionEntry">
@@ -481,6 +517,7 @@
     <entryLink id="f15a-1db4-8ec1-57e6" name="Mastodon" hidden="false" collective="false" import="false" targetId="7f24-2b72-9128-5330" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="6785-b58e-07b7-90d1" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="cb15-183a-65ae-0c78" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="8ecb-a86c-8e99-64f5" name="Medusa Squadron" hidden="true" collective="false" import="false" targetId="24c8-5f6a-d48a-27b7" type="selectionEntry">
@@ -492,9 +529,8 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="be86-377d-102c-3dc6" name="Bombard Sub-type:" hidden="false" targetId="d5df-57ac-8f3c-097b" primary="false"/>
         <categoryLink id="892f-d746-4dc6-d0ba" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="cce9-48f5-83cf-ae29" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
+        <categoryLink id="1c46-8077-364c-a610" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="b079-60fa-72a8-d6f6" name="Mortalis Destroyer Squad" hidden="false" collective="false" import="false" targetId="dbd4-930e-e003-9449" type="selectionEntry">
@@ -593,6 +629,13 @@
       </categoryLinks>
     </entryLink>
     <entryLink id="7ebb-53ec-28b5-3604" name="Reconnaissance Squad" hidden="false" collective="false" import="false" targetId="6db7-6e88-877e-35ca" type="selectionEntry">
+      <modifiers>
+        <modifier type="add" field="category" value="8f42-a824-fb5f-8fea">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="45f5-eb3e-97b1-a108" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="61f9-bd09-10a9-6164" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
@@ -611,6 +654,13 @@
       </categoryLinks>
     </entryLink>
     <entryLink id="f408-e0fb-e72e-e526" name="Scout Squad" hidden="false" collective="false" import="false" targetId="9b10-b657-a65a-9d60" type="selectionEntry">
+      <modifiers>
+        <modifier type="add" field="category" value="8f42-a824-fb5f-8fea">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="0a26-0757-21d6-a9db" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="c74f-4c14-e13e-4d31" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
@@ -631,7 +681,6 @@
     <entryLink id="0caf-045b-8cd0-c94c" name="Sicaran Omega Squadron" hidden="false" collective="false" import="false" targetId="c88b-fe44-34a3-97e1" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="cf47-b843-1960-e1ca" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="a735-9b5b-8326-9b83" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="fcf1-b943-59d3-513d" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
       </categoryLinks>
     </entryLink>
@@ -644,7 +693,6 @@
     <entryLink id="2def-48f3-6417-cace" name="Sicaran Squadron" hidden="false" collective="false" import="false" targetId="706a-9532-f06d-00ed" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="6290-20b4-083b-5cf7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="02d2-8433-8ff1-2d35" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="be31-9700-d4b9-a0f1" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
       </categoryLinks>
     </entryLink>
@@ -663,6 +711,7 @@
     <entryLink id="4d6a-b0fb-7f4b-c4d6" name="Sokar Stormbird" hidden="false" collective="false" import="false" targetId="f403-630f-71ae-5a7d" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="3203-43fb-b4fd-26a1" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="e512-7ba4-7da2-1159" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="af65-340c-7fa4-7254" name="Spatha Attack Bike Squadron" hidden="false" collective="false" import="false" targetId="4d72-1cc1-8bee-aa88" type="selectionEntry">
@@ -681,10 +730,22 @@
     <entryLink id="7305-4db8-7bc3-792c" name="Storm Eagle Gunship" hidden="false" collective="false" import="false" targetId="8aa5-ff31-7de7-19d4" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="58da-27bf-f569-3210" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="aea5-a18e-5430-0b26" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+        <categoryLink id="8bd7-6af2-4c71-c636" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="7da1-87b2-aefc-4592" name="Tactical Squad" hidden="false" collective="false" import="false" targetId="aa72-63e4-bc60-4611" type="selectionEntry">
+      <modifiers>
+        <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="b497-4f8c-5c04-6cf2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="774f-58a1-9733-b996" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
@@ -706,7 +767,6 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="9612-7c78-1b05-d6ed" name="Artillery Sub-type:" hidden="false" targetId="6f99-c178-6f9d-fb63" primary="false"/>
         <categoryLink id="8cb2-e427-0e3e-a31d" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
         <categoryLink id="c89f-9ad3-baf7-4829" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
@@ -734,14 +794,12 @@
       <categoryLinks>
         <categoryLink id="ae47-4313-8d1e-df9e" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="a8c6-b2b9-23ac-b90b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="5311-dee9-b1a1-4857" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="33c1-628d-e7c8-122c" name="Terminator Tartaros Squad" hidden="false" collective="false" import="false" targetId="1a8e-0ded-a4dc-2b4e" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="12bb-b57a-1b47-aeb9" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="23af-e0b7-0f11-5732" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="9aea-5522-8901-2438" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="ec3e-c95c-6b3c-2986" name="Thunderbolt Fighter" hidden="false" collective="false" import="false" targetId="5d24-1e9a-ad9d-95ca" type="selectionEntry">
@@ -760,6 +818,7 @@
     <entryLink id="8499-9821-d3c3-8376" name="Thunderhawk Gunship" hidden="false" collective="false" import="false" targetId="8754-3a4f-213b-bdc0" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="63c1-57f6-4612-25dd" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="8f5a-adda-a50e-46b9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="daed-8aa8-5696-793c" name="Tylos Rubio" hidden="false" collective="false" import="false" targetId="56bf-2c6d-a0fa-a145" type="selectionEntry">
@@ -778,6 +837,7 @@
     <entryLink id="b61b-8de4-1f2f-3904" name="Typhon Squadron" hidden="false" collective="false" import="false" targetId="d06a-3087-af13-ca95" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="09af-ccd7-cf50-09b0" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="9bcb-3b7a-7d70-4bd3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="0437-2483-6195-95b4" name="Veteran Squad" hidden="false" collective="false" import="false" targetId="a423-7dd8-3f1b-3e28" type="selectionEntry">
@@ -803,14 +863,29 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="68c2-d472-516b-4717" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="2eeb-5f75-8c6f-6ac7" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
-        <categoryLink id="24b4-09ff-b2af-ff2b" name="Bombard Sub-type:" hidden="false" targetId="d5df-57ac-8f3c-097b" primary="false"/>
+        <categoryLink id="bce7-c5b0-6408-5f19" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="10fe-3e6c-5b96-572c" name="Xiphon Interceptor" hidden="false" collective="false" import="false" targetId="596b-5478-e079-59ab" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="7c67-54c3-2b77-82a9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="aa89-9558-c12c-b5a8" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="ccb6-6158-d584-caa2" name="Seeker Squad" hidden="true" collective="false" import="false" targetId="58e6-f9cc-4c46-e258" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <infoLinks>
+        <infoLink id="4269-108d-034e-d1a4" name="Legiones Astartes (Raven Guard) " hidden="false" targetId="9924-9434-baa1-0894" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="5e69-9953-b8f4-f238" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="9191-0da6-7ced-eb9b" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
       </categoryLinks>
     </entryLink>
   </entryLinks>
@@ -850,6 +925,12 @@
         <infoLink id="5f03-968d-7f7b-976c" name="Move Through Cover" hidden="false" targetId="2b6f-bfec-759e-1746" type="rule"/>
         <infoLink id="6d1d-134b-6029-5438" name="Pathfinder" hidden="false" targetId="ec97-7aa8-49f5-b298" type="rule"/>
       </infoLinks>
+      <categoryLinks>
+        <categoryLink id="385b-e811-018a-cd64" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
+        <categoryLink id="d770-1c5b-320d-4c12" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="21b2-c021-325e-d0b3" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="74fd-26f0-cda4-cd6b" name="Light Sub-type:" hidden="false" targetId="bff2-ae16-74a8-8712" primary="false"/>
+      </categoryLinks>
       <selectionEntries>
         <selectionEntry id="6abf-622b-dee3-f98e" name="Moritat-Prime Kaedes Nex" hidden="false" collective="false" import="true" type="model">
           <constraints>
@@ -972,6 +1053,12 @@
       <infoLinks>
         <infoLink id="856f-4cc1-a5a8-0459" name="Loyalist" hidden="false" targetId="d1de-a45d-2b9b-c878" type="rule"/>
       </infoLinks>
+      <categoryLinks>
+        <categoryLink id="afca-b635-70d0-d41f" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
+        <categoryLink id="d718-986e-82a3-6418" name="Jump Infantry:" hidden="false" targetId="eee8-3c7c-2762-e33e" primary="false"/>
+        <categoryLink id="f790-47c0-39d9-f9a3" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="077f-e8dd-5f24-86e9" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+      </categoryLinks>
       <selectionEntries>
         <selectionEntry id="9115-3297-32da-6ac4" name="Corvus Corax" publicationId="817a-6288-e016-7469" page="333" hidden="false" collective="false" import="true" type="model">
           <constraints>
@@ -1445,6 +1532,11 @@ Corvus Corax may still Run on a turn when the Korvidine Pinions have been activa
           </modifiers>
         </infoLink>
       </infoLinks>
+      <categoryLinks>
+        <categoryLink id="cf6d-8fba-9f4c-c28b" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="ead3-4b26-1019-2b19" name="Jump Infantry:" hidden="false" targetId="eee8-3c7c-2762-e33e" primary="false"/>
+        <categoryLink id="675d-d44e-ad5b-cebe" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+      </categoryLinks>
       <selectionEntries>
         <selectionEntry id="c1bd-12eb-7627-28f3" name="Dark Furies" hidden="false" collective="false" import="true" type="model">
           <modifiers>
@@ -1604,6 +1696,11 @@ Corvus Corax may still Run on a turn when the Korvidine Pinions have been activa
       </costs>
     </selectionEntry>
     <selectionEntry id="0e66-8311-405c-1e49" name="Strike Captain Alvarex Maun" hidden="false" collective="false" import="true" type="unit">
+      <categoryLinks>
+        <categoryLink id="7f6d-d71e-e019-98cc" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
+        <categoryLink id="734e-eb71-18b5-ff92" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="2fe0-6132-a9c3-7cc1" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+      </categoryLinks>
       <selectionEntries>
         <selectionEntry id="ee1f-8713-4ba0-2299" name="Strike Captain Alvarex Maun" publicationId="d0df-7166-5cd3-89fd" hidden="false" collective="false" import="true" type="model">
           <constraints>
@@ -1737,14 +1834,48 @@ Corvus Corax may still Run on a turn when the Korvidine Pinions have been activa
         <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a825-305b-4c29-19a3" type="max"/>
       </constraints>
       <rules>
-        <rule id="e61b-37aa-0364-68da" name="Corax&apos;s Shame (PLACEHOLDER)" hidden="false"/>
+        <rule id="e61b-37aa-0364-68da" name="Corax&apos;s Shame" publicationId="09b3-d525-cdea-260c" page="15" hidden="false">
+          <description>If selected as part of an army with the Loyalist Allegiance, models with this special rule gain the Battle-hardened (1) special rule. If selected as part of an army with the Traitor Allegiance, models with this special rule gain the Hatred (Corvus Corax) special rule. 
+
+Additionally, if selected as part of an army that includes Corvus Corax, no models with this special rule may be deployed within 18&quot; of Corvus Corax (including when models from this unit enter play from Reserves) and Corvus Corax may never join a unit that has any models with this special rule.</description>
+        </rule>
       </rules>
       <infoLinks>
         <infoLink id="033d-e381-5c7f-02f8" name="Stubborn" hidden="false" targetId="7989-1f2c-a43d-82ae" type="rule"/>
         <infoLink id="20b5-4b86-f533-f797" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule"/>
-        <infoLink id="9126-9bd1-72fc-7a5b" name="Bulky (X)" hidden="false" targetId="676c-7b75-4b6f-9405" type="rule"/>
+        <infoLink id="9126-9bd1-72fc-7a5b" name="Bulky (X)" hidden="false" targetId="676c-7b75-4b6f-9405" type="rule">
+          <modifiers>
+            <modifier type="set" field="name" value="Bulky (2)"/>
+          </modifiers>
+        </infoLink>
         <infoLink id="15c7-f900-d1ff-d769" name="Deep Strike" hidden="false" targetId="f1e1-986f-c783-ca9e" type="rule"/>
+        <infoLink id="8b0a-d314-b356-2768" name="Hatred (X)" hidden="false" targetId="dc0b-fe69-6b71-e0a4" type="rule">
+          <modifiers>
+            <modifier type="set" field="name" value="Hatred (Corvus Corax)"/>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+        <infoLink id="38e6-a330-126a-ca5f" name="Battle-Hardened (X)" hidden="false" targetId="5c3b-ed0b-4ad0-d547" type="rule">
+          <modifiers>
+            <modifier type="set" field="name" value="Battle-hardened (1)"/>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
       </infoLinks>
+      <categoryLinks>
+        <categoryLink id="188c-d76b-84a6-638f" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="9cc5-6040-2587-922f" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+        <categoryLink id="c489-7c99-cc6f-01d0" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="5877-4eb0-e84d-2158" name="Terminators:" hidden="false" targetId="bab3-f50d-3e5f-2f78" primary="false"/>
+      </categoryLinks>
       <selectionEntries>
         <selectionEntry id="a176-8dbb-623f-26e1" name="Deliverer" hidden="false" collective="false" import="true" type="model">
           <constraints>
@@ -1849,6 +1980,9 @@ Corvus Corax may still Run on a turn when the Korvidine Pinions have been activa
               </characteristics>
             </profile>
           </profiles>
+          <categoryLinks>
+            <categoryLink id="14e4-d126-7891-ffc1" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
+          </categoryLinks>
           <entryLinks>
             <entryLink id="b2dd-b97c-4eb9-10b3" name="Deliverer Heavy Weapons" hidden="false" collective="false" import="true" targetId="2c85-3ae3-fbdf-2e60" type="selectionEntryGroup">
               <modifiers>

--- a/2022 - LA - Salamanders.cat
+++ b/2022 - LA - Salamanders.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="3547-84d8-d789-bab7" name="LA -  XVIII: Salamanders" revision="7" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="17" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="3547-84d8-d789-bab7" name="LA -  XVIII: Salamanders" revision="8" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="18" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entryLinks>
     <entryLink id="93d2-b1cb-b684-a9b3" name="  XVIII: Salamanders" hidden="false" collective="false" import="false" targetId="c805-ca3a-ff93-5e2f" type="selectionEntry">
       <constraints>
@@ -26,11 +26,13 @@
       <categoryLinks>
         <categoryLink id="2de5-e3bc-f6bc-5558" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="b475-cb4a-5a9b-cf9b" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
+        <categoryLink id="e43c-2895-7503-366a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="34f6-2994-6de1-98cc" name="Firedrake Terminator Squad" hidden="false" collective="false" import="false" targetId="6775-8379-8d6b-9614" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="26b1-529c-841e-80c6" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="1975-3b0c-9330-e098" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="13d2-61df-c76d-7b32" name="Lord Chaplain Nomus Rhy&apos;Tan" hidden="true" collective="false" import="false" targetId="74f6-96f4-ee55-9c78" type="selectionEntry">
@@ -49,11 +51,13 @@
       <categoryLinks>
         <categoryLink id="ac1a-5683-b0a6-a1f5" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="2ac4-69c5-3a1e-7314" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
+        <categoryLink id="1b50-8e8f-a15c-45d0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="5e51-de9f-0a93-825b" name="Pyroclast Squad" hidden="false" collective="false" import="false" targetId="71fe-d3bc-b7f9-75ca" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="eaf6-1e7a-32ab-b017" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="00dc-c4a6-a6fe-adf5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="4c5f-15e0-0de3-af6a" name="Vulkan" hidden="true" collective="false" import="false" targetId="8c74-40b1-5019-f4d4" type="selectionEntry">
@@ -66,6 +70,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="64a8-ba7d-4c9b-3f3e" name="New CategoryLink" hidden="false" targetId="ad5f-31db-8bc7-5c46" primary="true"/>
+        <categoryLink id="6d75-8f0a-3caa-689d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="2607-05cd-6852-2f52" name="Xiaphas Jurr" hidden="true" collective="false" import="false" targetId="30b8-05a5-fef7-fe66" type="selectionEntry">
@@ -99,6 +104,18 @@
       </categoryLinks>
     </entryLink>
     <entryLink id="a4da-67bc-f8a8-f809" name="Assault Squad" hidden="false" collective="false" import="false" targetId="a8e9-70e1-b8bc-8ee2" type="selectionEntry">
+      <modifiers>
+        <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="2c09-6a41-9893-34c6" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="c7d2-d2ea-9b06-b573" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
@@ -127,12 +144,23 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="f190-db2d-a2c7-1eff" name="Bombard Sub-type:" hidden="false" targetId="d5df-57ac-8f3c-097b" primary="false"/>
         <categoryLink id="0b05-b45f-95af-4b51" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="bb5c-0875-4fd3-0532" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
+        <categoryLink id="28fd-4f67-4e60-0344" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="5bfe-4044-5d78-0010" name="Breacher Squad" hidden="false" collective="false" import="false" targetId="ad97-c090-fa67-696f" type="selectionEntry">
+      <modifiers>
+        <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="4de4-52c1-f0c0-b14f" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="aa51-5de8-4934-d7c7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
@@ -255,7 +283,6 @@
     <entryLink id="68c6-587b-0403-66bc" name="Damocles Command Rhino" hidden="false" collective="false" import="false" targetId="e337-8239-5e92-7f5f" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="3cf3-34db-1c09-24cf" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="b6e7-c4fa-9818-a978" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="b22d-b29d-3ecb-d581" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -272,6 +299,18 @@
       </categoryLinks>
     </entryLink>
     <entryLink id="19bd-cdfd-0295-3a7d" name="Despoiler Squad" hidden="false" collective="false" import="false" targetId="4357-930e-165a-a6e3" type="selectionEntry">
+      <modifiers>
+        <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="d540-e102-a516-dc6a" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="f921-c892-6bd5-58ac" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
@@ -287,29 +326,31 @@
     <entryLink id="13c7-f976-5bce-99e3" name="Dreadclaw Drop Pod" hidden="false" collective="false" import="false" targetId="bbe8-818d-3068-d79c" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="a07e-4c3e-d9a0-003a" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="0da9-97ae-bde9-97db" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+        <categoryLink id="c7a5-1f0b-f52f-8e4c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="877a-d43b-10d1-f561" name="Falchion" hidden="false" collective="false" import="false" targetId="1fe8-7386-9509-d2d8" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="0197-885c-5bbc-d9e1" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="6571-df3a-e918-f0c2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="cd1d-73b9-ba01-2166" name="Fellblade" hidden="false" collective="false" import="false" targetId="9c3c-f15a-9a1f-c0d0" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="c528-6fb0-d7c9-6204" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="1952-c05e-5d56-5a6e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="4282-f953-0998-4a79" name="Fire Raptor Gunship" hidden="false" collective="false" import="false" targetId="f6e1-24e2-fbdb-c5ef" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="4eb7-1ef3-c705-dd39" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="3cf3-0f49-27a2-3db9" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="4815-79c1-278c-cba5" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="815c-31c8-b4a1-6f10" name="Glaive" hidden="false" collective="false" import="false" targetId="04e0-f69f-f759-b0b3" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="e62b-f0f1-fb5e-0b63" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="b602-a000-95a0-2ff4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="0e62-b141-65fa-29a7" name="Heavy Support Squad" hidden="false" collective="false" import="false" targetId="bac9-5389-e2e7-0b1f" type="selectionEntry">
@@ -376,7 +417,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="ae7a-f0ff-19f5-5f2f" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="e478-6037-8a93-6188" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+        <categoryLink id="f364-032f-cfae-fc52" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="3e47-03f4-f686-e15e" name="Legion Banehammer" hidden="true" collective="false" import="false" targetId="1240-c71c-3a60-cf20" type="selectionEntry">
@@ -389,7 +430,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="e7b4-f439-2771-1c54" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="5866-cb0d-619a-589d" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+        <categoryLink id="ad53-6061-7ea9-c8a3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="591f-5a82-e2ba-37da" name="Legion Macharius Heavy Tank Squadron" hidden="false" collective="false" import="false" targetId="36ed-ca59-0d95-d85c" type="selectionEntry">
@@ -454,7 +495,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="00a3-1b8f-655d-5005" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="58c8-b4c9-753f-fb32" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+        <categoryLink id="604f-99c8-c7bc-2c3a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="359d-0a15-9916-9c24" name="Legion Stormlord" hidden="true" collective="false" import="false" targetId="0887-0f66-2c7e-a5ba" type="selectionEntry">
@@ -467,7 +508,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="fa44-6b35-f2b4-8647" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="3e0f-4756-9f4e-42e8" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+        <categoryLink id="2b63-8f80-0766-7c7c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="6b9d-c046-31f7-df14" name="Legion Stormsword" hidden="true" collective="false" import="false" targetId="8e67-8f84-730c-2778" type="selectionEntry">
@@ -480,7 +521,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="ce95-7cc1-15e5-0109" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="5cd0-2e65-659e-0c48" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+        <categoryLink id="46c0-958c-3e3a-90f2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="eb80-0c80-2a5d-444d" name="Leviathan Dreadnought Talon" hidden="false" collective="false" import="false" targetId="c2a7-9e2c-fc65-1b78" type="selectionEntry">
@@ -492,6 +533,7 @@
     <entryLink id="f385-591a-76ae-6c96" name="Mastodon" hidden="false" collective="false" import="false" targetId="7f24-2b72-9128-5330" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="d593-48a9-a4ea-2872" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="0619-e8a6-a2e5-ce33" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="66a1-77c7-24f2-6f33" name="Medusa Squadron" hidden="true" collective="false" import="false" targetId="24c8-5f6a-d48a-27b7" type="selectionEntry">
@@ -503,9 +545,8 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="0010-889b-ac06-f553" name="Bombard Sub-type:" hidden="false" targetId="d5df-57ac-8f3c-097b" primary="false"/>
         <categoryLink id="44d8-bced-205a-2708" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="5edf-48cb-e721-6ef8" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
+        <categoryLink id="2657-51a4-cea5-be46" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="5213-d143-4913-79d0" name="Mortalis Destroyer Squad" hidden="false" collective="false" import="false" targetId="dbd4-930e-e003-9449" type="selectionEntry">
@@ -604,6 +645,13 @@
       </categoryLinks>
     </entryLink>
     <entryLink id="71c8-b9c3-03b7-5e46" name="Reconnaissance Squad" hidden="false" collective="false" import="false" targetId="6db7-6e88-877e-35ca" type="selectionEntry">
+      <modifiers>
+        <modifier type="add" field="category" value="8f42-a824-fb5f-8fea">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="94bf-9f97-a6cc-bdbd" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="b499-29d1-1084-9c1b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
@@ -622,6 +670,13 @@
       </categoryLinks>
     </entryLink>
     <entryLink id="1905-93de-51a5-c39a" name="Scout Squad" hidden="false" collective="false" import="false" targetId="9b10-b657-a65a-9d60" type="selectionEntry">
+      <modifiers>
+        <modifier type="add" field="category" value="8f42-a824-fb5f-8fea">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="f754-2f56-75b8-39bf" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="6736-d5b0-cac5-f893" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
@@ -642,7 +697,6 @@
     <entryLink id="279f-7714-301f-2ccb" name="Sicaran Omega Squadron" hidden="false" collective="false" import="false" targetId="c88b-fe44-34a3-97e1" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="1007-272e-be59-3e53" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="2635-1227-429d-496d" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="04a2-9cc9-83f4-a3f6" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
       </categoryLinks>
     </entryLink>
@@ -655,7 +709,6 @@
     <entryLink id="5738-89d2-d898-dd43" name="Sicaran Squadron" hidden="false" collective="false" import="false" targetId="706a-9532-f06d-00ed" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="5f74-6f21-6cc9-20fb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="0fd4-3767-7a89-5815" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="1e39-1810-c70a-7a3a" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
       </categoryLinks>
     </entryLink>
@@ -674,6 +727,7 @@
     <entryLink id="8e34-be48-fc63-1061" name="Sokar Stormbird" hidden="false" collective="false" import="false" targetId="f403-630f-71ae-5a7d" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="e242-af15-f16b-99f0" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="44c7-56d4-0c47-31af" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="28e1-088a-a00b-14a5" name="Spatha Attack Bike Squadron" hidden="false" collective="false" import="false" targetId="4d72-1cc1-8bee-aa88" type="selectionEntry">
@@ -692,10 +746,22 @@
     <entryLink id="e5f8-9815-7d06-4090" name="Storm Eagle Gunship" hidden="false" collective="false" import="false" targetId="8aa5-ff31-7de7-19d4" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="01b2-fd1e-2294-5d82" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="aa4c-ee04-25d3-3ff0" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+        <categoryLink id="2f4e-1098-6b0e-b788" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="9223-b6a2-72c3-f158" name="Tactical Squad" hidden="false" collective="false" import="false" targetId="aa72-63e4-bc60-4611" type="selectionEntry">
+      <modifiers>
+        <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="3bea-73b6-8ffe-4dca" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="0eb7-2d24-5c4f-7b36" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
@@ -717,7 +783,6 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="8a59-1510-5bfd-6eaf" name="Artillery Sub-type:" hidden="false" targetId="6f99-c178-6f9d-fb63" primary="false"/>
         <categoryLink id="8f9f-20c5-d188-6895" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
         <categoryLink id="140b-5729-a0b5-22e7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
@@ -745,14 +810,12 @@
       <categoryLinks>
         <categoryLink id="7286-858d-7b12-757d" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="f6f5-060e-5033-5561" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="f236-4e25-d525-f416" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="86ed-08f1-a8ec-dc32" name="Terminator Tartaros Squad" hidden="false" collective="false" import="false" targetId="1a8e-0ded-a4dc-2b4e" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="2a39-857d-f54d-9c2c" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="a647-e450-e635-41ec" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="c207-ac0c-8e52-bc1d" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="88d1-f74f-1ce1-b28b" name="Thunderbolt Fighter" hidden="false" collective="false" import="false" targetId="5d24-1e9a-ad9d-95ca" type="selectionEntry">
@@ -771,6 +834,7 @@
     <entryLink id="1f94-02a7-c8b1-904a" name="Thunderhawk Gunship" hidden="false" collective="false" import="false" targetId="8754-3a4f-213b-bdc0" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="f032-b807-395c-20c2" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="6452-0568-f373-36ad" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="1191-d33e-b4cd-60a9" name="Tylos Rubio" hidden="false" collective="false" import="false" targetId="56bf-2c6d-a0fa-a145" type="selectionEntry">
@@ -789,6 +853,7 @@
     <entryLink id="2260-bbe6-a8c2-1d7d" name="Typhon Squadron" hidden="false" collective="false" import="false" targetId="d06a-3087-af13-ca95" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="832e-3147-9188-d333" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="2205-836c-f187-f54e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="1042-91c1-17c2-50e5" name="Veteran Squad" hidden="false" collective="false" import="false" targetId="a423-7dd8-3f1b-3e28" type="selectionEntry">
@@ -814,14 +879,29 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="fa87-a330-0a86-a6d4" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="69db-07d3-07e5-e40a" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
-        <categoryLink id="c907-de68-2a27-0af8" name="Bombard Sub-type:" hidden="false" targetId="d5df-57ac-8f3c-097b" primary="false"/>
+        <categoryLink id="be46-4a53-ce54-1b0a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="4d2e-1b91-bb2c-ec0e" name="Xiphon Interceptor" hidden="false" collective="false" import="false" targetId="596b-5478-e079-59ab" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="a154-dcf6-2800-217f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="3de0-b87a-7b60-7eb7" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="46fb-2fd0-838e-7eea" name="Seeker Squad" hidden="true" collective="false" import="false" targetId="58e6-f9cc-4c46-e258" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <infoLinks>
+        <infoLink id="42ad-e723-3216-a788" name="Legiones Astartes (Salamanders) " hidden="false" targetId="5b72-d9a6-92c3-4a1c" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="b46b-8f20-ae5f-adcf" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="dc72-17d7-73c1-6a95" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
       </categoryLinks>
     </entryLink>
   </entryLinks>
@@ -861,6 +941,7 @@
       </infoLinks>
       <categoryLinks>
         <categoryLink id="97f1-63ad-b403-6ae7" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="ff2f-d33d-2e7c-9895" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="b52a-be67-5e91-6268" name="Dawnbringer" hidden="false" collective="false" import="true" type="upgrade">
@@ -1025,6 +1106,9 @@
               </characteristics>
             </profile>
           </profiles>
+          <categoryLinks>
+            <categoryLink id="ad9b-ee4b-9a7f-081f" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
+          </categoryLinks>
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="55.0"/>
           </costs>
@@ -1187,6 +1271,7 @@
         <categoryLink id="b47e-4128-4626-5ab1" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
         <categoryLink id="0d65-1662-e010-f889" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="f28b-f86f-8c4f-ba4f" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="a1cf-3d0c-18a6-773d" name="Terminators:" hidden="false" targetId="bab3-f50d-3e5f-2f78" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="a06f-66d8-a8c1-63fa" name="Firedrakes" hidden="false" collective="false" import="true" type="model">
@@ -1317,6 +1402,9 @@
               </characteristics>
             </profile>
           </profiles>
+          <categoryLinks>
+            <categoryLink id="7493-b565-8d7b-ebe9" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
+          </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="5aec-2671-da16-e919" name="1) Melee Options:" hidden="false" collective="false" import="true" defaultSelectionEntryId="c167-f4c9-6ab3-7a15">
               <constraints>
@@ -1482,8 +1570,9 @@
         <infoLink id="61e5-b6c9-2ba2-c317" name="Ferromantic Deflector" hidden="false" targetId="7884-e18a-16ee-068c" type="profile"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="5331-cf6a-8ca6-dc20" name="Dreadnought Unit-type:" hidden="false" targetId="4280-4963-02b5-e31d" primary="true"/>
         <categoryLink id="3af7-46b2-2419-4a55" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+        <categoryLink id="d849-8fbc-0faa-8dfb" name="Dreadnought Unit-type:" hidden="false" targetId="4280-4963-02b5-e31d" primary="false"/>
+        <categoryLink id="2ff0-6e13-57f0-e139" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
       </categoryLinks>
       <entryLinks>
         <entryLink id="8df9-b411-be3d-51a9" name="Dreadnought Drop Pod" hidden="false" collective="false" import="true" targetId="1ffe-82e4-12db-538d" type="selectionEntry">
@@ -1574,6 +1663,7 @@
       <categoryLinks>
         <categoryLink id="f22c-47a5-ca44-ccdc" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="b624-3e54-171d-2b09" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="a0e0-976d-1292-1fc3" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="ad7a-6a4c-6cc0-a007" name="Darkstar Falling" hidden="false" collective="false" import="true" type="upgrade">
@@ -1704,6 +1794,7 @@
       <categoryLinks>
         <categoryLink id="8e0a-7307-985f-50a6" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="4585-3e1e-8e4c-4a36" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="0aae-444b-0567-6f6a" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="9c05-d6b4-ed8b-c06a" name="Ignatus" hidden="false" collective="false" import="true" type="upgrade">

--- a/2022 - LA - Sons of Horus.cat
+++ b/2022 - LA - Sons of Horus.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="62c7-42f4-5523-af1b" name="LA -  XVI: Sons of Horus" revision="5" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="17" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="62c7-42f4-5523-af1b" name="LA -  XVI: Sons of Horus" revision="7" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="18" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entryLinks>
     <entryLink id="c2a2-9b6d-b384-3f43" name="  XVI: Sons of Horus" hidden="false" collective="false" import="false" targetId="01b4-57c7-bf61-2abf" type="selectionEntry">
       <constraints>
@@ -138,6 +138,18 @@
       </categoryLinks>
     </entryLink>
     <entryLink id="976e-1e33-d989-1476" name="Assault Squad" hidden="false" collective="false" import="false" targetId="a8e9-70e1-b8bc-8ee2" type="selectionEntry">
+      <modifiers>
+        <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="e196-f30f-88af-6df7" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="3d4b-f740-fb15-8228" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
@@ -166,12 +178,23 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="7ad4-2994-84dc-cf67" name="Bombard Sub-type:" hidden="false" targetId="d5df-57ac-8f3c-097b" primary="false"/>
         <categoryLink id="248e-c85a-b6d6-857e" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="7587-5330-2f0e-639d" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
+        <categoryLink id="3ac8-8ff3-8100-72de" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="7ae0-abf2-9c89-7c46" name="Breacher Squad" hidden="false" collective="false" import="false" targetId="ad97-c090-fa67-696f" type="selectionEntry">
+      <modifiers>
+        <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="023d-25b3-af63-4ed6" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="6b08-cdb7-c559-6ad7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
@@ -294,7 +317,6 @@
     <entryLink id="70d1-1da3-af70-f8b4" name="Damocles Command Rhino" hidden="false" collective="false" import="false" targetId="e337-8239-5e92-7f5f" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="2707-323f-d4f7-d83c" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="fa9b-4c89-5f00-0c15" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="1c40-efc2-b737-fe75" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -311,6 +333,18 @@
       </categoryLinks>
     </entryLink>
     <entryLink id="50cc-1a98-d330-f811" name="Despoiler Squad" hidden="false" collective="false" import="false" targetId="4357-930e-165a-a6e3" type="selectionEntry">
+      <modifiers>
+        <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="0c45-ab68-ca05-a713" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="221a-fead-fb30-7766" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
@@ -326,29 +360,31 @@
     <entryLink id="f892-38ef-43ef-b485" name="Dreadclaw Drop Pod" hidden="false" collective="false" import="false" targetId="bbe8-818d-3068-d79c" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="726e-1741-0e17-257d" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="8fe8-4d75-bf09-7a9e" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+        <categoryLink id="af6f-8fa1-be8d-ab53" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="cd69-d7e1-281d-92c2" name="Falchion" hidden="false" collective="false" import="false" targetId="1fe8-7386-9509-d2d8" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="c9e3-c57e-07b4-430a" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="f04f-29e8-f562-6aaf" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="a686-3572-9648-f413" name="Fellblade" hidden="false" collective="false" import="false" targetId="9c3c-f15a-9a1f-c0d0" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="210d-4413-aa5b-f52d" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="021c-3d91-163a-7a1a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="a1bb-eca2-1b35-c3b8" name="Fire Raptor Gunship" hidden="false" collective="false" import="false" targetId="f6e1-24e2-fbdb-c5ef" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="ac85-ba77-de25-6801" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="b9d1-9973-e5a3-74dc" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="c9e0-f198-62ee-6559" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="ef9b-780f-2c71-9129" name="Glaive" hidden="false" collective="false" import="false" targetId="04e0-f69f-f759-b0b3" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="3796-2f84-9305-de64" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="4db5-b750-90e7-cb26" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="5f51-164d-60e0-ab13" name="Heavy Support Squad" hidden="false" collective="false" import="false" targetId="bac9-5389-e2e7-0b1f" type="selectionEntry">
@@ -415,7 +451,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="cdab-8bac-d1bc-4605" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="84c4-698d-0f22-5d38" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+        <categoryLink id="2906-825a-29a1-a60b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="b455-e6ed-ddea-9480" name="Legion Banehammer" hidden="true" collective="false" import="false" targetId="1240-c71c-3a60-cf20" type="selectionEntry">
@@ -428,7 +464,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="4baa-3a1c-ec3b-a526" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="ecf7-28ff-b639-be3a" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+        <categoryLink id="f1c4-c235-f6f1-2894" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="132f-94b6-52aa-df0a" name="Legion Macharius Heavy Tank Squadron" hidden="false" collective="false" import="false" targetId="36ed-ca59-0d95-d85c" type="selectionEntry">
@@ -493,7 +529,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="1214-471f-5840-45b9" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="be21-3841-4daf-3427" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+        <categoryLink id="7a4d-edac-c3fd-cc13" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="0d89-f094-1e9f-0ffc" name="Legion Stormlord" hidden="true" collective="false" import="false" targetId="0887-0f66-2c7e-a5ba" type="selectionEntry">
@@ -506,7 +542,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="985e-3071-f56d-fe2f" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="f261-f00a-f65f-f47f" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+        <categoryLink id="9f54-3016-179e-351f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="a0b7-2afc-187c-072c" name="Legion Stormsword" hidden="true" collective="false" import="false" targetId="8e67-8f84-730c-2778" type="selectionEntry">
@@ -519,7 +555,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="a73f-3887-68be-61c9" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="5e50-aca8-ea27-cf41" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+        <categoryLink id="4dc9-64b1-cd49-6f65" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="a70c-faf4-f59d-47c1" name="Leviathan Dreadnought Talon" hidden="false" collective="false" import="false" targetId="c2a7-9e2c-fc65-1b78" type="selectionEntry">
@@ -531,6 +567,7 @@
     <entryLink id="9574-3763-b54a-dc08" name="Mastodon" hidden="false" collective="false" import="false" targetId="7f24-2b72-9128-5330" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="332c-f396-7746-b882" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="5dbc-94c2-bd54-119f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="10af-636e-0fcc-30de" name="Medusa Squadron" hidden="true" collective="false" import="false" targetId="24c8-5f6a-d48a-27b7" type="selectionEntry">
@@ -542,9 +579,8 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="fdab-b200-6862-c9ed" name="Bombard Sub-type:" hidden="false" targetId="d5df-57ac-8f3c-097b" primary="false"/>
         <categoryLink id="2c9b-7448-07f8-146c" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="260b-3a4c-5b9b-929c" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
+        <categoryLink id="1f32-cda0-5ee1-cd35" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="1597-f21c-1ec0-35b3" name="Mortalis Destroyer Squad" hidden="false" collective="false" import="false" targetId="dbd4-930e-e003-9449" type="selectionEntry">
@@ -643,6 +679,13 @@
       </categoryLinks>
     </entryLink>
     <entryLink id="2446-ab14-6e35-6d1e" name="Reconnaissance Squad" hidden="false" collective="false" import="false" targetId="6db7-6e88-877e-35ca" type="selectionEntry">
+      <modifiers>
+        <modifier type="add" field="category" value="8f42-a824-fb5f-8fea">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="76aa-00e6-9797-61bd" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="cd64-2c1f-637e-1e4f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
@@ -661,6 +704,13 @@
       </categoryLinks>
     </entryLink>
     <entryLink id="c2a3-8fb0-4ad3-549f" name="Scout Squad" hidden="false" collective="false" import="false" targetId="9b10-b657-a65a-9d60" type="selectionEntry">
+      <modifiers>
+        <modifier type="add" field="category" value="8f42-a824-fb5f-8fea">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="d122-28b5-e796-7fda" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="dff8-9a3d-6b04-ac0f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
@@ -681,7 +731,6 @@
     <entryLink id="389c-ce86-89a2-3776" name="Sicaran Omega Squadron" hidden="false" collective="false" import="false" targetId="c88b-fe44-34a3-97e1" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="abe7-4be2-eed3-9971" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="969b-b309-8775-3c1a" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="9527-c78b-175c-0594" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
       </categoryLinks>
     </entryLink>
@@ -694,7 +743,6 @@
     <entryLink id="0547-6d52-1f3f-ac18" name="Sicaran Squadron" hidden="false" collective="false" import="false" targetId="706a-9532-f06d-00ed" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="cecd-2fd2-c4cb-eaa7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="8860-d3df-8949-4d05" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="5786-dde9-1b3e-c114" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
       </categoryLinks>
     </entryLink>
@@ -713,6 +761,7 @@
     <entryLink id="00bb-4210-6011-0544" name="Sokar Stormbird" hidden="false" collective="false" import="false" targetId="f403-630f-71ae-5a7d" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="2601-e6bb-a438-f56f" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="9346-8593-8ae7-2102" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="c8c3-c970-b364-eb7d" name="Spatha Attack Bike Squadron" hidden="false" collective="false" import="false" targetId="4d72-1cc1-8bee-aa88" type="selectionEntry">
@@ -731,10 +780,22 @@
     <entryLink id="7730-3dcf-bb6e-ec1f" name="Storm Eagle Gunship" hidden="false" collective="false" import="false" targetId="8aa5-ff31-7de7-19d4" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="aef3-aa0e-aff3-69a7" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="c47d-348e-8cd9-5c2e" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+        <categoryLink id="347e-65e6-c5e8-5334" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="4781-3622-8679-be54" name="Tactical Squad" hidden="false" collective="false" import="false" targetId="aa72-63e4-bc60-4611" type="selectionEntry">
+      <modifiers>
+        <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="85ff-623d-8cf0-df89" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="228a-e216-3f8c-727a" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
@@ -756,7 +817,6 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="b87a-6d42-0ad9-f0b9" name="Artillery Sub-type:" hidden="false" targetId="6f99-c178-6f9d-fb63" primary="false"/>
         <categoryLink id="b8cb-40c9-c1c7-b573" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
         <categoryLink id="93f5-ce69-d670-5421" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
@@ -784,14 +844,12 @@
       <categoryLinks>
         <categoryLink id="ae20-d0c4-70c7-f9f7" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="59eb-fecc-0376-f1c2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="55ae-c6a3-6b41-87c0" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="6470-f57a-424d-00c6" name="Terminator Tartaros Squad" hidden="false" collective="false" import="false" targetId="1a8e-0ded-a4dc-2b4e" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="3577-609f-5b84-028f" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="6da1-2109-1f37-2e38" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="f9e1-c9c3-8d44-4ce5" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="3cd2-a32f-b28f-009f" name="Thunderbolt Fighter" hidden="false" collective="false" import="false" targetId="5d24-1e9a-ad9d-95ca" type="selectionEntry">
@@ -810,6 +868,7 @@
     <entryLink id="d011-3de2-3cc6-0f35" name="Thunderhawk Gunship" hidden="false" collective="false" import="false" targetId="8754-3a4f-213b-bdc0" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="16ad-24e9-b153-8bb6" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="27b1-e3c2-60b1-516c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="7837-a28a-8209-3530" name="Tylos Rubio" hidden="false" collective="false" import="false" targetId="56bf-2c6d-a0fa-a145" type="selectionEntry">
@@ -828,6 +887,7 @@
     <entryLink id="ac10-3866-dc00-e9b0" name="Typhon Squadron" hidden="false" collective="false" import="false" targetId="d06a-3087-af13-ca95" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="2cca-2349-9505-003b" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="50cd-7946-c0d5-8494" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="cba8-a086-7cdd-032a" name="Veteran Squad" hidden="false" collective="false" import="false" targetId="a423-7dd8-3f1b-3e28" type="selectionEntry">
@@ -853,14 +913,29 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="97e8-8e9d-08f5-3fd4" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="3d2c-8b71-21de-38bf" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
-        <categoryLink id="66bb-b300-17a9-53df" name="Bombard Sub-type:" hidden="false" targetId="d5df-57ac-8f3c-097b" primary="false"/>
+        <categoryLink id="4f40-d9d5-9b24-358b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="c517-a723-bc6e-81ea" name="Xiphon Interceptor" hidden="false" collective="false" import="false" targetId="596b-5478-e079-59ab" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="d06f-9f45-80cc-fa70" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="f1ae-df7c-541f-3f77" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="89a5-01f5-b9de-bd46" name="Seeker Squad" hidden="true" collective="false" import="false" targetId="58e6-f9cc-4c46-e258" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <infoLinks>
+        <infoLink id="dbda-3c87-a8c3-c89f" name="Legiones Astartes (Sons of Hours) " hidden="false" targetId="f4a2-e4ca-b8b2-35a1" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="bfeb-c007-501f-09d9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="28cc-a586-d1a5-07d4" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
       </categoryLinks>
     </entryLink>
   </entryLinks>
@@ -874,6 +949,11 @@
           <description>When any models with this special rule are used to make Melee Attacks against an enemy unit that includes any models with the Independent Character special rule or the Primarch Unit Type, all failed To Hit rolls of ‘1’ may be re-rolled. When a model with this special rule that is Engaged in a Challenge is used to make Melee  Attacks against a model with the Independent Character special rule or the Primarch Unit Type, all failed To Hit rolls may be re-rolled.</description>
         </rule>
       </rules>
+      <categoryLinks>
+        <categoryLink id="74fd-91d7-6d1c-8edd" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+        <categoryLink id="8cac-3a0b-8f04-2877" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="ed45-fc62-5dd5-769f" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+      </categoryLinks>
       <selectionEntries>
         <selectionEntry id="d566-70f1-05bc-642c" name="Chieftain" hidden="false" collective="false" import="true" type="model">
           <constraints>
@@ -1039,6 +1119,10 @@
       </costs>
     </selectionEntry>
     <selectionEntry id="f0a3-4ae4-e07a-91b8" name="Horus Lupercal" hidden="false" collective="false" import="true" type="unit">
+      <categoryLinks>
+        <categoryLink id="6438-a713-c788-02e4" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
+        <categoryLink id="be89-a0c6-b0cb-b46e" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+      </categoryLinks>
       <selectionEntries>
         <selectionEntry id="28c5-de31-09e9-9a57" name="The Serpent&apos;s Scales" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
@@ -1282,6 +1366,7 @@ the entire set of models before they are separated and must be applied to all mo
       </infoLinks>
       <categoryLinks>
         <categoryLink id="4caa-933a-6c61-0c7a" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="d534-6f34-1da7-062d" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="8e5a-163d-6dcf-8f4a" name="Reaver Chieftain" hidden="false" collective="false" import="true" type="model">
@@ -1313,6 +1398,9 @@ the entire set of models before they are separated and must be applied to all mo
               </characteristics>
             </profile>
           </profiles>
+          <categoryLinks>
+            <categoryLink id="9e64-6058-50b6-2676" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
+          </categoryLinks>
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
           </costs>
@@ -1550,6 +1638,8 @@ the entire set of models before they are separated and must be applied to all mo
       <categoryLinks>
         <categoryLink id="1f57-7f73-c9f6-c78c" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="008c-4ae3-4bb8-7464" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="0a8b-db6e-ba23-26ec" name="Line Sub-type:" hidden="false" targetId="6399-5c65-7833-1025" primary="false"/>
+        <categoryLink id="18b7-46e4-9b59-2827" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="e879-1248-f5b3-ae24" name="Maloghurst the Twisted" hidden="false" collective="false" import="true" type="model">
@@ -1684,6 +1774,8 @@ the entire set of models before they are separated and must be applied to all mo
       <categoryLinks>
         <categoryLink id="6cdb-94f4-0716-aa82" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="4897-8773-245a-fd7e" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="fa52-b947-779c-4a2b" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
+        <categoryLink id="ea4e-2199-7ddc-8cb8" name="Terminators:" hidden="false" targetId="bab3-f50d-3e5f-2f78" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="8313-092f-4568-b351" name="Ezekyle Abaddon" hidden="false" collective="false" import="true" type="model">
@@ -1819,6 +1911,7 @@ the entire set of models before they are separated and must be applied to all mo
       <categoryLinks>
         <categoryLink id="fcef-9b8a-6c3f-4fbe" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="6aca-3f5f-eceb-bb6f" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="4dff-4a2a-cd14-2871" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="1180-6721-0273-1236" name="Garviel Loken" hidden="false" collective="false" import="true" type="model">
@@ -1953,6 +2046,7 @@ remains in play and regains 1D3 Wounds.</description>
         <categoryLink id="705b-da26-7a7c-2f8c" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
         <categoryLink id="9f47-8b3b-90cc-998d" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="5156-399a-3fcc-8ca9" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="fbc7-2ac6-fa36-63d9" name="Terminators:" hidden="false" targetId="bab3-f50d-3e5f-2f78" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="f435-72d3-c60d-dc30" name="Justaerin" hidden="false" collective="false" import="true" type="upgrade">
@@ -2122,6 +2216,14 @@ remains in play and regains 1D3 Wounds.</description>
       </costs>
     </selectionEntry>
     <selectionEntry id="c3db-b014-dfaa-d189" name="Tybalt Marr" publicationId="d0df-7166-5cd3-89fd" page="92" hidden="false" collective="false" import="true" type="unit">
+      <constraints>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ecb0-3e9c-e3b6-fde7" type="max"/>
+      </constraints>
+      <categoryLinks>
+        <categoryLink id="773d-17eb-9834-2e2a" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="d4f8-7cfd-49ff-ca02" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="5dc1-6807-ef11-1755" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
+      </categoryLinks>
       <selectionEntries>
         <selectionEntry id="8165-001f-c7ba-8de5" name="Tybalt Marr" hidden="false" collective="false" import="true" type="model">
           <constraints>
@@ -2277,6 +2379,8 @@ remains in play and regains 1D3 Wounds.</description>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="1c94-5ba0-1947-6465" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="0e16-6c07-3df2-871e" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="1cd6-864c-cd5a-c20d" name="Jump Infantry:" hidden="false" targetId="eee8-3c7c-2762-e33e" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="f24a-6b3e-2d72-c19f" name="Reaver Aggressor Chieftain" hidden="false" collective="false" import="true" type="model">
@@ -2308,6 +2412,9 @@ remains in play and regains 1D3 Wounds.</description>
               </characteristics>
             </profile>
           </profiles>
+          <categoryLinks>
+            <categoryLink id="f1f5-1577-5721-4c9b" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
+          </categoryLinks>
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
           </costs>

--- a/2022 - LA - Space Wolves.cat
+++ b/2022 - LA - Space Wolves.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="ca15-13de-89cb-bbb2" name="LA -   VI: Space Wolves" revision="9" battleScribeVersion="2.03" authorName="Mr_Dark, UrsinePatriarch" authorContact="BSData Developers Discord" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="17" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="ca15-13de-89cb-bbb2" name="LA -   VI: Space Wolves" revision="10" battleScribeVersion="2.03" authorName="Mr_Dark, UrsinePatriarch" authorContact="BSData Developers Discord" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="18" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entryLinks>
     <entryLink id="ff53-69d9-ec0b-9caa" name="   VI: Space Wolves" hidden="false" collective="false" import="false" targetId="4916-965e-8339-44f6" type="selectionEntry">
       <constraints>
@@ -26,6 +26,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="ecf9-012f-8171-c36a" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true"/>
+        <categoryLink id="026f-5075-581f-d0fb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="145a-e620-0394-c8e6" name="Geigor Fell-Hand" hidden="false" collective="false" import="false" targetId="b4c7-4f96-122b-7ade" type="selectionEntry">
@@ -43,6 +44,18 @@
       </categoryLinks>
     </entryLink>
     <entryLink id="7a57-b5be-d2e5-93f1" name="Grey Slayer Pack" hidden="false" collective="false" import="false" targetId="4bbf-f3df-7b18-4a49" type="selectionEntry">
+      <modifiers>
+        <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="37a5-e559-aa6f-a23d" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="9fab-f8f9-82e9-e115" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
@@ -50,6 +63,18 @@
       </categoryLinks>
     </entryLink>
     <entryLink id="2e36-c0e4-643d-7f4e" name="Grey Stalker Pack" hidden="false" collective="false" import="false" targetId="4dbc-6266-853a-5114" type="selectionEntry">
+      <modifiers>
+        <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="c550-0f2f-8b47-f6ed" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="cc44-9321-b02a-11a5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
@@ -128,6 +153,18 @@
       </categoryLinks>
     </entryLink>
     <entryLink id="7d0a-baa4-fef8-2fb6" name="Assault Squad" hidden="false" collective="false" import="false" targetId="a8e9-70e1-b8bc-8ee2" type="selectionEntry">
+      <modifiers>
+        <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="9579-1448-0161-c917" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="74d2-3be1-9300-e5f4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
@@ -156,12 +193,23 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="075d-479e-f833-f0d6" name="Bombard Sub-type:" hidden="false" targetId="d5df-57ac-8f3c-097b" primary="false"/>
         <categoryLink id="9548-32a6-cd08-0fe4" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="5505-ffd5-5a65-a330" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
+        <categoryLink id="e7ff-e224-3b47-5afb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="46ca-3578-3252-5279" name="Breacher Squad" hidden="false" collective="false" import="false" targetId="ad97-c090-fa67-696f" type="selectionEntry">
+      <modifiers>
+        <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="6eb0-486f-577e-5627" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="739a-bfcc-85bb-c8aa" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
@@ -298,7 +346,6 @@
     <entryLink id="96a4-98a1-d338-3f29" name="Damocles Command Rhino" hidden="false" collective="false" import="false" targetId="e337-8239-5e92-7f5f" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="d338-30bf-599c-51da" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="a885-0770-49e8-e5f6" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="1226-be2f-2291-9f64" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -315,6 +362,18 @@
       </categoryLinks>
     </entryLink>
     <entryLink id="908b-c742-7cba-5421" name="Despoiler Squad" hidden="false" collective="false" import="false" targetId="4357-930e-165a-a6e3" type="selectionEntry">
+      <modifiers>
+        <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="15f3-c336-e9e6-adbb" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="bf2f-6245-0fd7-e32a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
@@ -330,29 +389,31 @@
     <entryLink id="42f1-f479-531e-d27c" name="Dreadclaw Drop Pod" hidden="false" collective="false" import="false" targetId="bbe8-818d-3068-d79c" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="4bad-9e6e-11a9-c5e8" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="5bbd-6c65-9962-1242" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+        <categoryLink id="03a9-09d2-055e-e1c3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="e640-d1e0-f223-6ae0" name="Falchion" hidden="false" collective="false" import="false" targetId="1fe8-7386-9509-d2d8" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="a620-4554-c1bf-9675" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="efe0-5bc8-d758-1037" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="f552-5192-a1ad-3567" name="Fellblade" hidden="false" collective="false" import="false" targetId="9c3c-f15a-9a1f-c0d0" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="5e37-217a-fc08-955c" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="daa5-581f-6bde-0d64" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="7951-37ba-ea97-1fbf" name="Fire Raptor Gunship" hidden="false" collective="false" import="false" targetId="f6e1-24e2-fbdb-c5ef" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="8e1f-3d06-c16f-92bf" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="8569-3d11-17f6-4a5b" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="6dc9-b166-08bf-9f29" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="4ce1-afcb-a998-139b" name="Glaive" hidden="false" collective="false" import="false" targetId="04e0-f69f-f759-b0b3" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="e916-03bd-32d8-4be5" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="7890-7142-1f66-e71d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="147f-e6f3-1e59-d1bd" name="Heavy Support Squad" hidden="false" collective="false" import="false" targetId="bac9-5389-e2e7-0b1f" type="selectionEntry">
@@ -419,7 +480,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="df0b-d5b9-a329-79f8" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="1b8b-d306-0ed9-6f64" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+        <categoryLink id="8eeb-eed3-1ba3-2abb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="40eb-8d27-4e31-9ea7" name="Legion Banehammer" hidden="true" collective="false" import="false" targetId="1240-c71c-3a60-cf20" type="selectionEntry">
@@ -432,7 +493,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="d672-c540-c41b-1144" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="054b-0019-7298-d806" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+        <categoryLink id="524d-6b64-9e34-ba14" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="2187-7689-25c3-8c0f" name="Legion Macharius Heavy Tank Squadron" hidden="false" collective="false" import="false" targetId="36ed-ca59-0d95-d85c" type="selectionEntry">
@@ -497,7 +558,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="7112-795a-da10-6412" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="bbb0-204e-d88f-e1c3" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+        <categoryLink id="a416-8088-db2f-998c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="8b7c-7ea0-397c-bd00" name="Legion Stormlord" hidden="true" collective="false" import="false" targetId="0887-0f66-2c7e-a5ba" type="selectionEntry">
@@ -510,7 +571,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="a632-972c-b2e7-c4a4" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="d73d-43d2-621c-bfdf" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+        <categoryLink id="9d6d-c576-79d7-f3ff" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="9cba-fa2b-41e3-1816" name="Legion Stormsword" hidden="true" collective="false" import="false" targetId="8e67-8f84-730c-2778" type="selectionEntry">
@@ -523,7 +584,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="84e7-3b48-82f5-a34e" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="adee-b8e7-1dcb-ddb2" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+        <categoryLink id="77b8-a56e-9978-a3a8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="69c5-c19e-f63a-8b1a" name="Leviathan Dreadnought Talon" hidden="false" collective="false" import="false" targetId="c2a7-9e2c-fc65-1b78" type="selectionEntry">
@@ -535,6 +596,7 @@
     <entryLink id="866b-22df-9377-8855" name="Mastodon" hidden="false" collective="false" import="false" targetId="7f24-2b72-9128-5330" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="b129-db81-daf0-788a" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="c906-2a18-cfc2-fdd8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="5077-05bd-eafc-1dfd" name="Medusa Squadron" hidden="true" collective="false" import="false" targetId="24c8-5f6a-d48a-27b7" type="selectionEntry">
@@ -546,9 +608,8 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="6b2a-0088-74ab-11ad" name="Bombard Sub-type:" hidden="false" targetId="d5df-57ac-8f3c-097b" primary="false"/>
         <categoryLink id="8522-1958-3938-5d6a" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="2e76-fb3c-9b53-eae3" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
+        <categoryLink id="d61b-2776-448a-61b6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="9438-c576-3b7f-9b59" name="Mortalis Destroyer Squad" hidden="false" collective="false" import="false" targetId="dbd4-930e-e003-9449" type="selectionEntry">
@@ -647,6 +708,13 @@
       </categoryLinks>
     </entryLink>
     <entryLink id="1041-1b38-81e8-e66d" name="Reconnaissance Squad" hidden="false" collective="false" import="false" targetId="6db7-6e88-877e-35ca" type="selectionEntry">
+      <modifiers>
+        <modifier type="add" field="category" value="8f42-a824-fb5f-8fea">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="023e-71c2-8c55-09be" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="70b5-db33-6588-0cd7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
@@ -665,6 +733,13 @@
       </categoryLinks>
     </entryLink>
     <entryLink id="e3ec-76e5-e3eb-e644" name="Scout Squad" hidden="false" collective="false" import="false" targetId="9b10-b657-a65a-9d60" type="selectionEntry">
+      <modifiers>
+        <modifier type="add" field="category" value="8f42-a824-fb5f-8fea">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="bd76-63cb-6fa9-40eb" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="650f-4395-8d57-116a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
@@ -685,7 +760,6 @@
     <entryLink id="1bfc-59f7-21fc-9522" name="Sicaran Omega Squadron" hidden="false" collective="false" import="false" targetId="c88b-fe44-34a3-97e1" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="fe28-67c6-1d19-8b59" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="3418-0642-06a7-5b3a" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="30dc-d245-86c7-92bf" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
       </categoryLinks>
     </entryLink>
@@ -698,7 +772,6 @@
     <entryLink id="ae13-45b3-410d-db09" name="Sicaran Squadron" hidden="false" collective="false" import="false" targetId="706a-9532-f06d-00ed" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="5adc-e50d-7ba6-196b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="923e-7e17-4108-4a4b" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="4826-382e-c68a-ec41" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
       </categoryLinks>
     </entryLink>
@@ -717,6 +790,7 @@
     <entryLink id="5b98-7257-55a6-1c70" name="Sokar Stormbird" hidden="false" collective="false" import="false" targetId="f403-630f-71ae-5a7d" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="d273-5150-7505-021e" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="08a6-064b-bb57-b5a4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="5faf-84f9-b693-f012" name="Spatha Attack Bike Squadron" hidden="false" collective="false" import="false" targetId="4d72-1cc1-8bee-aa88" type="selectionEntry">
@@ -735,10 +809,22 @@
     <entryLink id="2edd-54be-4991-b1fb" name="Storm Eagle Gunship" hidden="false" collective="false" import="false" targetId="8aa5-ff31-7de7-19d4" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="d672-0687-6d82-5a52" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="c6cd-8879-2665-30a6" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+        <categoryLink id="15c1-78a0-7544-4ba5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="4fcb-24e5-0465-48f5" name="Tactical Squad" hidden="false" collective="false" import="false" targetId="aa72-63e4-bc60-4611" type="selectionEntry">
+      <modifiers>
+        <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="d289-5834-1624-39ff" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="21b4-3d77-64bd-30f9" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
@@ -760,7 +846,6 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="af2d-ea3e-8d66-439d" name="Artillery Sub-type:" hidden="false" targetId="6f99-c178-6f9d-fb63" primary="false"/>
         <categoryLink id="89d2-f9bd-e35d-4876" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
         <categoryLink id="15d8-8e3e-60ab-789a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
@@ -788,14 +873,12 @@
       <categoryLinks>
         <categoryLink id="e48c-8501-977d-d4f4" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="285b-28b3-e711-7201" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="2ba1-0e56-ed2d-b732" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="1b00-d14d-b1b4-38aa" name="Terminator Tartaros Squad" hidden="false" collective="false" import="false" targetId="1a8e-0ded-a4dc-2b4e" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="35b2-e100-5f07-093b" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="376d-3b99-7653-20f9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="6a28-9bfd-99c6-d9e9" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="bf65-1ff7-f962-26b5" name="Thunderbolt Fighter" hidden="false" collective="false" import="false" targetId="5d24-1e9a-ad9d-95ca" type="selectionEntry">
@@ -814,6 +897,7 @@
     <entryLink id="8a3b-87e9-09e0-3e53" name="Thunderhawk Gunship" hidden="false" collective="false" import="false" targetId="8754-3a4f-213b-bdc0" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="1680-22c8-6098-2e71" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="0093-5702-39e7-da16" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="8cf1-c85b-4c68-6ef4" name="Tylos Rubio" hidden="false" collective="false" import="false" targetId="56bf-2c6d-a0fa-a145" type="selectionEntry">
@@ -832,6 +916,7 @@
     <entryLink id="30fc-7395-212a-8799" name="Typhon Squadron" hidden="false" collective="false" import="false" targetId="d06a-3087-af13-ca95" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="b3d4-4d1a-a01a-4bf5" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="3604-8de1-1c45-a66c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="0ad2-daf8-8b18-c43b" name="Veteran Squad" hidden="false" collective="false" import="false" targetId="a423-7dd8-3f1b-3e28" type="selectionEntry">
@@ -857,14 +942,29 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="1947-04fa-1624-fe75" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="42ec-70ca-5795-dbe4" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
-        <categoryLink id="7677-6b84-24a3-5c75" name="Bombard Sub-type:" hidden="false" targetId="d5df-57ac-8f3c-097b" primary="false"/>
+        <categoryLink id="6a2d-9e0c-4dc1-4b00" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="7232-6f4c-c3e1-6191" name="Xiphon Interceptor" hidden="false" collective="false" import="false" targetId="596b-5478-e079-59ab" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="bd3c-2782-2231-8c9a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="bb47-9aee-ad52-615e" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="4001-533a-8998-a443" name="Seeker Squad" hidden="true" collective="false" import="false" targetId="58e6-f9cc-4c46-e258" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <infoLinks>
+        <infoLink id="847f-add9-3409-74a3" name="Legiones Astartes (Space Wolves) " hidden="false" targetId="f806-8d12-07ab-fdaf" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="c198-3c27-918d-30c3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="6da4-ab27-5487-d257" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
       </categoryLinks>
     </entryLink>
   </entryLinks>
@@ -882,6 +982,10 @@
           </modifiers>
         </infoLink>
       </infoLinks>
+      <categoryLinks>
+        <categoryLink id="0c18-6f90-811e-6f2d" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
+        <categoryLink id="935c-5280-2665-ebbe" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+      </categoryLinks>
       <selectionEntries>
         <selectionEntry id="1c95-89ac-6ffc-46f3" name="Leman Russ" hidden="false" collective="false" import="true" type="model">
           <constraints>
@@ -1061,6 +1165,9 @@
       </rules>
       <categoryLinks>
         <categoryLink id="a231-01f6-2c07-1d34" name="Skirmish:" hidden="false" targetId="59a4-7b61-600a-c457" primary="false"/>
+        <categoryLink id="aa46-1901-68ca-1c6f" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="e1f3-747e-4b46-0a8e" name="Light Sub-type:" hidden="false" targetId="bff2-ae16-74a8-8712" primary="false"/>
+        <categoryLink id="f919-6f26-e787-b770" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="cdb9-9230-2585-94c5" name="Freki" hidden="false" collective="false" import="true" type="model">
@@ -1434,6 +1541,8 @@
       <categoryLinks>
         <categoryLink id="2ee4-2abc-3c87-55e6" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
         <categoryLink id="7469-45b8-1b62-5427" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="0ef2-5d12-a22c-7300" name="Terminators:" hidden="false" targetId="bab3-f50d-3e5f-2f78" primary="false"/>
+        <categoryLink id="38da-50e3-302b-8975" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="075a-c65e-c1eb-2ca9" name="Varagyr" hidden="false" collective="false" import="true" type="model">
@@ -1729,6 +1838,8 @@
       <categoryLinks>
         <categoryLink id="bbe7-7ff2-451e-b829" name="New CategoryLink" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="b448-e7f9-63a5-1209" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="1b8f-457a-d55c-4e91" name="Skirmish Sub-type:" hidden="false" targetId="59a4-7b61-600a-c457" primary="false"/>
+        <categoryLink id="1d25-440b-a838-dfd4" name="Line Sub-type:" hidden="false" targetId="6399-5c65-7833-1025" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="1f1f-8964-8920-6b19" name="Grey Slayers" hidden="false" collective="false" import="true" type="model">
@@ -2194,6 +2305,8 @@
       <categoryLinks>
         <categoryLink id="b526-a925-98fa-3c1b" name="New CategoryLink" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="4d9c-b591-869f-72e1" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="cebe-84b9-86a9-ad58" name="Skirmish Sub-type:" hidden="false" targetId="59a4-7b61-600a-c457" primary="false"/>
+        <categoryLink id="b50f-33ce-bd61-3d78" name="Line Sub-type:" hidden="false" targetId="6399-5c65-7833-1025" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="01e0-a54b-a263-07c2" name="Grey Stalkers" hidden="false" collective="false" import="true" type="model">
@@ -2727,6 +2840,7 @@
         <categoryLink id="d60f-4d22-ec3a-4ff4" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="d837-ea6b-4c27-6d28" name="Skirmish:" hidden="false" targetId="59a4-7b61-600a-c457" primary="false"/>
         <categoryLink id="630f-3af2-6436-6e5f" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="ed4d-3332-70b3-36a0" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="b7a3-a947-16cc-f6ac" name="Geigor Fell-Hand" hidden="false" collective="false" import="true" type="model">
@@ -2870,6 +2984,8 @@
       <categoryLinks>
         <categoryLink id="0638-55ed-3f00-f7e8" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="1e3f-2a84-0c72-44c8" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="11eb-fb8c-8da9-a2dd" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
+        <categoryLink id="b2ea-ff2e-17d8-7c33" name="Terminators:" hidden="false" targetId="bab3-f50d-3e5f-2f78" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="02e6-38a7-3cae-faa9" name="Hvarl Red-Blade" hidden="false" collective="false" import="true" type="model">
@@ -3003,6 +3119,10 @@
         <infoLink id="693a-d7ee-ebb9-7fb5" name="Scout" hidden="false" targetId="aacf-9a7e-982d-b793" type="rule"/>
         <infoLink id="f47d-7db5-4357-2fd8" name="Support Squad" hidden="false" targetId="768e-56d6-ca52-24ae" type="rule"/>
       </infoLinks>
+      <categoryLinks>
+        <categoryLink id="74d4-672b-5d83-787e" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="6ea9-87ae-dad3-a06a" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+      </categoryLinks>
       <selectionEntries>
         <selectionEntry id="57d5-858f-5248-0053" name="Hunters" hidden="false" collective="false" import="true" type="model">
           <constraints>
@@ -3317,6 +3437,12 @@
           <description>A Fenrisian Wolf Pack may only be chosen as a Retinue for a model with both the Legiones Astartes (Space Wolves) and Master of the Legion special rules. This Model is referred to as the Fenrisian Wolf Pack’s Leader for the purposes of this special rule. The Fenrisian Wolf Pack does not use up a Force Organisation slot and is considered part of the same unit as the model taken as its Leader. The Fenrisian Wolf Pack must be deployed with the model selected as its Leader deployed as part of the unit and the Leader may not voluntarily leave the Fenrisian Wolf Pack during play. A Fenrisian Wolf Pack may not be selected as part of an army without a Leader.</description>
         </rule>
       </rules>
+      <categoryLinks>
+        <categoryLink id="cd15-57a2-eb52-ba6e" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="3fa3-2b6b-9450-df23" name="Skirmish Sub-type:" hidden="false" targetId="59a4-7b61-600a-c457" primary="false"/>
+        <categoryLink id="902c-d0fe-d4c8-5002" name="Light Sub-type:" hidden="false" targetId="bff2-ae16-74a8-8712" primary="false"/>
+        <categoryLink id="a83a-860c-9cb5-1471" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+      </categoryLinks>
       <selectionEntries>
         <selectionEntry id="5b26-1509-991d-f166" name="Fenrisian Wolf" hidden="false" collective="false" import="true" type="model">
           <constraints>

--- a/2022 - LA - Thousand Sons.cat
+++ b/2022 - LA - Thousand Sons.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="abac-8dd1-df65-e253" name="LA -  XV: Thousand Sons" revision="9" battleScribeVersion="2.03" authorName="Arkangelmark5" authorContact="BSData Developers Discord" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="17" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="abac-8dd1-df65-e253" name="LA -  XV: Thousand Sons" revision="10" battleScribeVersion="2.03" authorName="Arkangelmark5" authorContact="BSData Developers Discord" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="18" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entryLinks>
     <entryLink id="5900-484e-9f23-c753" name="  XV: Thousand Sons" hidden="false" collective="false" import="false" targetId="21c3-2f28-7820-e51a" type="selectionEntry">
       <constraints>
@@ -101,6 +101,18 @@
       </categoryLinks>
     </entryLink>
     <entryLink id="2a9c-7cc1-c26b-384a" name="Assault Squad" hidden="false" collective="false" import="false" targetId="a8e9-70e1-b8bc-8ee2" type="selectionEntry">
+      <modifiers>
+        <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="80c9-6006-0cad-636d" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="9be3-ada3-a64a-6d9b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
@@ -129,12 +141,23 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="a3de-28d0-3ce6-0219" name="Bombard Sub-type:" hidden="false" targetId="d5df-57ac-8f3c-097b" primary="false"/>
         <categoryLink id="3974-a905-64e8-6a85" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="da94-39c4-c3f1-5e16" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
+        <categoryLink id="3b03-f1ce-3de3-235c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="99c8-f0b7-7334-7c9f" name="Breacher Squad" hidden="false" collective="false" import="false" targetId="ad97-c090-fa67-696f" type="selectionEntry">
+      <modifiers>
+        <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="7d5e-09d7-e265-0df6" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="fda0-da57-0e09-3b36" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
@@ -260,7 +283,6 @@
     <entryLink id="97fb-5eb3-b4e4-db61" name="Damocles Command Rhino" hidden="false" collective="false" import="false" targetId="e337-8239-5e92-7f5f" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="79a4-1109-306c-2d53" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="2022-9f33-d5f5-1708" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="0bd4-5197-36a1-abe1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -277,6 +299,18 @@
       </categoryLinks>
     </entryLink>
     <entryLink id="6a44-ab07-cb0d-7f6d" name="Despoiler Squad" hidden="false" collective="false" import="false" targetId="4357-930e-165a-a6e3" type="selectionEntry">
+      <modifiers>
+        <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="1197-91a9-cdc8-aad4" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="e692-0c21-f983-ee2f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
@@ -292,29 +326,31 @@
     <entryLink id="8eb9-da53-4df0-9a20" name="Dreadclaw Drop Pod" hidden="false" collective="false" import="false" targetId="bbe8-818d-3068-d79c" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="0fad-0b78-4d3c-9c84" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="775a-efa9-21cd-071e" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+        <categoryLink id="382b-504e-87e1-fbc0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="5c7e-d632-a1f7-31c2" name="Falchion" hidden="false" collective="false" import="false" targetId="1fe8-7386-9509-d2d8" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="eb65-8a7c-275f-2d90" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="beaf-07f8-a942-4a16" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="25dd-db68-56f0-0d09" name="Fellblade" hidden="false" collective="false" import="false" targetId="9c3c-f15a-9a1f-c0d0" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="efb1-38f6-cede-acc2" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="836e-d21e-6395-89b9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="3382-bc4e-5766-917f" name="Fire Raptor Gunship" hidden="false" collective="false" import="false" targetId="f6e1-24e2-fbdb-c5ef" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="eb9a-db3c-090e-c778" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="6ad7-fa26-04d1-955d" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="2283-e1b8-b295-b9f8" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="577e-1f0c-3ea2-ce15" name="Glaive" hidden="false" collective="false" import="false" targetId="04e0-f69f-f759-b0b3" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="cbd3-898e-21ad-1b03" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="d40d-7c84-fd8c-0c2a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="9d7f-87f1-a6f7-a9b6" name="Heavy Support Squad" hidden="false" collective="false" import="false" targetId="bac9-5389-e2e7-0b1f" type="selectionEntry">
@@ -381,7 +417,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="00f6-41d4-81b3-76e4" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="7854-79a3-1b57-05e0" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+        <categoryLink id="dd96-2953-2507-4fc0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="5c98-3dc1-f22b-08aa" name="Legion Banehammer" hidden="true" collective="false" import="false" targetId="1240-c71c-3a60-cf20" type="selectionEntry">
@@ -394,7 +430,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="dbfd-f303-2d66-adbe" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="0105-0a7e-4e38-c468" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+        <categoryLink id="b3a0-908c-6a19-279f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="6676-5302-e270-4855" name="Legion Macharius Heavy Tank Squadron" hidden="false" collective="false" import="false" targetId="36ed-ca59-0d95-d85c" type="selectionEntry">
@@ -459,7 +495,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="dde6-c705-9432-9404" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="d852-5c47-d514-60c8" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+        <categoryLink id="b1ee-7886-7084-e358" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="8195-844d-b3f3-5288" name="Legion Stormlord" hidden="true" collective="false" import="false" targetId="0887-0f66-2c7e-a5ba" type="selectionEntry">
@@ -472,7 +508,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="e54a-b42b-8e9e-d3ec" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="df5c-b4e0-9127-b35b" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+        <categoryLink id="fe45-78be-1409-fc40" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="48d8-0a9f-e2a6-11e6" name="Legion Stormsword" hidden="true" collective="false" import="false" targetId="8e67-8f84-730c-2778" type="selectionEntry">
@@ -485,7 +521,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="63e4-9753-3816-b496" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="621a-2d3e-af53-f618" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+        <categoryLink id="c934-587e-9917-632d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="c024-5c8b-0572-14dd" name="Leviathan Dreadnought Talon" hidden="false" collective="false" import="false" targetId="c2a7-9e2c-fc65-1b78" type="selectionEntry">
@@ -497,6 +533,7 @@
     <entryLink id="f8a9-bb4b-161f-0a03" name="Mastodon" hidden="false" collective="false" import="false" targetId="7f24-2b72-9128-5330" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="9da7-cdad-1da2-343e" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="501c-eb08-ec84-e481" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="fe14-86fe-12a7-cfb7" name="Medusa Squadron" hidden="true" collective="false" import="false" targetId="24c8-5f6a-d48a-27b7" type="selectionEntry">
@@ -508,9 +545,8 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="0806-7ccd-7368-b38a" name="Bombard Sub-type:" hidden="false" targetId="d5df-57ac-8f3c-097b" primary="false"/>
         <categoryLink id="6540-0169-9f36-5092" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="ea79-44ee-54c6-b3fb" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
+        <categoryLink id="f752-a39e-8108-97a9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="e07c-6d50-ba3c-2c4d" name="Mortalis Destroyer Squad" hidden="false" collective="false" import="true" targetId="dbd4-930e-e003-9449" type="selectionEntry">
@@ -609,6 +645,13 @@
       </categoryLinks>
     </entryLink>
     <entryLink id="64de-75cf-c7d1-40c9" name="Reconnaissance Squad" hidden="false" collective="false" import="false" targetId="6db7-6e88-877e-35ca" type="selectionEntry">
+      <modifiers>
+        <modifier type="add" field="category" value="8f42-a824-fb5f-8fea">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="2468-65f7-9c0a-770e" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="aacf-8a74-6fdf-0937" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
@@ -627,6 +670,13 @@
       </categoryLinks>
     </entryLink>
     <entryLink id="1704-0515-a9e4-b29e" name="Scout Squad" hidden="false" collective="false" import="false" targetId="9b10-b657-a65a-9d60" type="selectionEntry">
+      <modifiers>
+        <modifier type="add" field="category" value="8f42-a824-fb5f-8fea">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="a7c7-9db8-9556-0b55" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="20be-cbc2-2e7d-001b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
@@ -647,7 +697,6 @@
     <entryLink id="5677-104c-dab0-139b" name="Sicaran Omega Squadron" hidden="false" collective="false" import="false" targetId="c88b-fe44-34a3-97e1" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="ae8b-8fe9-7b4a-ea2e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="d3ce-0531-2414-1c43" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="228a-fb65-b620-80f7" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
       </categoryLinks>
     </entryLink>
@@ -660,7 +709,6 @@
     <entryLink id="0f72-6b3e-9034-8a3c" name="Sicaran Squadron" hidden="false" collective="false" import="false" targetId="706a-9532-f06d-00ed" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="f7ec-8877-ea57-3a38" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="5562-f0a0-b1e0-1772" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="ad6a-6983-8ca5-e7aa" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
       </categoryLinks>
     </entryLink>
@@ -679,6 +727,7 @@
     <entryLink id="f676-aae1-f729-7051" name="Sokar Stormbird" hidden="false" collective="false" import="false" targetId="f403-630f-71ae-5a7d" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="7090-6650-fdfe-e79e" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="a910-2956-2438-a7ab" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="7cbd-4031-cbed-74ed" name="Spatha Attack Bike Squadron" hidden="false" collective="false" import="false" targetId="4d72-1cc1-8bee-aa88" type="selectionEntry">
@@ -697,10 +746,22 @@
     <entryLink id="3e50-9098-4a8b-770f" name="Storm Eagle Gunship" hidden="false" collective="false" import="false" targetId="8aa5-ff31-7de7-19d4" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="12f5-c4ba-01c1-1c9a" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="f605-bc13-ed98-fd7d" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+        <categoryLink id="5c5e-02e6-bb22-9ed7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="aeb6-7fd7-b0eb-f99c" name="Tactical Squad" hidden="false" collective="false" import="false" targetId="aa72-63e4-bc60-4611" type="selectionEntry">
+      <modifiers>
+        <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="b9f0-d793-78b2-3059" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="7eca-10cd-f2a8-06d6" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
@@ -722,7 +783,6 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="aafc-7a28-8245-23e5" name="Artillery Sub-type:" hidden="false" targetId="6f99-c178-6f9d-fb63" primary="false"/>
         <categoryLink id="629c-db73-2a83-43de" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
         <categoryLink id="6fd3-a404-11dc-ec7d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
@@ -750,14 +810,12 @@
       <categoryLinks>
         <categoryLink id="e634-43c2-1198-b1eb" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="033c-7e01-a4c8-ee91" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="c065-3910-76a5-564b" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="5034-2e8a-21c5-06bb" name="Terminator Tartaros Squad" hidden="false" collective="false" import="false" targetId="1a8e-0ded-a4dc-2b4e" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="a635-101f-a4a1-e2ef" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="320e-4280-817a-bb5a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="f2c8-938d-7514-87a1" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="3b01-e912-2b38-9d0a" name="Thunderbolt Fighter" hidden="false" collective="false" import="false" targetId="5d24-1e9a-ad9d-95ca" type="selectionEntry">
@@ -776,6 +834,7 @@
     <entryLink id="a96c-46cc-4a9c-4786" name="Thunderhawk Gunship" hidden="false" collective="false" import="false" targetId="8754-3a4f-213b-bdc0" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="193e-d0f2-1d40-6cfc" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="6ea6-9cc0-746b-1102" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="6b5e-9cea-ae25-6d2b" name="Tylos Rubio" hidden="false" collective="false" import="false" targetId="56bf-2c6d-a0fa-a145" type="selectionEntry">
@@ -794,6 +853,7 @@
     <entryLink id="9967-c2e0-8192-fa08" name="Typhon Squadron" hidden="false" collective="false" import="false" targetId="d06a-3087-af13-ca95" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="4f0c-f9cd-7748-0c86" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="8c3f-676b-b372-344b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="22eb-15a1-aab6-d452" name="Veteran Squad" hidden="false" collective="false" import="false" targetId="a423-7dd8-3f1b-3e28" type="selectionEntry">
@@ -819,14 +879,29 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="056c-8130-a7a2-6864" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="32af-ce42-e9f2-7c54" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
-        <categoryLink id="c8b1-c2cf-f773-d5f7" name="Bombard Sub-type:" hidden="false" targetId="d5df-57ac-8f3c-097b" primary="false"/>
+        <categoryLink id="929c-1e02-015e-d72d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="538e-9e82-793f-c984" name="Xiphon Interceptor" hidden="false" collective="false" import="false" targetId="596b-5478-e079-59ab" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="c4aa-9d4d-0819-92f2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="d85a-619c-8d1c-0c83" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="24ba-d2c2-3e6a-cdc8" name="Seeker Squad" hidden="true" collective="false" import="false" targetId="58e6-f9cc-4c46-e258" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <infoLinks>
+        <infoLink id="8b46-7db6-f3c3-ad65" name="Legiones Astartes (Thousand Sons) " hidden="false" targetId="2377-1d73-44bc-fee2" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="3785-dd74-e83e-7694" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="5dc3-0e05-020e-d5fd" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
       </categoryLinks>
     </entryLink>
   </entryLinks>
@@ -1866,6 +1941,7 @@
         <categoryLink id="ee57-776c-ef90-1f77" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="3066-9075-b4df-8684" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="ea5b-1965-f2b0-cd0d" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+        <categoryLink id="4863-5593-dedb-fb54" name="Terminators:" hidden="false" targetId="bab3-f50d-3e5f-2f78" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="0ee5-6264-b5e4-5a9b" name="Sekhmet Inceptor" hidden="false" collective="false" import="true" type="model">
@@ -1893,7 +1969,6 @@
           <categoryLinks>
             <categoryLink id="9a2f-0507-13a4-8ac8" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
             <categoryLink id="7c63-0f76-63cb-2c82" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-            <categoryLink id="f6db-3d91-884f-18e0" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
           </categoryLinks>
           <selectionEntries>
             <selectionEntry id="a14c-93c1-d16e-d057" name="Psychic Discipline" hidden="false" collective="false" import="true" type="upgrade">
@@ -1984,7 +2059,6 @@
             </profile>
           </profiles>
           <categoryLinks>
-            <categoryLink id="fad8-29cf-a4e1-28a0" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
             <categoryLink id="9e82-d5b4-dc5f-8930" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
@@ -2368,6 +2442,8 @@
       </infoLinks>
       <categoryLinks>
         <categoryLink id="45af-d7ac-39f4-2234" name="Primarch:" hidden="false" targetId="ad5f-31db-8bc7-5c46" primary="false"/>
+        <categoryLink id="2f4f-2382-f656-0475" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
+        <categoryLink id="9f33-3de6-2245-536e" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="b643-0093-699a-1d81" name="Arch-Sorcerer" page="" hidden="false" collective="false" import="true" type="upgrade">

--- a/2022 - LA - Ultramarines.cat
+++ b/2022 - LA - Ultramarines.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="68ae-9855-b56a-95e6" name="LA -  XIII: Ultramarines" revision="9" battleScribeVersion="2.03" authorName="Mr_Dark, Alphalas, UrsinePatriarch" authorContact="BSData Developers Discord" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="17" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="68ae-9855-b56a-95e6" name="LA -  XIII: Ultramarines" revision="10" battleScribeVersion="2.03" authorName="Mr_Dark, Alphalas, UrsinePatriarch" authorContact="BSData Developers Discord" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="18" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entryLinks>
     <entryLink id="76b3-52d9-a195-2b31" name="  XIII: Ultramarines" hidden="false" collective="false" import="false" targetId="8e0f-3552-8842-f281" type="selectionEntry">
       <constraints>
@@ -33,6 +33,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="ca0e-9ea0-9afa-adb3" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="c1ef-40b1-7263-83a0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="055f-9c17-0de4-f903" name="Honoured Telemechrus" hidden="false" collective="false" import="false" targetId="c688-58bc-b6c5-c02b" type="selectionEntry">
@@ -56,6 +57,7 @@
     <entryLink id="0601-875a-65a7-9702" name="Invictarus Suzerain Squad" hidden="false" collective="false" import="false" targetId="ed63-e872-9410-a4b5" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="a64a-afb1-07f6-2e1c" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="6a17-2ae0-dd91-fce4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="a0ee-1e5c-eefb-cbe8" name="Praetorian Breacher Squad" hidden="false" collective="false" import="false" targetId="7587-35cc-01f6-b5d2" type="selectionEntry">
@@ -101,6 +103,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="5c12-7aef-b106-7159" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="3c4b-fd38-d4d8-9480" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="15f2-0f56-6650-9a06" name="Apothecarion Detachment" hidden="false" collective="false" import="false" targetId="81df-ffd4-a32b-b4a1" type="selectionEntry">
@@ -116,6 +119,18 @@
       </categoryLinks>
     </entryLink>
     <entryLink id="5a4e-4ae4-d306-0f94" name="Assault Squad" hidden="false" collective="false" import="false" targetId="a8e9-70e1-b8bc-8ee2" type="selectionEntry">
+      <modifiers>
+        <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="bbeb-55f5-e2e0-e267" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="0587-1681-790c-b01a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
@@ -144,12 +159,23 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="d2ec-56bd-bfd8-9faf" name="Bombard Sub-type:" hidden="false" targetId="d5df-57ac-8f3c-097b" primary="false"/>
         <categoryLink id="4a72-9436-7e09-58c9" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="4531-6b4e-809a-ea66" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
+        <categoryLink id="f897-825c-85c1-7c52" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="d512-7d42-1395-38fc" name="Breacher Squad" hidden="false" collective="false" import="false" targetId="ad97-c090-fa67-696f" type="selectionEntry">
+      <modifiers>
+        <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="fb71-201c-bb53-360f" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="3456-74cc-dbaa-22fa" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
@@ -272,7 +298,6 @@
     <entryLink id="3838-664d-df8f-b709" name="Damocles Command Rhino" hidden="false" collective="false" import="false" targetId="e337-8239-5e92-7f5f" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="a301-243e-4046-9ef1" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="0660-6890-9c4d-310f" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="9aeb-82de-847f-18d6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -289,6 +314,18 @@
       </categoryLinks>
     </entryLink>
     <entryLink id="c1dd-2f22-a40d-b85f" name="Despoiler Squad" hidden="false" collective="false" import="false" targetId="4357-930e-165a-a6e3" type="selectionEntry">
+      <modifiers>
+        <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="cf13-99d0-d540-c5ca" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="3ed7-89ba-35df-dd0b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
@@ -304,29 +341,31 @@
     <entryLink id="2ae3-51f3-e1a0-357d" name="Dreadclaw Drop Pod" hidden="false" collective="false" import="false" targetId="bbe8-818d-3068-d79c" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="b05d-806e-ce1c-8000" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="a835-8bb8-7025-59f1" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+        <categoryLink id="661b-0757-fa8b-1b68" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="b1fd-5d15-aae2-5ccf" name="Falchion" hidden="false" collective="false" import="false" targetId="1fe8-7386-9509-d2d8" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="eab0-94bc-adde-8950" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="1c6c-2429-319e-563d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="7592-f5b3-62d6-585b" name="Fellblade" hidden="false" collective="false" import="false" targetId="9c3c-f15a-9a1f-c0d0" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="32f2-a601-66cb-5ebc" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="1a61-5343-473b-d7ed" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="3f8d-6108-1eba-52e8" name="Fire Raptor Gunship" hidden="false" collective="false" import="false" targetId="f6e1-24e2-fbdb-c5ef" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="4ab0-5343-8d33-0852" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="3264-44af-d09e-e371" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="3c13-4cb7-93bc-09ef" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="897c-cf17-121f-dd2d" name="Glaive" hidden="false" collective="false" import="false" targetId="04e0-f69f-f759-b0b3" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="75ca-6ff3-9a11-2f0b" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="dfe2-ff73-1dbf-b436" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="7948-f5a4-0c23-bb50" name="Heavy Support Squad" hidden="false" collective="false" import="false" targetId="bac9-5389-e2e7-0b1f" type="selectionEntry">
@@ -393,7 +432,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="eb00-193a-3062-088e" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="0432-1377-7940-af08" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+        <categoryLink id="ac22-14fe-c617-bb30" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="532f-1bb1-a378-b707" name="Legion Banehammer" hidden="true" collective="false" import="false" targetId="1240-c71c-3a60-cf20" type="selectionEntry">
@@ -406,7 +445,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="6137-a9d0-3010-d963" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="3548-eee8-bd4e-295a" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+        <categoryLink id="9d50-cd48-689c-2b0f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="f1f1-cd0c-30d3-3340" name="Legion Macharius Heavy Tank Squadron" hidden="false" collective="false" import="false" targetId="36ed-ca59-0d95-d85c" type="selectionEntry">
@@ -471,7 +510,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="fdde-74f7-4573-8037" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="f97b-0ed4-d241-b396" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+        <categoryLink id="a6ad-d099-c367-5081" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="8820-3f8a-7f9c-b91f" name="Legion Stormlord" hidden="true" collective="false" import="false" targetId="0887-0f66-2c7e-a5ba" type="selectionEntry">
@@ -484,7 +523,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="3799-0c30-32c5-6b0a" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="3fdb-eb47-b646-652b" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+        <categoryLink id="4bc4-e4a7-6252-242b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="663f-29d7-844c-20f6" name="Legion Stormsword" hidden="true" collective="false" import="false" targetId="8e67-8f84-730c-2778" type="selectionEntry">
@@ -497,7 +536,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="99dd-6077-7202-7af0" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="eb35-2702-0277-ea7f" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+        <categoryLink id="472b-9de1-4069-451a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="08a5-52b0-a090-3edb" name="Leviathan Dreadnought Talon" hidden="false" collective="false" import="false" targetId="c2a7-9e2c-fc65-1b78" type="selectionEntry">
@@ -509,6 +548,7 @@
     <entryLink id="212b-318d-8265-6776" name="Mastodon" hidden="false" collective="false" import="false" targetId="7f24-2b72-9128-5330" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="1609-371b-95d8-e0ec" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="aec1-d564-f18b-ad00" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="bb2a-2637-b2ee-1844" name="Medusa Squadron" hidden="true" collective="false" import="false" targetId="24c8-5f6a-d48a-27b7" type="selectionEntry">
@@ -520,9 +560,8 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="88fe-967b-2956-dc0c" name="Bombard Sub-type:" hidden="false" targetId="d5df-57ac-8f3c-097b" primary="false"/>
         <categoryLink id="9d04-5a21-4dd9-f0f4" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="2af5-89e8-1d31-09e0" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
+        <categoryLink id="e595-4ee1-396b-c3c5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="f7fe-4e6f-5ef4-d7ef" name="Mortalis Destroyer Squad" hidden="false" collective="false" import="false" targetId="dbd4-930e-e003-9449" type="selectionEntry">
@@ -621,6 +660,13 @@
       </categoryLinks>
     </entryLink>
     <entryLink id="65c5-3be0-7a3b-2473" name="Reconnaissance Squad" hidden="false" collective="false" import="false" targetId="6db7-6e88-877e-35ca" type="selectionEntry">
+      <modifiers>
+        <modifier type="add" field="category" value="8f42-a824-fb5f-8fea">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="8740-5235-de3c-1dae" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="bfd9-4627-4b22-93b6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
@@ -639,6 +685,13 @@
       </categoryLinks>
     </entryLink>
     <entryLink id="6bce-5278-9da0-819c" name="Scout Squad" hidden="false" collective="false" import="false" targetId="9b10-b657-a65a-9d60" type="selectionEntry">
+      <modifiers>
+        <modifier type="add" field="category" value="8f42-a824-fb5f-8fea">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="8811-6377-505e-0135" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="8371-21cf-2bcc-6dd0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
@@ -659,7 +712,6 @@
     <entryLink id="f119-518a-0171-0785" name="Sicaran Omega Squadron" hidden="false" collective="false" import="false" targetId="c88b-fe44-34a3-97e1" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="724f-0abc-2389-e369" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="2c3d-4056-aab9-d080" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="5f13-d632-504e-50d3" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
       </categoryLinks>
     </entryLink>
@@ -672,7 +724,6 @@
     <entryLink id="01d9-6649-d136-f394" name="Sicaran Squadron" hidden="false" collective="false" import="false" targetId="706a-9532-f06d-00ed" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="5bb6-2d1a-6280-9377" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="0536-557d-b84f-1b71" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="9163-f2d4-a35c-d79b" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
       </categoryLinks>
     </entryLink>
@@ -691,6 +742,7 @@
     <entryLink id="5838-e0ae-041e-bf5b" name="Sokar Stormbird" hidden="false" collective="false" import="false" targetId="f403-630f-71ae-5a7d" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="7255-4402-4c25-3aa1" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="3b31-470b-b119-35d4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="6418-eab9-8cdf-e862" name="Spatha Attack Bike Squadron" hidden="false" collective="false" import="false" targetId="4d72-1cc1-8bee-aa88" type="selectionEntry">
@@ -709,10 +761,22 @@
     <entryLink id="947b-263d-02a6-fce2" name="Storm Eagle Gunship" hidden="false" collective="false" import="false" targetId="8aa5-ff31-7de7-19d4" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="f6e1-061b-657a-3b6a" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="76db-6ed5-f6ba-eed7" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+        <categoryLink id="030d-d536-d3c6-23d7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="3910-263b-0738-cbeb" name="Tactical Squad" hidden="false" collective="false" import="false" targetId="aa72-63e4-bc60-4611" type="selectionEntry">
+      <modifiers>
+        <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="d688-e5b0-580e-b518" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="23d5-8cbb-e7ac-9da6" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
@@ -734,7 +798,6 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="0010-066b-1766-3c53" name="Artillery Sub-type:" hidden="false" targetId="6f99-c178-6f9d-fb63" primary="false"/>
         <categoryLink id="89dd-a734-a87f-d233" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
         <categoryLink id="cf4d-39ec-39f4-30a8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
@@ -762,14 +825,12 @@
       <categoryLinks>
         <categoryLink id="9a9c-e747-c23f-87ad" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="67c0-3dc2-2ea3-abb6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="9cb6-a821-e4ba-f3b3" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="cb9f-8965-41ef-bf1d" name="Terminator Tartaros Squad" hidden="false" collective="false" import="false" targetId="1a8e-0ded-a4dc-2b4e" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="7170-4acc-5e10-8723" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="ff6b-2b23-5bfd-ea84" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="9382-74ca-fc3d-c32d" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="bee2-cfa3-bc11-02cc" name="Thunderbolt Fighter" hidden="false" collective="false" import="false" targetId="5d24-1e9a-ad9d-95ca" type="selectionEntry">
@@ -788,6 +849,7 @@
     <entryLink id="19e8-8e05-0538-14ff" name="Thunderhawk Gunship" hidden="false" collective="false" import="false" targetId="8754-3a4f-213b-bdc0" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="4b7d-647d-15b3-be5b" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="b40b-2c4d-5a56-fdde" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="81a5-dccd-497b-5fdc" name="Tylos Rubio" hidden="false" collective="false" import="false" targetId="56bf-2c6d-a0fa-a145" type="selectionEntry">
@@ -806,6 +868,7 @@
     <entryLink id="c302-bdce-f4a0-d98b" name="Typhon Squadron" hidden="false" collective="false" import="false" targetId="d06a-3087-af13-ca95" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="db4f-9e47-1049-421a" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="ebcc-bc75-ed11-793e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="147e-3ece-113b-567d" name="Veteran Squad" hidden="false" collective="false" import="false" targetId="a423-7dd8-3f1b-3e28" type="selectionEntry">
@@ -831,8 +894,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="d673-3a28-e1fb-4cf8" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="2f32-b3c7-f08a-1967" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
-        <categoryLink id="42d5-1297-75db-4f26" name="Bombard Sub-type:" hidden="false" targetId="d5df-57ac-8f3c-097b" primary="false"/>
+        <categoryLink id="6af2-0361-ba7c-6762" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="820c-10ee-b4f0-92a8" name="Xiphon Interceptor" hidden="false" collective="false" import="false" targetId="596b-5478-e079-59ab" type="selectionEntry">
@@ -841,9 +903,29 @@
         <categoryLink id="b1da-3607-ed7d-a268" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
       </categoryLinks>
     </entryLink>
+    <entryLink id="6537-127c-7018-6ed6" name="Seeker Squad" hidden="true" collective="false" import="false" targetId="58e6-f9cc-4c46-e258" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <infoLinks>
+        <infoLink id="cd70-391a-e137-48fe" name="Legiones Astartes (Ultramarines) " hidden="false" targetId="519d-a6ed-f57f-3642" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="10d6-a2aa-a83e-eb5d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="8406-3e04-d5b7-771b" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+      </categoryLinks>
+    </entryLink>
   </entryLinks>
   <sharedSelectionEntries>
     <selectionEntry id="a35d-8563-eb47-e985" name="Roboute Guilliman" hidden="false" collective="false" import="true" type="unit">
+      <categoryLinks>
+        <categoryLink id="7543-c1ba-1564-20a8" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
+        <categoryLink id="ceea-9434-a82b-934b" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+      </categoryLinks>
       <selectionEntries>
         <selectionEntry id="c91f-d9e6-97eb-9233" name="Roboute Guilliman" hidden="false" collective="false" import="true" type="model">
           <constraints>
@@ -1024,6 +1106,12 @@
           <description>An Invictarus Suzerain Squad may be selected as a Retinue Squad in a Detachment that includes at least one model with both the Master of the Legion and Legiones Astartes (Ultramarines) special rules, instead of as an Elites choice. A unit selected as a ‘Retinue Squad’ must have one model with both the Master of the Legion and Legiones Astartes (Ultramarines) special rules from the same Detachment selected by the controlling player as the Invictarus Suzerain Squad’s Leader for the purposes of this special rule. An Invictarus Suzerain Squad selected as a Retinue Squad does not use up a Force Organisation slot and is considered part of the same unit as the model selected as its Leader. An Invictarus Suzerain Squad selected as a Retinue Squad must be deployed with the model selected as its Leader deployed as part of the unit and the Leader may not voluntarily leave the Retinue Squad during play. One Suzerain in an Invictarus Suzerain Squad selected as a Retinue may exchange their bolt pistol for a Legion standard for +15 points.</description>
         </rule>
       </rules>
+      <categoryLinks>
+        <categoryLink id="c1fb-3d4b-27f5-b426" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="2515-1c11-b0e3-ede9" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="f8fc-6ad9-18f9-52bb" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+        <categoryLink id="2939-9165-c065-999f" name="Line Sub-type:" hidden="false" targetId="6399-5c65-7833-1025" primary="false"/>
+      </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="3062-8ad4-10a2-9744" name="2) Dedicated Transport:" hidden="false" collective="false" import="true">
           <constraints>
@@ -1038,6 +1126,9 @@
             <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3b5d-a171-63f8-93ab" type="min"/>
             <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fa9e-e533-5bea-307b" type="max"/>
           </constraints>
+          <categoryLinks>
+            <categoryLink id="995c-625b-eb78-487c" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
+          </categoryLinks>
           <selectionEntries>
             <selectionEntry id="1ca9-991d-ff13-4c7d" name="Suzerain w/Bolt Pistol &amp; Legatine Axe" hidden="false" collective="false" import="true" type="model">
               <profiles>
@@ -1319,6 +1410,12 @@
           </modifiers>
         </infoLink>
       </infoLinks>
+      <categoryLinks>
+        <categoryLink id="18bd-fce6-63db-d58d" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+        <categoryLink id="f8aa-a104-90eb-b32f" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="a5b1-bdaf-421c-1167" name="Line Sub-type:" hidden="false" targetId="6399-5c65-7833-1025" primary="false"/>
+        <categoryLink id="9d2c-fdc3-3b78-373f" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+      </categoryLinks>
       <selectionEntries>
         <selectionEntry id="3808-d884-54f1-c8c7" name="Praetorian Primus" hidden="false" collective="false" import="true" type="model">
           <constraints>
@@ -1567,6 +1664,12 @@
           </modifiers>
         </infoLink>
       </infoLinks>
+      <categoryLinks>
+        <categoryLink id="d762-cd12-7679-e649" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="51d5-8c99-7bfa-92f8" name="Terminators:" hidden="false" targetId="bab3-f50d-3e5f-2f78" primary="false"/>
+        <categoryLink id="07ca-16ef-6bbf-515a" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+        <categoryLink id="e47f-ba3e-879c-88fd" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+      </categoryLinks>
       <selectionEntries>
         <selectionEntry id="0ca3-4024-dbe5-6be3" name="Fulmentarus Decurion" hidden="false" collective="false" import="true" type="model">
           <constraints>
@@ -1590,6 +1693,9 @@
               </characteristics>
             </profile>
           </profiles>
+          <categoryLinks>
+            <categoryLink id="cea8-d359-a93d-931f" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
+          </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="7df2-f403-dfa4-a651" name="Melee Options:" hidden="false" collective="false" import="true" defaultSelectionEntryId="435c-ba08-f299-6063">
               <constraints>
@@ -1927,6 +2033,7 @@
       <categoryLinks>
         <categoryLink id="c823-19f8-80ae-939b" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="8ea4-d107-ba41-10c3" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="e1a7-e770-96e0-6224" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="8fb6-2c1b-d30b-e993" name="Remus Ventanus" hidden="false" collective="false" import="true" type="model">
@@ -2077,6 +2184,10 @@
           </modifiers>
         </infoLink>
       </infoLinks>
+      <categoryLinks>
+        <categoryLink id="2e8a-b2ef-e4fc-cf8d" name="Dreadnought Unit-type:" hidden="false" targetId="4280-4963-02b5-e31d" primary="false"/>
+        <categoryLink id="6c25-0ad5-bf61-85dd" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+      </categoryLinks>
       <selectionEntries>
         <selectionEntry id="5204-ec1a-dfe5-1940" name="Honoured Telemechrus" hidden="false" collective="false" import="true" type="model">
           <constraints>
@@ -2147,6 +2258,11 @@
       <infoLinks>
         <infoLink id="d481-c887-6aaa-1612" name="Chosen Warriors" hidden="false" targetId="13d1-9270-6539-08ed" type="rule"/>
       </infoLinks>
+      <categoryLinks>
+        <categoryLink id="64a6-866c-d4f5-f6df" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="0fa2-0756-6373-2c2a" name="Jump Infantry:" hidden="false" targetId="eee8-3c7c-2762-e33e" primary="false"/>
+        <categoryLink id="cbae-7580-9e8f-7512" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+      </categoryLinks>
       <selectionEntries>
         <selectionEntry id="a0db-8d26-958f-5f5f" name="Locutarus Strike Leader" hidden="false" collective="false" import="true" type="model">
           <constraints>
@@ -2411,6 +2527,10 @@
         </infoLink>
         <infoLink id="2a20-3379-5a88-7066" name="Bitter Duty" hidden="false" targetId="d1b8-31da-c53c-4fe2" type="rule"/>
       </infoLinks>
+      <categoryLinks>
+        <categoryLink id="dab5-4ae9-9a89-dbb7" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="ba64-c048-fbe1-1eec" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+      </categoryLinks>
       <selectionEntries>
         <selectionEntry id="9063-d5a3-8354-3cef" name="Nemesis Destroyer Sergeant" hidden="false" collective="false" import="true" type="model">
           <constraints>
@@ -2441,6 +2561,9 @@
               </characteristics>
             </profile>
           </profiles>
+          <categoryLinks>
+            <categoryLink id="aa98-3308-c2e0-fbd2" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
+          </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="3d76-9955-751a-735e" name="2) May take:" hidden="false" collective="false" import="true">
               <entryLinks>

--- a/2022 - LA - White Scars.cat
+++ b/2022 - LA - White Scars.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="caa9-c50e-8eed-2259" name="LA -   V: White Scars" revision="12" battleScribeVersion="2.03" authorName="Mr_Dark, UrsinePatriarch" authorContact="BSData Developers Discord" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="17" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="caa9-c50e-8eed-2259" name="LA -   V: White Scars" revision="14" battleScribeVersion="2.03" authorName="Mr_Dark, UrsinePatriarch" authorContact="BSData Developers Discord" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="18" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entryLinks>
     <entryLink id="a738-6a11-dfe7-286c" name="   V: White Scars" hidden="false" collective="false" import="false" targetId="e01e-5cdd-e512-8353" type="selectionEntry">
       <constraints>
@@ -10,7 +10,7 @@
         <categoryLink id="0a52-da7d-b209-7c15" name="New CategoryLink" hidden="false" targetId="e90d-e5a8-f42d-da84" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="2053-c79e-817a-32cb" name="Dark Sons of Death " hidden="false" collective="false" import="false" targetId="4372-ad51-04a6-97ce" type="selectionEntry">
+    <entryLink id="2053-c79e-817a-32cb" name="Dark Sons of Death" hidden="false" collective="false" import="false" targetId="4372-ad51-04a6-97ce" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
@@ -113,6 +113,18 @@
       </categoryLinks>
     </entryLink>
     <entryLink id="df73-276b-e085-14a0" name="Assault Squad" hidden="false" collective="false" import="false" targetId="a8e9-70e1-b8bc-8ee2" type="selectionEntry">
+      <modifiers>
+        <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="846d-a94a-a9e8-427c" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="c0c0-0996-70dd-5c54" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
@@ -141,12 +153,23 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="db7a-f1a0-f2ca-5812" name="Bombard Sub-type:" hidden="false" targetId="d5df-57ac-8f3c-097b" primary="false"/>
         <categoryLink id="0f93-492e-8169-7a87" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="c15a-71ef-3aac-7f0b" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
+        <categoryLink id="1fdd-a3db-02b0-70bb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="9a0a-94c1-0742-8bbc" name="Breacher Squad" hidden="false" collective="false" import="false" targetId="ad97-c090-fa67-696f" type="selectionEntry">
+      <modifiers>
+        <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="7c78-ebe2-dec5-947a" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="f30a-b16c-ec43-1040" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
@@ -295,6 +318,18 @@
       </categoryLinks>
     </entryLink>
     <entryLink id="4f05-7a4c-a312-a608" name="Despoiler Squad" hidden="false" collective="false" import="false" targetId="4357-930e-165a-a6e3" type="selectionEntry">
+      <modifiers>
+        <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="051e-f129-d3c3-0945" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="9072-d36e-9f9b-96b2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
@@ -310,29 +345,31 @@
     <entryLink id="d762-5ff7-fa8e-3b34" name="Dreadclaw Drop Pod" hidden="false" collective="false" import="false" targetId="bbe8-818d-3068-d79c" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="a078-ffb9-9a0a-d4f9" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="ff5c-ef44-fd88-df52" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+        <categoryLink id="caeb-982b-1e37-c7c3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="daa9-185a-9e5b-f35e" name="Falchion" hidden="false" collective="false" import="false" targetId="1fe8-7386-9509-d2d8" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="013f-38f9-6257-e5f7" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="4e46-9cd2-88ed-a8bc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="2d89-2165-4a7f-6410" name="Fellblade" hidden="false" collective="false" import="false" targetId="9c3c-f15a-9a1f-c0d0" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="c23a-5abd-7b76-5252" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="8a04-51fc-b8b7-fd9b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="16a6-8886-522c-4dee" name="Fire Raptor Gunship" hidden="false" collective="false" import="false" targetId="f6e1-24e2-fbdb-c5ef" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="3983-b2a3-c87a-d71d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="1816-0e04-42a4-341f" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="59bc-00f9-965a-de17" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="64c1-e741-f838-fdb3" name="Glaive" hidden="false" collective="false" import="false" targetId="04e0-f69f-f759-b0b3" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="959f-590b-a3f1-ed30" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="e2dc-5969-cb8e-9420" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="e5a3-7a87-cfa2-fd22" name="Heavy Support Squad" hidden="false" collective="false" import="false" targetId="bac9-5389-e2e7-0b1f" type="selectionEntry">
@@ -399,7 +436,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="485d-b1bb-da4e-8258" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="1dbb-6e21-0a14-2273" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+        <categoryLink id="c13b-90b7-3aca-2016" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="a03b-c860-f6ae-3219" name="Legion Banehammer" hidden="true" collective="false" import="false" targetId="1240-c71c-3a60-cf20" type="selectionEntry">
@@ -412,7 +449,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="a719-b239-4f2a-a1fc" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="0f46-d953-523e-02fa" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+        <categoryLink id="73dd-7cff-c520-952e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="3a7d-8fe1-bc8b-6d66" name="Legion Macharius Heavy Tank Squadron" hidden="false" collective="false" import="false" targetId="36ed-ca59-0d95-d85c" type="selectionEntry">
@@ -477,7 +514,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="13ad-3113-7bb8-786c" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="4c2e-b065-4f15-9ef7" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+        <categoryLink id="fd74-cfc8-54f1-e367" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="e6cb-a174-5822-5467" name="Legion Stormlord" hidden="true" collective="false" import="false" targetId="0887-0f66-2c7e-a5ba" type="selectionEntry">
@@ -490,7 +527,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="6041-1b54-20d4-31a9" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="b982-e2de-a114-f292" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+        <categoryLink id="ea5e-673e-ee05-8b70" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="f137-0415-8373-569b" name="Legion Stormsword" hidden="true" collective="false" import="false" targetId="8e67-8f84-730c-2778" type="selectionEntry">
@@ -503,7 +540,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="31d3-45af-06f7-5a4b" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="b802-ea7a-98ac-304a" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+        <categoryLink id="12dd-239f-9892-c85e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="eecd-f588-f45c-761a" name="Leviathan Dreadnought Talon" hidden="false" collective="false" import="false" targetId="c2a7-9e2c-fc65-1b78" type="selectionEntry">
@@ -515,6 +552,7 @@
     <entryLink id="e187-a2cc-f4ec-7471" name="Mastodon" hidden="false" collective="false" import="false" targetId="7f24-2b72-9128-5330" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="75a2-2af8-9a65-9159" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="e524-3fb6-50a5-56da" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="0986-d5e7-7615-80e9" name="Medusa Squadron" hidden="true" collective="false" import="false" targetId="24c8-5f6a-d48a-27b7" type="selectionEntry">
@@ -526,9 +564,8 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="272c-2ec5-6495-7253" name="Bombard Sub-type:" hidden="false" targetId="d5df-57ac-8f3c-097b" primary="false"/>
         <categoryLink id="d2b4-df48-cfdd-1055" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="f63c-2d43-2b98-ac7a" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
+        <categoryLink id="670c-4811-e490-859f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="18b6-d821-8185-8e10" name="Mortalis Destroyer Squad" hidden="false" collective="false" import="false" targetId="dbd4-930e-e003-9449" type="selectionEntry">
@@ -627,6 +664,13 @@
       </categoryLinks>
     </entryLink>
     <entryLink id="8ce8-1073-262c-ccbe" name="Reconnaissance Squad" hidden="false" collective="false" import="false" targetId="6db7-6e88-877e-35ca" type="selectionEntry">
+      <modifiers>
+        <modifier type="add" field="category" value="8f42-a824-fb5f-8fea">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="8664-0697-1ef0-ac29" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="e4ba-9002-0339-c126" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
@@ -645,6 +689,13 @@
       </categoryLinks>
     </entryLink>
     <entryLink id="91c2-a324-1dfc-3dcd" name="Scout Squad" hidden="false" collective="false" import="false" targetId="9b10-b657-a65a-9d60" type="selectionEntry">
+      <modifiers>
+        <modifier type="add" field="category" value="8f42-a824-fb5f-8fea">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="3194-3609-e54b-838f" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="bc78-acbd-3fa8-4fad" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
@@ -665,7 +716,6 @@
     <entryLink id="b40a-43c4-3700-dca0" name="Sicaran Omega Squadron" hidden="false" collective="false" import="false" targetId="c88b-fe44-34a3-97e1" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="8b2c-e02c-8f5b-b176" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="c804-389b-0f90-5860" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="d9e7-cc24-add1-e381" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
       </categoryLinks>
     </entryLink>
@@ -678,7 +728,6 @@
     <entryLink id="e81f-b70d-ed28-7417" name="Sicaran Squadron" hidden="false" collective="false" import="false" targetId="706a-9532-f06d-00ed" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="83e0-4077-384f-5c37" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="8896-eeec-69ad-6484" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="223d-ee24-ce15-2e49" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
       </categoryLinks>
     </entryLink>
@@ -697,6 +746,7 @@
     <entryLink id="a313-a7d9-3bbb-ad89" name="Sokar Stormbird" hidden="false" collective="false" import="false" targetId="f403-630f-71ae-5a7d" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="30e7-479c-024e-3fc0" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="4868-4812-3b0b-be23" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="1015-2244-ccff-9561" name="Spatha Attack Bike Squadron" hidden="false" collective="false" import="false" targetId="4d72-1cc1-8bee-aa88" type="selectionEntry">
@@ -715,10 +765,22 @@
     <entryLink id="1cd4-f6bd-b976-14a6" name="Storm Eagle Gunship" hidden="false" collective="false" import="false" targetId="8aa5-ff31-7de7-19d4" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="58a9-9b66-45c9-1e34" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="5cc4-5631-fcc7-d8b9" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+        <categoryLink id="54ef-68b4-3c40-1116" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="93bb-da90-5011-43e7" name="Tactical Squad" hidden="false" collective="false" import="false" targetId="aa72-63e4-bc60-4611" type="selectionEntry">
+      <modifiers>
+        <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="7bd9-4f37-ecdf-1146" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="ab58-4733-0473-78b3" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
@@ -740,7 +802,6 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="1e0f-623e-e2af-a28c" name="Artillery Sub-type:" hidden="false" targetId="6f99-c178-6f9d-fb63" primary="false"/>
         <categoryLink id="8abc-419a-7a26-bea0" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
         <categoryLink id="d20b-e93a-09d3-ae10" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
@@ -768,14 +829,12 @@
       <categoryLinks>
         <categoryLink id="cbff-b3a0-46b8-7839" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="f6e6-9660-af5c-a632" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="bb79-77ec-8d86-6b80" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="8725-2b20-0868-5cb0" name="Terminator Tartaros Squad" hidden="false" collective="false" import="false" targetId="1a8e-0ded-a4dc-2b4e" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="db29-f70f-faa2-f64b" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="5199-d4bd-e16e-210c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="8704-12ad-4106-0e49" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="fe07-50f6-8493-8dfc" name="Thunderbolt Fighter" hidden="false" collective="false" import="false" targetId="5d24-1e9a-ad9d-95ca" type="selectionEntry">
@@ -794,6 +853,7 @@
     <entryLink id="5dcb-7fcd-f9af-00e3" name="Thunderhawk Gunship" hidden="false" collective="false" import="false" targetId="8754-3a4f-213b-bdc0" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="1362-8c41-e977-2159" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="5568-5b0c-9d74-31d9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="38fa-ae4f-b028-8090" name="Tylos Rubio" hidden="false" collective="false" import="false" targetId="56bf-2c6d-a0fa-a145" type="selectionEntry">
@@ -812,6 +872,7 @@
     <entryLink id="6e42-d226-f62a-0a18" name="Typhon Squadron" hidden="false" collective="false" import="false" targetId="d06a-3087-af13-ca95" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="7fc5-c47a-5786-e43f" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="530b-8d6b-e028-1e0e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="1f36-1727-5fb8-0be0" name="Veteran Squad" hidden="false" collective="false" import="false" targetId="a423-7dd8-3f1b-3e28" type="selectionEntry">
@@ -837,14 +898,28 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="dfd7-3c46-5203-a621" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="13fa-41f1-1433-03d9" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
-        <categoryLink id="df5c-03c8-9b6e-c3c6" name="Bombard Sub-type:" hidden="false" targetId="d5df-57ac-8f3c-097b" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="5d29-0596-7ae3-0826" name="Xiphon Interceptor" hidden="false" collective="false" import="false" targetId="596b-5478-e079-59ab" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="502f-37ab-06b1-d362" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="1250-5c32-da20-447c" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="f3d6-432a-0cfc-4f6e" name="Seeker Squad" hidden="true" collective="false" import="false" targetId="58e6-f9cc-4c46-e258" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <infoLinks>
+        <infoLink id="2e72-a332-555b-872d" name="Legiones Astartes (White Scars) " hidden="false" targetId="4b54-8bd0-9fdd-cbc4" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="b681-23f1-6a3b-97bb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="dcda-725c-cd42-c3e3" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
       </categoryLinks>
     </entryLink>
   </entryLinks>
@@ -1956,6 +2031,12 @@
         <infoLink id="05d6-7d9b-7c19-a97f" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule"/>
         <infoLink id="7a81-4ee1-2626-1bdb" name="Stubborn" hidden="false" targetId="7989-1f2c-a43d-82ae" type="rule"/>
       </infoLinks>
+      <categoryLinks>
+        <categoryLink id="54e2-d6ae-9451-cef4" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="e3e9-8ad6-46b0-b979" name="Terminators:" hidden="false" targetId="bab3-f50d-3e5f-2f78" primary="false"/>
+        <categoryLink id="5e67-a444-7e40-3af2" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
+        <categoryLink id="b6ea-20c7-9037-cfba" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+      </categoryLinks>
       <selectionEntries>
         <selectionEntry id="a42b-18eb-0912-d5fc" name="The Tails of the Dragon" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
@@ -2039,6 +2120,18 @@
       </costs>
     </selectionEntry>
     <selectionEntry id="54fb-d060-193b-675d" name="Tsolmon Khan" hidden="false" collective="false" import="true" type="model">
+      <modifiers>
+        <modifier type="add" field="category" value="6d79-a3e4-381f-7b0f">
+          <conditions>
+            <condition field="selections" scope="54fb-d060-193b-675d" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6fb4-adf6-dbe8-86af" type="equalTo"/>
+          </conditions>
+        </modifier>
+        <modifier type="add" field="category" value="8b4f-bfe2-ce7b-f1b1">
+          <conditions>
+            <condition field="selections" scope="54fb-d060-193b-675d" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6fb4-adf6-dbe8-86af" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <constraints>
         <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4965-5d02-18e1-a3a3" type="max"/>
       </constraints>
@@ -2080,6 +2173,10 @@
         <infoLink id="1291-95b0-e128-bb5f" name="Legiones Astartes (White Scars) " hidden="false" targetId="4b54-8bd0-9fdd-cbc4" type="rule"/>
         <infoLink id="3ed4-f97d-0a0c-4f87" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule"/>
       </infoLinks>
+      <categoryLinks>
+        <categoryLink id="41ee-5421-603b-a66a" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="e395-ef58-e407-4efd" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
+      </categoryLinks>
       <selectionEntries>
         <selectionEntry id="664d-90dd-c50a-08d0" name="Tians&apos;han" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
@@ -2198,6 +2295,7 @@
       <categoryLinks>
         <categoryLink id="0020-4301-b8cb-e152" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="1bd4-4a45-a9d6-fc0c" name="Terminators:" hidden="false" targetId="bab3-f50d-3e5f-2f78" primary="false"/>
+        <categoryLink id="86cc-121b-a65c-422a" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="db53-d618-c96b-4a8c" name="Dedicated Transport" hidden="false" collective="false" import="true">
@@ -2448,6 +2546,10 @@
         <infoLink id="337f-0774-bea7-a762" name="Move Through Cover" hidden="false" targetId="2b6f-bfec-759e-1746" type="rule"/>
         <infoLink id="056d-2b1f-e7f3-4c45" name="Pathfinder" hidden="false" targetId="ec97-7aa8-49f5-b298" type="rule"/>
       </infoLinks>
+      <categoryLinks>
+        <categoryLink id="f5c8-2bd1-122d-be0e" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="afc4-8a34-2caa-f28a" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
+      </categoryLinks>
       <selectionEntries>
         <selectionEntry id="7afd-2248-2e02-e05f" name="Sojutsu Pattern Voidbike" publicationId="817a-6288-e016-7469" page="183" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>

--- a/2022 - LA - Word Bearers.cat
+++ b/2022 - LA - Word Bearers.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="1df7-bbbc-b70e-6a3f" name="LA -  XVII: Word Bearers" revision="7" battleScribeVersion="2.03" authorName="UrsinePatriarch" authorContact="BSData Developers Discord" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="17" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="1df7-bbbc-b70e-6a3f" name="LA -  XVII: Word Bearers" revision="8" battleScribeVersion="2.03" authorName="UrsinePatriarch" authorContact="BSData Developers Discord" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="18" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entryLinks>
     <entryLink id="70a7-c1ee-bf88-94ab" name="  XVII: Word Bearers" hidden="false" collective="false" import="false" targetId="9dbf-0760-d7ae-f125" type="selectionEntry">
       <constraints>
@@ -124,6 +124,18 @@
       </categoryLinks>
     </entryLink>
     <entryLink id="9b66-5b73-5cf5-c120" name="Assault Squad" hidden="false" collective="false" import="false" targetId="a8e9-70e1-b8bc-8ee2" type="selectionEntry">
+      <modifiers>
+        <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="3881-8858-afbc-3835" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="2ccb-d039-d379-2946" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
@@ -152,12 +164,23 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="8d07-037e-6321-0b74" name="Bombard Sub-type:" hidden="false" targetId="d5df-57ac-8f3c-097b" primary="false"/>
         <categoryLink id="f5a6-5b65-0b2e-121f" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="e804-4779-c114-c6c9" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
+        <categoryLink id="e3c1-ba4b-1b2c-c991" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="69a5-9e26-74af-d7c1" name="Breacher Squad" hidden="false" collective="false" import="false" targetId="ad97-c090-fa67-696f" type="selectionEntry">
+      <modifiers>
+        <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="1699-edcf-65bb-138b" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="eaa2-4659-9648-0fce" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
@@ -280,7 +303,6 @@
     <entryLink id="c1c3-fd36-d3cc-eeb1" name="Damocles Command Rhino" hidden="false" collective="false" import="false" targetId="e337-8239-5e92-7f5f" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="fd94-3ba7-c0db-afe3" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="2348-984b-9138-d594" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="f051-b8e1-4cd9-84b9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -297,6 +319,18 @@
       </categoryLinks>
     </entryLink>
     <entryLink id="548a-db08-c96f-8f76" name="Despoiler Squad" hidden="false" collective="false" import="false" targetId="4357-930e-165a-a6e3" type="selectionEntry">
+      <modifiers>
+        <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="fc9e-9b32-f6e8-9d9b" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="7a98-a76b-b593-89f3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
@@ -312,29 +346,31 @@
     <entryLink id="7af8-af9d-da7f-aacc" name="Dreadclaw Drop Pod" hidden="false" collective="false" import="false" targetId="bbe8-818d-3068-d79c" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="ce22-2ca7-3f07-1653" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="ce61-a55f-c179-dd61" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+        <categoryLink id="8012-7182-f884-09c9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="5d81-b075-d037-42e0" name="Falchion" hidden="false" collective="false" import="false" targetId="1fe8-7386-9509-d2d8" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="3aab-a7f5-e68c-e9bd" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="9de9-0c76-8a1c-c9a2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="d752-5db5-a92a-b8c9" name="Fellblade" hidden="false" collective="false" import="false" targetId="9c3c-f15a-9a1f-c0d0" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="c33a-390b-16b4-0ff2" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="e979-7f00-70f4-4c8e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="a37a-0e15-f6bc-ca4e" name="Fire Raptor Gunship" hidden="false" collective="false" import="false" targetId="f6e1-24e2-fbdb-c5ef" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="b25e-e15c-74c8-9700" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="78f1-a061-7887-a408" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="16c5-e434-f27e-7ee3" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="8dba-4de2-0398-98fd" name="Glaive" hidden="false" collective="false" import="false" targetId="04e0-f69f-f759-b0b3" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="3609-6015-c84c-8622" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="a5cb-f13d-79c7-d9d9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="8f59-c585-338b-e312" name="Heavy Support Squad" hidden="false" collective="false" import="false" targetId="bac9-5389-e2e7-0b1f" type="selectionEntry">
@@ -401,7 +437,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="1e9e-0a41-4f57-2485" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="d1d3-4e05-1e7a-ad06" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+        <categoryLink id="674d-1283-4504-1ea1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="c54a-f2f6-3bc4-be9f" name="Legion Banehammer" hidden="true" collective="false" import="false" targetId="1240-c71c-3a60-cf20" type="selectionEntry">
@@ -414,7 +450,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="4e5e-cd04-9a92-a82d" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="b970-21fd-dc23-1a85" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+        <categoryLink id="ca91-3ccd-d822-c4a1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="e3bd-780b-dd71-5667" name="Legion Macharius Heavy Tank Squadron" hidden="false" collective="false" import="false" targetId="36ed-ca59-0d95-d85c" type="selectionEntry">
@@ -479,7 +515,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="6abe-4d98-04b8-be27" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="4206-ca66-5338-7c1e" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+        <categoryLink id="0bbb-5bec-cfc1-5ee8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="5c71-a511-085a-98e9" name="Legion Stormlord" hidden="true" collective="false" import="false" targetId="0887-0f66-2c7e-a5ba" type="selectionEntry">
@@ -492,7 +528,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="a6c2-ed05-7ab6-c49f" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="e179-c636-c1ba-f783" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+        <categoryLink id="074a-67ee-b638-16d0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="da76-e9b3-4058-0a1e" name="Legion Stormsword" hidden="true" collective="false" import="false" targetId="8e67-8f84-730c-2778" type="selectionEntry">
@@ -505,7 +541,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="6385-ad6d-55ab-9c55" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="80a7-a4ca-8646-b142" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+        <categoryLink id="45c7-ec87-ba10-ae92" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="cff8-0677-a8ef-76f2" name="Leviathan Dreadnought Talon" hidden="false" collective="false" import="false" targetId="c2a7-9e2c-fc65-1b78" type="selectionEntry">
@@ -517,6 +553,7 @@
     <entryLink id="298a-064a-13f2-2b5c" name="Mastodon" hidden="false" collective="false" import="false" targetId="7f24-2b72-9128-5330" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="b68c-caf0-8215-6aa0" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="6fa0-c15a-1c43-2fe7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="c8e1-9692-62e0-b3ba" name="Medusa Squadron" hidden="true" collective="false" import="false" targetId="24c8-5f6a-d48a-27b7" type="selectionEntry">
@@ -528,9 +565,8 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="f6a9-2f94-228c-bbd1" name="Bombard Sub-type:" hidden="false" targetId="d5df-57ac-8f3c-097b" primary="false"/>
         <categoryLink id="63ca-023d-72bf-52d3" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="5a3c-0489-f7bd-5b29" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
+        <categoryLink id="af40-5e2c-a2c4-f2b5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="6539-871b-6268-f8ed" name="Mortalis Destroyer Squad" hidden="false" collective="false" import="false" targetId="dbd4-930e-e003-9449" type="selectionEntry">
@@ -629,6 +665,13 @@
       </categoryLinks>
     </entryLink>
     <entryLink id="8d99-1055-fa44-86fe" name="Reconnaissance Squad" hidden="false" collective="false" import="false" targetId="6db7-6e88-877e-35ca" type="selectionEntry">
+      <modifiers>
+        <modifier type="add" field="category" value="8f42-a824-fb5f-8fea">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="5b36-7f37-ac16-b8e2" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="e7ba-1e2d-fd98-3788" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
@@ -647,6 +690,13 @@
       </categoryLinks>
     </entryLink>
     <entryLink id="6560-0faa-293c-1c02" name="Scout Squad" hidden="false" collective="false" import="false" targetId="9b10-b657-a65a-9d60" type="selectionEntry">
+      <modifiers>
+        <modifier type="add" field="category" value="8f42-a824-fb5f-8fea">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="b863-dbe9-afd0-cf4b" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="6d4b-8e54-f734-59aa" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
@@ -667,7 +717,6 @@
     <entryLink id="70f8-f2fb-eaef-8f09" name="Sicaran Omega Squadron" hidden="false" collective="false" import="false" targetId="c88b-fe44-34a3-97e1" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="7d3d-96b2-8093-f228" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="f55f-493b-b751-bff5" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="af32-30e4-ea99-66e8" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
       </categoryLinks>
     </entryLink>
@@ -680,7 +729,6 @@
     <entryLink id="5d10-4ec4-fd7f-c4fe" name="Sicaran Squadron" hidden="false" collective="false" import="false" targetId="706a-9532-f06d-00ed" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="9c53-79ba-20b4-0c38" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="ba03-524f-a75b-4454" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="e3f1-775a-11cb-e0e0" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
       </categoryLinks>
     </entryLink>
@@ -699,6 +747,7 @@
     <entryLink id="df73-2b98-e82c-c9ed" name="Sokar Stormbird" hidden="false" collective="false" import="false" targetId="f403-630f-71ae-5a7d" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="ca2c-dbe5-4243-7fb5" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="c3ab-62fd-d965-1d70" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="ccf0-7f32-d119-382b" name="Spatha Attack Bike Squadron" hidden="false" collective="false" import="false" targetId="4d72-1cc1-8bee-aa88" type="selectionEntry">
@@ -717,10 +766,22 @@
     <entryLink id="ad5c-55be-00df-6d99" name="Storm Eagle Gunship" hidden="false" collective="false" import="false" targetId="8aa5-ff31-7de7-19d4" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="8dbb-a7d3-f20f-6e29" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="eac0-1553-efd2-c10a" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+        <categoryLink id="97a9-34e3-1d79-ae00" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="c1e5-b58d-63bb-b4dd" name="Tactical Squad" hidden="false" collective="false" import="false" targetId="aa72-63e4-bc60-4611" type="selectionEntry">
+      <modifiers>
+        <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="b479-a6c4-cd52-41b2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="02b3-909a-4794-a59d" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
@@ -742,7 +803,6 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="b0a4-0243-b394-d1d1" name="Artillery Sub-type:" hidden="false" targetId="6f99-c178-6f9d-fb63" primary="false"/>
         <categoryLink id="2eb8-ab14-8b83-4687" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
         <categoryLink id="33c6-6162-3a63-3ff0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
@@ -770,14 +830,12 @@
       <categoryLinks>
         <categoryLink id="058d-05f1-5f39-3edc" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="1c81-c897-ae05-6c44" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="e5f5-bacb-82f0-3fa2" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="c16a-a744-396d-f9e8" name="Terminator Tartaros Squad" hidden="false" collective="false" import="false" targetId="1a8e-0ded-a4dc-2b4e" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="33f9-6907-1a15-62f6" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="77a4-ff21-107b-cdfc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="0cad-8a07-ce19-fced" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="6435-2676-8f7e-2c0b" name="Thunderbolt Fighter" hidden="false" collective="false" import="false" targetId="5d24-1e9a-ad9d-95ca" type="selectionEntry">
@@ -796,6 +854,7 @@
     <entryLink id="e112-71dc-7994-2f71" name="Thunderhawk Gunship" hidden="false" collective="false" import="false" targetId="8754-3a4f-213b-bdc0" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="9938-0256-9406-57a1" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="372d-5596-4075-e149" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="f178-f071-3715-9e89" name="Tylos Rubio" hidden="false" collective="false" import="false" targetId="56bf-2c6d-a0fa-a145" type="selectionEntry">
@@ -814,6 +873,7 @@
     <entryLink id="f698-283f-9e0a-7a5b" name="Typhon Squadron" hidden="false" collective="false" import="false" targetId="d06a-3087-af13-ca95" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="1708-8a76-2904-1441" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="b07f-2afe-ded2-2109" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="a547-033b-bcab-34dd" name="Veteran Squad" hidden="false" collective="false" import="false" targetId="a423-7dd8-3f1b-3e28" type="selectionEntry">
@@ -839,8 +899,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="8f21-44df-bac1-25ef" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="2753-2b13-2d77-9bad" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
-        <categoryLink id="b273-b2e9-7504-796b" name="Bombard Sub-type:" hidden="false" targetId="d5df-57ac-8f3c-097b" primary="false"/>
+        <categoryLink id="66a7-be4c-7b7b-b5f8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="844d-9ee1-1e02-2fa8" name="Xiphon Interceptor" hidden="false" collective="false" import="false" targetId="596b-5478-e079-59ab" type="selectionEntry">
@@ -849,7 +908,7 @@
         <categoryLink id="0f38-66ff-d5e4-e000" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="f98a-c47f-c564-7cfc" name="Procurators" hidden="false" collective="false" import="true" targetId="9cca-47d5-0779-79a2" type="selectionEntry">
+    <entryLink id="f98a-c47f-c564-7cfc" name="Procurators" hidden="false" collective="false" import="false" targetId="9cca-47d5-0779-79a2" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditionGroups>
@@ -865,6 +924,22 @@
       <categoryLinks>
         <categoryLink id="3150-7c35-659c-1e26" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="0abe-7863-06fb-b202" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="db3a-34bf-5577-b933" name="Seeker Squad" hidden="true" collective="false" import="false" targetId="58e6-f9cc-4c46-e258" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <infoLinks>
+        <infoLink id="8d8d-0014-b6b3-1ab7" name="Legiones Astartes (Word Bearers) " hidden="false" targetId="21ba-24fc-3fad-00fe" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="5b14-7b30-0fe2-af56" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="4977-f50e-a0dd-5ed7" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
       </categoryLinks>
     </entryLink>
   </entryLinks>
@@ -1023,6 +1098,13 @@
       </costs>
     </selectionEntry>
     <selectionEntry id="9289-65f7-e452-51a5" name="Lorgar " hidden="false" collective="false" import="true" type="unit">
+      <modifiers>
+        <modifier type="add" field="category" value="9055-7410-8ffd-b8e7">
+          <conditions>
+            <condition field="selections" scope="9289-65f7-e452-51a5" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="86f6-6646-2bef-31ee" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <constraints>
         <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ba96-d53f-37f7-984b" type="max"/>
         <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="cbbb-98c1-fb5c-7844" type="max"/>
@@ -1045,6 +1127,8 @@ In addition, once per battle, one friendly unit composed entirely of models with
       </infoLinks>
       <categoryLinks>
         <categoryLink id="26e2-2438-3fe6-0af3" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="69cd-1ac9-f49d-16e1" name="Psyker:" hidden="false" targetId="6e0c-29ba-a445-8321" primary="false"/>
+        <categoryLink id="5a9e-fc41-ec12-1b8f" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="42b4-8e18-3d94-a2c1" name="Lorgar Choice:" hidden="false" collective="false" import="true" defaultSelectionEntryId="b851-3073-1d88-4c68">
@@ -1070,6 +1154,56 @@ In addition, once per battle, one friendly unit composed entirely of models with
                   </characteristics>
                 </profile>
               </profiles>
+              <selectionEntries>
+                <selectionEntry id="580d-f719-30eb-d878" name="Devotion" hidden="false" collective="false" import="true" type="upgrade">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5877-a6c2-bdd7-991b" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cb48-fb45-01eb-43a9" type="min"/>
+                  </constraints>
+                  <profiles>
+                    <profile id="6142-21b6-9311-5507" name="Devotion" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+                      <characteristics>
+                        <characteristic name="Range" typeId="95ba-cda7-b831-6066">12&quot;</characteristic>
+                        <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">8</characteristic>
+                        <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">2</characteristic>
+                        <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Pistol 1, Concussive (2), Graviton Pulse, Haywire, Master-crafted</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <infoLinks>
+                    <infoLink id="984d-3149-69f9-6590" name="Concussive (X)" hidden="false" targetId="7ce5-1bfb-64e6-f826" type="rule"/>
+                    <infoLink id="8194-206f-b15e-4d2e" name="Graviton Pulse" hidden="false" targetId="5b9c-2738-616c-abdf" type="rule"/>
+                    <infoLink id="4d6f-29b4-20a0-15e1" name="Haywire" hidden="false" targetId="1dd4-7a75-5c59-8425" type="rule"/>
+                  </infoLinks>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="4dd8-ebdd-1395-f138" name="Illuminarum" hidden="false" collective="false" import="true" type="upgrade">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6a2c-069d-94f3-586b" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ed2f-2c5e-e6c7-a67d" type="max"/>
+                  </constraints>
+                  <profiles>
+                    <profile id="dd77-b27e-bc94-a5a2" name="Illuminarum" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+                      <characteristics>
+                        <characteristic name="Range" typeId="95ba-cda7-b831-6066">-</characteristic>
+                        <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">+2</characteristic>
+                        <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">2</characteristic>
+                        <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Melee, Master-crafted, Armourbane (Melee), Brutal (2)</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <infoLinks>
+                    <infoLink id="6b2a-bc41-089f-3845" name="Master-crafted" hidden="false" targetId="6de0-55b0-bf21-48b9" type="rule"/>
+                    <infoLink id="76c6-caad-6e6d-7e28" name="Armourbane (X)" hidden="false" targetId="cb59-f920-f071-7cd4" type="rule"/>
+                    <infoLink id="7225-23a2-5dac-df75" name="Brutal (X)" hidden="false" targetId="5079-1fec-d32b-8b84" type="rule"/>
+                  </infoLinks>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
               <entryLinks>
                 <entryLink id="86cc-b915-8718-4bf2" name="Aetheric Lightning" hidden="false" collective="false" import="true" targetId="b477-d985-8b95-69de" type="selectionEntry">
                   <constraints>
@@ -1089,8 +1223,6 @@ In addition, once per battle, one friendly unit composed entirely of models with
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ea53-04e2-505d-ee84" type="min"/>
                   </constraints>
                 </entryLink>
-                <entryLink id="a722-919e-641f-35cd" name="Devotion" hidden="false" collective="false" import="true" targetId="4301-5393-8521-356d" type="selectionEntry"/>
-                <entryLink id="f124-ef8d-f2a6-d5d9" name="Illuminarum" hidden="false" collective="false" import="true" targetId="9ee0-0423-fef4-d52f" type="selectionEntry"/>
               </entryLinks>
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
@@ -1138,8 +1270,8 @@ In addition, once per battle, one friendly unit composed entirely of models with
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6544-b492-8f95-448a" type="min"/>
                   </constraints>
                 </entryLink>
-                <entryLink id="6feb-3285-8e03-cde7" name="Devotion" hidden="false" collective="false" import="true" targetId="4301-5393-8521-356d" type="selectionEntry"/>
-                <entryLink id="9843-329d-51b4-2149" name="Illuminarum" hidden="false" collective="false" import="true" targetId="9ee0-0423-fef4-d52f" type="selectionEntry"/>
+                <entryLink id="6feb-3285-8e03-cde7" name="Devotion" hidden="false" collective="false" import="true" targetId="580d-f719-30eb-d878" type="selectionEntry"/>
+                <entryLink id="9843-329d-51b4-2149" name="Illuminarum" hidden="false" collective="false" import="true" targetId="4dd8-ebdd-1395-f138" type="selectionEntry"/>
               </entryLinks>
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0"/>
@@ -1187,6 +1319,8 @@ In addition, once per battle, one friendly unit composed entirely of models with
       <categoryLinks>
         <categoryLink id="768a-11a0-1cb1-d896" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="75a1-c482-1a18-e139" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="1937-18d3-3af6-806c" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+        <categoryLink id="fd96-34a3-5cd2-680a" name="Jump Infantry:" hidden="false" targetId="eee8-3c7c-2762-e33e" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="9109-0ac9-239f-f762" name="Iconoclast" hidden="false" collective="false" import="true" type="model">
@@ -1267,6 +1401,9 @@ In addition, once per battle, one friendly unit composed entirely of models with
               </entryLinks>
             </selectionEntryGroup>
           </selectionEntryGroups>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+          </costs>
         </selectionEntry>
         <selectionEntry id="9d7c-a887-22cf-340e" name="Incendiary" hidden="false" collective="false" import="true" type="model">
           <constraints>
@@ -1468,54 +1605,6 @@ In addition, once per battle, one friendly unit composed entirely of models with
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="240.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="4301-5393-8521-356d" name="Devotion" hidden="false" collective="false" import="true" type="upgrade">
-      <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a39f-de3e-239d-4f1b" type="max"/>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3b3c-c35b-4adb-a0c8" type="min"/>
-      </constraints>
-      <profiles>
-        <profile id="5fa4-3950-f3b6-b108" name="Devotion" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
-          <characteristics>
-            <characteristic name="Range" typeId="95ba-cda7-b831-6066">12&quot;</characteristic>
-            <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">8</characteristic>
-            <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">2</characteristic>
-            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Pistol 1, Concussive (2), Graviton Pulse, Haywire, Master-crafted</characteristic>
-          </characteristics>
-        </profile>
-      </profiles>
-      <infoLinks>
-        <infoLink id="2fe8-3d4e-f1e6-0bd6" name="Concussive (X)" hidden="false" targetId="7ce5-1bfb-64e6-f826" type="rule"/>
-        <infoLink id="43c3-6761-d81d-d1f9" name="Graviton Pulse" hidden="false" targetId="5b9c-2738-616c-abdf" type="rule"/>
-        <infoLink id="34b9-4e83-8e5b-29d8" name="Haywire" hidden="false" targetId="1dd4-7a75-5c59-8425" type="rule"/>
-      </infoLinks>
-      <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="9ee0-0423-fef4-d52f" name="Illuminarum" hidden="false" collective="false" import="true" type="upgrade">
-      <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="33c0-6ac4-061e-3e55" type="min"/>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f2a9-f5cb-39b7-6469" type="max"/>
-      </constraints>
-      <profiles>
-        <profile id="1efd-5aad-6eaf-72fb" name="Illuminarum" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
-          <characteristics>
-            <characteristic name="Range" typeId="95ba-cda7-b831-6066">-</characteristic>
-            <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">+2</characteristic>
-            <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">2</characteristic>
-            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Melee, Master-crafted, Armourbane (Melee), Brutal (2)</characteristic>
-          </characteristics>
-        </profile>
-      </profiles>
-      <infoLinks>
-        <infoLink id="4c5b-5232-59ec-17d2" name="Master-crafted" hidden="false" targetId="6de0-55b0-bf21-48b9" type="rule"/>
-        <infoLink id="b500-163c-9e3f-6180" name="Armourbane (X)" hidden="false" targetId="cb59-f920-f071-7cd4" type="rule"/>
-        <infoLink id="3e0c-5885-5735-9650" name="Brutal (X)" hidden="false" targetId="5079-1fec-d32b-8b84" type="rule"/>
-      </infoLinks>
-      <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
-      </costs>
-    </selectionEntry>
     <selectionEntry id="4f8e-79b2-b286-d40e" name="Anaktis Kul Blade Slave" hidden="false" collective="false" import="true" type="model">
       <profiles>
         <profile id="49fb-4398-38a2-49f4" name="Anaktis Kul Blade Slave" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
@@ -1554,6 +1643,11 @@ In addition, once per battle, one friendly unit composed entirely of models with
         </infoLink>
         <infoLink id="80b6-d93b-76ac-ef8e" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule"/>
       </infoLinks>
+      <categoryLinks>
+        <categoryLink id="12b2-c421-a2f1-8907" name="Corrupted Sub-type:" hidden="false" targetId="9055-7410-8ffd-b8e7" primary="false"/>
+        <categoryLink id="f886-4ca2-1868-07e2" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="52a9-15b7-149f-b6d7" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+      </categoryLinks>
       <selectionEntries>
         <selectionEntry id="0dd6-4f8c-91d1-ee32" name="Anaktis Blade" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
@@ -1626,7 +1720,7 @@ In addition, once per battle, one friendly unit composed entirely of models with
     </selectionEntry>
     <selectionEntry id="6be5-394d-9d79-344b" name="Argel Tal" hidden="false" collective="false" import="true" type="model">
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8333-54c1-daf4-046d" type="max"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8333-54c1-daf4-046d" type="max"/>
       </constraints>
       <profiles>
         <profile id="da51-6ca2-c7d5-451e" name="Argel Tal" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
@@ -1664,6 +1758,12 @@ In addition, once per battle, one friendly unit composed entirely of models with
           </modifiers>
         </infoLink>
       </infoLinks>
+      <categoryLinks>
+        <categoryLink id="cba8-9fd4-5e85-e6ed" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
+        <categoryLink id="a847-6e8a-66a4-fa17" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="c096-bb42-1c27-67a6" name="Corrupted Sub-type:" hidden="false" targetId="9055-7410-8ffd-b8e7" primary="false"/>
+        <categoryLink id="5230-23dd-655d-ab3a" name="Jump Infantry:" hidden="false" targetId="eee8-3c7c-2762-e33e" primary="false"/>
+      </categoryLinks>
       <selectionEntries>
         <selectionEntry id="14c5-57da-1235-56d4" name="Two Daemonic Talons" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
@@ -1748,7 +1848,7 @@ Argel Tal may not Run in any Turn in which the Umbral Pinions have been activate
     </selectionEntry>
     <selectionEntry id="18c4-d715-caba-b450" name="High Chaplain Erebus" hidden="false" collective="false" import="true" type="model">
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9578-e447-6e7c-4ba2" type="max"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9578-e447-6e7c-4ba2" type="max"/>
       </constraints>
       <profiles>
         <profile id="af3e-ad7a-2a90-23a2" name="High Chaplain Erebus" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
@@ -1786,6 +1886,12 @@ Psychic Weapon</description>
         </infoLink>
         <infoLink id="a94d-4b88-ece7-d111" name="Fearless" hidden="false" targetId="b48c-d7e1-2a83-2f5b" type="rule"/>
       </infoLinks>
+      <categoryLinks>
+        <categoryLink id="d3d0-99c4-cb4c-969c" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="35e4-8e2b-e655-7bba" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
+        <categoryLink id="9acc-39e7-b768-439f" name="Corrupted Sub-type:" hidden="false" targetId="9055-7410-8ffd-b8e7" primary="false"/>
+        <categoryLink id="c6bf-c6ef-ae4a-4995" name="Psyker:" hidden="false" targetId="6e0c-29ba-a445-8321" primary="false"/>
+      </categoryLinks>
       <selectionEntries>
         <selectionEntry id="20eb-1d18-ef3b-6a39" name="Crux Malifica" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
@@ -1882,7 +1988,7 @@ Psychic Weapon</description>
     </selectionEntry>
     <selectionEntry id="e61d-db78-6f56-3c05" name="Kor Phaeron" hidden="false" collective="false" import="true" type="model">
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="196c-7b3c-c0f9-8008" type="max"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="196c-7b3c-c0f9-8008" type="max"/>
       </constraints>
       <profiles>
         <profile id="55c8-44f1-be1e-ef48" name="Kor Phaeron" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
@@ -2050,7 +2156,7 @@ Threatening Entreaties - Kor Phaeron and the unit he has joined gain the Fearles
     </selectionEntry>
     <selectionEntry id="f511-e558-6bff-6543" name="Zardu Layak" hidden="false" collective="false" import="true" type="model">
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="574e-7e54-7db7-60a3" type="max"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="574e-7e54-7db7-60a3" type="max"/>
       </constraints>
       <profiles>
         <profile id="e53d-63ae-2ac4-427a" name="Zardu Layak" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
@@ -2088,6 +2194,12 @@ as the Aetheric Lightning Psychic Weapon</description>
         <infoLink id="d324-8719-89c0-dd00" name="Legiones Astartes (Word Bearers) " hidden="false" targetId="21ba-24fc-3fad-00fe" type="rule"/>
         <infoLink id="8932-28c5-60c8-9155" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule"/>
       </infoLinks>
+      <categoryLinks>
+        <categoryLink id="cd36-7aef-4bad-b59e" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="49db-339f-dd98-686b" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
+        <categoryLink id="9ace-0389-f30c-2062" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="d74c-384e-1128-4d7a" name="Corrupted Sub-type:" hidden="false" targetId="9055-7410-8ffd-b8e7" primary="false"/>
+      </categoryLinks>
       <selectionEntries>
         <selectionEntry id="2bac-34cb-8346-fc49" name="The Azurda Char&apos;is" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
@@ -2216,6 +2328,10 @@ as the Aetheric Lightning Psychic Weapon</description>
           <description>A unit that includes any models with this special rule may not be joined by any model that does not also have this special rule (this includes Legion Techmarines and Legion Apothecaries, which may not be assigned to a unit with this special rule unless they also have this special rule).</description>
         </rule>
       </rules>
+      <categoryLinks>
+        <categoryLink id="5aff-13d0-9bfc-03ef" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="c840-64ca-a73b-7f3c" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+      </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="9229-d848-0adf-91c7" name="2) Procurants" hidden="false" collective="false" import="true" defaultSelectionEntryId="9c94-e8e3-2c5a-6f24">
           <modifiers>

--- a/2022 - LA - World Eaters.cat
+++ b/2022 - LA - World Eaters.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="d901-0eca-48b5-304a" name="LA -  XII: World Eaters" revision="8" battleScribeVersion="2.03" authorName="UrsinePatriarch" authorContact="BSData Developers Discord" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="18" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="d901-0eca-48b5-304a" name="LA -  XII: World Eaters" revision="10" battleScribeVersion="2.03" authorName="UrsinePatriarch" authorContact="BSData Developers Discord" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="18" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entryLinks>
     <entryLink id="d647-fd99-73e0-bd57" name="Angron" hidden="false" collective="false" import="false" targetId="6352-8efa-0cc4-cfa7" type="selectionEntry">
       <modifiers>
@@ -11,10 +11,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="e3d0-6c05-8d56-6e01" name="New CategoryLink" hidden="false" targetId="ad5f-31db-8bc7-5c46" primary="true"/>
-        <categoryLink id="b9df-6e9f-bc76-9968" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="false"/>
         <categoryLink id="b212-8e0c-46ce-f3b9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="dfe3-9dbf-52fd-9631" name="Independant Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
-        <categoryLink id="d6c2-5a95-2c50-582a" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="eae7-92b5-7fb5-0667" name="Khârn the Bloody" hidden="false" collective="false" import="false" targetId="e726-7208-d919-a4a1" type="selectionEntry">
@@ -28,9 +25,6 @@
       <categoryLinks>
         <categoryLink id="9a45-dc53-86fd-a519" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="3cd1-2a33-5ca2-8154" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="9220-f305-3d8e-5388" name="Independant Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
-        <categoryLink id="b5b5-a986-cf0b-f8fa" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
-        <categoryLink id="8fbf-5446-8439-7d5b" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="e38a-7bdf-7ddc-7084" name="Shabran Darr" hidden="false" collective="false" import="false" targetId="aa6d-c70a-199f-1db5" type="selectionEntry">
@@ -49,8 +43,6 @@
       <categoryLinks>
         <categoryLink id="5380-a98e-902b-7621" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="7196-76e9-d9ce-2f13" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="04f7-f1e9-d144-5f4c" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
-        <categoryLink id="5c3e-5676-a666-e485" name="Independant Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
         <categoryLink id="eaeb-08e5-5cda-7c6a" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -89,8 +81,6 @@
       <categoryLinks>
         <categoryLink id="c631-e91c-7b35-038d" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="8ba5-d6d8-3c2a-cf09" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="da90-6f7c-a866-ed37" name="Independant Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
-        <categoryLink id="8325-a1d8-1787-4316" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
         <categoryLink id="b9d3-c817-7e77-1c90" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -98,7 +88,6 @@
       <categoryLinks>
         <categoryLink id="6809-da13-d863-b286" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="63b2-2890-7ed2-7b00" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="28c9-6dff-4ea5-fa85" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="72f5-627b-f9c0-c6bf" name="  XII: World Eaters" hidden="false" collective="false" import="false" targetId="90ee-77dd-1b7f-ddfe" type="selectionEntry">
@@ -126,8 +115,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="b686-7fdf-ec1f-956e" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="61f9-887e-f8ab-e665" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
-        <categoryLink id="c611-0451-b06b-9c18" name="Bombard Sub-type:" hidden="false" targetId="d5df-57ac-8f3c-097b" primary="false"/>
+        <categoryLink id="7bdc-02ef-f4d8-d8b8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="7fb6-9ea7-83ab-efa1" name="Vindicator Squadron" hidden="false" collective="false" import="false" targetId="9245-0776-6747-adb8" type="selectionEntry">
@@ -146,6 +134,7 @@
     <entryLink id="cb9e-4257-d7e5-23f2" name="Typhon Squadron" hidden="false" collective="false" import="false" targetId="d06a-3087-af13-ca95" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="3cfd-be32-1879-77b2" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="f12b-b3c2-781a-5805" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="8eb6-4832-e4be-14ca" name="Tylos Rubio" hidden="false" collective="false" import="false" targetId="56bf-2c6d-a0fa-a145" type="selectionEntry">
@@ -164,6 +153,7 @@
     <entryLink id="1528-2655-0329-c2df" name="Thunderhawk Gunship" hidden="false" collective="false" import="false" targetId="8754-3a4f-213b-bdc0" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="c697-ac01-974f-d163" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="2559-d869-f135-c64e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="15d3-53a0-372e-6a1c" name="Thunderbolt Fighter" hidden="false" collective="false" import="false" targetId="5d24-1e9a-ad9d-95ca" type="selectionEntry">
@@ -183,7 +173,6 @@
       <categoryLinks>
         <categoryLink id="943b-f22e-7486-e366" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="7ab8-5171-4b59-cccf" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="cb45-08ab-8ae5-3d63" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="7c3d-c611-42a7-6dbf" name="Terminator Indomitus Squad" hidden="false" collective="false" import="false" targetId="aa7f-bd4c-5231-d459" type="selectionEntry">
@@ -197,7 +186,6 @@
       <categoryLinks>
         <categoryLink id="7862-9fa1-f510-7267" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="e887-aae5-f55b-4a9c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="6fdf-a5d9-563e-d736" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="c4af-98b6-a14f-1afb" name="Terminator Cataphractii Squad" hidden="false" collective="false" import="false" targetId="d91a-a3c7-d7be-4293" type="selectionEntry">
@@ -221,7 +209,6 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="51e2-d1c8-940a-2bf4" name="Artillery Sub-type:" hidden="false" targetId="6f99-c178-6f9d-fb63" primary="false"/>
         <categoryLink id="1d3a-0f50-83b4-6e54" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
         <categoryLink id="07a3-482d-516b-2be1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
@@ -233,6 +220,18 @@
       </categoryLinks>
     </entryLink>
     <entryLink id="8d00-818a-411f-bb94" name="Tactical Squad" hidden="false" collective="false" import="false" targetId="aa72-63e4-bc60-4611" type="selectionEntry">
+      <modifiers>
+        <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="86a1-96aa-bd3c-e50f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="6e8e-a6d2-2b0a-b9ce" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
@@ -242,7 +241,7 @@
     <entryLink id="92d0-ae38-6ae1-02df" name="Storm Eagle Gunship" hidden="false" collective="false" import="false" targetId="8aa5-ff31-7de7-19d4" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="c094-c914-ef71-1891" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="4561-ad94-b6cc-bb0d" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+        <categoryLink id="b5c0-55d7-e2ea-b98a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="17b5-4ae6-c333-9348" name="Spatha Attack Bike Squadron" hidden="false" collective="false" import="false" targetId="4d72-1cc1-8bee-aa88" type="selectionEntry">
@@ -261,6 +260,7 @@
     <entryLink id="9978-135b-f50a-2126" name="Sokar Stormbird" hidden="false" collective="false" import="false" targetId="f403-630f-71ae-5a7d" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="2465-7881-2bd9-3642" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="1fd0-9b05-a903-2341" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="18fe-4c30-5218-5261" name="Sky-Hunter Squadron" hidden="false" collective="false" import="false" targetId="6263-c696-2f2e-c105" type="selectionEntry">
@@ -278,7 +278,6 @@
     <entryLink id="3c94-7378-be96-61ab" name="Sicaran Squadron" hidden="false" collective="false" import="false" targetId="706a-9532-f06d-00ed" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="7e51-4152-a467-fecf" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="28c8-74ea-aca9-b538" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="4794-1343-9e4b-fc1a" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
       </categoryLinks>
     </entryLink>
@@ -291,7 +290,6 @@
     <entryLink id="ba49-9bef-dacf-bc65" name="Sicaran Omega Squadron" hidden="false" collective="false" import="false" targetId="c88b-fe44-34a3-97e1" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="46c8-5118-d4d7-4f93" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="b003-588c-bdca-566c" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="2806-6ea9-5f33-5cd3" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
       </categoryLinks>
     </entryLink>
@@ -308,6 +306,13 @@
       </categoryLinks>
     </entryLink>
     <entryLink id="1ab4-66a8-0366-7069" name="Scout Squad" hidden="false" collective="false" import="false" targetId="9b10-b657-a65a-9d60" type="selectionEntry">
+      <modifiers>
+        <modifier type="add" field="category" value="8f42-a824-fb5f-8fea">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="93a1-4b84-ee73-f8ba" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="a205-053b-6086-3c22" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
@@ -326,6 +331,13 @@
       </categoryLinks>
     </entryLink>
     <entryLink id="9066-3ed5-196e-e303" name="Reconnaissance Squad" hidden="false" collective="false" import="false" targetId="6db7-6e88-877e-35ca" type="selectionEntry">
+      <modifiers>
+        <modifier type="add" field="category" value="8f42-a824-fb5f-8fea">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="db66-fe0b-23a3-15be" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="11e0-6037-2a25-b59f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
@@ -435,14 +447,14 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="ab13-015b-bb3e-8195" name="Bombard Sub-type:" hidden="false" targetId="d5df-57ac-8f3c-097b" primary="false"/>
         <categoryLink id="7535-aed8-898c-8204" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="9e4a-2c86-1bb5-2e64" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
+        <categoryLink id="6e39-6251-3836-aa4d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="d1f7-b7cc-38ae-b34a" name="Mastodon" hidden="false" collective="false" import="false" targetId="7f24-2b72-9128-5330" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="1f66-aa58-e689-3240" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="909f-9f57-88f0-24a1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="944d-5882-4dfe-0bfa" name="Leviathan Dreadnought Talon" hidden="false" collective="false" import="false" targetId="c2a7-9e2c-fc65-1b78" type="selectionEntry">
@@ -461,7 +473,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="11e9-079d-a166-a603" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="64c3-111b-663f-b243" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+        <categoryLink id="0f33-287a-934e-2d4b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="1f97-bf58-5325-e7c8" name="Legion Stormlord" hidden="true" collective="false" import="false" targetId="0887-0f66-2c7e-a5ba" type="selectionEntry">
@@ -474,7 +486,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="1f8f-9637-18bb-84b3" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="ad6f-c077-a8c5-b298" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+        <categoryLink id="a051-c87b-3ceb-359c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="78c0-bd86-99b4-3d35" name="Legion Stormblade" hidden="true" collective="false" import="false" targetId="4ac0-4b85-58da-0907" type="selectionEntry">
@@ -487,7 +499,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="8dc6-172d-2f5d-6e2e" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="dca2-cc89-ad85-a9ce" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+        <categoryLink id="37a3-1063-c0e7-15b4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="0605-ec8d-6663-886f" name="Legion Shadowsword" hidden="false" collective="false" import="false" targetId="8a75-acc6-6fd6-90b8" type="selectionEntry">
@@ -552,7 +564,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="5c5a-ea18-1ae9-dcf3" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="4d31-2f07-e985-081a" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+        <categoryLink id="5642-51a6-3b4f-ffea" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="0a1c-5ad3-c7fc-494d" name="Legion Baneblade" hidden="true" collective="false" import="false" targetId="ee5c-0952-bf95-6333" type="selectionEntry">
@@ -565,7 +577,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="29d8-6c54-d110-d283" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="95e9-4248-1069-d4cd" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+        <categoryLink id="780e-8505-eb88-ff08" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="f6dd-6d5b-c299-0673" name="Land Raider Spartan" hidden="false" collective="false" import="false" targetId="bac1-f30e-2c04-d27d" type="selectionEntry">
@@ -625,29 +637,31 @@
     <entryLink id="1a75-cc22-6e04-d9f3" name="Glaive" hidden="false" collective="false" import="false" targetId="04e0-f69f-f759-b0b3" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="9e7e-7589-e7ab-dfb8" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="5e83-c9e9-095d-704e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="1c75-2909-9649-b8c8" name="Fire Raptor Gunship" hidden="false" collective="false" import="false" targetId="f6e1-24e2-fbdb-c5ef" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="6984-e026-6945-1404" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="51d4-0626-3b77-532a" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="f953-c46b-6a7c-e883" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="c815-dbde-58b4-87cc" name="Fellblade" hidden="false" collective="false" import="false" targetId="9c3c-f15a-9a1f-c0d0" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="ef6c-fbc2-9e91-32b4" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="faaf-6c80-46a5-8abb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="a0ad-db6b-ce33-f849" name="Falchion" hidden="false" collective="false" import="false" targetId="1fe8-7386-9509-d2d8" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="8527-a3ab-a2d2-6d13" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="c8df-a444-27c0-44d4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="8be5-dd6c-2276-908d" name="Dreadclaw Drop Pod" hidden="false" collective="false" import="false" targetId="bbe8-818d-3068-d79c" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="5e1f-4881-1e04-f96e" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="aac1-c6ff-001b-c607" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+        <categoryLink id="6790-3a53-a02a-43c0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="6c53-3a25-88ea-4e3b" name="Destroyer Assault Squad" hidden="false" collective="false" import="false" targetId="d30b-59bb-8ae0-36d1" type="selectionEntry">
@@ -657,6 +671,18 @@
       </categoryLinks>
     </entryLink>
     <entryLink id="8fca-6360-d5ba-c5a2" name="Despoiler Squad" hidden="false" collective="false" import="false" targetId="4357-930e-165a-a6e3" type="selectionEntry">
+      <modifiers>
+        <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="3256-8276-77bb-1575" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="823b-d94a-5ab2-90a9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
@@ -678,7 +704,6 @@
     <entryLink id="a2e7-8aba-5a78-727f" name="Damocles Command Rhino" hidden="false" collective="false" import="false" targetId="e337-8239-5e92-7f5f" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="1be8-a420-b14a-19a9" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="be2e-d00f-46af-9015" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="1f09-3b1e-1ee1-bf90" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -817,12 +842,23 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="cba0-737d-889c-d679" name="Bombard Sub-type:" hidden="false" targetId="d5df-57ac-8f3c-097b" primary="false"/>
         <categoryLink id="6f98-dc70-2956-4b6e" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="5610-4132-8528-5e8f" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
+        <categoryLink id="7dcb-8897-289a-6bb3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="7366-521a-bae5-0a02" name="Breacher Squad" hidden="false" collective="false" import="false" targetId="ad97-c090-fa67-696f" type="selectionEntry">
+      <modifiers>
+        <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="ead3-18c3-4dcd-dd49" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="8c99-dc6a-f877-2a0b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
@@ -830,6 +866,18 @@
       </categoryLinks>
     </entryLink>
     <entryLink id="1d63-9ec6-1bc1-3085" name="Assault Squad" hidden="false" collective="false" import="false" targetId="a8e9-70e1-b8bc-8ee2" type="selectionEntry">
+      <modifiers>
+        <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="0774-a66d-297c-14f6" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="756d-e6b6-75b3-9f19" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
@@ -846,6 +894,22 @@
       <categoryLinks>
         <categoryLink id="5816-e8b9-f2b8-c2d0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="69c9-4ef4-031e-0ffe" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="1d84-d081-c72e-e242" name="Seeker Squad" hidden="true" collective="false" import="false" targetId="58e6-f9cc-4c46-e258" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <infoLinks>
+        <infoLink id="282a-cfa0-f347-c75b" name="Legiones Astartes (World Eaters) " hidden="false" targetId="405d-019f-9ef6-423c" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="3329-4017-e23f-4891" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="2b21-d6e1-987f-fb24" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
       </categoryLinks>
     </entryLink>
   </entryLinks>
@@ -868,6 +932,10 @@
         </infoLink>
         <infoLink id="11a4-5d44-61d3-2e00" name="Stubborn" hidden="false" targetId="7989-1f2c-a43d-82ae" type="rule"/>
       </infoLinks>
+      <categoryLinks>
+        <categoryLink id="5c3d-505d-be3a-0021" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="ee5e-db50-34f8-2da8" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+      </categoryLinks>
       <selectionEntries>
         <selectionEntry id="bb97-5922-24bd-d6ca" name="Blood Bonded" hidden="false" collective="false" import="true" type="model">
           <constraints>
@@ -1304,7 +1372,7 @@
     </selectionEntry>
     <selectionEntry id="aa6d-c70a-199f-1db5" name="Shabran Darr" hidden="false" collective="false" import="true" type="unit">
       <constraints>
-        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c6f2-ce96-4619-a14e" type="max"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c6f2-ce96-4619-a14e" type="max"/>
       </constraints>
       <rules>
         <rule id="3c7e-33bc-d8bb-8933" name="Head-hunter" hidden="false">
@@ -1330,8 +1398,9 @@
         </infoLink>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="a677-835d-a148-0d48" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
         <categoryLink id="82c7-7ee7-c815-1285" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
+        <categoryLink id="6018-e91b-ef03-2ee3" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="66fc-9632-84b0-aa90" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="912e-502f-2838-ef01" name="The Liberator" hidden="false" collective="false" import="true" type="upgrade">
@@ -1441,6 +1510,12 @@
         </infoLink>
         <infoLink id="9f9a-d927-04d9-579a" name="Ravening Madmen" hidden="false" targetId="1864-f270-d462-ecb5" type="rule"/>
       </infoLinks>
+      <categoryLinks>
+        <categoryLink id="dac3-55aa-0d1b-36b7" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+        <categoryLink id="cf1c-50e5-11f5-a5c0" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="080b-8aab-b802-323a" name="Terminators:" hidden="false" targetId="bab3-f50d-3e5f-2f78" primary="false"/>
+        <categoryLink id="4259-2c1a-9160-12f3" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+      </categoryLinks>
       <selectionEntries>
         <selectionEntry id="0ef2-9852-5b60-2ff2" name="Devoured" hidden="false" collective="false" import="true" type="model">
           <constraints>
@@ -1466,7 +1541,6 @@
           </profiles>
           <categoryLinks>
             <categoryLink id="e96c-7be7-50c9-2e1d" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
-            <categoryLink id="a536-bfa8-c022-eec4" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="a999-8d13-e96f-b721" name="Weapon Options" hidden="false" collective="false" import="true" defaultSelectionEntryId="83ef-25d3-f484-916e">
@@ -1705,6 +1779,13 @@
       </costs>
     </selectionEntry>
     <selectionEntry id="2fb9-74a8-43b0-dd00" name="Rampager Squad" hidden="false" collective="false" import="true" type="unit">
+      <modifiers>
+        <modifier type="add" field="category" value="eee8-3c7c-2762-e33e">
+          <conditions>
+            <condition field="selections" scope="2fb9-74a8-43b0-dd00" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a298-8584-70ed-18ce" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <infoLinks>
         <infoLink id="a803-4071-5d85-92c7" name="Legiones Astartes (World Eaters) " hidden="false" targetId="405d-019f-9ef6-423c" type="rule"/>
         <infoLink id="ed22-c7f9-5c36-1e71" name="Furious Charge (X)" hidden="false" targetId="2821-9269-862f-0554" type="rule">
@@ -1715,6 +1796,10 @@
         <infoLink id="58cf-084a-5f23-934d" name="Chosen Warriors" hidden="false" targetId="13d1-9270-6539-08ed" type="rule"/>
         <infoLink id="f193-1b95-b0ab-0fc3" name="Stubborn" hidden="false" targetId="7989-1f2c-a43d-82ae" type="rule"/>
       </infoLinks>
+      <categoryLinks>
+        <categoryLink id="27fd-7bde-4c05-e9f2" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="56af-118e-8128-ae96" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+      </categoryLinks>
       <selectionEntries>
         <selectionEntry id="316d-d623-06cc-0a1b" name="Rampager Champion" hidden="false" collective="false" import="true" type="model">
           <constraints>
@@ -2173,7 +2258,7 @@
     </selectionEntry>
     <selectionEntry id="6352-8efa-0cc4-cfa7" name="Angron" hidden="false" collective="false" import="true" type="model">
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="426b-a3da-a898-7dd8" type="max"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="426b-a3da-a898-7dd8" type="max"/>
       </constraints>
       <profiles>
         <profile id="90ce-d522-db2a-f9d2" name="Angron" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
@@ -2217,8 +2302,8 @@
         <infoLink id="ff06-648d-8872-53e5" name="Legiones Astartes (World Eaters) " hidden="false" targetId="405d-019f-9ef6-423c" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="0405-c10f-d1c4-d642" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
         <categoryLink id="8d69-ffc8-873e-2e42" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
+        <categoryLink id="b990-1902-a070-c6d2" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="646c-85f5-7755-cc45" name="Gorefather &amp; Gorechild" hidden="false" collective="false" import="true" type="upgrade">
@@ -2337,7 +2422,7 @@
     </selectionEntry>
     <selectionEntry id="e812-10d1-b911-90c5" name="Gahlan Surlak" hidden="false" collective="false" import="true" type="model">
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0606-8335-857a-a6d4" type="max"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0606-8335-857a-a6d4" type="max"/>
       </constraints>
       <profiles>
         <profile id="2038-4e8b-96cf-a832" name="Gahlan Surlak" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
@@ -2361,6 +2446,11 @@
         <infoLink id="7cba-d485-b59f-7d53" name="Sacred Trust" hidden="false" targetId="7cdc-4095-eb1e-2b07" type="rule"/>
         <infoLink id="b04b-077c-a729-1a77" name="Legiones Astartes (World Eaters) " hidden="false" targetId="405d-019f-9ef6-423c" type="rule"/>
       </infoLinks>
+      <categoryLinks>
+        <categoryLink id="9218-c0cc-8dc7-a683" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="6456-b9f2-a391-2c29" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
+        <categoryLink id="58d8-8eda-8902-2a74" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+      </categoryLinks>
       <selectionEntries>
         <selectionEntry id="01fb-10e7-0c43-2b0d" name="Fleshripper" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
@@ -2443,7 +2533,7 @@
     </selectionEntry>
     <selectionEntry id="e726-7208-d919-a4a1" name="Khârn the Bloody" hidden="false" collective="false" import="true" type="model">
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="40b6-ae71-99d5-3c02" type="max"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="40b6-ae71-99d5-3c02" type="max"/>
       </constraints>
       <infoLinks>
         <infoLink id="9edd-a134-ccb1-feba" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule"/>
@@ -2459,6 +2549,11 @@
           </modifiers>
         </infoLink>
       </infoLinks>
+      <categoryLinks>
+        <categoryLink id="6d76-7591-3f6a-4f2c" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="2e2e-a670-504f-7861" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="a72b-1dd1-a0d9-f099" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
+      </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="3017-90ed-f8d5-20fb" name="Melee Weapon" hidden="false" collective="false" import="true">
           <constraints>

--- a/2022 - Legiones Astartes.cat
+++ b/2022 - Legiones Astartes.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="6393-649c-7213-a327" name="(HH V2) Legions Astartes" revision="43" battleScribeVersion="2.03" authorName="Various" authorUrl="https://github.com/BSData/horus-heresy" library="true" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="17" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="6393-649c-7213-a327" name="(HH V2) Legions Astartes" revision="45" battleScribeVersion="2.03" authorName="Various" authorUrl="https://github.com/BSData/horus-heresy" library="true" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="18" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <profileTypes>
     <profileType id="7002-2f9a-59c4-2742" name="Prosperine Arcana">
       <characteristicTypes>
@@ -181,6 +181,36 @@
     </categoryEntry>
     <categoryEntry id="372b-4586-83da-2145" name="Master of the Keshig" hidden="false"/>
   </categoryEntries>
+  <selectionEntries>
+    <selectionEntry id="2494-402e-655d-d47f" name="Rite of War" hidden="false" collective="false" import="true" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="aceb-adc5-47f5-2599" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9125-3c51-5d9e-e289" type="max"/>
+      </constraints>
+      <categoryLinks>
+        <categoryLink id="4438-f76c-00cc-7358" name="New CategoryLink" hidden="false" targetId="d494-e450-d4aa-579a" primary="true"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="274f-af11-55a3-720e" name="Rites of War (Text Only / Work in Progress)" hidden="false" collective="false" import="true" targetId="cf3e-1d75-6f91-651f" type="selectionEntryGroup">
+          <modifiers>
+            <modifier type="set" field="797b-0bd6-8cbf-f25a" value="0.0">
+              <conditionGroups>
+                <conditionGroup type="and">
+                  <conditions>
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ad5f-31db-8bc7-5c46" type="equalTo"/>
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0068-6b0a-0086-3d6b" type="equalTo"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+  </selectionEntries>
   <sharedSelectionEntries>
     <selectionEntry id="82f5-cca1-51a0-31dd" name="Venom Spheres" hidden="false" collective="false" import="true" type="upgrade">
       <modifiers>
@@ -5722,6 +5752,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
       </infoLinks>
       <categoryLinks>
         <categoryLink id="e07d-b552-90ef-c096" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="4048-d50e-f863-8094" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="baa7-a991-0755-959a" name="Legion Rhino Transport" hidden="false" collective="false" import="true" type="upgrade">
@@ -6942,6 +6973,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
       <categoryLinks>
         <categoryLink id="2a0a-16f7-36a7-f414" name="Skirmish:" hidden="false" targetId="59a4-7b61-600a-c457" primary="false"/>
         <categoryLink id="ca35-8e83-c135-9eaf" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="ed2e-e758-859f-2c45" name="Cavalry Sub-type:" hidden="false" targetId="6d79-a3e4-381f-7b0f" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="97b6-65f8-df73-9551" name="Legion Outriders" hidden="false" collective="false" import="true" type="model">
@@ -7440,6 +7472,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
     <selectionEntry id="c88b-fe44-34a3-97e1" name="Sicaran Omega Squadron" hidden="false" collective="false" import="true" type="unit">
       <categoryLinks>
         <categoryLink id="08b4-0dc4-d272-47f7" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="7ee1-e5c8-570a-223d" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="e11b-4170-0afd-b025" name="Sicaran Omega" hidden="false" collective="false" import="true" type="model">
@@ -7693,6 +7726,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
     <selectionEntry id="706a-9532-f06d-00ed" name="Sicaran Squadron" hidden="false" collective="false" import="true" type="unit">
       <categoryLinks>
         <categoryLink id="5fe4-5ce9-cf62-2d10" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="f060-128a-f58f-c334" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="e229-745c-0b62-4472" name="Sicaran " hidden="false" collective="false" import="true" type="model">
@@ -8042,6 +8076,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
         <categoryLink id="1163-32f2-db8f-454d" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
         <categoryLink id="dc9f-873e-9fc8-ea6f" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="9d9d-6ddd-12f8-5e6f" name="Deep Strike:" hidden="false" targetId="0d4f-ff28-d819-a512" primary="false"/>
+        <categoryLink id="cec9-0cba-c60c-7a82" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="52b1-1b7c-90bf-eed2" name="Legion Fire Raptor Gunship" hidden="false" collective="false" import="true" type="model">
@@ -8394,6 +8429,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
       </infoLinks>
       <categoryLinks>
         <categoryLink id="243d-5b6e-2794-2a35" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="2a7a-c446-f5fa-4eed" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="b727-c8cf-cc17-d0b1" name="Pintle Mounted Twin-linked Bolter" hidden="false" collective="false" import="true" type="upgrade">
@@ -8797,6 +8833,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
       </infoLinks>
       <categoryLinks>
         <categoryLink id="d675-3186-3f30-b772" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="3856-c687-8257-b20c" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="ede9-4deb-570d-70c0" name="Termite Assault Drill" hidden="false" collective="false" import="true" type="model">
@@ -9376,6 +9413,10 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
       </costs>
     </selectionEntry>
     <selectionEntry id="bac1-f30e-2c04-d27d" name="Land Raider Spartan" publicationId="a716-c1c4-7b26-8424" hidden="false" collective="false" import="true" type="unit">
+      <categoryLinks>
+        <categoryLink id="6d48-bea4-6fac-1463" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="9c02-a9fe-a9c9-039f" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
+      </categoryLinks>
       <selectionEntries>
         <selectionEntry id="305c-37ae-3cda-349b" name="Land Raider Spartan" hidden="false" collective="false" import="true" type="model">
           <constraints>
@@ -9402,6 +9443,9 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
             <infoLink id="12c9-5cb0-62dc-c628" name="Assault Vehicle" hidden="false" targetId="aa61-11f6-2bb5-7c0e" type="rule"/>
             <infoLink id="5aa5-4dd4-8efb-210f" name="Power of the Machine Spirit" hidden="false" targetId="5a93-13e0-809d-782a" type="rule"/>
           </infoLinks>
+          <categoryLinks>
+            <categoryLink id="d5ba-65fa-1d63-2df7" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+          </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="d1f4-6aec-65e6-1071" name="Two Sponson Mounted Weapons:" hidden="false" collective="false" import="true" defaultSelectionEntryId="84eb-ea1a-f49b-f9d2">
               <constraints>
@@ -9658,8 +9702,43 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
           </conditions>
         </modifier>
       </modifiers>
+      <categoryLinks>
+        <categoryLink id="555c-4c0c-29a0-082a" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+      </categoryLinks>
       <selectionEntries>
         <selectionEntry id="d862-5767-da41-cff0" name="Legion Praetor" hidden="false" collective="false" import="true" type="model">
+          <modifiers>
+            <modifier type="add" field="category" value="8b4f-bfe2-ce7b-f1b1">
+              <conditionGroups>
+                <conditionGroup type="and">
+                  <conditions>
+                    <condition field="selections" scope="d862-5767-da41-cff0" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6fb4-adf6-dbe8-86af" type="equalTo"/>
+                    <condition field="selections" scope="d862-5767-da41-cff0" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e8a8-b526-beab-bb82" type="equalTo"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+            <modifier type="add" field="category" value="6d79-a3e4-381f-7b0f">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="d862-5767-da41-cff0" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e8a8-b526-beab-bb82" type="equalTo"/>
+                    <condition field="selections" scope="d862-5767-da41-cff0" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6fb4-adf6-dbe8-86af" type="equalTo"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+            <modifier type="add" field="category" value="eee8-3c7c-2762-e33e">
+              <conditions>
+                <condition field="selections" scope="d862-5767-da41-cff0" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a298-8584-70ed-18ce" type="equalTo"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="9231-183c-b97b-63f9">
+              <conditions>
+                <condition field="selections" scope="d862-5767-da41-cff0" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0c0f-f751-cc4e-4951" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9e1a-a8bc-1c40-3dca" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4b3c-ec8d-3ad5-bcff" type="max"/>
@@ -9791,15 +9870,8 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                   </costs>
                 </entryLink>
                 <entryLink id="a5ef-e7a2-a480-3f5a" name="Boarding Shield" hidden="false" collective="false" import="true" targetId="0c0f-f751-cc4e-4951" type="selectionEntry">
-                  <modifiers>
-                    <modifier type="set" field="hidden" value="true">
-                      <conditions>
-                        <condition field="selections" scope="d862-5767-da41-cff0" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0c0f-f751-cc4e-4951" type="atLeast"/>
-                      </conditions>
-                    </modifier>
-                  </modifiers>
                   <constraints>
-                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2e31-567f-8c8f-4fe4" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2e31-567f-8c8f-4fe4" type="max"/>
                   </constraints>
                 </entryLink>
                 <entryLink id="4d91-5262-e11e-a82a" name="Paragon Blade" hidden="false" collective="false" import="true" targetId="2ab9-0e45-405e-056b" type="selectionEntry">
@@ -10259,6 +10331,11 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
       </costs>
     </selectionEntry>
     <selectionEntry id="1b79-1951-5a63-4b9e" name="Praetor, Cataphractii" hidden="false" collective="false" import="true" type="unit">
+      <categoryLinks>
+        <categoryLink id="e1e8-360b-92f0-10e3" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+        <categoryLink id="e6ff-3685-f0a8-be34" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="a60b-1cf4-5ab4-bbff" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+      </categoryLinks>
       <selectionEntries>
         <selectionEntry id="de73-2d79-156f-6f64" name="Legion Cataphractii Praetor" hidden="false" collective="false" import="true" type="model">
           <modifiers>
@@ -10470,6 +10547,10 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
       </costs>
     </selectionEntry>
     <selectionEntry id="3760-204e-444c-1044" name="Praetor, Tartaros" hidden="false" collective="false" import="true" type="unit">
+      <categoryLinks>
+        <categoryLink id="9d49-2d09-dd7c-30c3" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="5225-7937-685c-e9db" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+      </categoryLinks>
       <selectionEntries>
         <selectionEntry id="a2f0-15d9-2b7a-2204" name="Legion Tartaros Praetor" hidden="false" collective="false" import="true" type="model">
           <modifiers>
@@ -10810,6 +10891,36 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
             <modifier type="set" field="name" value="Diabolist">
               <conditions>
                 <condition field="selections" scope="25a2-7a52-632a-6b2c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4e1a-275e-e691-5b92" type="equalTo"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="6d79-a3e4-381f-7b0f">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="c681-938e-6d11-cd43" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6fb4-adf6-dbe8-86af" type="equalTo"/>
+                    <condition field="selections" scope="c681-938e-6d11-cd43" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e8a8-b526-beab-bb82" type="equalTo"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+            <modifier type="add" field="category" value="8b4f-bfe2-ce7b-f1b1">
+              <conditionGroups>
+                <conditionGroup type="and">
+                  <conditions>
+                    <condition field="selections" scope="c681-938e-6d11-cd43" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e8a8-b526-beab-bb82" type="equalTo"/>
+                    <condition field="selections" scope="c681-938e-6d11-cd43" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6fb4-adf6-dbe8-86af" type="equalTo"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+            <modifier type="add" field="category" value="9231-183c-b97b-63f9">
+              <conditions>
+                <condition field="selections" scope="25a2-7a52-632a-6b2c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0c0f-f751-cc4e-4951" type="atLeast"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="eee8-3c7c-2762-e33e">
+              <conditions>
+                <condition field="selections" scope="c681-938e-6d11-cd43" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a298-8584-70ed-18ce" type="equalTo"/>
               </conditions>
             </modifier>
           </modifiers>
@@ -11686,7 +11797,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
-        <entryLink id="81e6-b38c-8fb0-59c2" name="0) Legiones Consularis" hidden="false" collective="false" import="true" targetId="3cbf-9466-2558-2c22" type="selectionEntryGroup"/>
+        <entryLink id="81e6-b38c-8fb0-59c2" name=" Legiones Consularis" hidden="false" collective="false" import="true" targetId="3cbf-9466-2558-2c22" type="selectionEntryGroup"/>
         <entryLink id="078b-68aa-45b8-07e1" name="Warlord" hidden="false" collective="false" import="true" targetId="0176-56a3-d590-b103" type="selectionEntry">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
@@ -11704,7 +11815,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4294-41c2-9b8c-5a9a" type="max"/>
           </constraints>
         </entryLink>
-        <entryLink id="ef5f-4571-be9d-968e" name="0) Consul Additional Wargear and Options" hidden="false" collective="false" import="true" targetId="244a-2a7c-1349-94e7" type="selectionEntryGroup"/>
+        <entryLink id="ef5f-4571-be9d-968e" name=" Consul Additional Wargear and Options" hidden="false" collective="false" import="true" targetId="244a-2a7c-1349-94e7" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
@@ -11720,6 +11831,11 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
         <infoLink id="f8ab-cf6d-9da3-5a91" name="Inexorable" hidden="false" targetId="d863-8a5e-ddb6-d5a4" type="rule"/>
         <infoLink id="c405-ddd9-40d3-5b72" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule"/>
       </infoLinks>
+      <categoryLinks>
+        <categoryLink id="9c7a-acc7-9230-fcc4" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="6901-e4b0-c5cc-a02b" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="a872-59ee-deae-90b7" name="Terminators:" hidden="false" targetId="bab3-f50d-3e5f-2f78" primary="false"/>
+      </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="87b7-091d-4bc3-9164" name="One Legion Tartaros may take:" hidden="false" collective="false" import="true">
           <entryLinks>
@@ -12176,6 +12292,12 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
           </modifiers>
         </infoLink>
       </infoLinks>
+      <categoryLinks>
+        <categoryLink id="a545-688e-0342-1a55" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="d924-8839-45ef-d725" name="Terminators:" hidden="false" targetId="bab3-f50d-3e5f-2f78" primary="false"/>
+        <categoryLink id="30ff-487a-51ee-62ce" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="8cc9-9b8f-dc8b-183f" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+      </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="b908-ada3-76ab-8d4d" name="2) One Legion Cataphractii may take:" hidden="false" collective="false" import="true">
           <entryLinks>
@@ -13818,6 +13940,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
       <categoryLinks>
         <categoryLink id="ebd3-8853-ca06-24e5" name="New CategoryLink" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="d5a1-47f5-0e3c-716d" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="ad69-ee1e-ec47-c17e" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="8725-b9d1-1e86-0364" name="0) Legion Breacher Sergeant" hidden="false" collective="false" import="true" type="model">
@@ -15027,12 +15150,19 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
       </costs>
     </selectionEntry>
     <selectionEntry id="b6cd-dd1a-6b2c-41d6" name="Land Raider Proteus Carrier Squadron" publicationId="a716-c1c4-7b26-8424" hidden="false" collective="false" import="true" type="unit">
+      <categoryLinks>
+        <categoryLink id="6ca2-562a-dfaa-1587" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="b6b7-ab3c-3390-4f3f" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
+      </categoryLinks>
       <entryLinks>
         <entryLink id="9957-bf01-9adf-6e12" name="Land Raider Proteus Carrier" hidden="false" collective="false" import="true" targetId="c123-bdc6-a6ba-79a2" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4e0c-5277-704f-309a" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="8134-cef0-54f5-59dd" type="min"/>
           </constraints>
+          <categoryLinks>
+            <categoryLink id="7b2a-2caf-531a-d3e9" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+          </categoryLinks>
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="205.0"/>
           </costs>
@@ -15045,7 +15175,15 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
     </selectionEntry>
     <selectionEntry id="6db7-6e88-877e-35ca" name="Reconnaissance Squad" hidden="false" collective="false" import="true" type="unit">
       <infoLinks>
-        <infoLink id="9660-4ebf-fe5a-7582" name="Support Squad" hidden="false" targetId="768e-56d6-ca52-24ae" type="rule"/>
+        <infoLink id="9660-4ebf-fe5a-7582" name="Support Squad" hidden="false" targetId="768e-56d6-ca52-24ae" type="rule">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
         <infoLink id="e99b-20d4-2063-3040" name="Infiltrate" hidden="false" targetId="0e32-5b92-a95a-8464" type="rule"/>
         <infoLink id="7a21-fcdd-adae-34b8" name="Scout" hidden="false" targetId="aacf-9a7e-982d-b793" type="rule"/>
       </infoLinks>
@@ -15613,7 +15751,15 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
         <infoLink id="1e59-9bd4-20c6-6183" name="Scout" hidden="false" targetId="aacf-9a7e-982d-b793" type="rule"/>
         <infoLink id="3ae1-247d-2b45-ed67" name="Infiltrate" hidden="false" targetId="0e32-5b92-a95a-8464" type="rule"/>
         <infoLink id="0b0b-5b2f-efae-3df1" name="Move Through Cover" hidden="false" targetId="2b6f-bfec-759e-1746" type="rule"/>
-        <infoLink id="7ec2-fc4e-5d86-fb0f" name="Support Squad" hidden="false" targetId="768e-56d6-ca52-24ae" type="rule"/>
+        <infoLink id="7ec2-fc4e-5d86-fb0f" name="Support Squad" hidden="false" targetId="768e-56d6-ca52-24ae" type="rule">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="1b9e-4e93-3914-a6e1" name="New CategoryLink" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
@@ -16169,6 +16315,33 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
       </costs>
     </selectionEntry>
     <selectionEntry id="0aca-632d-1642-8af9" name="Command Squad" publicationId="a716-c1c4-7b26-8424" hidden="false" collective="false" import="true" type="unit">
+      <modifiers>
+        <modifier type="add" field="category" value="6d79-a3e4-381f-7b0f">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="0aca-632d-1642-8af9" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e8a8-b526-beab-bb82" type="equalTo"/>
+                <condition field="selections" scope="0aca-632d-1642-8af9" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6fb4-adf6-dbe8-86af" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+        <modifier type="add" field="category" value="eee8-3c7c-2762-e33e">
+          <conditions>
+            <condition field="selections" scope="0aca-632d-1642-8af9" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a298-8584-70ed-18ce" type="equalTo"/>
+          </conditions>
+        </modifier>
+        <modifier type="add" field="category" value="8b4f-bfe2-ce7b-f1b1">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition field="selections" scope="0aca-632d-1642-8af9" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6fb4-adf6-dbe8-86af" type="equalTo"/>
+                <condition field="selections" scope="0aca-632d-1642-8af9" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e8a8-b526-beab-bb82" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <infoLinks>
         <infoLink id="02d5-3877-a9dc-a549" name="Chosen Warriors" hidden="false" targetId="13d1-9270-6539-08ed" type="rule"/>
         <infoLink id="9572-c1be-441e-b2ec" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule"/>
@@ -16176,10 +16349,16 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
       </infoLinks>
       <categoryLinks>
         <categoryLink id="3e96-ebb7-ea5c-1f67" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="8430-1e9e-bcd9-21cb" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="514d-d9f2-5e0a-c62a" name="Legion Chosen" publicationId="a716-c1c4-7b26-8424" hidden="false" collective="false" import="true" type="model">
+          <modifiers>
+            <modifier type="add" field="category" value="9231-183c-b97b-63f9">
+              <conditions>
+                <condition field="selections" scope="0aca-632d-1642-8af9" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0c0f-f751-cc4e-4951" type="atLeast"/>
+              </conditions>
+            </modifier>
+          </modifiers>
           <constraints>
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0f7c-9597-1d77-df46" type="min"/>
             <constraint field="selections" scope="parent" value="8.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9ca8-9586-fdbb-7423" type="max"/>
@@ -16411,6 +16590,13 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
           </costs>
         </selectionEntry>
         <selectionEntry id="1b1c-a109-a237-bad8" name="Legion Standard Bearer" publicationId="a716-c1c4-7b26-8424" hidden="false" collective="false" import="true" type="model">
+          <modifiers>
+            <modifier type="add" field="category" value="9231-183c-b97b-63f9">
+              <conditions>
+                <condition field="selections" scope="0aca-632d-1642-8af9" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0c0f-f751-cc4e-4951" type="atLeast"/>
+              </conditions>
+            </modifier>
+          </modifiers>
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6a0a-6f12-8ae4-77cd" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3e1c-7762-cad0-30fe" type="max"/>
@@ -18457,6 +18643,34 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="415c-6834-f4d2-d967" name="Apothecary" publicationId="a716-c1c4-7b26-8424" hidden="false" collective="false" import="true" type="model">
+          <modifiers>
+            <modifier type="add" field="category" value="6d79-a3e4-381f-7b0f">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="415c-6834-f4d2-d967" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6fb4-adf6-dbe8-86af" type="equalTo"/>
+                    <condition field="selections" scope="415c-6834-f4d2-d967" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e8a8-b526-beab-bb82" type="equalTo"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+            <modifier type="add" field="category" value="eee8-3c7c-2762-e33e">
+              <conditions>
+                <condition field="selections" scope="415c-6834-f4d2-d967" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a298-8584-70ed-18ce" type="equalTo"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="8b4f-bfe2-ce7b-f1b1">
+              <conditionGroups>
+                <conditionGroup type="and">
+                  <conditions>
+                    <condition field="selections" scope="415c-6834-f4d2-d967" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a298-8584-70ed-18ce" type="equalTo"/>
+                    <condition field="selections" scope="415c-6834-f4d2-d967" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6fb4-adf6-dbe8-86af" type="equalTo"/>
+                    <condition field="selections" scope="415c-6834-f4d2-d967" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e8a8-b526-beab-bb82" type="equalTo"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="82ba-ef67-8481-b3f6" type="min"/>
             <constraint field="selections" scope="parent" value="7.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="aed5-305a-f104-74d5" type="max"/>
@@ -18660,6 +18874,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
       </infoLinks>
       <categoryLinks>
         <categoryLink id="13fc-715d-8968-5d54" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="129e-3d72-2602-afcd" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="53c3-7eec-4676-996e" name="Legion Seeker" hidden="false" collective="false" import="true" type="model">
@@ -19254,6 +19469,38 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="fc32-089e-1c59-70bd" name="Techmarine" publicationId="a716-c1c4-7b26-8424" hidden="false" collective="false" import="true" type="model">
+          <modifiers>
+            <modifier type="add" field="category" value="8b4f-bfe2-ce7b-f1b1">
+              <conditionGroups>
+                <conditionGroup type="and">
+                  <conditions>
+                    <condition field="selections" scope="fc32-089e-1c59-70bd" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6fb4-adf6-dbe8-86af" type="equalTo"/>
+                    <condition field="selections" scope="fc32-089e-1c59-70bd" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e8a8-b526-beab-bb82" type="equalTo"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+            <modifier type="add" field="category" value="6d79-a3e4-381f-7b0f">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="fc32-089e-1c59-70bd" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e8a8-b526-beab-bb82" type="equalTo"/>
+                    <condition field="selections" scope="fc32-089e-1c59-70bd" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6fb4-adf6-dbe8-86af" type="equalTo"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+            <modifier type="add" field="category" value="eee8-3c7c-2762-e33e">
+              <conditions>
+                <condition field="selections" scope="fc32-089e-1c59-70bd" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a298-8584-70ed-18ce" type="equalTo"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="9231-183c-b97b-63f9">
+              <conditions>
+                <condition field="selections" scope="fc32-089e-1c59-70bd" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0c0f-f751-cc4e-4951" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cc3e-d2ef-58cf-da34" type="min"/>
             <constraint field="selections" scope="parent" value="8.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e93f-befc-bf06-3edd" type="max"/>
@@ -19741,7 +19988,6 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
     <selectionEntry id="f806-8a4e-d0d6-beaa" name="Centurion, Tartaros " publicationId="a716-c1c4-7b26-8424" hidden="false" collective="false" import="true" type="unit">
       <categoryLinks>
         <categoryLink id="cccf-e162-2ea4-885a" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="ef44-0d1e-aaaf-9f04" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
         <categoryLink id="1237-8d7a-91b2-1565" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="9db9-a73f-ccf4-06a3" name="Terminators:" hidden="false" targetId="bab3-f50d-3e5f-2f78" primary="false"/>
       </categoryLinks>
@@ -21482,6 +21728,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
       <categoryLinks>
         <categoryLink id="ad0e-b2d4-1566-3b4a" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="a940-6e68-996d-f176" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
+        <categoryLink id="8cda-e93d-10a1-8cbc" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="94f8-f071-903e-a4f9" name="2) Pintle mounted Weapon:" hidden="false" collective="false" import="true">
@@ -22300,6 +22547,11 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
         </infoLink>
         <infoLink id="ca09-f724-2cbe-f6c1" name="Retinue" hidden="false" targetId="6b79-ac44-4d89-2124" type="rule"/>
       </infoLinks>
+      <categoryLinks>
+        <categoryLink id="2b45-00e1-5c3d-c2e5" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="c33e-fa91-93da-9bc9" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+        <categoryLink id="d4ab-bc77-4c9d-1887" name="Terminators:" hidden="false" targetId="bab3-f50d-3e5f-2f78" primary="false"/>
+      </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="9fa9-d220-698d-8220" name="Dedicated Transport" hidden="false" collective="false" import="true">
           <constraints>
@@ -23082,6 +23334,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
       </infoLinks>
       <categoryLinks>
         <categoryLink id="5af8-d955-210c-10a3" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="ef93-17f4-c267-1520" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="f021-2e22-98b8-3772" name="Sabre" hidden="false" collective="false" import="true" type="model">
@@ -23104,6 +23357,9 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
               </characteristics>
             </profile>
           </profiles>
+          <categoryLinks>
+            <categoryLink id="5101-eca4-4a32-4c77" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+          </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="6261-4456-2d7b-82b0" name="1) Centreline Mounted Weapon" hidden="false" collective="false" import="true">
               <constraints>
@@ -23293,6 +23549,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
       </infoLinks>
       <categoryLinks>
         <categoryLink id="6b9a-cce1-8d40-60e4" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="c641-0dd3-091e-e12d" name="Cavalry Sub-type:" hidden="false" targetId="6d79-a3e4-381f-7b0f" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="d0b2-a77a-a4f4-0ae1" name="Legion Sky-Hunter" hidden="false" collective="false" import="true" type="model">
@@ -23585,6 +23842,8 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
       </infoLinks>
       <categoryLinks>
         <categoryLink id="3221-f712-3792-f219" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="3d58-a8ec-020b-21cf" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
+        <categoryLink id="d133-87ac-1427-324e" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="1d23-3f85-0a01-95b9" name="Hull (Front) Mounted Vengeance launcher" hidden="false" collective="false" import="true" type="upgrade">
@@ -23720,6 +23979,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
       <categoryLinks>
         <categoryLink id="4520-160b-f580-ec31" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="faad-a55f-fe5f-79ba" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
+        <categoryLink id="c58b-a48e-6286-c40d" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="68ac-5612-184b-904d" name="Hull (Front) Mounted Rotary Missile Launcher" hidden="false" collective="false" import="true" type="upgrade">
@@ -23807,6 +24067,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
       </infoLinks>
       <categoryLinks>
         <categoryLink id="1412-8efa-2452-8bc5" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="29bc-6a15-b80d-6d8a" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="e6da-2d8a-93c6-16fc" name="Proteus Land Speeder" publicationId="a716-c1c4-7b26-8424" page="61" hidden="false" collective="false" import="true" type="model">
@@ -23838,6 +24099,9 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
               </characteristics>
             </profile>
           </profiles>
+          <categoryLinks>
+            <categoryLink id="04bb-9232-6cae-47f2" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+          </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="f24c-7b68-d78c-11e2" name="1) Heavy Bolter Options" hidden="false" collective="false" import="true" defaultSelectionEntryId="e8ee-9957-bb72-3155">
               <constraints>
@@ -24041,6 +24305,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
       </infoLinks>
       <categoryLinks>
         <categoryLink id="75e1-504c-336a-7c0a" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="f730-f34b-420b-afc6" name="Cavalry Sub-type:" hidden="false" targetId="6d79-a3e4-381f-7b0f" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="f498-772c-158e-206f" name="Javelin Land Speeder" hidden="false" collective="false" import="true" type="model">
@@ -24245,12 +24510,19 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
         <infoLink id="e4a6-3e1b-b7ee-eacf" name="Legiones Astartes (X)" hidden="false" targetId="61cf-75c2-56cd-2a31" type="rule"/>
         <infoLink id="a976-a8c0-c396-da7f" name="Reactor Blast" hidden="false" targetId="85c2-d84d-6a4f-ab64" type="rule"/>
       </infoLinks>
+      <categoryLinks>
+        <categoryLink id="86d3-3093-9f34-edee" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="1dad-6367-e309-77a9" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
+      </categoryLinks>
       <selectionEntries>
         <selectionEntry id="8547-be6e-bfb0-60b3" name="Cerberus" hidden="false" collective="false" import="true" type="model">
           <constraints>
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bc94-14df-61dd-2696" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="21d5-7bca-f689-6180" type="min"/>
           </constraints>
+          <categoryLinks>
+            <categoryLink id="3c86-f984-9801-c6ad" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+          </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="6c2c-6557-be98-903a" name="May take:" hidden="false" collective="false" import="true">
               <selectionEntries>
@@ -24486,6 +24758,10 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
         <infoLink id="b4de-2db4-32dd-e5fd" name="Legiones Astartes (X)" hidden="false" targetId="61cf-75c2-56cd-2a31" type="rule"/>
         <infoLink id="195a-ea3e-6ddd-377e" name="Crushing Weight" hidden="false" targetId="9eb0-9165-e000-818a" type="rule"/>
       </infoLinks>
+      <categoryLinks>
+        <categoryLink id="fe38-80b1-1c38-1590" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
+        <categoryLink id="85a4-3c3e-2fc2-7234" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+      </categoryLinks>
       <selectionEntries>
         <selectionEntry id="f16c-c9da-4006-35ae" name="Typhon" hidden="false" collective="false" import="true" type="model">
           <constraints>
@@ -24507,6 +24783,9 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
               </characteristics>
             </profile>
           </profiles>
+          <categoryLinks>
+            <categoryLink id="c3fb-b663-3e8c-fac8" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+          </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="8ebc-e1b7-eee0-81bc" name="May take:" hidden="false" collective="false" import="true">
               <selectionEntries>
@@ -24759,6 +25038,11 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
       <infoLinks>
         <infoLink id="07a8-da6b-c28a-8a71" name="Legiones Astartes (X)" hidden="false" targetId="61cf-75c2-56cd-2a31" type="rule"/>
       </infoLinks>
+      <categoryLinks>
+        <categoryLink id="704b-3891-a51f-3057" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="ae99-700e-db56-fc27" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
+        <categoryLink id="7852-636a-6edc-9978" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+      </categoryLinks>
       <selectionEntries>
         <selectionEntry id="fc06-c710-470b-99ae" name="Turret Mounted volkite carronade" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
@@ -25064,6 +25348,10 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
         <infoLink id="0505-3d1c-8d9f-1105" name="Transport Bay" hidden="false" targetId="0662-8b8d-38e8-60f8" type="rule"/>
         <infoLink id="81ed-9d7b-eeed-9e1d" name="Power of the Machine Spirit" hidden="false" targetId="5a93-13e0-809d-782a" type="rule"/>
       </infoLinks>
+      <categoryLinks>
+        <categoryLink id="cca7-c9fd-447a-36c2" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+        <categoryLink id="ccb4-5b60-80ac-4a82" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
+      </categoryLinks>
       <selectionEntries>
         <selectionEntry id="8a23-6541-e864-1e40" name="Two Turret Mounted heavy bolters" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
@@ -25569,6 +25857,11 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
         </infoLink>
         <infoLink id="a310-4590-e65c-62ca" name="Legiones Astartes (X)" hidden="false" targetId="61cf-75c2-56cd-2a31" type="rule"/>
       </infoLinks>
+      <categoryLinks>
+        <categoryLink id="88d9-9034-d534-b855" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="fd9e-c13c-b241-9b51" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
+        <categoryLink id="231c-19d1-0097-c872" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+      </categoryLinks>
       <selectionEntries>
         <selectionEntry id="486e-36c1-d7ea-2f90" name="Two Sponson Mounted lascannon" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
@@ -25721,6 +26014,11 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
       <infoLinks>
         <infoLink id="15a8-a5e0-f032-b2a3" name="Legiones Astartes (X)" hidden="false" targetId="61cf-75c2-56cd-2a31" type="rule"/>
       </infoLinks>
+      <categoryLinks>
+        <categoryLink id="3f32-f85a-9a93-cf46" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="f2ce-ce8c-5b2a-e655" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
+        <categoryLink id="494f-55cb-75d9-3608" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+      </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="5d20-b6dc-ff35-54d2" name="Sponson Weapon Options" hidden="false" collective="false" import="true" defaultSelectionEntryId="2109-dd9f-a792-edf4">
           <constraints>
@@ -26230,6 +26528,11 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
       <infoLinks>
         <infoLink id="f8fe-6717-2851-61cb" name="Legiones Astartes (X)" hidden="false" targetId="61cf-75c2-56cd-2a31" type="rule"/>
       </infoLinks>
+      <categoryLinks>
+        <categoryLink id="4346-61f7-6ddb-7db4" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="0163-3f12-80b9-2221" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
+        <categoryLink id="eb3d-4f92-8ccb-b662" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+      </categoryLinks>
       <selectionEntries>
         <selectionEntry id="c431-f201-a8d6-f155" name="Hull (Front) Mounted volcano cannon" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
@@ -26455,6 +26758,10 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
         <infoLink id="d071-7a4b-dce8-1467" name="Assault Vehicle" hidden="false" targetId="aa61-11f6-2bb5-7c0e" type="rule"/>
         <infoLink id="cd13-f4ef-53ed-22cd" name="Power of the Machine Spirit" hidden="false" targetId="5a93-13e0-809d-782a" type="rule"/>
       </infoLinks>
+      <categoryLinks>
+        <categoryLink id="c823-b87e-dfcc-925b" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+        <categoryLink id="8775-c7f6-d071-55c9" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+      </categoryLinks>
       <selectionEntries>
         <selectionEntry id="abe9-4c40-4438-185a" name="Two Sponson Mounted Gravis Lascannon" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
@@ -26667,9 +26974,14 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
           </repeats>
         </modifier>
         <modifier type="increment" field="1882-f7ef-7aa3-5304" value="1.0">
-          <conditions>
-            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="equalTo"/>
-          </conditions>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="equalTo"/>
+                <condition field="d2ee-04cb-5f8a-2642" scope="roster" value="1000.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="any" type="lessThan"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
         </modifier>
       </modifiers>
       <constraints>
@@ -26683,6 +26995,10 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
       </costs>
     </selectionEntry>
     <selectionEntry id="23e4-c64b-65b4-c8a5" name="Rapier Battery" hidden="false" collective="false" import="true" type="unit">
+      <categoryLinks>
+        <categoryLink id="6beb-8854-14dd-3db9" name="Artillery Sub-type:" hidden="false" targetId="6f99-c178-6f9d-fb63" primary="false"/>
+        <categoryLink id="fbe0-eca3-2aa2-eecc" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+      </categoryLinks>
       <selectionEntries>
         <selectionEntry id="925b-d3f3-4d4c-fe67" name="Rapier Carrier (&amp; Gunners)" hidden="false" collective="false" import="true" type="unit">
           <constraints>
@@ -26964,6 +27280,11 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
         <infoLink id="c4c0-ddb6-6c5a-f668" name="Stubborn" hidden="false" targetId="7989-1f2c-a43d-82ae" type="rule"/>
         <infoLink id="4036-b363-6d45-9825" name="Hexagrammatic Wards" hidden="false" targetId="5529-bb7a-9448-b1f5" type="rule"/>
       </infoLinks>
+      <categoryLinks>
+        <categoryLink id="ab57-875b-98c5-7677" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="f0cb-e19d-2d73-aa3f" name="Terminators:" hidden="false" targetId="bab3-f50d-3e5f-2f78" primary="false"/>
+        <categoryLink id="a888-0301-9c87-ae58" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+      </categoryLinks>
       <selectionEntries>
         <selectionEntry id="0740-a851-4e97-fced" name="Nullificator" hidden="false" collective="false" import="true" type="model">
           <constraints>
@@ -27155,6 +27476,9 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
       <infoLinks>
         <infoLink id="a87a-f9bb-ddda-a09b" name="Dreadnought Talon" hidden="false" targetId="a924-2634-73fd-aa96" type="rule"/>
       </infoLinks>
+      <categoryLinks>
+        <categoryLink id="9cb2-ea17-2bc6-e904" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+      </categoryLinks>
       <selectionEntries>
         <selectionEntry id="5524-7631-a4d9-9cf9" name="Castra Ferrum Dreadnought" hidden="false" collective="false" import="true" type="model">
           <constraints>
@@ -27216,6 +27540,9 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
               </characteristics>
             </profile>
           </profiles>
+          <categoryLinks>
+            <categoryLink id="f292-0604-29fa-a71e" name="Dreadnought Unit-type:" hidden="false" targetId="4280-4963-02b5-e31d" primary="false"/>
+          </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="cdb1-bf93-df94-2bf9" name="4) May take:" hidden="false" collective="false" import="true">
               <constraints>
@@ -27478,6 +27805,12 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
         <infoLink id="000f-9e04-08d3-63aa" name="Support Squad" hidden="false" targetId="768e-56d6-ca52-24ae" type="rule"/>
         <infoLink id="f2fa-16dd-9ff8-3933" name="Legiones Astartes (X)" hidden="false" targetId="61cf-75c2-56cd-2a31" type="rule"/>
       </infoLinks>
+      <categoryLinks>
+        <categoryLink id="b6c0-167e-21e2-2f1a" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="ba6c-bb79-909d-33f1" name="Terminators:" hidden="false" targetId="bab3-f50d-3e5f-2f78" primary="false"/>
+        <categoryLink id="0a43-ec27-0c1e-4c5b" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="5ff7-87f5-f921-d1c4" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+      </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="23e2-4e21-6229-2444" name="3) One Legion Indomitus may take:" hidden="false" collective="false" import="true">
           <entryLinks>
@@ -28832,6 +29165,11 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
         <infoLink id="141f-f300-6f10-9d89" name="Assault Vehicle" hidden="false" targetId="aa61-11f6-2bb5-7c0e" type="rule"/>
         <infoLink id="93ba-565b-dbbd-1e06" name="Legiones Astartes (X)" hidden="false" targetId="61cf-75c2-56cd-2a31" type="rule"/>
       </infoLinks>
+      <categoryLinks>
+        <categoryLink id="058b-6702-8234-f0ed" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="7c45-ee7e-6400-4d51" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
+        <categoryLink id="cc66-00ce-9e49-e357" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+      </categoryLinks>
       <selectionEntries>
         <selectionEntry id="50f2-4e31-2b38-674a" name="Turret Mounted Deathstorm Missile Launcher" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
@@ -28879,6 +29217,8 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
     <selectionEntry id="af13-fb4e-b792-61a3" name="Deathstorm Drop Pod Squadron" hidden="false" collective="false" import="true" type="unit">
       <categoryLinks>
         <categoryLink id="7f67-e0ca-2b9d-4b1c" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="false"/>
+        <categoryLink id="5d80-eb88-5146-595d" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
+        <categoryLink id="3d06-f7a7-200e-832c" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="386b-3c90-c349-97d8" name="Deathstorm Drop Pod" hidden="false" collective="false" import="true" type="model">
@@ -29338,8 +29678,8 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
         <infoLink id="3d13-aab1-b477-9ff8" name="The Emperor Protects" hidden="false" targetId="3379-5303-2e43-2925" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="95ec-1537-b93b-3d8c" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="false"/>
         <categoryLink id="04e3-a81a-89b2-5f49" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
+        <categoryLink id="793a-67fe-8731-7c9f" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="e353-952c-5733-c446" name="Libertas" hidden="false" collective="false" import="true" type="upgrade">
@@ -29462,9 +29802,9 @@ Garro is fighting in a Challenge</characteristic>
         <infoLink id="ea9c-10bd-f952-5ef1" name="The Emperor Protects" hidden="false" targetId="3379-5303-2e43-2925" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="d242-a40e-bed7-3bd2" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="false"/>
         <categoryLink id="b8cf-ff1a-662e-6f72" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
         <categoryLink id="e2a6-00ad-2796-c89b" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="0528-07cf-ec83-bdab" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="7a6e-ff13-9c39-ff1d" name="The Aegis Argentum" publicationId="d0df-7166-5cd3-89fd" page="7" hidden="false" collective="false" import="true" type="upgrade">
@@ -29571,6 +29911,11 @@ containing the model that failed its Check. If the Psyker survives Perils of the
       <infoLinks>
         <infoLink id="8cde-36cb-0589-e44b" name="Legiones Astartes (X)" hidden="false" targetId="61cf-75c2-56cd-2a31" type="rule"/>
       </infoLinks>
+      <categoryLinks>
+        <categoryLink id="12f4-8864-ab57-f9f9" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="c519-b6ff-7f40-4d69" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
+        <categoryLink id="7f7a-19de-90a2-4c95" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+      </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="a1ce-4972-035a-a620" name="Pintle mounted Weapon Options" hidden="false" collective="false" import="true">
           <constraints>
@@ -29754,6 +30099,11 @@ containing the model that failed its Check. If the Psyker survives Perils of the
       <infoLinks>
         <infoLink id="bc6a-8883-a0ff-e069" name="Legiones Astartes (X)" hidden="false" targetId="61cf-75c2-56cd-2a31" type="rule"/>
       </infoLinks>
+      <categoryLinks>
+        <categoryLink id="46f1-e90b-bf1d-882c" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="5f4a-4ffd-a8a7-2c3e" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
+        <categoryLink id="9823-f559-b33c-66e6" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+      </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="5734-cb77-82a2-59b9" name="Pintle mounted Weapon Options" hidden="false" collective="false" import="true">
           <constraints>
@@ -29955,6 +30305,11 @@ containing the model that failed its Check. If the Psyker survives Perils of the
       <infoLinks>
         <infoLink id="0645-24ef-aa12-a7c1" name="Legiones Astartes (X)" hidden="false" targetId="61cf-75c2-56cd-2a31" type="rule"/>
       </infoLinks>
+      <categoryLinks>
+        <categoryLink id="6730-3426-65c4-b313" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="2c58-a573-56d4-ec73" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
+        <categoryLink id="d6e3-8a15-0d26-6d93" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+      </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="41fe-3541-5ffc-4f29" name="Pintle mounted Weapon Options" hidden="false" collective="false" import="true">
           <constraints>
@@ -30178,6 +30533,11 @@ containing the model that failed its Check. If the Psyker survives Perils of the
       <infoLinks>
         <infoLink id="d357-62f4-00d0-a82a" name="Legiones Astartes (X)" hidden="false" targetId="61cf-75c2-56cd-2a31" type="rule"/>
       </infoLinks>
+      <categoryLinks>
+        <categoryLink id="3218-f8aa-2242-3c25" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
+        <categoryLink id="40ad-88a5-9830-de8c" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+        <categoryLink id="b90d-8751-2096-6845" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+      </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="ccea-9d02-b454-42c7" name="Pintle mounted Weapon Options" hidden="false" collective="false" import="true">
           <constraints>
@@ -30358,6 +30718,11 @@ containing the model that failed its Check. If the Psyker survives Perils of the
       <infoLinks>
         <infoLink id="7c7e-4763-9b30-e57e" name="Legiones Astartes (X)" hidden="false" targetId="61cf-75c2-56cd-2a31" type="rule"/>
       </infoLinks>
+      <categoryLinks>
+        <categoryLink id="0051-5fd8-4005-30c2" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="cb74-1081-9d7d-ec9c" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
+        <categoryLink id="c703-dfd8-1371-b64a" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+      </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="ae21-7282-6660-f3b6" name="Pintle mounted Weapon Options" hidden="false" collective="false" import="true">
           <constraints>
@@ -30540,6 +30905,9 @@ containing the model that failed its Check. If the Psyker survives Perils of the
       </profiles>
       <categoryLinks>
         <categoryLink id="e4bb-66e5-0a98-68ea" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+        <categoryLink id="5907-22d5-cb57-2222" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
+        <categoryLink id="1bfc-4442-f18b-c57b" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="f3aa-c912-cb85-0629" name="Bombard Sub-type:" hidden="false" targetId="d5df-57ac-8f3c-097b" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="b4f4-a12a-e7da-3341" name="Pintle mounted Weapon Options" hidden="false" collective="false" import="true">
@@ -30680,6 +31048,7 @@ containing the model that failed its Check. If the Psyker survives Perils of the
       <categoryLinks>
         <categoryLink id="22a2-27bf-4393-a373" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="5a1c-be86-80f6-e75a" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
+        <categoryLink id="3f93-8cb4-0e5b-5212" name="Bombard Sub-type:" hidden="false" targetId="d5df-57ac-8f3c-097b" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="8284-84eb-0766-e52a" name="Medusa" hidden="false" collective="false" import="true" type="model">
@@ -30857,6 +31226,7 @@ containing the model that failed its Check. If the Psyker survives Perils of the
       <categoryLinks>
         <categoryLink id="94ed-969e-a5ce-0329" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="0644-2894-5f41-865b" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
+        <categoryLink id="3f81-0762-9f6e-ad96" name="Bombard Sub-type:" hidden="false" targetId="d5df-57ac-8f3c-097b" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="22ac-4249-fe05-dbab" name="Basilisk" hidden="false" collective="false" import="true" type="model">
@@ -31053,6 +31423,7 @@ containing the model that failed its Check. If the Psyker survives Perils of the
       <categoryLinks>
         <categoryLink id="992a-101e-f1c0-2b6f" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="53cc-a648-20ea-e349" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
+        <categoryLink id="32f2-4ab0-d1cd-7cf0" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="711c-9e09-5b39-7922" name="Four Centerline (Front) Mounted Autocannon" hidden="false" collective="false" import="true" type="upgrade">
@@ -31190,6 +31561,7 @@ containing the model that failed its Check. If the Psyker survives Perils of the
       <categoryLinks>
         <categoryLink id="b39e-518d-9b15-bc14" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="56be-a381-5681-4467" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
+        <categoryLink id="2a64-c9fa-2381-f3f9" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="b870-bb30-dc67-fce8" name="Hull (Front) Mounted Avenger bolt cannon" hidden="false" collective="false" import="true" type="upgrade">
@@ -31344,6 +31716,7 @@ containing the model that failed its Check. If the Psyker survives Perils of the
       <categoryLinks>
         <categoryLink id="8d00-8a0b-d3d5-58a7" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="5822-e87b-5749-5a7d" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
+        <categoryLink id="ad65-dae6-bb16-edb5" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="c254-6dc7-a769-8eec" name="Two Centerline Mounted Lascannon" hidden="false" collective="false" import="true" type="upgrade">
@@ -31478,6 +31851,7 @@ containing the model that failed its Check. If the Psyker survives Perils of the
       </infoLinks>
       <categoryLinks>
         <categoryLink id="d336-17f0-8acd-e800" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="bca2-1860-4302-4477" name="Artillery Sub-type:" hidden="false" targetId="6f99-c178-6f9d-fb63" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="2d6c-d5b2-c713-2f69" name="All Tarantula Sentry Guns in the unit may take:" hidden="false" collective="false" import="true">
@@ -31766,6 +32140,10 @@ containing the model that failed its Check. If the Psyker survives Perils of the
       </costs>
     </selectionEntry>
     <selectionEntry id="681a-7426-96af-caac" name="Land Raider Phobos Squadron" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="b053-4b8e-8514-cb3f" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="c478-ab4e-1a65-2daa" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
+      </categoryLinks>
       <selectionEntries>
         <selectionEntry id="8bf3-9b8d-578a-38f1" name="Land Raider Phobos " hidden="false" collective="false" import="true" type="model">
           <constraints>
@@ -31793,6 +32171,7 @@ containing the model that failed its Check. If the Psyker survives Perils of the
           </infoLinks>
           <categoryLinks>
             <categoryLink id="2451-04e8-30e7-d5d0" name="Reinforced Sub-type:" hidden="false" targetId="9b0d-738c-10e4-4ec1" primary="false"/>
+            <categoryLink id="b08d-7960-6500-e359" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="3106-822e-0676-e9fa" name="2) Pintle mounted Weapon:" hidden="false" collective="false" import="true">
@@ -31993,6 +32372,10 @@ containing the model that failed its Check. If the Psyker survives Perils of the
       </costs>
     </selectionEntry>
     <selectionEntry id="4996-8971-603f-e2a2" name="Land Raider Achilles Squadron" hidden="false" collective="false" import="true" type="unit">
+      <categoryLinks>
+        <categoryLink id="29c9-1260-337f-9318" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="7cbe-d959-214a-a663" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
+      </categoryLinks>
       <selectionEntries>
         <selectionEntry id="b0f8-6c2c-125d-8805" name="Land Raider Achilles" hidden="false" collective="false" import="true" type="model">
           <constraints>
@@ -32029,6 +32412,7 @@ containing the model that failed its Check. If the Psyker survives Perils of the
           </infoLinks>
           <categoryLinks>
             <categoryLink id="c3af-f5d6-2210-9218" name="Reinforced Sub-type:" hidden="false" targetId="9b0d-738c-10e4-4ec1" primary="false"/>
+            <categoryLink id="8d73-a0a0-a804-6122" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
           </categoryLinks>
           <selectionEntries>
             <selectionEntry id="b44b-a321-7724-b2b6" name="1) Hull (Front) Mounted Achillus quad launcher" hidden="false" collective="false" import="true" type="upgrade">
@@ -32258,6 +32642,11 @@ containing the model that failed its Check. If the Psyker survives Perils of the
         <infoLink id="aa5f-e709-8881-62d4" name="Deep Strike" hidden="false" targetId="f1e1-986f-c783-ca9e" type="rule"/>
         <infoLink id="4ace-3c04-b51b-1c84" name="Assault Vehicle" hidden="false" targetId="aa61-11f6-2bb5-7c0e" type="rule"/>
       </infoLinks>
+      <categoryLinks>
+        <categoryLink id="7230-f0b9-a9e3-1a41" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="f4b6-841c-0647-e523" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
+        <categoryLink id="54c6-4521-16ef-9033" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+      </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="9efc-950b-d435-50ce" name="Havoc Launcher Options" hidden="false" collective="false" import="true" defaultSelectionEntryId="e050-2037-d90c-6db3">
           <constraints>
@@ -32305,6 +32694,7 @@ containing the model that failed its Check. If the Psyker survives Perils of the
     <selectionEntry id="36ed-ca59-0d95-d85c" name="Legion Macharius Heavy Tank Squadron" hidden="false" collective="false" import="true" type="unit">
       <categoryLinks>
         <categoryLink id="4740-ca67-2937-0722" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
+        <categoryLink id="901e-f757-8434-fc68" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="e41f-865b-9859-5eea" name="Macharius Heavy Tank" hidden="false" collective="false" import="true" type="model">
@@ -32582,6 +32972,7 @@ containing the model that failed its Check. If the Psyker survives Perils of the
     <selectionEntry id="6bf4-d9b2-127c-d477" name="Legion Minotaur Battery" hidden="false" collective="false" import="true" type="unit">
       <categoryLinks>
         <categoryLink id="ddec-50ef-3b4b-2ecc" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
+        <categoryLink id="21f1-ca40-79ab-4374" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="9b42-399b-151e-1aba" name="Minotaur" hidden="false" collective="false" import="true" type="model">
@@ -32694,6 +33085,7 @@ containing the model that failed its Check. If the Psyker survives Perils of the
     <selectionEntry id="528b-183f-5e27-8b0c" name="Legion Malcador Assault Tank Squadron" hidden="false" collective="false" import="true" type="unit">
       <categoryLinks>
         <categoryLink id="bd2a-3b6a-6bc2-faf2" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
+        <categoryLink id="0fbb-025e-4fde-5df9" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="5477-cc2b-ef70-878d" name="Malcador Assault Tank" hidden="false" collective="false" import="true" type="model">
@@ -34991,6 +35383,7 @@ During a Reaction made in any Phase, a player may not choose to activate a model
       <categoryLinks>
         <categoryLink id="c3d3-52b0-def7-592d" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="b857-6717-ae82-50fc" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="45c3-04df-2fcc-c0e5" name="Jump Infantry:" hidden="false" targetId="eee8-3c7c-2762-e33e" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="e6b7-06f3-c392-64c0" name="0) Legion Assault Sergeant" hidden="false" collective="false" import="true" type="model">
@@ -36055,6 +36448,7 @@ During a Reaction made in any Phase, a player may not choose to activate a model
       </infoLinks>
       <categoryLinks>
         <categoryLink id="ce73-ce2e-305f-269d" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="7aae-5c6b-5782-4d71" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="2515-c6a7-16d6-ac9e" name="0) Destroyer Sergeant" hidden="false" collective="false" import="true" type="model">


### PR DESCRIPTION
### DONE LIST (only took about 5-6hrs...)
Fix for Delegatus / MotL. – Added an additional “And” to the increment for Delegatus that the Force must be less than 1000pts for the increment for MotL to go up by 1.
This is because the rule only allows the MotL below 1000pts, rather than giving an additional MotL. So a 1500pts army could not have both a Delegatus and another MotL as both would have Master of the Legion.

Added Selection entry “Rite of War” to LA Roots
Added Min 1, Max 1 to Rite of War Root
Linked the SSEG “Rite of War” to the Root
Added modifier for “Set max 1 in parent to 0” with an “And” of Equal to 0 Primarch or Master of the Legion in force. 

Changed lots of stuff in LA and all 18 legions as many categories either missing or not correct.

Recon Company
* Recon and Scouts need “Support Squad” set hidden
* Recon and Scouts add compulsory Troops
* Add Legion Seekers Root for Troops (not compulsory troops)
* Remove Compulsory for Assault, Breacher, Despoiler, Recon, Tactical, Grey Stalker, Grey Slayer (and any other legion compulsory troop).

### TO DO LIST
For Recon Company - maybe “Hide” all units with “Heavy” for convenience of users

Angel's Wrath
Add Storm Eagle DT to all units able to take Rhino and hide rhino
Add Non-Flying Vehicle category to all non-flying vehicles.
IMPOSSIBLE TO DO! All infantry without jump packs need to be on a flying transport

Sky-Huner Phalanx
Sky-hunters and Proteus Land Speeders need Root for Troops & add compulsory Troops
Add Line category to Sky-hunters 
Add Non-Flying/Fast/Skimmer Vehicle category to all non-flying vehicles.
IMPOSSIBLE TO DO! All infantry must be embarked upon a model with both flyer and transport sub-type. Though could be made that vehicles like Land Raiders, Rhinos, Spartans and other ground dedicated transports are hidden from dedicated transports as well.
Drop Pod Assault
Add Legion Drop-pods and Dreadclaw Drop-pods DT to all units able to take Rhino or Land Raider, then and hide rhino and Land Raider.
Limit Dreadnought type units to Max 1 and make either Dreadclaw or Dreadnought Drop-pod compulsory.

Pride of the Legion
Add Root for Veterans, Cata Termy, Tart Termy for Troops (But do not add compulsory – See below)
Add tickbox to Veterans, Cata Termy, Tart Termy with a max based on how many compulsories the FoC has which if ticked gives them “Line” and “Compulsory Troops” only if ticked.
Add Root for any Elite Termy to make Troops (can add compulsory troop to these)
Underworld Assault
Add Termite Assault Drill DT to all units able to take Rhino and hide rhino.
Termite Assault Drill needs a Root for Fast Attack and Heavy support
IMPOSSIBLE TO DO! All units in a Detachment using this Rite of War that begin play on the battlefield and not in Reserve, gain the Stubborn special rule until the end of the turn in which any units assigned to a Subterranean Assault (see page 101) are deployed onto the battlefield.
IMPOSSIBLE TO DO! All Infantry units that do not have a version of the Bulky (X) special rule in a Detachment using this Rite of War must begin the battle Embarked on a Legion Termite Assault Drill.
IMPOSSIBLE TO DO! Any models selected as part of a Detachment using this Rite of War that are not Legion Termite Assault Drills, or Embarked on a Legion Termite Assault Drill, may not be placed into Reserve and cannot take part in any alternative deployments (such as Deep Strike Assaults or Flanking Assaults).

Armoured Spearhead
Add Land Raider Carrier DT to all units able to take Rhino
Add Root for Predator squads as Troops (and add compulsory troop)
Add Root for Sicaran Squadrons squads as Elites
Add Master of Armour SE and Root as HQ (and compulsory HQ) which links to single Pred or Sicaran which must take Master of Armour Warlord trait. If taken must be Warlord (as a result hide Primarchs and other characters which must be the warlord as well).
IMPOSSIBLE TO DO! All units in a Detachment using this Rite of War with the Infantry Type must begin the battle Embarked upon a model with the Transport Sub-type; any Infantry models in a Detachment using this Rite of War, both those deployed on the battlefield and in Reserves, that are not Embarked upon a model with the Transport Subtype at the beginning of the controlling player’s first turn must be removed as casualties.
May need to work out how to implement “Detachment using this Rite of War may not include any models with a Movement Characteristic of 0 or ‘-’.”

Bretren of Iron
Add Root for Castellax Battle-automata Maniples as non-compulsory troops
Add Root for Vorax Battleautomata Maniple asnon-Compulsory Fast Attack
Add Root for Domitar Battle-automata Maniples as non-Compulsory Elites
Add Root for Thanatar Siege-automata Maniple (with Max 1 in force of a single Thanatar) as non-Compulsory Heavy Support
Add option for Legion Techmarine to take cortex controller at +20 points
Limitations
Need to work out how to implement A Detachment using this Rite of War may not have more units that include one or more models with the Automata Unit Type than the total number of units it includes that do not include any models with the Automata Unit Type.
Need to work out how to implement At least one model with a cortex controller must be included in the Detachment for every three models with the Automata Unit Type in the Detachment.
Add in Paragon of Metal a Max 0 modifier if this RoW is taken.
Set min 1 Forge Lord Legiones Consularis upgrade for this RoW

Fury of the Ancients
Add Root for Contemptor Dreadnought Talons may be taken as Troops choices (and Compulsory Troops).
Add tickbox to Legion Contemptor Dreadnought Talons a max based on how many compulsories the FoC has which if ticked gives them “Line” and “Compulsory Troops” only if ticked.
Add Venerable Ancient SE and Root as HQ (and compulsory HQ) which links to single Contemptor (+30pts) which must take Venerable Ancient Warlord trait. If taken must be Warlord (as a result hide Primarchs and other characters which must be the warlord as well).
*Remove Compulsory for Assault, Breacher, Despoiler, Recon, Tactical, Grey Stalker, Grey Slayer (and any other legion compulsory troop).
Hide all consul’s apart from Forge Lord, Legion Primus Medicae & Legion Mortificator.
Add a “Non-Dreadnought FA” hidden SE (can be done in LA file) with max 1 in Force non-dreadnought Fast Attack to be added to all Fast attack choices. Have it set with Max 1 in parent, Min 0 in parent inside of SE. Then Min 0 set to 1 if Fury of the Ancients RoW.
Add a “Non-Dreadnought HS” hidden SE (can be done in LA file) with max 1 in Force non-dreadnought Heavy Support to be added to all Heavy Support choices. Have it set with Max 1 in parent, Min 0 in parent inside of SE. Then Min 0 set to 1 if Fury of the Ancients RoW..
