### PR TITLE
Fix: Removed duplicate rule entries from Legiones Astartes category

### DIFF
--- a/2022 - Legiones Astartes.cat
+++ b/2022 - Legiones Astartes.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="6393-649c-7213-a327" name="(HH V2) Legions Astartes" revision="54" battleScribeVersion="2.03" authorName="Various" authorUrl="https://github.com/BSData/horus-heresy" library="true" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="20" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="6393-649c-7213-a327" name="(HH V2) Legions Astartes" revision="55" battleScribeVersion="2.03" authorName="Various" authorUrl="https://github.com/BSData/horus-heresy" library="true" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="22" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <profileTypes>
     <profileType id="7002-2f9a-59c4-2742" name="Prosperine Arcana">
       <characteristicTypes>
@@ -13,172 +13,7 @@
     </profileType>
   </profileTypes>
   <categoryEntries>
-    <categoryEntry id="11f2-472f-c1d1-9ae9" name="Legiones Astartes" hidden="false">
-      <infoLinks>
-        <infoLink id="a47d-d90a-3162-524c" name="Legiones Astartes (Alpha Legion)" hidden="false" targetId="2a9e-be1f-d6c1-0ec4" type="rule">
-          <modifiers>
-            <modifier type="set" field="hidden" value="true">
-              <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c0df-c1fa-5ddc-9ee5" type="equalTo"/>
-              </conditions>
-            </modifier>
-          </modifiers>
-        </infoLink>
-        <infoLink id="1293-e142-0731-ae47" name="Legiones Astartes (Raven Guard)" hidden="false" targetId="9924-9434-baa1-0894" type="rule">
-          <modifiers>
-            <modifier type="set" field="hidden" value="true">
-              <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dc34-fe08-dd44-fb99" type="equalTo"/>
-              </conditions>
-            </modifier>
-          </modifiers>
-        </infoLink>
-        <infoLink id="4361-39c4-207a-21f1" name="Legiones Astartes (Salamanders)" hidden="false" targetId="5b72-d9a6-92c3-4a1c" type="rule">
-          <modifiers>
-            <modifier type="set" field="hidden" value="true">
-              <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c805-ca3a-ff93-5e2f" type="equalTo"/>
-              </conditions>
-            </modifier>
-          </modifiers>
-        </infoLink>
-        <infoLink id="b17a-cb38-cb4b-7673" name="Legiones Astartes (Word Bearers)" hidden="false" targetId="21ba-24fc-3fad-00fe" type="rule">
-          <modifiers>
-            <modifier type="set" field="hidden" value="true">
-              <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9dbf-0760-d7ae-f125" type="equalTo"/>
-              </conditions>
-            </modifier>
-          </modifiers>
-        </infoLink>
-        <infoLink id="42a9-921e-f7bf-cd13" name="Legiones Astartes (Sons of Hours)" hidden="false" targetId="f4a2-e4ca-b8b2-35a1" type="rule">
-          <modifiers>
-            <modifier type="set" field="hidden" value="true">
-              <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="01b4-57c7-bf61-2abf" type="equalTo"/>
-              </conditions>
-            </modifier>
-          </modifiers>
-        </infoLink>
-        <infoLink id="2f6f-d685-fa71-719d" name="Legiones Astartes (Thousand Sons)" hidden="false" targetId="2377-1d73-44bc-fee2" type="rule">
-          <modifiers>
-            <modifier type="set" field="hidden" value="true">
-              <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="21c3-2f28-7820-e51a" type="equalTo"/>
-              </conditions>
-            </modifier>
-          </modifiers>
-        </infoLink>
-        <infoLink id="9c89-cd56-fcbd-eacd" name="Legiones Astartes (Dark Angels)" hidden="false" targetId="513e-0647-996a-6229" type="rule">
-          <modifiers>
-            <modifier type="set" field="hidden" value="true">
-              <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b2b4-2198-0b90-dd9f" type="equalTo"/>
-              </conditions>
-            </modifier>
-          </modifiers>
-        </infoLink>
-        <infoLink id="d537-a711-e820-72f4" name="Legiones Astartes (Blood Angels)" hidden="false" targetId="b0d1-ccab-8708-500f" type="rule">
-          <modifiers>
-            <modifier type="set" field="hidden" value="true">
-              <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="296e-301e-3ce1-1c15" type="equalTo"/>
-              </conditions>
-            </modifier>
-          </modifiers>
-        </infoLink>
-        <infoLink id="b471-17d7-a204-243a" name="Legiones Astartes (Iron Hands)" hidden="false" targetId="2e45-4b61-44fb-260b" type="rule">
-          <modifiers>
-            <modifier type="set" field="hidden" value="true">
-              <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bfc9-c99c-bf8a-3917" type="equalTo"/>
-              </conditions>
-            </modifier>
-          </modifiers>
-        </infoLink>
-        <infoLink id="117f-8832-c467-b5cd" name="Legiones Astartes (World Eaters)" hidden="false" targetId="405d-019f-9ef6-423c" type="rule">
-          <modifiers>
-            <modifier type="set" field="hidden" value="true">
-              <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="90ee-77dd-1b7f-ddfe" type="equalTo"/>
-              </conditions>
-            </modifier>
-          </modifiers>
-        </infoLink>
-        <infoLink id="cf02-1149-e53e-18e6" name="Legiones Astartes (Night Lords)" hidden="false" targetId="8280-d4ea-b131-4970" type="rule">
-          <modifiers>
-            <modifier type="set" field="hidden" value="true">
-              <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b28b-71f7-e4f4-8f9c" type="equalTo"/>
-              </conditions>
-            </modifier>
-          </modifiers>
-        </infoLink>
-        <infoLink id="ebee-e254-e5dd-a7a2" name="Legiones Astartes (Emperor&apos;s Children)" hidden="false" targetId="4a36-8b9d-6b6c-51e1" type="rule">
-          <modifiers>
-            <modifier type="set" field="hidden" value="true">
-              <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3edc-a1b9-6dc6-b1ea" type="equalTo"/>
-              </conditions>
-            </modifier>
-          </modifiers>
-        </infoLink>
-        <infoLink id="f0d0-acf7-93c1-e2bb" name="Legiones Astartes (Ultramarines)" hidden="false" targetId="519d-a6ed-f57f-3642" type="rule">
-          <modifiers>
-            <modifier type="set" field="hidden" value="true">
-              <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8e0f-3552-8842-f281" type="equalTo"/>
-              </conditions>
-            </modifier>
-          </modifiers>
-        </infoLink>
-        <infoLink id="a312-b9eb-38a7-0858" name="Legiones Astartes (Iron Warriors)" hidden="false" targetId="c77b-f3fc-5dc8-1330" type="rule">
-          <modifiers>
-            <modifier type="set" field="hidden" value="true">
-              <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5f54-457a-fbb9-6730" type="equalTo"/>
-              </conditions>
-            </modifier>
-          </modifiers>
-        </infoLink>
-        <infoLink id="b85f-946f-1f98-9ba5" name="Legiones Astartes (White Scars)" hidden="false" targetId="4b54-8bd0-9fdd-cbc4" type="rule">
-          <modifiers>
-            <modifier type="set" field="hidden" value="true">
-              <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
-              </conditions>
-            </modifier>
-          </modifiers>
-        </infoLink>
-        <infoLink id="9740-18b6-d341-6540" name="Legiones Astartes (Imperial Fists)" hidden="false" targetId="e876-4f8f-a30f-8b22" type="rule">
-          <modifiers>
-            <modifier type="set" field="hidden" value="true">
-              <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a0e1-f2c4-8bcd-0723" type="equalTo"/>
-              </conditions>
-            </modifier>
-          </modifiers>
-        </infoLink>
-        <infoLink id="1d22-ac9a-2663-8d6d" name="Legiones Astartes (Death Guard)" hidden="false" targetId="48a9-493f-e255-5070" type="rule">
-          <modifiers>
-            <modifier type="set" field="hidden" value="true">
-              <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dd1f-1c51-706c-e5f7" type="equalTo"/>
-              </conditions>
-            </modifier>
-          </modifiers>
-        </infoLink>
-        <infoLink id="0dc2-92a8-5cee-5d66" name="Legiones Astartes (Space Wolves)" hidden="false" targetId="f806-8d12-07ab-fdaf" type="rule">
-          <modifiers>
-            <modifier type="set" field="hidden" value="true">
-              <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4916-965e-8339-44f6" type="equalTo"/>
-              </conditions>
-            </modifier>
-          </modifiers>
-        </infoLink>
-      </infoLinks>
-    </categoryEntry>
+    <categoryEntry id="11f2-472f-c1d1-9ae9" name="Legiones Astartes" hidden="false"/>
   </categoryEntries>
   <selectionEntries>
     <selectionEntry id="2494-402e-655d-d47f" name="Rite of War" hidden="false" collective="false" import="true" type="upgrade">
@@ -30662,6 +30497,9 @@ containing the model that failed its Check. If the Psyker survives Perils of the
         <infoLink id="6ac0-eadc-fabf-2b5b" name="Shrapnel Pistol" hidden="false" targetId="237f-c069-a680-dfae" type="profile"/>
         <infoLink id="94b7-5962-43ca-b15f" name="Pinning" hidden="false" targetId="1c96-205c-59a0-3cf2" type="rule"/>
       </infoLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="9b30-d725-82b2-637e" name="Two Alchem Pistols" hidden="false" collective="true" import="true" type="upgrade">
       <modifiers>
@@ -30677,6 +30515,9 @@ containing the model that failed its Check. If the Psyker survives Perils of the
         <infoLink id="4b41-bafd-16be-1259" name="Fleshbane" hidden="false" targetId="40cd-9505-253c-e76f" type="rule"/>
         <infoLink id="a2e6-8c37-6f40-f80f" name="Gets Hot" hidden="false" targetId="679f-9d97-5ace-a652" type="rule"/>
       </infoLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="a03e-291a-b611-b548" name="Two Asphyx Bolt Pistols" hidden="false" collective="true" import="true" type="upgrade">
       <modifiers>
@@ -30690,6 +30531,9 @@ containing the model that failed its Check. If the Psyker survives Perils of the
         <infoLink id="195d-38e6-0878-c706" name="Asphyx Bolt Pistol" hidden="false" targetId="7a88-ce87-0cb7-6a99" type="profile"/>
         <infoLink id="c4cf-374b-fc01-2419" name="Shred" hidden="false" targetId="5e7e-1628-8174-6f2c" type="rule"/>
       </infoLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="dacb-96f1-2d0d-fe04" name="Asphyx Bolt Pistol &amp; Bolt Pistol" hidden="false" collective="true" import="true" type="upgrade">
       <modifiers>
@@ -30729,18 +30573,27 @@ containing the model that failed its Check. If the Psyker survives Perils of the
         <infoLink id="bcaa-32d5-41f5-654b" name="Template Weapons" hidden="false" targetId="5e0e-88e6-db81-5a70" type="rule"/>
         <infoLink id="78c7-fb0e-6c8a-9aa4" name="Dragon&apos;s Breath" hidden="false" targetId="655c-988f-74b5-7e17" type="rule"/>
       </infoLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="d202-8f0a-8fe9-a59c" name="Two Hand Flamers" hidden="false" collective="true" import="true" type="upgrade">
       <infoLinks>
         <infoLink id="5574-6e30-5576-b532" name="Hand Flamer" hidden="false" targetId="eb62-ccfd-b605-ab5e" type="profile"/>
         <infoLink id="b45d-8ddf-712f-c9e3" name="Template Weapons" hidden="false" targetId="5e0e-88e6-db81-5a70" type="rule"/>
       </infoLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="837a-2c69-79d3-f382" name="Two Volkite Serpenta" hidden="false" collective="true" import="true" type="upgrade">
       <infoLinks>
         <infoLink id="7b85-f0ea-9ddf-27ac" name="Volkite Serpenta" hidden="false" targetId="6150-1ce8-ef78-f686" type="profile"/>
         <infoLink id="ef1a-95ef-18c6-dc3a" name="Deflagrate" hidden="false" targetId="60bc-f79a-67ae-be4f" type="rule"/>
       </infoLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="681a-7426-96af-caac" name="Land Raider Phobos Squadron" hidden="false" collective="false" import="true" type="unit">
       <categoryLinks>
@@ -36541,6 +36394,9 @@ During a Reaction made in any Phase, a player may not choose to activate a model
         <infoLink id="bf53-ff2c-e567-3f46" name="Fleshbane" hidden="false" targetId="40cd-9505-253c-e76f" type="rule"/>
         <infoLink id="17bb-eb4a-d122-5b24" name="Gets Hot" hidden="false" targetId="679f-9d97-5ace-a652" type="rule"/>
       </infoLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="263e-fa2a-768b-aa9c" name="Two Asphyx Bolt Pistols" hidden="false" collective="false" import="true" type="upgrade">
       <modifiers>
@@ -36554,6 +36410,9 @@ During a Reaction made in any Phase, a player may not choose to activate a model
         <infoLink id="7715-a104-bb65-7ade" name="Asphyx Bolt Pistol" hidden="false" targetId="7a88-ce87-0cb7-6a99" type="profile"/>
         <infoLink id="ea12-2789-dee3-16b9" name="Shred" hidden="false" targetId="5e7e-1628-8174-6f2c" type="rule"/>
       </infoLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="cfa6-e4c6-a328-6f4f" name="Two Bolt Pistols" hidden="false" collective="false" import="true" type="upgrade">
       <infoLinks>
@@ -36576,12 +36435,18 @@ During a Reaction made in any Phase, a player may not choose to activate a model
         <infoLink id="a870-8fa1-8bbf-a0d6" name="Template Weapons" hidden="false" targetId="5e0e-88e6-db81-5a70" type="rule"/>
         <infoLink id="2ca0-5cf2-881d-b514" name="Dragon&apos;s Breath" hidden="false" targetId="655c-988f-74b5-7e17" type="rule"/>
       </infoLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="5b3f-2b0e-245b-712f" name="Two Hand Flamers" hidden="false" collective="false" import="true" type="upgrade">
       <infoLinks>
         <infoLink id="69ed-86b6-6792-4d28" name="Hand Flamer" hidden="false" targetId="eb62-ccfd-b605-ab5e" type="profile"/>
         <infoLink id="a32c-1f44-053c-6d42" name="Template Weapons" hidden="false" targetId="5e0e-88e6-db81-5a70" type="rule"/>
       </infoLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="73dc-8e0f-abbe-27d6" name="Two Shrapnel Pistols" hidden="true" collective="false" import="true" type="upgrade">
       <modifiers>
@@ -36595,12 +36460,18 @@ During a Reaction made in any Phase, a player may not choose to activate a model
         <infoLink id="3b88-300f-08ea-2e1c" name="Shrapnel Pistol" hidden="false" targetId="237f-c069-a680-dfae" type="profile"/>
         <infoLink id="6616-1705-c5ff-bfc5" name="Pinning" hidden="false" targetId="1c96-205c-59a0-3cf2" type="rule"/>
       </infoLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="5148-691a-f7fc-aa9c" name="Two Volkite Serpenta" hidden="false" collective="false" import="true" type="upgrade">
       <infoLinks>
         <infoLink id="ee6c-fb54-a7ac-dd89" name="Volkite Serpenta" hidden="false" targetId="6150-1ce8-ef78-f686" type="profile"/>
         <infoLink id="8cc3-938a-bd96-82bd" name="Deflagrate" hidden="false" targetId="60bc-f79a-67ae-be4f" type="rule"/>
       </infoLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="e3d6-451d-82c9-b445" name="Asphyx Bolt Pistol &amp; Bolt Pistol" hidden="false" collective="false" import="true" type="upgrade">
       <modifiers>


### PR DESCRIPTION
This removes the SE links from underneath the  Legiones Astartes category so that it is now only applied via the SE, which can be assigned to a model or unit as needed (not all units should get Legiones Astartes (X) rules).

## Added Units

None

## Fixed Units

Any with Legiones Astartes category that shouldn't have also been receiving the Legiones Astartes (X) special rules

### Related Issues

N/A

## Not done yet

Still need to go through and add the new SE to any units that should have it (and don't) and remove it from any units that shouldn't have it (and do).

## Test Case

Can't upload Rosters... GitHub doesn't support the file type.
