### PR TITLE
SW issue and spelling issue for RoW

### DIFF
--- a/2022 - Horus Heresy.gst
+++ b/2022 - Horus Heresy.gst
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<gameSystem id="28d4-bd2e-4858-ece6" name="(HH V2) Horus Heresy (2022)" revision="26" battleScribeVersion="2.03" xmlns="http://www.battlescribe.net/schema/gameSystemSchema">
+<gameSystem id="28d4-bd2e-4858-ece6" name="(HH V2) Horus Heresy (2022)" revision="27" battleScribeVersion="2.03" xmlns="http://www.battlescribe.net/schema/gameSystemSchema">
   <publications>
     <publication id="e77a-823a-da94-16b9" name="Warhammer: The Horus Heresy - Age of Darkness Rulebook" shortName="Main Rules" publicationDate="June 2022"/>
     <publication id="817a-6288-e016-7469" name="Liber Astartes – Loyalist Legiones Astartes Army Book" shortName="LA - Loyalist" publicationDate="June 2022"/>
@@ -8627,7 +8627,7 @@ Limitations
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="a621-2c8c-3df0-89d3" name="Underworld Aaasult" publicationId="a716-c1c4-7b26-8424" page="100" hidden="false" collective="false" import="true" type="upgrade">
+        <selectionEntry id="a621-2c8c-3df0-89d3" name="Underworld Assault" publicationId="a716-c1c4-7b26-8424" page="100" hidden="false" collective="false" import="true" type="upgrade">
           <rules>
             <rule id="bc0e-857d-6ab6-7aa8" name="Underworld Aaasult" publicationId="a716-c1c4-7b26-8424" page="100" hidden="false">
               <description>Effects

--- a/2022 - LA - Space Wolves.cat
+++ b/2022 - LA - Space Wolves.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="ca15-13de-89cb-bbb2" name="LA -   VI: Space Wolves" revision="15" battleScribeVersion="2.03" authorName="Mr_Dark, UrsinePatriarch" authorContact="BSData Developers Discord" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="26" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="ca15-13de-89cb-bbb2" name="LA -   VI: Space Wolves" revision="16" battleScribeVersion="2.03" authorName="Mr_Dark, UrsinePatriarch" authorContact="BSData Developers Discord" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="26" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entryLinks>
     <entryLink id="ff53-69d9-ec0b-9caa" name="   VI: Space Wolves" hidden="false" collective="false" import="false" targetId="4916-965e-8339-44f6" type="selectionEntry">
       <constraints>
@@ -2251,28 +2251,14 @@
             <constraint field="selections" scope="parent" value="19.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e294-a914-7f6c-f4d0" type="max"/>
             <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="79a7-3f45-06f3-beec" type="min"/>
           </constraints>
-          <profiles>
-            <profile id="a9da-5857-c0e5-aa5c" name="Grey Slayer" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
-              <characteristics>
-                <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Skirmish, Line)</characteristic>
-                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
-                <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
-                <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
-                <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
-                <characteristic name="T" typeId="c32b-5fdd-3fbe-9b1f">4</characteristic>
-                <characteristic name="W" typeId="57ee-1126-32a9-5672">1</characteristic>
-                <characteristic name="I" typeId="62d3-22d7-2d49-52dc">4</characteristic>
-                <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">1</characteristic>
-                <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">7</characteristic>
-                <characteristic name="Save" typeId="e593-6b3c-f169-04f0">3+</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
           <selectionEntries>
             <selectionEntry id="3817-4281-fe35-c72e" name=" Grey Slayer w/Combat Shield, Fenrisian Axe" hidden="false" collective="false" import="true" type="model">
               <constraints>
                 <constraint field="selections" scope="parent" value="19.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b3e4-1fe7-4f21-d3b1" type="max"/>
               </constraints>
+              <infoLinks>
+                <infoLink id="5a66-18dc-57cb-deff" name="Grey Slayer" hidden="false" targetId="a9da-5857-c0e5-aa5c" type="profile"/>
+              </infoLinks>
               <entryLinks>
                 <entryLink id="9427-5ae1-4dbf-78f6" name="Fenrisian Axe" hidden="false" collective="false" import="true" targetId="394d-2287-e1bc-2ba1" type="selectionEntry">
                   <constraints>
@@ -2295,6 +2281,9 @@
               <constraints>
                 <constraint field="selections" scope="parent" value="19.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0591-2e71-4bc7-c0f2" type="max"/>
               </constraints>
+              <infoLinks>
+                <infoLink id="93c3-ce1a-2f86-0620" name="Grey Slayer" hidden="false" targetId="a9da-5857-c0e5-aa5c" type="profile"/>
+              </infoLinks>
               <entryLinks>
                 <entryLink id="9afa-1e8c-f2fb-95b9" name="Combat Shield" hidden="false" collective="false" import="true" targetId="7f4a-84b2-f992-4558" type="selectionEntry">
                   <constraints>
@@ -2317,6 +2306,9 @@
               <constraints>
                 <constraint field="selections" scope="parent" value="19.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f469-4a17-5017-6460" type="max"/>
               </constraints>
+              <infoLinks>
+                <infoLink id="0c0a-f2a8-bd18-00b8" name="Grey Slayer" hidden="false" targetId="a9da-5857-c0e5-aa5c" type="profile"/>
+              </infoLinks>
               <selectionEntryGroups>
                 <selectionEntryGroup id="01fe-956a-8c5b-ad37" name="Bayonet:" hidden="false" collective="false" import="true">
                   <constraints>
@@ -2375,6 +2367,9 @@
               </costs>
             </selectionEntry>
             <selectionEntry id="fc48-8eea-bc4e-f014" name="Grey Slayer w/ Options" hidden="false" collective="false" import="true" type="model">
+              <infoLinks>
+                <infoLink id="e480-d8fd-c483-ab4c" name="Grey Slayer" hidden="false" targetId="a9da-5857-c0e5-aa5c" type="profile"/>
+              </infoLinks>
               <selectionEntryGroups>
                 <selectionEntryGroup id="9c8b-06cd-57f8-921a" name="4) May take:" hidden="false" collective="false" import="true">
                   <entryLinks>
@@ -2552,6 +2547,9 @@
               <constraints>
                 <constraint field="selections" scope="parent" value="19.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eafc-d323-e557-addc" type="max"/>
               </constraints>
+              <infoLinks>
+                <infoLink id="2755-3657-0ca6-05b4" name="Grey Slayer" hidden="false" targetId="a9da-5857-c0e5-aa5c" type="profile"/>
+              </infoLinks>
               <selectionEntryGroups>
                 <selectionEntryGroup id="0672-8a8b-a371-3cf6" name="Bayonet:" hidden="false" collective="false" import="true">
                   <constraints>
@@ -2602,6 +2600,9 @@
               <constraints>
                 <constraint field="selections" scope="parent" value="19.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ed71-d9e1-d05d-9917" type="max"/>
               </constraints>
+              <infoLinks>
+                <infoLink id="638d-f604-5753-d1b9" name="Grey Slayer" hidden="false" targetId="a9da-5857-c0e5-aa5c" type="profile"/>
+              </infoLinks>
               <selectionEntryGroups>
                 <selectionEntryGroup id="0d0d-54d2-e990-aba6" name="Bayonet:" hidden="false" collective="false" import="true">
                   <constraints>
@@ -2652,6 +2653,9 @@
               <constraints>
                 <constraint field="selections" scope="parent" value="19.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0f3b-8b30-4203-600f" type="max"/>
               </constraints>
+              <infoLinks>
+                <infoLink id="a584-c907-0e0c-d75c" name="Grey Slayer" hidden="false" targetId="a9da-5857-c0e5-aa5c" type="profile"/>
+              </infoLinks>
               <selectionEntryGroups>
                 <selectionEntryGroup id="788a-76c9-78fa-ba60" name="Bayonet:" hidden="false" collective="false" import="true">
                   <constraints>
@@ -2699,6 +2703,9 @@
               <constraints>
                 <constraint field="selections" scope="parent" value="19.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="41d6-34e1-bd03-fc0c" type="max"/>
               </constraints>
+              <infoLinks>
+                <infoLink id="f865-bc19-79bc-2288" name="Grey Slayer" hidden="false" targetId="a9da-5857-c0e5-aa5c" type="profile"/>
+              </infoLinks>
               <selectionEntryGroups>
                 <selectionEntryGroup id="ae61-bacb-8d80-bf2d" name="Bayonet:" hidden="false" collective="false" import="true">
                   <constraints>
@@ -2749,6 +2756,9 @@
               <constraints>
                 <constraint field="selections" scope="parent" value="19.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a2fb-6c4f-bcb5-6f33" type="max"/>
               </constraints>
+              <infoLinks>
+                <infoLink id="8978-8d5a-a65f-c77b" name="Grey Slayer" hidden="false" targetId="a9da-5857-c0e5-aa5c" type="profile"/>
+              </infoLinks>
               <entryLinks>
                 <entryLink id="680f-5aac-26db-cee1" name="Combat Shield" hidden="false" collective="false" import="true" targetId="7f4a-84b2-f992-4558" type="selectionEntry">
                   <constraints>
@@ -2771,6 +2781,9 @@
               <constraints>
                 <constraint field="selections" scope="parent" value="19.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0d55-8c38-1df0-216f" type="max"/>
               </constraints>
+              <infoLinks>
+                <infoLink id="37e9-d97d-1da8-6edc" name="Grey Slayer" hidden="false" targetId="a9da-5857-c0e5-aa5c" type="profile"/>
+              </infoLinks>
               <entryLinks>
                 <entryLink id="a0ed-8766-a1e7-13af" name="Combat Shield" hidden="false" collective="false" import="true" targetId="7f4a-84b2-f992-4558" type="selectionEntry">
                   <constraints>
@@ -2793,6 +2806,9 @@
               <constraints>
                 <constraint field="selections" scope="parent" value="19.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c526-40b9-27a3-5d74" type="max"/>
               </constraints>
+              <infoLinks>
+                <infoLink id="6eae-1d7d-02ab-9d95" name="Grey Slayer" hidden="false" targetId="a9da-5857-c0e5-aa5c" type="profile"/>
+              </infoLinks>
               <entryLinks>
                 <entryLink id="fe10-d98a-3819-ed0d" name="Combat Shield" hidden="false" collective="false" import="true" targetId="7f4a-84b2-f992-4558" type="selectionEntry">
                   <constraints>
@@ -3113,28 +3129,14 @@
             <constraint field="selections" scope="parent" value="19.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7ab2-6b29-93f3-b5b3" type="max"/>
             <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bf05-da1d-123e-1e5e" type="min"/>
           </constraints>
-          <profiles>
-            <profile id="4d62-74ee-7111-a22c" name="Grey Stalker" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
-              <characteristics>
-                <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Skirmish, Line)</characteristic>
-                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
-                <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
-                <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
-                <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
-                <characteristic name="T" typeId="c32b-5fdd-3fbe-9b1f">4</characteristic>
-                <characteristic name="W" typeId="57ee-1126-32a9-5672">1</characteristic>
-                <characteristic name="I" typeId="62d3-22d7-2d49-52dc">4</characteristic>
-                <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">1</characteristic>
-                <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">7</characteristic>
-                <characteristic name="Save" typeId="e593-6b3c-f169-04f0">3+</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
           <selectionEntries>
             <selectionEntry id="8f76-5bfd-9088-e7cb" name=" Grey Stalker w/ Fenrisian Axe" hidden="false" collective="false" import="true" type="model">
               <constraints>
                 <constraint field="selections" scope="parent" value="19.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3cad-2fed-f34d-2086" type="max"/>
               </constraints>
+              <infoLinks>
+                <infoLink id="ba37-3162-9ca2-dd99" name="Grey Stalker" hidden="false" targetId="4d62-74ee-7111-a22c" type="profile"/>
+              </infoLinks>
               <entryLinks>
                 <entryLink id="1fd5-5f60-6c78-24dc" name="Fenrisian Axe" hidden="false" collective="false" import="true" targetId="394d-2287-e1bc-2ba1" type="selectionEntry">
                   <constraints>
@@ -3151,6 +3153,9 @@
               <constraints>
                 <constraint field="selections" scope="parent" value="19.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="06fe-b505-2913-2ada" type="max"/>
               </constraints>
+              <infoLinks>
+                <infoLink id="bde1-b7f5-43e2-3d7a" name="Grey Stalker" hidden="false" targetId="4d62-74ee-7111-a22c" type="profile"/>
+              </infoLinks>
               <entryLinks>
                 <entryLink id="cfa0-87a3-89be-a6fa" name="Power Axe" hidden="false" collective="true" import="true" targetId="ef98-66ac-fcaf-c15d" type="selectionEntry">
                   <constraints>
@@ -3170,6 +3175,9 @@
               <constraints>
                 <constraint field="selections" scope="parent" value="19.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3372-06f2-49c4-d52e" type="max"/>
               </constraints>
+              <infoLinks>
+                <infoLink id="054d-10f1-067c-cead" name="Grey Stalker" hidden="false" targetId="4d62-74ee-7111-a22c" type="profile"/>
+              </infoLinks>
               <entryLinks>
                 <entryLink id="6094-5a13-4f61-0c12" name="Power Lance" hidden="false" collective="false" import="true" targetId="fca3-4ec1-c581-1ba3" type="selectionEntry">
                   <constraints>
@@ -3189,6 +3197,9 @@
               <constraints>
                 <constraint field="selections" scope="parent" value="19.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6f44-8552-2534-7e07" type="max"/>
               </constraints>
+              <infoLinks>
+                <infoLink id="cc0d-24a3-a431-9545" name="Grey Stalker" hidden="false" targetId="4d62-74ee-7111-a22c" type="profile"/>
+              </infoLinks>
               <entryLinks>
                 <entryLink id="94c7-d414-bd2e-aadc" name="Power Maul" hidden="false" collective="true" import="true" targetId="98e8-f217-dea9-0493" type="selectionEntry">
                   <constraints>
@@ -3208,6 +3219,9 @@
               <constraints>
                 <constraint field="selections" scope="parent" value="19.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="797a-f56d-70f9-4116" type="max"/>
               </constraints>
+              <infoLinks>
+                <infoLink id="c169-f0af-b78a-2482" name="Grey Stalker" hidden="false" targetId="4d62-74ee-7111-a22c" type="profile"/>
+              </infoLinks>
               <entryLinks>
                 <entryLink id="6b9f-f342-9711-6d3f" name="Power Sword" hidden="false" collective="true" import="true" targetId="fa06-cac0-3d98-125e" type="selectionEntry">
                   <constraints>
@@ -3224,6 +3238,9 @@
               </costs>
             </selectionEntry>
             <selectionEntry id="a482-de3c-4324-a64f" name="Grey Stalker w/ Options" hidden="false" collective="false" import="true" type="model">
+              <infoLinks>
+                <infoLink id="854e-4e5c-ad06-96ca" name="Grey Stalker" hidden="false" targetId="4d62-74ee-7111-a22c" type="profile"/>
+              </infoLinks>
               <selectionEntryGroups>
                 <selectionEntryGroup id="5e09-8755-2cb5-f9d3" name="4) May take:" hidden="false" collective="false" import="true">
                   <constraints>
@@ -3505,6 +3522,9 @@
               <constraints>
                 <constraint field="selections" scope="parent" value="19.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e2bb-3a7a-fd75-ed17" type="max"/>
               </constraints>
+              <infoLinks>
+                <infoLink id="d6b4-2d12-4915-90ba" name="Grey Stalker" hidden="false" targetId="4d62-74ee-7111-a22c" type="profile"/>
+              </infoLinks>
               <entryLinks>
                 <entryLink id="5139-5148-36db-7ddd" name="Chainsword" hidden="false" collective="false" import="true" targetId="b5b7-b50a-ac86-9173" type="selectionEntry">
                   <constraints>
@@ -4358,6 +4378,38 @@
       </entryLinks>
     </selectionEntryGroup>
   </sharedSelectionEntryGroups>
+  <sharedProfiles>
+    <profile id="a9da-5857-c0e5-aa5c" name="Grey Slayer" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
+      <characteristics>
+        <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Skirmish, Line)</characteristic>
+        <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
+        <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
+        <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
+        <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
+        <characteristic name="T" typeId="c32b-5fdd-3fbe-9b1f">4</characteristic>
+        <characteristic name="W" typeId="57ee-1126-32a9-5672">1</characteristic>
+        <characteristic name="I" typeId="62d3-22d7-2d49-52dc">4</characteristic>
+        <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">1</characteristic>
+        <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">7</characteristic>
+        <characteristic name="Save" typeId="e593-6b3c-f169-04f0">3+</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="4d62-74ee-7111-a22c" name="Grey Stalker" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
+      <characteristics>
+        <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Skirmish, Line)</characteristic>
+        <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
+        <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
+        <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
+        <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
+        <characteristic name="T" typeId="c32b-5fdd-3fbe-9b1f">4</characteristic>
+        <characteristic name="W" typeId="57ee-1126-32a9-5672">1</characteristic>
+        <characteristic name="I" typeId="62d3-22d7-2d49-52dc">4</characteristic>
+        <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">1</characteristic>
+        <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">7</characteristic>
+        <characteristic name="Save" typeId="e593-6b3c-f169-04f0">3+</characteristic>
+      </characteristics>
+    </profile>
+  </sharedProfiles>
   <catalogueLinks>
     <catalogueLink id="2f60-18fb-e6ed-8574" name="(HH V2) Legions Astartes" targetId="6393-649c-7213-a327" type="catalogue" importRootEntries="true"/>
   </catalogueLinks>


### PR DESCRIPTION
Unit profiles were not appearing in the unit on "View Roster" because of the way it was input.
This is an issue with whoever coded it. They forgot that putting a profile into a selection entry group doesn't show it. It needs to be in a selection entry that is picked.
I have moved the profile to shared profiles and entry linked in all the selection entries to fix.
I'm sure there are going to be a ton of these out there...
#2525

Fix to spelling mistake
#2524
