### PR TITLE
Libre Imperium

### DIFF
--- a/2022 - Horus Heresy.gst
+++ b/2022 - Horus Heresy.gst
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<gameSystem id="28d4-bd2e-4858-ece6" name="(HH V2) Horus Heresy (2022)" revision="32" battleScribeVersion="2.03" xmlns="http://www.battlescribe.net/schema/gameSystemSchema">
+<gameSystem id="28d4-bd2e-4858-ece6" name="(HH V2) Horus Heresy (2022)" revision="34" battleScribeVersion="2.03" xmlns="http://www.battlescribe.net/schema/gameSystemSchema">
   <publications>
     <publication id="e77a-823a-da94-16b9" name="Warhammer: The Horus Heresy - Age of Darkness Rulebook" shortName="Main Rules" publicationDate="June 2022"/>
     <publication id="817a-6288-e016-7469" name="Liber Astartes – Loyalist Legiones Astartes Army Book" shortName="LA - Loyalist" publicationDate="June 2022"/>
@@ -1208,8 +1208,21 @@ In addition, when a Fast Vehicle moves, it may choose to move at Flat-out:</desc
   </entryLinks>
   <sharedSelectionEntries>
     <selectionEntry id="d0b6-712f-0b12-a308" name="Loyalist" hidden="false" collective="false" import="true" type="upgrade">
+      <modifiers>
+        <modifier type="set" field="e537-c291-62d8-d539" value="1.0">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e0d0-c905-b01e-fc15" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4d60-2ab7-244f-3414" type="greaterThan"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="17a8-c4c9-2bf7-6a21" type="max"/>
+        <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e537-c291-62d8-d539" type="min"/>
       </constraints>
       <costs>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
@@ -7386,7 +7399,7 @@ Hull Mounted (Rear) Heavy Bolter</characteristic>
         </infoLink>
       </infoLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="75.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="d5f5-a83b-ed8e-61c0" name="Hammerfall Bunker" publicationId="d0df-7166-5cd3-89fd" page="96" hidden="false" collective="false" import="true" type="unit">
@@ -7674,6 +7687,48 @@ Hull Mounted (Rear) Mounted Twin-linked Heavy Bolter or Heavy Flamers</character
           </characteristics>
         </profile>
       </profiles>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="e0d0-c905-b01e-fc15" name="Legio Custodes" hidden="false" collective="false" import="true" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a09d-8300-eb1c-c2c7" type="max"/>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8df0-2736-90e5-6a5b" type="max"/>
+      </constraints>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="4d60-2ab7-244f-3414" name="Sisters of Silence" hidden="false" collective="false" import="true" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3dd6-4bcb-1da6-6d7e" type="max"/>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0a34-84c6-39e6-9361" type="max"/>
+      </constraints>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="f689-fd0d-ffb0-c255" name="Solar Auxilia" hidden="false" collective="false" import="true" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="96e2-2823-321a-2ab1" type="max"/>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f837-7b9c-1cbd-43f5" type="max"/>
+      </constraints>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="9021-d66d-2e3d-8ab6" name="Nemesis Bolter" hidden="false" collective="true" import="true" type="upgrade">
+      <infoLinks>
+        <infoLink id="315f-b593-5dce-8ca9" name="Rending (X)" hidden="false" targetId="0ac9-fab7-aef3-de1d" type="rule">
+          <modifiers>
+            <modifier type="set" field="name" value="Rending (5+)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="05f4-3418-59f9-bec4" name="Sniper" hidden="false" targetId="9cd8-e726-5dbe-b106" type="rule"/>
+        <infoLink id="26c3-5ea5-d7ee-c144" name="Pinning" hidden="false" targetId="1c96-205c-59a0-3cf2" type="rule"/>
+        <infoLink id="5c00-94c9-5297-c63f" name="Nemesis Bolter" hidden="false" targetId="b134-c4c0-b491-66ae" type="profile"/>
+      </infoLinks>
       <costs>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
       </costs>

--- a/2022 - LA - White Scars.cat
+++ b/2022 - LA - White Scars.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="caa9-c50e-8eed-2259" name="LA -   V: White Scars" revision="21" battleScribeVersion="2.03" authorName="Mr_Dark, UrsinePatriarch" authorContact="BSData Developers Discord" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="32" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="caa9-c50e-8eed-2259" name="LA -   V: White Scars" revision="21" battleScribeVersion="2.03" authorName="Mr_Dark, UrsinePatriarch" authorContact="BSData Developers Discord" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="34" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entryLinks>
     <entryLink id="a738-6a11-dfe7-286c" name="   V: White Scars" hidden="false" collective="false" import="false" targetId="e01e-5cdd-e512-8353" type="selectionEntry">
       <constraints>
@@ -3021,6 +3021,19 @@
       <categoryLinks>
         <categoryLink id="f749-b5f0-50f2-abdb" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="4648-4a07-f101-2134" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="e5d5-49da-3a13-170f" name="Knight Centura" hidden="true" collective="false" import="false" targetId="6445-e0ea-58ac-ac6c" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="54fb-d060-193b-675d" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="8788-7df7-6bf0-e6e8" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="false"/>
+        <categoryLink id="6d1d-d078-d026-d60f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
   </entryLinks>

--- a/2022 - LI - Custodes.cat
+++ b/2022 - LI - Custodes.cat
@@ -1,0 +1,2266 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<catalogue id="2f2b-1f31-c455-1701" name="2022 - LI - Custodes" revision="1" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="34" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+  <categoryEntries>
+    <categoryEntry id="ccca-a9de-0cd9-f8be" name="Legio Custodes" hidden="false">
+      <rules>
+        <rule id="9300-b317-6b65-c72a" name="Legio Custodes" hidden="false">
+          <description>• All models with this special rule gain +1 Attacks when locked in combat with a Nemesis unit.
+• A unit composed entirely of models with this special rule gains an additional bonus of +1 to all Charge are Nemesis units.
+• When rolling to Hit while Engaged with a Nemesis unis, a model with this special rule will never need to roll better than 4+ to score a Hit - unless the Nemesis unit is composed entirely of models with the Primarch Unit Type, or the attacking model is in a Challenge with a model that has the Primarch Unit Type.
+
+NEMESIS UNITS
+A &quot;Nemesis&apos; unit is defined as any enemy unit that fulfils at least one of the following conditions:
+• The unit includes one of more models with at least one of the following Unit Types or Unit Sub-types: - Primarch, Dreadnought, Monstrous, Reinforced, Bombard, Daemon, Corrupted, Super-heavy, Unique or Knight.
+• The majority of models in the unit have a value of 5 of more in any one of the following Characteristics: - Weapons Skill, Balistic Skill, Wounds or Initiative.
+• A unit includes an enemy Warlord.</description>
+        </rule>
+      </rules>
+    </categoryEntry>
+  </categoryEntries>
+  <entryLinks>
+    <entryLink id="8abb-00fb-4157-9177" name="Legio Custodes" hidden="false" collective="false" import="false" targetId="e0d0-c905-b01e-fc15" type="selectionEntry">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b861-6325-05ff-faba" type="min"/>
+      </constraints>
+      <categoryLinks>
+        <categoryLink id="a7d7-0c14-596d-b293" name="New CategoryLink" hidden="false" targetId="e90d-e5a8-f42d-da84" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="c2d3-d387-5be2-1aa5" name="Clade Adamus Assassin" hidden="false" collective="false" import="false" targetId="0510-bd97-e047-88bf" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="ebb6-a6e5-6aab-2bc4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="939a-bd17-2192-7d96" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="1faf-f8c2-b4df-f6fb" name="Clade Callidus Assassin" hidden="false" collective="false" import="false" targetId="aeac-aef4-984e-fe79" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="3382-7158-4c7f-b59d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="1e55-bf73-a19d-b372" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="0de0-6655-7989-a65f" name="Clade Eversor Assassin" hidden="false" collective="false" import="false" targetId="5d50-77c2-5943-4c3f" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="830f-83f7-fbee-5cf2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="64e0-bbc5-0720-3b4f" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="db48-0a1f-91ea-3474" name="Clade Culexus Assassin" hidden="false" collective="false" import="false" targetId="4d3f-0c69-bf50-9076" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="33d5-9fdc-348a-e6e5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="5446-0858-9531-ee45" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="507b-2156-8d39-2643" name="Clade Vanus Infocyte Assassin" hidden="false" collective="false" import="false" targetId="3976-8d49-21fc-2633" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="416c-f569-edde-7c1b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="662f-6f08-3bb3-0b9f" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="5739-6710-11b3-011d" name="Clade Venenum Assassin" hidden="false" collective="false" import="false" targetId="32f2-1209-7402-4d0d" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="dab5-8473-0dcb-030c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="ef96-2fae-c347-830c" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="6827-ea41-aa37-1e85" name="Clade Vindicare Assassin" hidden="false" collective="false" import="false" targetId="abaf-b2fa-1d41-a315" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="ec46-4464-f769-590a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="3c06-808a-b5b8-3749" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="1595-7192-9e5e-26a9" name="Constantin Valdor (Placeholder)" hidden="false" collective="false" import="false" targetId="2e44-7b4f-37dd-05f4" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="17f6-6098-0dbf-e27c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="13c9-8366-95ab-62ab" name="New CategoryLink" hidden="false" targetId="ad5f-31db-8bc7-5c46" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="d518-801b-fe9a-03f8" name="Custodes Tribune (Placeholder)" hidden="false" collective="false" import="false" targetId="d485-7848-0118-2dc3" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="8dc3-8d38-d807-d501" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="e66d-6558-458f-6eae" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="90af-a3d2-5caf-fb2e" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="608e-6aee-421f-3e30" name="Custodian Shield Captain (Placeholder)" hidden="false" collective="false" import="false" targetId="8247-80e7-81c0-d382" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="e312-4038-319f-8798" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="5e05-1cfb-3fab-a389" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="0332-ccb5-ae69-b162" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="9ccf-710a-120d-b858" name="Hetaeron Guard Squad (Placeholder)" hidden="false" collective="false" import="false" targetId="76da-acc0-3ffb-6161" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="6c6f-d217-da4a-f3f3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="7e8a-2bdb-4800-48b9" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="4ffe-afe4-30ee-9d4d" name="Compulsory Elite:" hidden="false" targetId="bb1f-ae32-b587-c3e1" primary="false"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="1fdd-ef9e-a979-0b44" name="Aquilon Terminator Squad (Placeholder)" hidden="false" collective="false" import="false" targetId="258c-214d-bc9d-35e1" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="975d-e109-d5bd-7068" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="6f50-248f-d8e0-f877" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="86cb-0998-7a8c-4996" name="Compulsory Elite:" hidden="false" targetId="bb1f-ae32-b587-c3e1" primary="false"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="27f9-55f5-91f4-b2a8" name="Contemptor-Achillus Dreadnought (Placeholder)" hidden="false" collective="false" import="false" targetId="1ba9-e9e5-0f7e-27e0" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="9a09-e830-1510-c66a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="cacf-350a-7981-0abe" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="1c3f-5c95-29b8-0549" name="Compulsory Elite:" hidden="false" targetId="bb1f-ae32-b587-c3e1" primary="false"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="da13-587f-7be9-66be" name="Custodian Guard Squad (Placeholder)" hidden="false" collective="false" import="false" targetId="7cec-fe1b-5748-7af3" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="046e-f52c-1705-678f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="29eb-c36e-75ff-003c" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="901a-865f-b9d9-f198" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="ebd8-b84b-ff52-81da" name="Sentinel Guard Squad (Placeholder)" hidden="false" collective="false" import="false" targetId="206f-680f-4be9-6307" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="283b-9bf8-51c2-fc3f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="2e7d-7993-769b-59e8" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="dd75-438b-d47e-bb9d" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="71ba-936f-5f8d-228b" name="Agamatus Jetbike Squadron (Placeholder)" hidden="false" collective="false" import="false" targetId="f6b3-1e25-1353-0a50" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="e519-9c3c-2ae3-2c19" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="8a99-7c4b-782a-8d54" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="65bb-7a39-4350-741e" name="Pallas Attack Speeder Squadron (Placeholder)" hidden="false" collective="false" import="false" targetId="2ce3-4ce5-d86f-543f" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="c710-2671-3cfb-8db7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="9415-2e52-7a11-d13b" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="9fdd-741c-affb-289a" name="Custodian Venatari Squad (Placeholder)" hidden="false" collective="false" import="false" targetId="4c7e-42e0-1c1e-5ba9" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="8d2b-5293-abf8-2065" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="4520-024b-fc8e-05ce" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="656c-b6b9-7dcf-b89c" name="Sagittarum Guard Squad (Placeholder)" hidden="false" collective="false" import="false" targetId="8a39-6452-e075-c8d6" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="1eab-2543-5401-8fd8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="3023-fbd5-f9ad-a69f" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="689b-1084-e8c8-6e9b" name="Caladius Grav-Tank (Placeholder)" hidden="false" collective="false" import="false" targetId="d052-4523-d8da-0c55" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="ad5a-737c-b0ab-c723" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="42d6-e888-330f-39b2" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="0e1f-efc9-d81d-9c7e" name="Contemptor-Galatus Dreadnought (Placeholder)" hidden="false" collective="false" import="false" targetId="5787-ff0f-aaab-2ae5" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="43c5-1053-74b3-054e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="085f-0c31-d88c-30f5" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="12bb-7e2b-f4ac-9b94" name="Telemon Heavy Dreadnought (Placeholder)" hidden="false" collective="false" import="false" targetId="2fea-f040-7934-ae7a" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="4689-f35f-ec9d-bb67" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="a43b-4f90-b009-182a" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="36ee-7fd7-accc-604e" name="Orion Assault Dropship (Placeholder)" hidden="false" collective="false" import="false" targetId="1a49-8b97-1f6d-3a8d" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="7fe7-71bf-70cc-f8e9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="e2f9-76b9-eb66-903d" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="6b3f-84ff-d24d-7c4d" name="Ares Gunship (Placeholder)" hidden="false" collective="false" import="false" targetId="e145-3c36-e1eb-5d08" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="2545-36db-5e09-10ce" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="ab0b-897d-307f-e973" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+  </entryLinks>
+  <sharedSelectionEntries>
+    <selectionEntry id="2b98-427e-c91d-959a" name="Warlord Trait (Custodes)" publicationId="15a4-fc68-502d-48a9" page="17" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="981e-5353-dd39-e63a" name="Golden Exemplar" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
+          <characteristics>
+            <characteristic name="Text" typeId="c68e-2cda-b67b-baca">Any combat with at least one friendly model within 12&quot; of a Warlord with this Trait, or a combat which includes a Warlord with this Train, gains a bonus of +1 to the number of Wounds caused for the purposes of deciding which side has won the combat during the Assault phase. In addition, while engaged in a Challenge a Warlord with this Trait adds a bonus of +1 to their Attacks and Initiative Characteristics.</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="2e44-7b4f-37dd-05f4" name="Constantin Valdor (Placeholder)" publicationId="15a4-fc68-502d-48a9" page="18" hidden="false" collective="false" import="true" type="unit">
+      <constraints>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6219-d007-0481-39ae" type="max"/>
+      </constraints>
+      <categoryLinks>
+        <categoryLink id="be43-c176-c4d7-d2c2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="4be9-11e6-026c-7213" name="Legio Custodes" hidden="false" targetId="ccca-a9de-0cd9-f8be" primary="false"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="2e47-1bab-310c-dcc3" name="Constantin Valdor" hidden="false" collective="false" import="true" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a275-7d8d-5575-979b" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7d44-d219-631e-551f" type="max"/>
+          </constraints>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="7983-f82d-7876-6c7a" name="Can take:" hidden="false" collective="false" import="true">
+              <selectionEntries>
+                <selectionEntry id="9399-103d-9bb6-44f3" name="Teleport Transponder Array" hidden="false" collective="false" import="true" type="upgrade">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2c2d-5c7e-e1a7-63b0" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="125.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="350.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="d485-7848-0118-2dc3" name="Custodes Tribune (Placeholder)" publicationId="15a4-fc68-502d-48a9" page="20" hidden="false" collective="false" import="true" type="unit">
+      <constraints>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="71e4-b4f2-dfdc-f424" type="max"/>
+      </constraints>
+      <categoryLinks>
+        <categoryLink id="b7a3-405c-6c63-1be3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="9b32-44ae-0ea6-a7e7" name="Legio Custodes" hidden="false" targetId="ccca-a9de-0cd9-f8be" primary="false"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="f94c-1850-fa96-3b80" name="Custodes Tribune" hidden="false" collective="false" import="true" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4012-4122-c6ae-0278" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="530b-af68-3640-17b6" type="max"/>
+          </constraints>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="0e52-dcd8-8008-88f0" name="Tribune Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="5338-f912-8efa-5500">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b06d-4b27-31d1-c3fb" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="df1f-6f68-673e-cd08" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="5338-f912-8efa-5500" name="Guardian Spear" hidden="false" collective="false" import="true" targetId="2bb9-0525-4865-407c" type="selectionEntry"/>
+                <entryLink id="35ac-2f57-09de-f2fb" name="Pyrithire Spear" hidden="false" collective="false" import="true" targetId="4620-e360-7dd2-f908" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="0c35-bdee-a932-9206" name="Adrasite Spear" hidden="false" collective="false" import="true" targetId="0e0b-dbe3-3d1a-14a9" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="80d7-e8ea-f760-7c32" name="Sentinel Warblade" hidden="false" collective="false" import="true" targetId="6909-d6c6-8d05-0e57" type="selectionEntry"/>
+                <entryLink id="9464-6576-ae15-0d36" name="Paragon Blade" hidden="false" collective="false" import="true" targetId="2ab9-0e45-405e-056b" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="0281-832b-19e6-50c1" name="Meridian Swords " hidden="false" collective="false" import="true" targetId="9664-33bc-927e-5ba3" type="selectionEntry"/>
+                <entryLink id="d420-be7e-17f3-efcc" name="Solarite Power Gauntlet" hidden="false" collective="false" import="true" targetId="9786-98f2-bdab-5103" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="30.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="0b72-32dc-e863-1a55" name="Solarite Power Talon" hidden="false" collective="false" import="true" targetId="208d-ad3b-4008-334e" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="f71a-9a59-3640-e910" name="Two Solarite Power Talons" hidden="false" collective="false" import="true" targetId="bd49-770c-b509-884f" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="9146-b43c-8dc9-b221" name="Paragon Glaive" hidden="false" collective="false" import="true" targetId="a9fc-4298-7b35-8ef4" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="30.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="9f52-9a89-827f-3e02" name="Guardian Axe" hidden="false" collective="false" import="true" targetId="1334-e423-944e-9499" type="selectionEntry"/>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="575d-0451-21b0-c388" name="Can take any of the following" hidden="false" collective="false" import="true">
+              <selectionEntries>
+                <selectionEntry id="14f2-0f27-87c6-79ae" name="Teleport Transponder Array" hidden="false" collective="false" import="true" type="upgrade">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="14ba-2eb8-f824-e1e1" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="125.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+              <entryLinks>
+                <entryLink id="af42-e5fa-0228-3d20" name="Archaeotech Pistol" hidden="false" collective="false" import="true" targetId="c22a-ed4d-af68-bf00" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="82b4-fede-f21e-3863" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="343f-bd92-7907-8276" name="Praesidium Shield" hidden="false" collective="false" import="true" targetId="6f59-3dda-0590-37c7" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eb34-222f-feda-602d" type="max"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="300.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="8247-80e7-81c0-d382" name="Custodian Shield Captain (Placeholder)" publicationId="15a4-fc68-502d-48a9" page="21" hidden="false" collective="false" import="true" type="unit">
+      <categoryLinks>
+        <categoryLink id="130c-2996-f4f8-712b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="79dc-942e-f0cc-b874" name="Legio Custodes" hidden="false" targetId="ccca-a9de-0cd9-f8be" primary="false"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="f999-996c-45d7-d934" name="Custodian Shield Captain" hidden="false" collective="false" import="true" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="02d1-db64-9289-ec7c" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="323b-0058-a301-3bd7" type="max"/>
+          </constraints>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="1f78-bdf3-7d0f-cad3" name="Can take any of the following" hidden="false" collective="false" import="true">
+              <entryLinks>
+                <entryLink id="d324-40af-fbc9-8e63" name="Archaeotech Pistol" hidden="false" collective="false" import="true" targetId="c22a-ed4d-af68-bf00" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b048-5c6f-8599-12c8" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="f066-0c1c-f8f7-2bba" name="Praesidium Shield" hidden="false" collective="false" import="true" targetId="6f59-3dda-0590-37c7" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8223-f4e7-9e20-131f" type="max"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="0756-23af-a5bb-73ab" name="Shield Captain Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="4b7d-e00a-fa27-7bc8">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3c38-7ac8-c896-4c2d" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="94b9-a49c-2840-f792" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="4b7d-e00a-fa27-7bc8" name="Guardian Spear" hidden="false" collective="false" import="true" targetId="2bb9-0525-4865-407c" type="selectionEntry"/>
+                <entryLink id="2206-6c40-bad5-4341" name="Pyrithire Spear" hidden="false" collective="false" import="true" targetId="4620-e360-7dd2-f908" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="e83a-be04-274a-352b" name="Adrasite Spear" hidden="false" collective="false" import="true" targetId="0e0b-dbe3-3d1a-14a9" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="0904-9ebb-64e1-3fab" name="Sentinel Warblade" hidden="false" collective="false" import="true" targetId="6909-d6c6-8d05-0e57" type="selectionEntry"/>
+                <entryLink id="bb6c-e4e5-bee3-6ec4" name="Paragon Blade" hidden="false" collective="false" import="true" targetId="2ab9-0e45-405e-056b" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="b87f-701e-02c4-a4a5" name="Meridian Swords " hidden="false" collective="false" import="true" targetId="9664-33bc-927e-5ba3" type="selectionEntry"/>
+                <entryLink id="3366-4ffe-91f8-dc65" name="Solarite Power Gauntlet" hidden="false" collective="false" import="true" targetId="9786-98f2-bdab-5103" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="30.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="bc29-946e-24ba-5bd1" name="Solarite Power Talon" hidden="false" collective="false" import="true" targetId="208d-ad3b-4008-334e" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="ad7b-b13b-1d3c-54eb" name="Two Solarite Power Talons" hidden="false" collective="false" import="true" targetId="bd49-770c-b509-884f" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="d22b-e7ac-8cca-ca7f" name="Paragon Glaive" hidden="false" collective="false" import="true" targetId="a9fc-4298-7b35-8ef4" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="30.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="cae7-76fc-6200-2e40" name="Guardian Axe" hidden="false" collective="false" import="true" targetId="1334-e423-944e-9499" type="selectionEntry"/>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="200.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="76da-acc0-3ffb-6161" name="Hetaeron Guard Squad (Placeholder)" publicationId="15a4-fc68-502d-48a9" page="22" hidden="false" collective="false" import="true" type="unit">
+      <categoryLinks>
+        <categoryLink id="32f8-7e42-c31c-ccd5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="938c-a0fe-81b1-0843" name="Legio Custodes" hidden="false" targetId="ccca-a9de-0cd9-f8be" primary="false"/>
+      </categoryLinks>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="144e-50c0-8ffc-1650" name="Hetaeron Guard" hidden="false" collective="false" import="true">
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4463-e5da-9c52-a851" type="min"/>
+            <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bb4d-0ee9-f13e-a532" type="max"/>
+          </constraints>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="73b0-c967-ec6b-74b0" name="1) Hetaeron without Shields" hidden="false" collective="false" import="true" defaultSelectionEntryId="d1c0-9b0e-0222-8e83">
+              <modifiers>
+                <modifier type="decrement" field="1563-a1cc-e8b0-c05c" value="3.0"/>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1563-a1cc-e8b0-c05c" type="min"/>
+              </constraints>
+              <selectionEntries>
+                <selectionEntry id="0900-03f8-9f60-23a3" name="Hetaeron w/ Guardian Axe" hidden="false" collective="false" import="true" type="model">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8091-b493-9ee4-4f59" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="6377-c528-4e3f-f5cf" name="Guardian Axe" hidden="false" collective="false" import="true" targetId="3780-57f7-1eb8-0851" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a218-a94a-ed7b-1852" type="min"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="118a-6a5e-0d42-27d9" type="max"/>
+                      </constraints>
+                    </entryLink>
+                  </entryLinks>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="70.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="68dd-1247-003e-31d0" name="Hetaeron w/ Guardian Spear" hidden="false" collective="false" import="true" type="model">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="455e-ca78-7320-59ab" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="c3b0-b490-fc59-0959" name="Guardian Spear" hidden="false" collective="false" import="true" targetId="9e55-ae31-3ba6-d720" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b566-4641-724e-3b7c" type="min"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="04e6-ee16-dbd4-347a" type="max"/>
+                      </constraints>
+                    </entryLink>
+                  </entryLinks>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="70.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="d1c0-9b0e-0222-8e83" name="Hetaeron w/ Meridian Swords" hidden="false" collective="false" import="true" type="model">
+                  <modifiers>
+                    <modifier type="decrement" field="98c1-6851-703c-3ae2" value="3.0"/>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="38c5-e375-7aa6-3f7b" type="max"/>
+                    <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="98c1-6851-703c-3ae2" type="min"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="7b02-807e-5990-01e7" name="Meridian Swords" hidden="false" collective="false" import="true" targetId="695d-f7d5-6f32-1d3a" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5808-8206-581e-8a79" type="min"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="603f-7109-cc19-261f" type="max"/>
+                      </constraints>
+                    </entryLink>
+                  </entryLinks>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="70.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="d643-d571-5467-a7bf" name="Hetaeron w/ Paragon Blade" hidden="false" collective="false" import="true" type="model">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="603d-961a-19b7-0c1c" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="665f-1d45-360b-7d55" name="Paragon Blade" hidden="false" collective="false" import="true" targetId="f99c-9468-c0c6-a865" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="082d-51ee-8adf-a8f8" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3185-6444-8fa0-e326" type="min"/>
+                      </constraints>
+                      <costs>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0"/>
+                      </costs>
+                    </entryLink>
+                  </entryLinks>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="70.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="9050-4a75-81e6-c20f" name="Hetaeron w/ Pyrithire Spear" hidden="false" collective="false" import="true" type="model">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="271d-186d-b22f-9630" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="8569-29e4-4360-f8a1" name="Pyrithire Spear" hidden="false" collective="false" import="true" targetId="4c16-32b1-1a7a-928b" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7ec1-47e9-b4db-209c" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a3dc-82cb-9744-8777" type="min"/>
+                      </constraints>
+                      <costs>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                      </costs>
+                    </entryLink>
+                  </entryLinks>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="70.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="ff4a-b46c-3eeb-c5b6" name="Hetaeron w/ Sentinel Warblade" hidden="false" collective="false" import="true" type="model">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="47dc-66c0-8cef-682b" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="2054-e3a8-ad38-981f" name="Sentinel Warblade" hidden="false" collective="false" import="true" targetId="0c34-7afc-bced-140f" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3c15-480c-1c52-e101" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a5e3-b0f3-609d-9fba" type="min"/>
+                      </constraints>
+                    </entryLink>
+                  </entryLinks>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="70.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="4ae2-beb7-91aa-75f2" name="Hetaeron w/ Solarite Power Gauntlet" hidden="false" collective="false" import="true" type="model">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9377-8eec-eab1-52a8" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="56a5-77fa-6d8c-aa04" name="Solarite Power Gauntlet" hidden="false" collective="false" import="true" targetId="85f2-5b5a-1526-a121" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2d6f-656a-fe9d-b5bf" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="09a4-d56a-629b-82c8" type="min"/>
+                      </constraints>
+                      <costs>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="30.0"/>
+                      </costs>
+                    </entryLink>
+                  </entryLinks>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="70.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="44a3-8211-6a91-9271" name="Hetaeron w/ Solarite Power Talon" hidden="false" collective="false" import="true" type="model">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8537-53de-c95c-c238" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="fab5-4edb-0127-07f4" name="Solarite Power Talon" hidden="false" collective="false" import="true" targetId="d9bd-74cb-097b-14de" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0d2c-5c9d-d31a-4572" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a2e4-452c-6a48-d355" type="min"/>
+                      </constraints>
+                      <costs>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                      </costs>
+                    </entryLink>
+                  </entryLinks>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="70.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="050c-3505-51c6-25f1" name="Hetaeron w/ Two Solarite Power Talons" hidden="false" collective="false" import="true" type="model">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2e65-c83d-5c95-8bbf" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="7971-7f4e-7908-e2a2" name="Two Solarite Power Talons" hidden="false" collective="false" import="true" targetId="da0b-91f0-8baa-d330" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ae1a-9ac1-f8fd-db3a" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f389-ccfc-e871-06d0" type="min"/>
+                      </constraints>
+                      <costs>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                      </costs>
+                    </entryLink>
+                  </entryLinks>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="70.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="27da-bde5-6577-407f" name="Hetaeron w/ Adrasite Spear" hidden="false" collective="false" import="true" type="model">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3725-989f-9b01-bc46" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="c3d5-70f6-944f-11e5" name="Adrasite Spear" hidden="false" collective="false" import="true" targetId="101f-346d-b8fa-a5c3" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7607-39f0-ec74-5521" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a4db-da5d-bd83-cc68" type="min"/>
+                      </constraints>
+                      <costs>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                      </costs>
+                    </entryLink>
+                  </entryLinks>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="70.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="1c72-21e6-3d26-ef76" name="2) Hetaeron with Shields" hidden="false" collective="false" import="true">
+              <selectionEntries>
+                <selectionEntry id="be78-0985-c054-c276" name="Hetaeron w/ Guardian Axe &amp; Praesidium Shield" hidden="false" collective="false" import="true" type="model">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cce3-69f6-fb62-9d5d" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="1f7b-7d4b-116c-16bb" name="Guardian Axe" hidden="false" collective="false" import="true" targetId="3780-57f7-1eb8-0851" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1669-815c-d63f-b196" type="min"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ff4c-8b4a-130f-f9aa" type="max"/>
+                      </constraints>
+                    </entryLink>
+                    <entryLink id="2278-0023-cb48-fa1d" name="Praesidium Shield" hidden="false" collective="false" import="true" targetId="4e51-f06c-0dff-e3e8" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="542b-5c14-ddec-45a8" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a7df-e166-1c18-4cb5" type="min"/>
+                      </constraints>
+                      <costs>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                      </costs>
+                    </entryLink>
+                  </entryLinks>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="70.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="f8c1-dabd-384f-5164" name="Hetaeron w/ Guardian Spear &amp; Praesidium Shield" hidden="false" collective="false" import="true" type="model">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dd39-fdd3-2e7d-7a69" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="416a-4e01-51ce-3b49" name="Guardian Spear" hidden="false" collective="false" import="true" targetId="9e55-ae31-3ba6-d720" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9caa-962d-05f2-7357" type="min"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c40d-fffa-a39f-882f" type="max"/>
+                      </constraints>
+                    </entryLink>
+                    <entryLink id="1a38-e288-90a9-b60a" name="Praesidium Shield" hidden="false" collective="false" import="true" targetId="4e51-f06c-0dff-e3e8" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d0ea-46b4-31ee-3b71" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0ca0-b4c3-b623-2508" type="min"/>
+                      </constraints>
+                      <costs>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                      </costs>
+                    </entryLink>
+                  </entryLinks>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="70.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="6295-c32e-3981-a9df" name="Hetaeron w/ Meridian Swords &amp; Praesidium Shield" hidden="false" collective="false" import="true" type="model">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9359-db30-ea12-b2de" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="2495-2d6f-cf87-daa3" name="Meridian Swords" hidden="false" collective="false" import="true" targetId="695d-f7d5-6f32-1d3a" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e625-d514-bb16-7483" type="min"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3185-8dfc-dd7b-2348" type="max"/>
+                      </constraints>
+                    </entryLink>
+                    <entryLink id="da75-5fd1-af77-df59" name="Praesidium Shield" hidden="false" collective="false" import="true" targetId="4e51-f06c-0dff-e3e8" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c2af-68ba-03ba-d4fc" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b924-3899-38ae-3596" type="min"/>
+                      </constraints>
+                      <costs>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                      </costs>
+                    </entryLink>
+                  </entryLinks>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="70.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="2f05-a815-2fcc-5462" name="Hetaeron w/ Paragon Blade &amp; Praesidium Shield" hidden="false" collective="false" import="true" type="model">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3a05-459c-1634-3eb4" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="ceb0-8052-3dae-bfe7" name="Paragon Blade" hidden="false" collective="false" import="true" targetId="f99c-9468-c0c6-a865" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="254b-1408-b2ef-3384" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b3db-55d8-f7c1-1fb6" type="min"/>
+                      </constraints>
+                      <costs>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="544a-6cdf-853c-45a2" name="Praesidium Shield" hidden="false" collective="false" import="true" targetId="4e51-f06c-0dff-e3e8" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a076-59b0-731b-0a96" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0a2e-0f3d-3755-e6f1" type="min"/>
+                      </constraints>
+                      <costs>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                      </costs>
+                    </entryLink>
+                  </entryLinks>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="70.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="4d1d-1fa5-c4b2-67fc" name="Hetaeron w/ Pyrithire Spear &amp; Praesidium Shield" hidden="false" collective="false" import="true" type="model">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2d68-54b8-cc7a-a573" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="91e0-37ad-5bd3-89d2" name="Pyrithire Spear" hidden="false" collective="false" import="true" targetId="4c16-32b1-1a7a-928b" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2e0a-c05e-f94c-7d58" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="160e-dbca-1bbe-5b7a" type="min"/>
+                      </constraints>
+                      <costs>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="272f-4b9d-3df1-43fd" name="Praesidium Shield" hidden="false" collective="false" import="true" targetId="4e51-f06c-0dff-e3e8" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3003-9c1b-eb8b-33ca" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a2b3-9fc4-743d-7197" type="min"/>
+                      </constraints>
+                      <costs>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                      </costs>
+                    </entryLink>
+                  </entryLinks>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="70.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="42ca-34ed-d91a-a5d9" name="Hetaeron w/ Sentinel Warblade &amp; Praesidium Shield" hidden="false" collective="false" import="true" type="model">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5687-1d8f-c145-43e9" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="87fe-069a-66eb-eee8" name="Sentinel Warblade" hidden="false" collective="false" import="true" targetId="0c34-7afc-bced-140f" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c393-e160-da12-70ed" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="faa7-c438-4aab-89a0" type="min"/>
+                      </constraints>
+                    </entryLink>
+                    <entryLink id="169d-b49f-83e0-ddb6" name="Praesidium Shield" hidden="false" collective="false" import="true" targetId="4e51-f06c-0dff-e3e8" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7024-d971-169c-1590" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bf01-9886-c729-2dc8" type="min"/>
+                      </constraints>
+                      <costs>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                      </costs>
+                    </entryLink>
+                  </entryLinks>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="70.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="f47d-5da4-6c07-7789" name="Hetaeron w/ Solarite Power Gauntlet &amp; Praesidium Shield" hidden="false" collective="false" import="true" type="model">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9e47-8f79-09d2-205b" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="0e1e-f861-93a3-a103" name="Solarite Power Gauntlet" hidden="false" collective="false" import="true" targetId="85f2-5b5a-1526-a121" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="119f-1295-823a-a68f" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fad3-cc91-30bc-7e80" type="min"/>
+                      </constraints>
+                      <costs>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="30.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="bda5-00bc-1671-65cb" name="Praesidium Shield" hidden="false" collective="false" import="true" targetId="4e51-f06c-0dff-e3e8" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5f5c-a0e1-5ff9-4530" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6797-4af0-09d7-d0c3" type="min"/>
+                      </constraints>
+                      <costs>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                      </costs>
+                    </entryLink>
+                  </entryLinks>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="70.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="56e6-585a-a982-eee2" name="Hetaeron w/ Solarite Power Talon &amp; Praesidium Shield" hidden="false" collective="false" import="true" type="model">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a09c-31d6-911f-f070" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="c677-b0d8-a7c0-9d54" name="Solarite Power Talon" hidden="false" collective="false" import="true" targetId="d9bd-74cb-097b-14de" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="586b-9a5f-a8eb-8a1a" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5cf4-1a21-c867-3a85" type="min"/>
+                      </constraints>
+                      <costs>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="26eb-af64-bc02-119c" name="Praesidium Shield" hidden="false" collective="false" import="true" targetId="4e51-f06c-0dff-e3e8" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="08a0-2e61-5fcf-5e98" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="55ef-9e3c-098d-d272" type="min"/>
+                      </constraints>
+                      <costs>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                      </costs>
+                    </entryLink>
+                  </entryLinks>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="70.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="87e7-fc17-d0b5-1d04" name="Hetaeron w/ Two Solarite Power Talons &amp; Praesidium Shield" hidden="false" collective="false" import="true" type="model">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d85e-59e7-689f-0456" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="6518-c382-31c8-4317" name="Two Solarite Power Talons" hidden="false" collective="false" import="true" targetId="da0b-91f0-8baa-d330" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="61b6-11d7-fe76-9779" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="99d5-ffd7-011a-f1ae" type="min"/>
+                      </constraints>
+                      <costs>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="9866-d431-1e46-f835" name="Praesidium Shield" hidden="false" collective="false" import="true" targetId="4e51-f06c-0dff-e3e8" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6cb9-ed8b-9c56-7e35" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e860-f1be-9e4a-4709" type="min"/>
+                      </constraints>
+                      <costs>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                      </costs>
+                    </entryLink>
+                  </entryLinks>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="70.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="d30a-9e0a-90a4-b4c0" name="Hetaeron w/ Adrasite Spear &amp; Praesidium Shield" hidden="false" collective="false" import="true" type="model">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b2de-1134-69bb-7b00" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="0412-79e6-7ad0-341e" name="Adrasite Spear" hidden="false" collective="false" import="true" targetId="101f-346d-b8fa-a5c3" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="04f2-a30c-8fd9-e677" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e9c2-3d4a-268b-aec2" type="min"/>
+                      </constraints>
+                      <costs>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="2e92-d822-aa8c-38bd" name="Praesidium Shield" hidden="false" collective="false" import="true" targetId="4e51-f06c-0dff-e3e8" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1c77-6fc9-ff50-82bf" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9f17-ea1a-3f30-9267" type="min"/>
+                      </constraints>
+                      <costs>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                      </costs>
+                    </entryLink>
+                  </entryLinks>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="70.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="34f9-9123-78f9-c34a" name="3) Hetaeron with Vexilla &amp;" hidden="false" collective="false" import="true">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2569-feef-f888-f352" type="max"/>
+              </constraints>
+              <selectionEntries>
+                <selectionEntry id="ef43-583e-8ae4-fe0f" name="Hetaeron w/ Master-Crafted Power Axe and Vexilla" hidden="false" collective="false" import="true" type="model">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b74f-fe54-bcb7-b026" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="3a49-6e55-b5c9-1033" name="Magisterium Vexilla" hidden="false" collective="false" import="true" targetId="df30-d357-3ee0-a102" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0127-cd63-3ac0-6b64" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6906-a8d4-7b2d-9d51" type="min"/>
+                      </constraints>
+                    </entryLink>
+                    <entryLink id="3db3-fae2-da49-f8b2" name="Power Axe" hidden="false" collective="false" import="true" targetId="ef98-66ac-fcaf-c15d" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e390-87e8-7ebf-831a" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5aee-47bd-8077-4ed7" type="min"/>
+                      </constraints>
+                    </entryLink>
+                  </entryLinks>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="85.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="5ed1-f7ea-c6b6-b27c" name="Hetaeron w/ Master-Crafted Power Lance and Vexilla" hidden="false" collective="false" import="true" type="model">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="80ee-e6e1-dd2f-b0a7" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="0f91-1bdf-403c-cba4" name="Magisterium Vexilla" hidden="false" collective="false" import="true" targetId="df30-d357-3ee0-a102" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4d9a-db85-6faa-aab1" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bb72-2c11-d05b-c184" type="min"/>
+                      </constraints>
+                    </entryLink>
+                    <entryLink id="f00c-f67c-5fd4-a8e1" name="Power Lance" hidden="false" collective="false" import="true" targetId="fca3-4ec1-c581-1ba3" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7cc5-18f3-1630-1091" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="247f-ac6e-aa5c-627f" type="min"/>
+                      </constraints>
+                    </entryLink>
+                  </entryLinks>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="85.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="0854-afcf-2739-03c8" name="Hetaeron w/ Master-Crafted Power Maul and Vexilla" hidden="false" collective="false" import="true" type="model">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="702b-a009-457b-fe33" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="4688-73f8-fb09-1a48" name="Magisterium Vexilla" hidden="false" collective="false" import="true" targetId="df30-d357-3ee0-a102" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e27c-448d-d4c8-9af4" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1b86-3c74-efc4-df0e" type="min"/>
+                      </constraints>
+                    </entryLink>
+                    <entryLink id="0f73-6e49-3ab3-de1b" name="Power Maul" hidden="false" collective="false" import="true" targetId="98e8-f217-dea9-0493" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4c2f-eb5f-cd22-6b8c" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ed2c-ffe2-d661-41f1" type="min"/>
+                      </constraints>
+                    </entryLink>
+                  </entryLinks>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="85.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="881c-4181-efda-5d3c" name="Hetaeron w/ Master-Crafted Power Sword and Vexilla" hidden="false" collective="false" import="true" type="model">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bcc7-247f-851c-236f" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="c2fc-e5c6-d3bb-3d6b" name="Magisterium Vexilla" hidden="false" collective="false" import="true" targetId="df30-d357-3ee0-a102" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2d43-b038-8e8b-f911" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="31fa-35a6-06d6-39c0" type="min"/>
+                      </constraints>
+                    </entryLink>
+                    <entryLink id="7504-5158-7b5e-aff5" name="Power Sword" hidden="false" collective="false" import="true" targetId="fa06-cac0-3d98-125e" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="73fe-589e-ac70-9363" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3504-3658-7623-e79a" type="min"/>
+                      </constraints>
+                    </entryLink>
+                  </entryLinks>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="85.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="a601-5e4f-1ab0-59a9" name="Hetaeron w/ Master-Crafted Sentinal Warblade &amp; Vexilla" hidden="false" collective="false" import="true" type="model">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="96f8-ada5-3e75-a7fb" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="66c8-e3e3-ca38-dcb6" name="Sentinel Warblade" hidden="false" collective="false" import="true" targetId="0c34-7afc-bced-140f" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3de7-0d8e-e6c1-38eb" type="min"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="17a1-daca-c31c-c37b" type="max"/>
+                      </constraints>
+                    </entryLink>
+                    <entryLink id="4ef1-e3f1-8d36-f4d5" name="Magisterium Vexilla" hidden="false" collective="false" import="true" targetId="df30-d357-3ee0-a102" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fa1c-8fef-eee8-d7f5" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0e57-0687-00c4-4c5a" type="min"/>
+                      </constraints>
+                    </entryLink>
+                  </entryLinks>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="90.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="91d0-6274-7727-683f" name="Dedicated Transport (Custodes)" hidden="false" collective="false" import="true" targetId="fe3c-f221-2044-bc2b" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="258c-214d-bc9d-35e1" name="Aquilon Terminator Squad (Placeholder)" publicationId="15a4-fc68-502d-48a9" page="23" hidden="false" collective="false" import="true" type="unit">
+      <categoryLinks>
+        <categoryLink id="12ab-2abe-e379-ae07" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="5797-77fd-47c1-3b72" name="Legio Custodes" hidden="false" targetId="ccca-a9de-0cd9-f8be" primary="false"/>
+      </categoryLinks>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="e35e-3b4a-634c-27c7" name="Aquilon Terminator" hidden="false" collective="false" import="true" defaultSelectionEntryId="3b03-cf93-c721-4c45">
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dd7c-4dbc-c38a-fbac" type="min"/>
+            <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0d8c-395c-1724-2001" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="fdce-89a7-5d0c-ab5f" name="Aquilon w/ Solarite Power Gauntlet &amp; Twin-Linked Adrathic Destructor" hidden="false" collective="false" import="true" type="model">
+              <entryLinks>
+                <entryLink id="d3bb-f0a3-897c-3f31" name="Solarite Power Gauntlet" hidden="false" collective="false" import="true" targetId="85f2-5b5a-1526-a121" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5f87-0f4c-ab0d-41d6" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="68ce-4e08-95ce-471a" type="max"/>
+                  </constraints>
+                </entryLink>
+                <entryLink id="1d2f-9b10-598f-fbe6" name="Twin-Linked Adrathic Destructor" hidden="false" collective="false" import="true" targetId="1887-051d-c262-513b" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="699e-4a4b-680a-b8ca" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="45fc-099f-5a6e-ff8d" type="max"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="105.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="e6d8-b264-6ebb-213d" name="Aquilon w/ Solarite Power Gauntlet &amp; Infernus Firepike" hidden="false" collective="false" import="true" type="model">
+              <entryLinks>
+                <entryLink id="86f0-fc19-9835-a1ae" name="Solarite Power Gauntlet" hidden="false" collective="false" import="true" targetId="85f2-5b5a-1526-a121" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c26a-d606-36dc-f466" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e0e7-6a69-dab0-2c5e" type="max"/>
+                  </constraints>
+                </entryLink>
+                <entryLink id="2c7c-4202-780a-573a" name="Infernus Firepike" hidden="false" collective="false" import="true" targetId="2b1d-a84d-9b3f-8ad6" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ac3c-03b6-a1c6-b96c" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ed65-d10d-cfb7-7736" type="max"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="105.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="f5f5-d024-af1b-83c5" name="Aquilon w/ Solarite Power Talon &amp; Twin-Linked Adrathic Destructor" hidden="false" collective="false" import="true" type="model">
+              <entryLinks>
+                <entryLink id="0093-16fc-2f6a-9ed1" name="Solarite Power Talon" hidden="false" collective="false" import="true" targetId="d9bd-74cb-097b-14de" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b191-b01f-1520-9a5c" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9ba3-a332-31f9-7d0e" type="max"/>
+                  </constraints>
+                </entryLink>
+                <entryLink id="7903-64c7-79c8-9d31" name="Twin-Linked Adrathic Destructor" hidden="false" collective="false" import="true" targetId="1887-051d-c262-513b" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c8bf-82a8-047a-1812" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d072-3ef8-4527-6ad7" type="max"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="105.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="3b03-cf93-c721-4c45" name="Aquilon w/ Solarite Power Gauntlet &amp; Lastrum Storm Bolter" hidden="false" collective="false" import="true" type="model">
+              <entryLinks>
+                <entryLink id="a03a-6821-bb33-0165" name="Solarite Power Gauntlet" hidden="false" collective="false" import="true" targetId="85f2-5b5a-1526-a121" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f48a-f220-9c7b-dceb" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5824-9325-270a-beb2" type="max"/>
+                  </constraints>
+                </entryLink>
+                <entryLink id="95a0-a0b9-185c-6d45" name="Lastrum Storm Bolter" hidden="false" collective="false" import="true" targetId="9724-e7e9-59b0-8c35" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0b36-206e-9381-1af9" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e520-8d67-4cb8-a690" type="max"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="90.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="b50a-3dc9-3a90-c15c" name="Aquilon w/ Solarite Power Gauntlet &amp; Solarite Power Talon" hidden="false" collective="false" import="true" type="model">
+              <entryLinks>
+                <entryLink id="0e98-87e1-f133-a0ca" name="Solarite Power Gauntlet" hidden="false" collective="false" import="true" targetId="85f2-5b5a-1526-a121" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b308-e7d2-500f-351b" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3d56-1ae6-0b7b-290f" type="max"/>
+                  </constraints>
+                </entryLink>
+                <entryLink id="2701-1a04-e7fa-9815" name="Solarite Power Talon" hidden="false" collective="false" import="true" targetId="d9bd-74cb-097b-14de" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ede2-cec6-b256-8f59" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2561-f6d3-ba70-85c4" type="max"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="90.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="e10f-e6da-6a20-ae01" name="Aquilon w/ Solarite Power Talon &amp; Infernus Firepike" hidden="false" collective="false" import="true" type="model">
+              <entryLinks>
+                <entryLink id="adcb-96c3-d4b4-fa1a" name="Solarite Power Talon" hidden="false" collective="false" import="true" targetId="d9bd-74cb-097b-14de" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fc1b-cbc7-4ce3-b96a" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="43ad-bc00-547f-c3f4" type="max"/>
+                  </constraints>
+                </entryLink>
+                <entryLink id="4d8e-873b-8844-3b1a" name="Infernus Firepike" hidden="false" collective="false" import="true" targetId="2b1d-a84d-9b3f-8ad6" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a05a-d02c-239f-dbd3" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6d75-6734-4034-1ee9" type="max"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="105.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="02d3-2f77-69a4-b0a5" name="Aquilon w/ Solarite 2X Power Talons" hidden="false" collective="false" import="true" type="model">
+              <entryLinks>
+                <entryLink id="b703-cfc7-7407-5943" name="Two Solarite Power Talons" hidden="false" collective="false" import="true" targetId="da0b-91f0-8baa-d330" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0b1e-8f1f-2898-5357" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a9f4-491b-3df2-a4b9" type="max"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="90.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="68d9-52e0-0e62-e879" name="Aquilon w/ Solarite Power Talon &amp; Lastrum Storm Bolter" hidden="false" collective="false" import="true" type="model">
+              <entryLinks>
+                <entryLink id="6012-1063-bd7e-4c41" name="Solarite Power Talon" hidden="false" collective="false" import="true" targetId="d9bd-74cb-097b-14de" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6a5f-6299-8785-68e2" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="80a7-5bda-6604-e66c" type="max"/>
+                  </constraints>
+                </entryLink>
+                <entryLink id="5083-fcc0-de20-4a6c" name="Lastrum Storm Bolter" hidden="false" collective="false" import="true" targetId="9724-e7e9-59b0-8c35" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bdb7-17ab-67d2-ea2a" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="339c-1bf8-9c64-def3" type="max"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="90.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="34f9-fd7b-750c-12ff" name="Dedicated Transport (Custodes)" hidden="false" collective="false" import="true" targetId="fe3c-f221-2044-bc2b" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="1ba9-e9e5-0f7e-27e0" name="Contemptor-Achillus Dreadnought (Placeholder)" publicationId="15a4-fc68-502d-48a9" page="24" hidden="false" collective="false" import="true" type="unit">
+      <categoryLinks>
+        <categoryLink id="53a2-5f11-f40b-8286" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="02dd-cc73-a253-8af4" name="Legio Custodes" hidden="false" targetId="ccca-a9de-0cd9-f8be" primary="false"/>
+        <categoryLink id="0505-09c4-f3b8-ed82" name="Dreadnought Unit-type:" hidden="false" targetId="4280-4963-02b5-e31d" primary="false"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="ef49-f7b4-8073-0fdf" name="Contemptor-Achillus Dreadnought " hidden="false" collective="false" import="true" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4603-d647-8921-d87a" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ea3d-636d-f4ba-e935" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="eaae-8f8e-c368-d7ad" name="Achillus Dreadspear with In-built Corvae Las-Pulser" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2f52-ae55-93cc-5564" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8467-895b-9c36-4b57" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="f761-0032-38b2-78c9" name="Corvae Las-Pulser" hidden="false" collective="false" import="true" targetId="94ed-c2ef-d612-1ef9" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3bf6-e39e-2fbc-fbb2" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="14f8-32b9-3e1e-7522" type="max"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="fbc6-59d1-a432-0789" name="In-built weapon on Gravis Power Fist" hidden="false" collective="false" import="true" defaultSelectionEntryId="365c-7c2f-c51d-4fe2">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c595-771c-8d31-a10d" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d2f3-5806-abf4-a88a" type="min"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="a0ea-8678-9d63-1231" name="Twin-Linked Adrathic Destructor" hidden="false" collective="false" import="true" targetId="6613-a83e-8274-6e06" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="2bab-d336-0da7-00e3" name="Infernus Incinerator" hidden="false" collective="false" import="true" targetId="abcd-6d7c-8232-6bb8" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="365c-7c2f-c51d-4fe2" name="Lastrum Storm Bolter" hidden="false" collective="false" import="true" targetId="b3bf-5df7-9ac4-c0cf" type="selectionEntry"/>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks>
+            <entryLink id="fb08-d673-e512-d104" name="Gravis Power Fist" hidden="false" collective="false" import="true" targetId="08be-6994-6a63-6279" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ca2a-d98e-3ddd-fe40" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3cf9-57df-526f-7fa3" type="min"/>
+              </constraints>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="250.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="7cec-fe1b-5748-7af3" name="Custodian Guard Squad (Placeholder)" publicationId="15a4-fc68-502d-48a9" page="25" hidden="false" collective="false" import="true" type="unit">
+      <categoryLinks>
+        <categoryLink id="0548-5096-7747-dd7c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="5f75-16bc-27f0-2193" name="Legio Custodes" hidden="false" targetId="ccca-a9de-0cd9-f8be" primary="false"/>
+      </categoryLinks>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="ecf8-243f-2a4f-ab80" name="Custodian Guard" hidden="false" collective="false" import="true" defaultSelectionEntryId="1d66-83bc-7363-e501">
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="65bc-ce61-a441-0bc0" type="min"/>
+            <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2f3e-462d-fb3b-9d0b" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="1d66-83bc-7363-e501" name="Custodian Guard w/ Guardian Spear" hidden="false" collective="false" import="true" type="model">
+              <constraints>
+                <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a081-d724-d013-de0a" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="dc4f-398d-7081-9987" name="Guardian Spear" hidden="false" collective="false" import="true" targetId="9e55-ae31-3ba6-d720" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8ec6-74ce-a116-bcea" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="91c7-d0b7-8465-d0a2" type="max"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="45.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="7546-51fe-0073-06fd" name="Custodian Guard w/ Pyrihite Spear" hidden="false" collective="false" import="true" type="model">
+              <constraints>
+                <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5bca-cefe-704c-191f" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="1006-05c3-bf5e-6750" name="Pyrithire Spear" hidden="false" collective="false" import="true" targetId="4c16-32b1-1a7a-928b" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="447c-a318-b615-a277" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e233-96db-c99d-c0f8" type="max"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="60.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="be52-52ce-b2cf-bf20" name="Custodian Guard w/ Adrasite Spear" hidden="false" collective="false" import="true" type="model">
+              <constraints>
+                <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="651d-e622-cb68-89f7" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="f436-d8d3-811d-19d0" name="Adrasite Spear" hidden="false" collective="false" import="true" targetId="101f-346d-b8fa-a5c3" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e232-1995-348c-c1f9" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="18d2-2a24-6e1d-2d1e" type="max"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="55.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="0a74-0ea1-da5f-e3b7" name="Custodian Guard w/ Guardian Axe" hidden="false" collective="false" import="true" type="model">
+              <constraints>
+                <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fce7-ebfc-7298-fb6a" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="55c4-5034-eaa8-5f9c" name="Guardian Axe" hidden="false" collective="false" import="true" targetId="3780-57f7-1eb8-0851" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="27d2-1f2e-e81a-3f88" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7232-7ab0-b4c2-af59" type="max"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="45.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="1897-23e9-d912-2a24" name="One may exchange Guardian Spear for Magisterium Vexilla &amp;:" hidden="false" collective="false" import="true">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8eee-28c2-82a3-989d" type="max"/>
+              </constraints>
+              <selectionEntries>
+                <selectionEntry id="064c-5f3d-0e75-95b2" name="Custodian Guard w/ Sentinal Warblade &amp; Vexilla" hidden="false" collective="false" import="true" type="model">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9b87-5c47-314c-4d11" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="65.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="8dc5-b5d6-e154-a8eb" name="Custodian Guard w/ Master-Crafted Power Lance &amp; Vexilla" hidden="false" collective="false" import="true" type="model">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="03b0-22a5-e285-1ad4" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="60.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="8de9-3bdc-c580-b9aa" name="Custodian Guard w/ Master-Crafted Power Maul &amp; Vexilla" hidden="false" collective="false" import="true" type="model">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c0be-98a1-3648-d311" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="60.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="67fb-8d60-68ee-2fae" name="Custodian Guard w/ Master-Crafted Power Axe &amp; Vexilla" hidden="false" collective="false" import="true" type="model">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ff1d-5a5e-cfea-42af" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="60.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="8497-6360-cc95-acf2" name="Custodian Guard w/ Master-Crafted Power Sword &amp; Vexilla" hidden="false" collective="false" import="true" type="model">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d03e-62e3-dc63-2602" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="60.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="f15c-d249-876c-f954" name="Dedicated Transport (Custodes)" hidden="false" collective="false" import="true" targetId="fe3c-f221-2044-bc2b" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="206f-680f-4be9-6307" name="Sentinel Guard Squad (Placeholder)" publicationId="15a4-fc68-502d-48a9" page="26" hidden="false" collective="false" import="true" type="unit">
+      <categoryLinks>
+        <categoryLink id="6e65-60e4-f576-4988" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="edd2-c21f-69bd-061d" name="Legio Custodes" hidden="false" targetId="ccca-a9de-0cd9-f8be" primary="false"/>
+      </categoryLinks>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="c7ab-7d94-ef16-db4d" name="Sentinel Guard" hidden="false" collective="false" import="true" defaultSelectionEntryId="2906-1c80-a8ed-6672">
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1f04-1fab-9b69-57d5" type="min"/>
+            <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fb24-7914-8d0e-0617" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="3df2-dffe-be7f-cf85" name="Sentinel Guard w/ Solarite Power Talon &amp;  Shield" hidden="false" collective="false" import="true" type="model">
+              <entryLinks>
+                <entryLink id="5a32-0414-d944-4387" name="Praesidium Shield" hidden="false" collective="false" import="true" targetId="4e51-f06c-0dff-e3e8" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="aa59-dd31-950c-654e" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a0b6-1d24-6f20-cb77" type="max"/>
+                  </constraints>
+                </entryLink>
+                <entryLink id="c6c1-a11f-1c69-c5e6" name="Solarite Power Talon" hidden="false" collective="false" import="true" targetId="d9bd-74cb-097b-14de" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1c70-4cd4-ea45-7669" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d7b2-beab-9ef3-3aba" type="max"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="55.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="fb12-f008-703b-3f30" name="Sentinel Guard w/ Solarite Power Gauntlet &amp; Shield" hidden="false" collective="false" import="true" type="model">
+              <entryLinks>
+                <entryLink id="4a05-e54e-52a3-3e4b" name="Praesidium Shield" hidden="false" collective="false" import="true" targetId="4e51-f06c-0dff-e3e8" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a3dd-8e31-87b0-f94e" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="efc8-a035-8402-21d6" type="max"/>
+                  </constraints>
+                </entryLink>
+                <entryLink id="a974-15fd-ffb2-5a39" name="Solarite Power Gauntlet" hidden="false" collective="false" import="true" targetId="85f2-5b5a-1526-a121" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bac9-7818-f455-0169" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5dfa-7454-ff54-e4a4" type="max"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="75.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="2906-1c80-a8ed-6672" name="Sentinel Guard w/ Sentinel Warblade &amp; Shield" hidden="false" collective="false" import="true" type="model">
+              <entryLinks>
+                <entryLink id="32ce-775f-871b-10cb" name="Sentinel Warblade" hidden="false" collective="false" import="true" targetId="0c34-7afc-bced-140f" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a892-20bb-63fa-3845" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="161f-b1f0-3cd0-0aa1" type="max"/>
+                  </constraints>
+                </entryLink>
+                <entryLink id="eee1-2b8a-0267-0b01" name="Praesidium Shield" hidden="false" collective="false" import="true" targetId="4e51-f06c-0dff-e3e8" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7862-aa2d-a35c-fe35" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e9b9-36b5-d24f-1580" type="max"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="45.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="1afd-794c-438a-636d" name="One may exchange Praesidium Shield for Magisterium Vexilla" hidden="false" collective="false" import="true">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e3d3-5cdf-a513-8830" type="max"/>
+              </constraints>
+              <selectionEntries>
+                <selectionEntry id="d3f4-29cb-5cef-7472" name="Sentinel Guard w/ Solarite Power Talon &amp; Vexilla" hidden="false" collective="false" import="true" type="model">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0541-0773-7cc1-f1ba" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="c950-4cf2-ebf0-21e4" name="Solarite Power Talon" hidden="false" collective="false" import="true" targetId="208d-ad3b-4008-334e" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f46b-9a8f-6f7d-d364" type="min"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ccf3-4a3b-64d6-8cc3" type="max"/>
+                      </constraints>
+                    </entryLink>
+                    <entryLink id="3ac6-efdb-edd4-3d0b" name="Magisterium Vexilla" hidden="false" collective="false" import="true" targetId="3ac5-b28c-104a-9de5" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="660b-aafe-4d27-a076" type="min"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8aa3-3f4e-97f6-14bf" type="max"/>
+                      </constraints>
+                    </entryLink>
+                  </entryLinks>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="65.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="3665-6d98-26e6-ef50" name="Sentinel Guard w/ Solarite Power Gauntlet &amp; Vexilla" hidden="false" collective="false" import="true" type="model">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e651-d2c6-a054-e432" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="83bb-0ec2-09f9-066e" name="Solarite Power Gauntlet" hidden="false" collective="false" import="true" targetId="9786-98f2-bdab-5103" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="48d0-294d-f767-01f3" type="min"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a10f-c47c-a9c2-151d" type="max"/>
+                      </constraints>
+                    </entryLink>
+                    <entryLink id="5e80-f8e7-67c0-4418" name="Magisterium Vexilla" hidden="false" collective="false" import="true" targetId="3ac5-b28c-104a-9de5" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="29a6-5791-d377-35e7" type="min"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7371-14b0-2ab9-16f6" type="max"/>
+                      </constraints>
+                    </entryLink>
+                  </entryLinks>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="85.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="bf33-5019-fe30-a70a" name="Sentinel Guard w/ Sentinel Warblade &amp; Vexilla" hidden="false" collective="false" import="true" type="model">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e2fa-48c7-b65b-962b" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="5708-e255-93d0-023a" name="Magisterium Vexilla" hidden="false" collective="false" import="true" targetId="3ac5-b28c-104a-9de5" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f392-8b1f-830a-8d09" type="min"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="efd6-5199-cfba-7696" type="max"/>
+                      </constraints>
+                    </entryLink>
+                    <entryLink id="41df-2a5b-8959-78ff" name="Solarite Power Gauntlet" hidden="false" collective="false" import="true" targetId="9786-98f2-bdab-5103" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7f19-7124-2079-af4b" type="min"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1946-dd7c-838e-5c81" type="max"/>
+                      </constraints>
+                    </entryLink>
+                  </entryLinks>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="55.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="5b51-aa48-6a14-df0f" name="Dedicated Transport (Custodes)" hidden="false" collective="false" import="true" targetId="fe3c-f221-2044-bc2b" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="bf7c-a1e1-f983-987e" name="Coronus Grav-carrier (Placeholder)" publicationId="15a4-fc68-502d-48a9" page="27" hidden="false" collective="false" import="true" type="unit">
+      <categoryLinks>
+        <categoryLink id="09ec-fc5e-3f34-aeb8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="b673-5b47-1b69-42ed" name="Legio Custodes" hidden="false" targetId="ccca-a9de-0cd9-f8be" primary="false"/>
+        <categoryLink id="4776-46fc-0598-b8ab" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+      </categoryLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="180.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="f6b3-1e25-1353-0a50" name="Agamatus Jetbike Squadron (Placeholder)" publicationId="15a4-fc68-502d-48a9" page="28" hidden="false" collective="false" import="true" type="unit">
+      <categoryLinks>
+        <categoryLink id="3f92-c5f9-653d-5ecc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="99f3-cd79-499a-6777" name="Legio Custodes" hidden="false" targetId="ccca-a9de-0cd9-f8be" primary="false"/>
+      </categoryLinks>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="8d01-3189-ae6c-a55c" name="Agamatus" hidden="false" collective="false" import="true" defaultSelectionEntryId="dc21-c3d6-0f64-8f5f">
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bcd6-3504-4faf-ecec" type="min"/>
+            <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cb43-efa1-7233-1572" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="dc21-c3d6-0f64-8f5f" name="Agamatus with Lastrum Bolt Cannon" hidden="false" collective="false" import="true" type="model">
+              <constraints>
+                <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a1ef-716e-c774-56c5" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="e9b2-db21-079f-bb81" name="Lastrum Bolt Cannon" hidden="false" collective="false" import="true" targetId="97a4-45e2-fa61-bd02" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4700-f95c-f3b5-4199" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b15c-d1a8-6abc-9934" type="max"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="85.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="bc7b-9471-b7b9-dbd9" name="Agamatus with Adrathic Devastator" hidden="false" collective="false" import="true" type="model">
+              <constraints>
+                <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="678f-ee06-82e8-82f9" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="1ccb-952e-eb48-e8a9" name="Adrathic Devastator" hidden="false" collective="false" import="true" targetId="0425-2ab6-977c-8b81" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="86a5-4f78-29fd-5a6a" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5493-1fcc-c384-ec5d" type="max"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="100.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="c410-e50f-8751-bda1" name="Agamatus with Twin-linked Corvae Las-Pulser" hidden="false" collective="false" import="true" type="model">
+              <constraints>
+                <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9669-af76-2a82-db4c" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="af91-03a2-b92a-a70f" name="Corvae Las-Pulser" hidden="false" collective="false" import="true" targetId="d066-58b3-e43a-b8ad" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b87b-0d79-527c-3ed6" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8af1-0a7f-0072-6791" type="max"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="120.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="2ce3-4ce5-d86f-543f" name="Pallas Attack Speeder Squadron (Placeholder)" publicationId="15a4-fc68-502d-48a9" page="29" hidden="false" collective="false" import="true" type="unit">
+      <categoryLinks>
+        <categoryLink id="7027-dfa5-fe27-cc35" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="85b0-e22c-c5d6-8d28" name="Legio Custodes" hidden="false" targetId="ccca-a9de-0cd9-f8be" primary="false"/>
+      </categoryLinks>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="cd47-ac62-0faf-7e79" name="Pallas Attack Speeders" hidden="false" collective="false" import="true" defaultSelectionEntryId="e663-dd2e-7812-e408">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ccf8-86cb-2bf7-aa10" type="min"/>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c5a4-14b4-a70a-95c5" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="e663-dd2e-7812-e408" name="Pallas with Twin-Linked Arachnus Blaze Cannon" publicationId="15a4-fc68-502d-48a9" page="29" hidden="false" collective="false" import="true" type="model">
+              <categoryLinks>
+                <categoryLink id="01f1-f064-5384-5dfb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+                <categoryLink id="cb6c-c2b2-8add-13da" name="Legio Custodes" hidden="false" targetId="ccca-a9de-0cd9-f8be" primary="false"/>
+              </categoryLinks>
+              <entryLinks>
+                <entryLink id="2f39-a580-9869-d17a" name="Twin-Linked Arachnus Blaze Cannon" hidden="false" collective="false" import="true" targetId="1f5b-6e05-e40b-7305" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e1af-4115-1d5d-b569" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6730-05bf-decc-0995" type="max"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="60.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="3394-a13d-f029-e555" name="Pallas with Twin-Linked Adrathic Devastator" publicationId="15a4-fc68-502d-48a9" page="29" hidden="false" collective="false" import="true" type="model">
+              <categoryLinks>
+                <categoryLink id="77f0-b604-ed69-9dec" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+                <categoryLink id="8f99-1140-18b2-45d4" name="Legio Custodes" hidden="false" targetId="ccca-a9de-0cd9-f8be" primary="false"/>
+              </categoryLinks>
+              <entryLinks>
+                <entryLink id="8a74-5ed5-7929-40a8" name="Twin-Linked Adrathic Destructor" hidden="false" collective="false" import="true" targetId="1887-051d-c262-513b" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0946-5269-4b23-f223" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3de3-d161-dc3e-387a" type="max"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="80.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="4c7e-42e0-1c1e-5ba9" name="Custodian Venatari Squad (Placeholder)" publicationId="15a4-fc68-502d-48a9" page="30" hidden="false" collective="false" import="true" type="unit">
+      <categoryLinks>
+        <categoryLink id="1c49-58d9-8b74-05a2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="0745-c1b4-72c6-74a1" name="Legio Custodes" hidden="false" targetId="ccca-a9de-0cd9-f8be" primary="false"/>
+      </categoryLinks>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="1cc3-f17b-b8ac-9cf2" name="Custodian Venatari" hidden="false" collective="false" import="true" defaultSelectionEntryId="a10f-c01d-df2a-9b2f">
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="22ab-6b90-fcd2-85a7" type="min"/>
+            <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="288b-11c9-e28d-4472" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="a10f-c01d-df2a-9b2f" name="Venatari w/ Kinetic Destoyer and Tarsus Buckler" hidden="false" collective="false" import="true" type="upgrade">
+              <selectionEntries>
+                <selectionEntry id="d0d7-a54c-fe1b-40b6" name="Kinetic Destoyer" hidden="false" collective="true" import="true" type="upgrade">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7b3f-23ff-b4a3-4758" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6544-6ab9-8cee-c219" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="e516-8b74-cea2-bae4" name="Tarsus Buckler" hidden="false" collective="true" import="true" type="upgrade">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d2d2-6e11-24ca-de30" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8b14-abce-9f97-9fe0" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="70.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="2b53-452a-435d-f29d" name="Venatari w/ Venatari Lance" hidden="false" collective="false" import="true" type="upgrade">
+              <selectionEntries>
+                <selectionEntry id="d3cf-dfab-f0d7-3997" name="Venatari Lance" hidden="false" collective="true" import="true" type="upgrade">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9866-8a8e-d8f1-9972" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c8df-920d-9ac6-8906" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="80.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="8a39-6452-e075-c8d6" name="Sagittarum Guard Squad (Placeholder)" publicationId="15a4-fc68-502d-48a9" page="31" hidden="false" collective="false" import="true" type="unit">
+      <categoryLinks>
+        <categoryLink id="cbf0-cc0f-b7fd-b02d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="c763-fe2f-a626-b6b5" name="Legio Custodes" hidden="false" targetId="ccca-a9de-0cd9-f8be" primary="false"/>
+      </categoryLinks>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="2d8d-94fa-5c7f-7cd5" name="Sagittarum Guard" hidden="false" collective="false" import="true" defaultSelectionEntryId="a1ba-cf9d-5ba4-7172">
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="50d0-06da-fd35-fb46" type="min"/>
+            <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="35c7-66da-78f8-e5a9" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="a1ba-cf9d-5ba4-7172" name="Sagittarum Guard w/ Adrastus Bolt Caliver" hidden="false" collective="false" import="true" type="model">
+              <constraints>
+                <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7cc5-a33c-d2a4-c71a" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="50.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="c1a4-cce9-495b-1a0c" name="Sentinal Guard w/ Magisterium Vexilla and Adrathic Destructor" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c262-0f6f-280c-06ed" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="c87c-a8f6-322e-76f1" name="Dedicated Transport (Custodes)" hidden="false" collective="false" import="true" targetId="fe3c-f221-2044-bc2b" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="d052-4523-d8da-0c55" name="Caladius Grav-Tank (Placeholder)" publicationId="15a4-fc68-502d-48a9" page="32" hidden="false" collective="false" import="true" type="unit">
+      <categoryLinks>
+        <categoryLink id="ecbd-ba21-8af6-2874" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="1eec-5085-73ac-1c83" name="Legio Custodes" hidden="false" targetId="ccca-a9de-0cd9-f8be" primary="false"/>
+        <categoryLink id="037e-ef27-0c8f-8ac8" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+        <categoryLink id="dbc0-fcbe-109a-ac3f" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="847b-8e71-b21b-ed65" name="Caladius Grav-Tank" hidden="false" collective="false" import="true" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6aa2-7d50-7a14-64b6" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b19a-89e0-e556-2bc1" type="max"/>
+          </constraints>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="6730-f5ac-9387-f215" name="Turret Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="a353-d24a-2437-d74e">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="09ed-a4ac-7516-8340" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9e78-f2e8-9e4c-f396" type="min"/>
+              </constraints>
+              <selectionEntries>
+                <selectionEntry id="a353-d24a-2437-d74e" name="Turret Mounted Illastus Accelerator Cannon" hidden="false" collective="false" import="true" type="upgrade">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="23ab-75e4-cc9c-e992" name="Turret Mounted Enchanced Arachnus Blaze Cannon" hidden="false" collective="false" import="true" type="upgrade">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="35.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks>
+            <entryLink id="94fc-3cf5-7b1f-55ef" name="Twin-Linked Lastrum Bolt Cannon" hidden="false" collective="false" import="true" targetId="5eb8-dd6c-05ee-17d5" type="selectionEntry"/>
+          </entryLinks>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="225.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="5787-ff0f-aaab-2ae5" name="Contemptor-Galatus Dreadnought (Placeholder)" publicationId="15a4-fc68-502d-48a9" page="33" hidden="false" collective="false" import="true" type="unit">
+      <categoryLinks>
+        <categoryLink id="c64f-3c2a-d8b4-0e46" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="4e4d-3398-bd5f-0f0e" name="Legio Custodes" hidden="false" targetId="ccca-a9de-0cd9-f8be" primary="false"/>
+        <categoryLink id="e7ff-9696-4459-bd50" name="Dreadnought Unit-type:" hidden="false" targetId="4280-4963-02b5-e31d" primary="false"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="715d-bee3-8359-f223" name="Contemptor-Galatus Dreadnought" hidden="false" collective="false" import="true" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ec71-a5be-4e08-258b" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="385f-bc39-89f5-a530" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="6132-733d-d289-3421" name="Galatus Warblade with in-built Twin-linked Infernus  Incinerator" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bc18-83e1-4030-2f87" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a0eb-c1c0-baaf-93d9" type="max"/>
+              </constraints>
+              <selectionEntries>
+                <selectionEntry id="a679-c62d-e8b6-9b82" name="Galatus Warblade" hidden="false" collective="false" import="true" type="upgrade">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b563-e299-0850-5367" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e09f-8ceb-588d-c5a2" type="min"/>
+                  </constraints>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+              <entryLinks>
+                <entryLink id="7030-8730-a3a0-d828" name="Twin-linked Infernus Incinerator" page="" hidden="false" collective="false" import="true" targetId="53e1-df76-4226-e438" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7b7b-63ef-b08d-37b9" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a5b7-d2ff-0523-a2d2" type="max"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="36c6-5d33-3e04-01be" name="Gravis Praesidium Shield" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d0a0-d09e-202b-4b55" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cdf5-c0d5-fa44-f4ae" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="235.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="2fea-f040-7934-ae7a" name="Telemon Heavy Dreadnought (Placeholder)" publicationId="15a4-fc68-502d-48a9" page="34" hidden="false" collective="false" import="true" type="unit">
+      <categoryLinks>
+        <categoryLink id="7d0f-aba0-5504-0287" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="98da-c0f6-3ec3-5ffd" name="Legio Custodes" hidden="false" targetId="ccca-a9de-0cd9-f8be" primary="false"/>
+        <categoryLink id="61d7-1091-25c3-d808" name="Dreadnought Unit-type:" hidden="false" targetId="4280-4963-02b5-e31d" primary="false"/>
+        <categoryLink id="dd1f-b6f9-7b56-014c" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="cafb-4553-f84d-e02d" name="Telemon Heavy Dreadnought" hidden="false" collective="false" import="true" type="unit">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ac6c-d695-bc4c-74b9" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1f3e-1577-ed41-f2b6" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="2c80-c155-6567-1a70" name="Spiculus Bolt Launcher" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="07ed-0e3e-5042-198e" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8260-7205-dbb2-0c91" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="b70a-b4e7-94a3-0c3d" name="Weapon 1" hidden="false" collective="false" import="true" defaultSelectionEntryId="9e4e-33c0-6c79-f6aa">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4aeb-6bcc-b188-d4fc" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="417f-2d1f-8778-c90e" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="9e4e-33c0-6c79-f6aa" name="Telemon Cestus and in-built Proteus Plasma Projectors" hidden="false" collective="false" import="true" targetId="0f39-7a65-86f9-e0c0" type="selectionEntry"/>
+                <entryLink id="d647-9a6d-3521-c877" name="Arachnus Storm Cannon" hidden="false" collective="false" import="true" targetId="e6cc-a982-98c3-3889" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="35.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="ea89-8a09-2668-3721" name="Iliastus Accelerator Culverin" hidden="false" collective="false" import="true" targetId="fffc-fd3f-63aa-11fb" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0"/>
+                  </costs>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="0a5c-9d92-e283-5ede" name="Weapon 2" hidden="false" collective="false" import="true" defaultSelectionEntryId="9aa8-2e24-4be3-0a6a">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9bf5-d5bf-c440-758f" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="180d-b636-a423-9923" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="9aa8-2e24-4be3-0a6a" name="Telemon Cestus and in-built Proteus Plasma Projectors" hidden="false" collective="false" import="true" targetId="0f39-7a65-86f9-e0c0" type="selectionEntry"/>
+                <entryLink id="4bc4-2d29-bfd6-7fc8" name="Arachnus Storm Cannon" hidden="false" collective="false" import="true" targetId="e6cc-a982-98c3-3889" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="35.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="1e60-e856-55ef-0788" name="Iliastus Accelerator Culverin" hidden="false" collective="false" import="true" targetId="fffc-fd3f-63aa-11fb" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0"/>
+                  </costs>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks>
+            <entryLink id="8f71-de23-3588-7c3c" name="Placeholder Pts Upgrades" hidden="false" collective="false" import="true" targetId="2757-d97b-b315-934a" type="selectionEntry"/>
+          </entryLinks>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="365.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="1a49-8b97-1f6d-3a8d" name="Orion Assault Dropship (Placeholder)" publicationId="15a4-fc68-502d-48a9" page="35" hidden="false" collective="false" import="true" type="unit">
+      <categoryLinks>
+        <categoryLink id="a78e-19ad-defb-227d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="eaf9-bfd2-d41b-80a0" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+        <categoryLink id="b453-06ee-ef58-1a22" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
+        <categoryLink id="99f6-3c92-eb7b-f901" name="Hover Sub-type" hidden="false" targetId="3a7a-8bb7-b0d3-e2e7" primary="false"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="5d53-f751-9175-f224" name="Orion Assault Dropship" hidden="false" collective="false" import="true" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bc95-d296-5790-e52b" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="05fe-4675-c77a-6664" type="max"/>
+          </constraints>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="600.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="e145-3c36-e1eb-5d08" name="Ares Gunship (Placeholder)" publicationId="15a4-fc68-502d-48a9" page="36" hidden="false" collective="false" import="true" type="unit">
+      <categoryLinks>
+        <categoryLink id="66b6-0bad-6355-8276" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="bbf4-a690-6e1c-3121" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+        <categoryLink id="135a-02cf-2615-e6be" name="Hover Sub-type" hidden="false" targetId="3a7a-8bb7-b0d3-e2e7" primary="false"/>
+        <categoryLink id="ca13-8262-92d9-b19f" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="d071-e0b4-112f-ecc1" name="Ares Gunship" hidden="false" collective="false" import="true" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3078-030d-8476-7bfb" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c158-2cf4-29d2-09cb" type="max"/>
+          </constraints>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="650.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="2757-d97b-b315-934a" name="Placeholder Pts Upgrades" hidden="false" collective="false" import="true" type="upgrade">
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="1.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="6f59-3dda-0590-37c7" name="Praesidium Shield (TBC)" hidden="false" collective="false" import="true" type="upgrade">
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="bd49-770c-b509-884f" name="Two Solarite Power Talons (TBC)" hidden="false" collective="false" import="true" type="upgrade">
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="0e0b-dbe3-3d1a-14a9" name="Adrasite Spear (TBC)" hidden="false" collective="false" import="true" type="upgrade">
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="1334-e423-944e-9499" name="Guardian Axe (TBC)" hidden="false" collective="false" import="true" type="upgrade">
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="2bb9-0525-4865-407c" name="Guardian Spear (TBC)" hidden="false" collective="false" import="true" type="upgrade">
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="9664-33bc-927e-5ba3" name="Meridian Swords (TBC)" hidden="false" collective="false" import="true" type="upgrade">
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="4620-e360-7dd2-f908" name="Pyrithire Spear (TBC)" hidden="false" collective="false" import="true" type="upgrade">
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="6909-d6c6-8d05-0e57" name="Sentinel Warblade (TBC)" hidden="false" collective="false" import="true" type="upgrade">
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="9786-98f2-bdab-5103" name="Solarite Power Gauntlet (TBC)" hidden="false" collective="false" import="true" type="upgrade">
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="208d-ad3b-4008-334e" name="Solarite Power Talon (TBC)" hidden="false" collective="false" import="true" type="upgrade">
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="3ac5-b28c-104a-9de5" name="Magisterium Vexilla (TBC)" hidden="false" collective="false" import="true" type="upgrade">
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="df30-d357-3ee0-a102" name="Magisterium Vexilla (TBC)" hidden="false" collective="true" import="true" type="upgrade">
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="0c34-7afc-bced-140f" name="Sentinel Warblade (TBC)" hidden="false" collective="true" import="true" type="upgrade">
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="da0b-91f0-8baa-d330" name="Two Solarite Power Talons (TBC)" hidden="false" collective="true" import="true" type="upgrade">
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="d9bd-74cb-097b-14de" name="Solarite Power Talon (TBC)" hidden="false" collective="true" import="true" type="upgrade">
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="85f2-5b5a-1526-a121" name="Solarite Power Gauntlet (TBC)" hidden="false" collective="true" import="true" type="upgrade">
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="4c16-32b1-1a7a-928b" name="Pyrithire Spear (TBC)" hidden="false" collective="true" import="true" type="upgrade">
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="695d-f7d5-6f32-1d3a" name="Meridian Swords (TBC)" hidden="false" collective="true" import="true" type="upgrade">
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="9e55-ae31-3ba6-d720" name="Guardian Spear (TBC)" hidden="false" collective="true" import="true" type="upgrade">
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="3780-57f7-1eb8-0851" name="Guardian Axe (TBC)" hidden="false" collective="true" import="true" type="upgrade">
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="101f-346d-b8fa-a5c3" name="Adrasite Spear (TBC)" hidden="false" collective="true" import="true" type="upgrade">
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="f944-64cf-5589-d29a" name="Infernus Firepike (TBC)" hidden="false" collective="false" import="true" type="upgrade">
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="2b1d-a84d-9b3f-8ad6" name="Infernus Firepike (TBC)" hidden="false" collective="true" import="true" type="upgrade">
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="b3bf-5df7-9ac4-c0cf" name="Lastrum Storm Bolter (TBC)" hidden="false" collective="false" import="true" type="upgrade">
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="9724-e7e9-59b0-8c35" name="Lastrum Storm Bolter (TBC)" hidden="false" collective="true" import="true" type="upgrade">
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="abcd-6d7c-8232-6bb8" name="Infernus Incinerator (TBC)" hidden="false" collective="false" import="true" type="upgrade">
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="0fe1-7553-87cc-d2c5" name="Gravis Power Fist (TBC)" hidden="false" collective="false" import="true" type="upgrade">
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="94ed-c2ef-d612-1ef9" name="Corvae Las-Pulser (TBC)" hidden="false" collective="false" import="true" type="upgrade">
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="4e51-f06c-0dff-e3e8" name="Praesidium Shield (TBC)" hidden="false" collective="true" import="true" type="upgrade">
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="5700-71dd-e321-4697" name="Lastrum Bolt Cannon (TBC)" hidden="false" collective="false" import="true" type="upgrade">
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="97a4-45e2-fa61-bd02" name="Lastrum Bolt Cannon (TBC)" hidden="false" collective="true" import="true" type="upgrade">
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="d066-58b3-e43a-b8ad" name="Twin-linked Corvae Las-Pulser (TBC)" hidden="false" collective="true" import="true" type="upgrade">
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="7bd8-c2b4-b888-f3df" name="Adrathic Devastator (TBC)" hidden="false" collective="false" import="true" type="upgrade">
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="0425-2ab6-977c-8b81" name="Adrathic Devastator (TBC)" hidden="false" collective="true" import="true" type="upgrade">
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="b052-d281-1269-9408" name="Twin-Linked Arachnus Blaze Cannon (TBC)" hidden="false" collective="false" import="true" type="upgrade">
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="1f5b-6e05-e40b-7305" name="Twin-Linked Arachnus Blaze Cannon (TBC)" hidden="false" collective="true" import="true" type="upgrade">
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="5eb8-dd6c-05ee-17d5" name="Twin-Linked Lastrum Bolt Cannon (TBC)" hidden="false" collective="false" import="true" type="upgrade">
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="53e1-df76-4226-e438" name="Twin-linked Infernus Incinerator (TBC)" hidden="false" collective="false" import="true" type="upgrade">
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="0f39-7a65-86f9-e0c0" name="Telemon Cestus and in-built Proteus Plasma Projectors (TBC)" hidden="false" collective="false" import="true" type="upgrade">
+      <selectionEntries>
+        <selectionEntry id="a2b8-1e1f-5094-fe17" name="Telemon Cestus (TBC)" hidden="false" collective="true" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2c56-818e-3c8d-4558" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1d6f-2162-5a4f-d8b0" type="max"/>
+          </constraints>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="e697-206f-a464-b0b5" name=" Proteus Plasma Projectors (TBC)" hidden="false" collective="true" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="db3c-6d63-5dcc-e69f" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="05e7-0e69-9cbf-6666" type="max"/>
+          </constraints>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="e6cc-a982-98c3-3889" name="Arachnus Storm Cannon (TBC)" hidden="false" collective="false" import="true" type="upgrade">
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="fffc-fd3f-63aa-11fb" name="Iliastus Accelerator Culverin (TBC)" hidden="false" collective="false" import="true" type="upgrade">
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="a9fc-4298-7b35-8ef4" name="Paragon Glaive (TBC)" hidden="false" collective="false" import="true" type="upgrade">
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="f99c-9468-c0c6-a865" name="Paragon Blade" hidden="false" collective="true" import="true" type="upgrade">
+      <infoLinks>
+        <infoLink id="1985-f503-d41d-0917" name="Murderous Strike (X)" hidden="false" targetId="93b9-1454-0e7c-42ae" type="rule">
+          <modifiers>
+            <modifier type="set" field="name" value="Murderous Strike (6+)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="4047-0eac-4a12-7285" name="Specialist Weapon" hidden="false" targetId="1a1f-3c9b-b097-5886" type="rule"/>
+        <infoLink id="6968-f31e-4b62-5dfa" name="Paragon Blade" hidden="false" targetId="b581-7729-f3d6-d2fc" type="profile"/>
+      </infoLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+  </sharedSelectionEntries>
+  <sharedSelectionEntryGroups>
+    <selectionEntryGroup id="fe3c-f221-2044-bc2b" name="Dedicated Transport (Custodes)" hidden="false" collective="false" import="true">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8084-b6ae-172e-e92b" type="max"/>
+      </constraints>
+      <entryLinks>
+        <entryLink id="025c-7938-6588-b014" name="Coronus Grav-carrier (Placeholder)" hidden="false" collective="false" import="true" targetId="bf7c-a1e1-f983-987e" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b147-8841-e0f2-07cb" type="max"/>
+          </constraints>
+        </entryLink>
+      </entryLinks>
+    </selectionEntryGroup>
+  </sharedSelectionEntryGroups>
+  <catalogueLinks>
+    <catalogueLink id="e048-9e5e-507c-5ba4" name="2022 - Liber Imperium Library" targetId="f3f1-b05f-eefe-4ee4" type="catalogue" importRootEntries="true"/>
+    <catalogueLink id="60d6-cab6-4580-b772" name="2022 - Mech Library" targetId="3129-da35-55e0-642d" type="catalogue" importRootEntries="true"/>
+  </catalogueLinks>
+</catalogue>

--- a/2022 - LI - Sisters Of Silence.cat
+++ b/2022 - LI - Sisters Of Silence.cat
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<catalogue id="585a-5ac2-a233-a6a6" name="2022 - LI - Sisters of Silence" revision="1" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="34" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+  <entryLinks>
+    <entryLink id="40fe-f2c8-6823-f3ff" name="Sisters of Silence" hidden="false" collective="false" import="false" targetId="4d60-2ab7-244f-3414" type="selectionEntry">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e448-ba5a-2280-ce3c" type="min"/>
+      </constraints>
+      <categoryLinks>
+        <categoryLink id="eada-8ff8-8101-fa97" name="New CategoryLink" hidden="false" targetId="e90d-e5a8-f42d-da84" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="9fcc-affc-d2d3-801b" name="Clade Adamus Assassin" hidden="false" collective="false" import="false" targetId="0510-bd97-e047-88bf" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="4a46-5125-30b2-58eb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="cdae-b1eb-9139-c670" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="fb30-9ae2-24a2-ce4b" name="Clade Callidus Assassin" hidden="false" collective="false" import="false" targetId="aeac-aef4-984e-fe79" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="9f40-5381-5fa9-ff07" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="4ece-317f-fa88-c9dc" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="541e-cf67-4b9f-6c52" name="Clade Culexus Assassin" hidden="false" collective="false" import="false" targetId="4d3f-0c69-bf50-9076" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="0554-66f1-d9a4-6b3f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="511f-2e1a-4340-8ed0" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="c46d-110d-b423-0178" name="Clade Eversor Assassin" hidden="false" collective="false" import="false" targetId="5d50-77c2-5943-4c3f" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="3722-d272-2ba6-56ff" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="f1a4-0e7b-55ae-1725" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="c1ef-16b9-c5b7-050f" name="Clade Vanus Infocyte Assassin" hidden="false" collective="false" import="false" targetId="3976-8d49-21fc-2633" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="a8ef-5436-0bfc-ebc4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="9880-3e16-87fc-b544" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="fbf5-dc22-9817-0ea2" name="Clade Venenum Assassin" hidden="false" collective="false" import="false" targetId="32f2-1209-7402-4d0d" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="503b-d19d-0678-bd4a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="0298-947e-6d65-0952" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="c4f7-7b4a-fb94-8bef" name="Clade Vindicare Assassin" hidden="false" collective="false" import="false" targetId="abaf-b2fa-1d41-a315" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="e9da-df40-21af-28b8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="8fe2-94b1-8785-b200" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="bdac-b3e6-0348-2011" name="Knight Centura" hidden="false" collective="false" import="false" targetId="6445-e0ea-58ac-ac6c" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="f027-e8f2-00c6-f4db" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="461b-c81c-3b0b-8ebe" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="83f0-bd2d-d50e-ac48" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
+      </categoryLinks>
+    </entryLink>
+  </entryLinks>
+  <catalogueLinks>
+    <catalogueLink id="e048-9e5e-507c-5ba4" name="2022 - Liber Imperium Library" targetId="f3f1-b05f-eefe-4ee4" type="catalogue" importRootEntries="true"/>
+    <catalogueLink id="60d6-cab6-4580-b772" name="2022 - Mech Library" targetId="3129-da35-55e0-642d" type="catalogue" importRootEntries="true"/>
+  </catalogueLinks>
+</catalogue>

--- a/2022 - LI - Solar Auxilia.cat
+++ b/2022 - LI - Solar Auxilia.cat
@@ -1,0 +1,4393 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<catalogue id="6af7-3fee-5bc1-7533" name="2022 - LI - Solar Auxilia" revision="1" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="34" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+  <entryLinks>
+    <entryLink id="5176-b5f9-93f1-f535" name="Solar Auxilia" hidden="false" collective="false" import="false" targetId="f689-fd0d-ffb0-c255" type="selectionEntry">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2d28-dc52-f9e3-4cc8" type="min"/>
+      </constraints>
+      <categoryLinks>
+        <categoryLink id="cba9-ee29-fb68-4d2e" name="New CategoryLink" hidden="false" targetId="e90d-e5a8-f42d-da84" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="1c53-7ff6-b4ad-004f" name="Clade Adamus Assassin" hidden="true" collective="false" import="false" targetId="0510-bd97-e047-88bf" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="3b3f-0e08-0bb5-243e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="834a-3a88-7c06-f571" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="4d3b-0ea0-3605-6b54" name="Clade Callidus Assassin" hidden="true" collective="false" import="false" targetId="aeac-aef4-984e-fe79" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="60dd-52bb-de63-f971" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="ccc2-a1dd-f54e-6e5a" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="11d3-b9f4-7d36-b934" name="Clade Culexus Assassin" hidden="true" collective="false" import="false" targetId="4d3f-0c69-bf50-9076" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="4fb6-5322-4837-6f54" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="42e4-5383-d946-981e" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="ab97-2608-b62b-1670" name="Clade Eversor Assassin" hidden="true" collective="false" import="false" targetId="5d50-77c2-5943-4c3f" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="0657-b49a-2468-31f3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="8787-5f6c-3aa6-90c3" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="bbaf-d03d-bd3d-0041" name="Clade Vanus Infocyte Assassin" hidden="true" collective="false" import="false" targetId="3976-8d49-21fc-2633" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="7a27-b79f-94b2-ec01" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="77f8-0f46-a2c1-5876" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="78e5-0e7e-047f-bdfe" name="Clade Venenum Assassin" hidden="true" collective="false" import="false" targetId="32f2-1209-7402-4d0d" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="1d84-6feb-47e3-a530" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="a2ce-4974-ff6c-680e" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="9a2e-8b77-517e-d26e" name="Clade Vindicare Assassin" hidden="true" collective="false" import="false" targetId="abaf-b2fa-1d41-a315" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="fcf5-3ac0-68f4-6fac" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="d36b-cc1c-f34d-61ac" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="de2a-9dad-ac9f-acb8" name="Solar Auxilia Legate Marshal" hidden="false" collective="false" import="false" targetId="9dd4-325a-c1cb-fac2" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="ee17-6c7f-eaf9-3bad" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="a5a3-7a89-6ceb-869b" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
+        <categoryLink id="9f46-eeaa-6d50-4461" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="66e5-ccf5-813f-c285" name="Auxilia Tactical Command Tercio" hidden="false" collective="false" import="false" targetId="e9d4-7207-71e0-0762" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="ae33-ec9e-6580-f355" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="f0dc-1c12-3dc1-1eb0" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
+        <categoryLink id="4b88-e690-a860-9593" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="a242-53dd-ea9d-f575" name="Auxilia Veletaris Tercio" hidden="false" collective="false" import="false" targetId="1905-2087-cffc-4839" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="651a-7993-8e52-2915" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="9aad-b5e8-c664-cbe2" name="Compulsory Elite:" hidden="false" targetId="bb1f-ae32-b587-c3e1" primary="false"/>
+        <categoryLink id="3c8b-25ba-7140-990f" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="dac0-7b81-a856-9c82" name="Medicae Section (PH)" hidden="false" collective="false" import="false" targetId="f28b-5804-f1fd-c187" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="766c-e4f5-ee83-3e97" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="0dc5-c352-d1f9-1d96" name="Compulsory Elite:" hidden="false" targetId="bb1f-ae32-b587-c3e1" primary="false"/>
+        <categoryLink id="d76e-62a4-def0-c7ce" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="78d3-5777-ada5-f697" name="Surgeon-Primus Aevos Jovan" hidden="true" collective="false" import="false" targetId="c032-86a2-3757-80e4" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="9120-2371-ecc7-e1ba" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="b045-2281-4b3c-9ddb" name="Compulsory Elite:" hidden="false" targetId="bb1f-ae32-b587-c3e1" primary="false"/>
+        <categoryLink id="f0a0-c2e9-ca37-d599" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="4c93-38d3-fad6-1c39" name="Charonite Ogryn Section (PH)" hidden="false" collective="false" import="true" targetId="6728-8632-5bf2-79bb" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="5c3d-4769-4f4d-a2ce" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="e26d-7d39-db08-79e1" name="Compulsory Elite:" hidden="false" targetId="bb1f-ae32-b587-c3e1" primary="false"/>
+        <categoryLink id="d3d0-d59c-c111-0625" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="5be2-1846-2870-ba0b" name="Auxilia Veletaris Tercio" hidden="true" collective="false" import="false" targetId="1905-2087-cffc-4839" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a09b-28bd-8ffc-f4f0" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="2487-0ee0-6607-a560" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="fd02-44a6-83fa-ece7" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
+        <categoryLink id="516f-012d-99f9-8514" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="67af-429c-2973-c7e3" name="Auxilia Infantry Tercio" hidden="false" collective="false" import="false" targetId="e3d9-ef46-4077-e1f5" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="2d85-9cea-9317-2cfb" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
+        <categoryLink id="04c9-6447-531c-b4c8" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="149c-7c16-c0cf-0e47" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="9b10-d8e7-3354-08f5" name="Castellax Battle-Automata Maniple " hidden="true" collective="false" import="false" targetId="537f-846d-90e3-2526" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e0e8-1223-7794-2e95" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="5d1c-6b1e-50a0-0e6c" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="09ec-3faf-d447-1913" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="7742-1a31-7420-3fe6" name="Thallax Cohort" hidden="true" collective="false" import="false" targetId="25c8-3e0f-e22d-a7eb" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e0e8-1223-7794-2e95" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="a369-8b1e-eb51-ac7d" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="c044-20ca-8fb0-6718" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="bbe6-d7b6-2c80-e7ab" name="Arvus Transport" hidden="false" collective="false" import="false" targetId="5041-9403-02b7-af14" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="3ae4-de9e-f922-10aa" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="916c-bc5e-04f4-8436" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="247f-6c99-bc3b-2739" name="Legion Primaris-Lightning Strike Fighter" hidden="false" collective="false" import="true" targetId="428d-bd65-c88e-1430" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="087c-8fe0-c01a-0df1" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="2bf5-fad9-222b-b6c4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="b52a-141f-5bf1-1e56" name="Legion Thunderbolt Fighter" hidden="false" collective="false" import="true" targetId="6201-e908-c475-db6b" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="1f07-e625-a049-e21c" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="8c4e-43be-06fb-5ddb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+      </categoryLinks>
+    </entryLink>
+  </entryLinks>
+  <sharedSelectionEntries>
+    <selectionEntry id="9dd4-325a-c1cb-fac2" name="Solar Auxilia Legate Marshal" hidden="false" collective="false" import="true" type="unit">
+      <modifiers>
+        <modifier type="remove" field="category" value="9231-183c-b97b-63f9">
+          <conditions>
+            <condition field="selections" scope="9dd4-325a-c1cb-fac2" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="583e-62cb-53f1-f952" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="154d-0b2b-1215-38bb" type="max"/>
+      </constraints>
+      <categoryLinks>
+        <categoryLink id="e7bd-8dd9-39fd-4e7d" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="3890-ed31-5e7e-4b77" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+        <categoryLink id="fb94-9780-7cb6-f0d9" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="3e04-d00a-bb4a-5f72" name="Solar Auxilia Legate Marshal" hidden="false" collective="false" import="true" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="642f-3acc-3f7b-b045" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="76ee-5716-057a-39d3" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="e9cb-d568-e5b5-0b8b" name="Solar Auxilia Legate Marshal" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
+              <modifiers>
+                <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Infantry (Character)">
+                  <conditions>
+                    <condition field="selections" scope="9dd4-325a-c1cb-fac2" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="583e-62cb-53f1-f952" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="set" field="e593-6b3c-f169-04f0" value="2+">
+                  <conditionGroups>
+                    <conditionGroup type="and">
+                      <conditions>
+                        <condition field="selections" scope="9dd4-325a-c1cb-fac2" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="583e-62cb-53f1-f952" type="equalTo"/>
+                        <condition field="selections" scope="9dd4-325a-c1cb-fac2" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="523c-d7fb-5288-fe13" type="equalTo"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
+              <characteristics>
+                <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Heavy, Character)</characteristic>
+                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">6</characteristic>
+                <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">5</characteristic>
+                <characteristic name="BS" typeId="74ae-c840-0036-d244">5</characteristic>
+                <characteristic name="S" typeId="e478-41d4-a092-48a8">3</characteristic>
+                <characteristic name="T" typeId="c32b-5fdd-3fbe-9b1f">3</characteristic>
+                <characteristic name="W" typeId="57ee-1126-32a9-5672">4</characteristic>
+                <characteristic name="I" typeId="62d3-22d7-2d49-52dc">4</characteristic>
+                <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">4</characteristic>
+                <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">10</characteristic>
+                <characteristic name="Save" typeId="e593-6b3c-f169-04f0">3+</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <infoLinks>
+            <infoLink id="0fc8-2807-0ca2-92dc" name="Battle-Hardened (X)" hidden="false" targetId="5c3b-ed0b-4ad0-d547" type="rule">
+              <modifiers>
+                <modifier type="set" field="name" value="Battle-Hardened (1)"/>
+              </modifiers>
+            </infoLink>
+            <infoLink id="e674-1cda-ba3c-0cfb" name="Stubborn" hidden="false" targetId="7989-1f2c-a43d-82ae" type="rule"/>
+          </infoLinks>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="494c-7f28-ee5a-75b4" name="May exchange a Laspistol for one of the following:" hidden="false" collective="false" import="true" defaultSelectionEntryId="d3cf-77b5-079a-4dbe">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="51c8-bbaa-36ad-bfc6" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ad2b-2890-95b2-fab7" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="d3cf-77b5-079a-4dbe" name="Laspistol" hidden="false" collective="false" import="true" targetId="654d-be88-b0a8-7ae5" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="name" value="Master-Crafted Laspistol">
+                      <conditions>
+                        <condition field="selections" scope="3e04-d00a-bb4a-5f72" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8a84-4890-8103-289c" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                </entryLink>
+                <entryLink id="2a22-15ca-5d08-71ae" name="Needle Pistol" hidden="false" collective="false" import="true" targetId="fdd4-06c7-4608-b07f" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="name" value="Master-Crafted Needle Pistol">
+                      <conditions>
+                        <condition field="selections" scope="3e04-d00a-bb4a-5f72" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8a84-4890-8103-289c" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="af99-1a62-f693-cb3a" name="Hand Flamer" hidden="false" collective="false" import="true" targetId="e337-adf4-a11f-0280" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="name" value="Master-Crafted Hand Flamer">
+                      <conditions>
+                        <condition field="selections" scope="3e04-d00a-bb4a-5f72" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8a84-4890-8103-289c" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="7c18-0383-5ebe-bf0f" name="Volkite Serpenta" hidden="false" collective="false" import="true" targetId="d535-1da8-290d-69a6" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="name" value="Master-Crafted Volkite Serpenta">
+                      <conditions>
+                        <condition field="selections" scope="3e04-d00a-bb4a-5f72" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8a84-4890-8103-289c" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="a58f-8088-29db-5b91" name="Plasma Pistol" hidden="false" collective="false" import="true" targetId="717f-cf0a-1593-4bd8" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="name" value="Master-Crafted Plasma Pistol">
+                      <conditions>
+                        <condition field="selections" scope="3e04-d00a-bb4a-5f72" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8a84-4890-8103-289c" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="c0a6-a24a-54f4-7ee4" name="Archaeotech Pistol" hidden="false" collective="false" import="true" targetId="c22a-ed4d-af68-bf00" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="0418-a453-19d9-0cf5" name="Blast Pistol" hidden="false" collective="false" import="true" targetId="2460-375d-31f4-4bdf" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="name" value="Master-Crafted Blast Pistol">
+                      <conditions>
+                        <condition field="selections" scope="3e04-d00a-bb4a-5f72" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8a84-4890-8103-289c" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="dec0-ab2a-7634-c289" name="Inferno Pistol" hidden="false" collective="false" import="true" targetId="3f00-1930-8fcb-41c5" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="name" value="Master-Crafted Inferno Pistol">
+                      <conditions>
+                        <condition field="selections" scope="3e04-d00a-bb4a-5f72" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8a84-4890-8103-289c" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                  </costs>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="060d-d998-a340-70ee" name="May exchange a Close Combat Weapon for one of the following:" hidden="false" collective="false" import="true" defaultSelectionEntryId="506a-61e7-02e4-b9d2">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f421-7c44-1712-6c45" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d2a5-16d0-6ab1-95a1" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="63de-97e9-14b9-fb86" name="Thunder Hammer" hidden="false" collective="false" import="true" targetId="838c-4002-713d-d7c6" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="name" value="Master-Crafted Thunder Hammer">
+                      <conditions>
+                        <condition field="selections" scope="3e04-d00a-bb4a-5f72" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7835-34c0-8253-3fc5" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="d517-c9ee-4dae-cd38" name="Power Fist" hidden="false" collective="false" import="true" targetId="768d-b89b-7328-d749" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="name" value="Master-Crafted Power Fist">
+                      <conditions>
+                        <condition field="selections" scope="3e04-d00a-bb4a-5f72" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7835-34c0-8253-3fc5" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="0711-3a39-f9b3-3003" name="Paragon Blade" hidden="false" collective="false" import="true" targetId="2ab9-0e45-405e-056b" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="name" value="Master-Crafted Paragon Blade">
+                      <conditions>
+                        <condition field="selections" scope="3e04-d00a-bb4a-5f72" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7835-34c0-8253-3fc5" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="506a-61e7-02e4-b9d2" name="Close Combat Weapon" hidden="false" collective="false" import="true" targetId="3d50-2f85-06ff-6aee" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="name" value="Master-Crafted Close Combat Weapon">
+                      <conditions>
+                        <condition field="selections" scope="3e04-d00a-bb4a-5f72" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7835-34c0-8253-3fc5" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                </entryLink>
+                <entryLink id="b458-bb3b-f3a1-0982" name="Charnabal Weapon" hidden="false" collective="false" import="true" targetId="e749-ba9b-bb76-a7d9" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="name" value="Master-Crafted Charnabal Weapon">
+                      <conditions>
+                        <condition field="selections" scope="3e04-d00a-bb4a-5f72" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7835-34c0-8253-3fc5" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="702b-b338-e356-7610" name="Power Weapon" hidden="false" collective="false" import="true" targetId="d2db-7598-f55f-86fe" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="name" value="Master-Crafted Power Weapon">
+                      <conditions>
+                        <condition field="selections" scope="3e04-d00a-bb4a-5f72" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7835-34c0-8253-3fc5" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                  </costs>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="07e2-587b-9f0a-e149" name="May exchange their Heavy Void Armour for:" hidden="false" collective="false" import="true" defaultSelectionEntryId="7824-fbd3-35e7-91a3">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="02f1-a4f0-d8b8-fa23" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e6ba-d4b0-43a6-24cc" type="max"/>
+              </constraints>
+              <selectionEntries>
+                <selectionEntry id="b45f-b236-29dd-7081" name="Heavy Artificer Armour" hidden="false" collective="false" import="true" type="upgrade">
+                  <profiles>
+                    <profile id="dfe9-8247-fa41-9cf2" name="Heavy Artificer Armour" publicationId="a716-c1c4-7b26-8424" page="140" hidden="false" typeId="2a1f-7837-f0ef-be44" typeName="Wargear Item">
+                      <characteristics>
+                        <characteristic name="Description" typeId="347e-ee4a-764f-6be3">Artificer armour confers a 2+ Armour Save. Also gives the unit Heavy Subtype.</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+              <entryLinks>
+                <entryLink id="a86a-c573-bd96-0cf3" name="Artificer Armour" hidden="false" collective="false" import="true" targetId="583e-62cb-53f1-f952" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="7824-fbd3-35e7-91a3" name="Heavy Void Armour" hidden="false" collective="false" import="true" targetId="523c-d7fb-5288-fe13" type="selectionEntry"/>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="3851-30f7-d72e-2640" name="May take:" hidden="false" collective="false" import="true">
+              <entryLinks>
+                <entryLink id="a18d-814a-9b13-632d" name="Cyber-Familiar" hidden="false" collective="false" import="true" targetId="6c85-4601-cf58-7b35" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f223-ca37-5e24-a3b7" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="ab8f-5cf4-7a11-ff19" name="Meltabombs" hidden="false" collective="false" import="true" targetId="b9dd-3b21-f3f8-78e3" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dae9-9c53-21e7-e6e7" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="e965-a735-2112-0e2a" name="Cortex Controller" hidden="true" collective="false" import="true" targetId="2fda-455f-d34d-97e0" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="false">
+                      <conditions>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a09b-28bd-8ffc-f4f0" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8096-270e-9a56-194d" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                  </costs>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="686a-a910-a6db-9a2c" name="May exchange their Refractor Field for:" hidden="false" collective="false" import="true" defaultSelectionEntryId="68ed-44f7-2499-8b0a">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="23bf-701c-7905-2bc7" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c31a-6600-c275-190e" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="68ed-44f7-2499-8b0a" name="Refractor Field" hidden="false" collective="false" import="true" targetId="a06a-55a5-070b-1d0e" type="selectionEntry"/>
+                <entryLink id="12d3-5e50-067c-e513" name="Iron Halo" hidden="false" collective="false" import="true" targetId="b081-bf3c-f43d-4bd5" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0"/>
+                  </costs>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="1073-b7e4-9759-2b54" name="May upgrade any one weapon to have Master-Crafted" hidden="false" collective="false" import="true">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d67b-3aa8-ba1a-5890" type="max"/>
+              </constraints>
+              <selectionEntries>
+                <selectionEntry id="7835-34c0-8253-3fc5" name="Melee" hidden="false" collective="false" import="true" type="upgrade">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e14c-f070-417d-1b75" type="max"/>
+                  </constraints>
+                  <infoLinks>
+                    <infoLink id="1074-fc94-4661-76c2" name="Master-crafted" hidden="false" targetId="6de0-55b0-bf21-48b9" type="rule"/>
+                  </infoLinks>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="8a84-4890-8103-289c" name="Ranged" hidden="false" collective="false" import="true" type="upgrade">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="true">
+                      <conditions>
+                        <condition field="selections" scope="3e04-d00a-bb4a-5f72" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c22a-ed4d-af68-bf00" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d644-17a9-3e38-7949" type="max"/>
+                  </constraints>
+                  <infoLinks>
+                    <infoLink id="9d94-a14e-104c-5d58" name="Master-crafted" hidden="false" targetId="6de0-55b0-bf21-48b9" type="rule"/>
+                  </infoLinks>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks>
+            <entryLink id="747b-ab3a-1b23-c5d8" name="Frag Grenades" hidden="false" collective="false" import="true" targetId="cf9c-327b-3449-00d7" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="22cf-47f1-b8ae-5bbf" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8c3e-3226-7e2c-2a66" type="max"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="7c88-b040-a5e8-49c2" name="Krak Grenades" hidden="false" collective="false" import="true" targetId="99df-2421-acf7-a5ad" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e3e8-fb71-668a-f3dd" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b2ff-6848-ac65-c2a1" type="max"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="5f7b-b709-e3a6-b28c" name="Cohort Doctrines" hidden="false" collective="false" import="true" targetId="9da6-635b-fa1d-2c2b" type="selectionEntryGroup"/>
+          </entryLinks>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="85.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="6112-2c54-ceb5-a24d" name="Void Armour" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="1ede-a380-56ce-bd90" name="Void Armour" publicationId="15a4-fc68-502d-48a9" page="159" hidden="false" typeId="2a1f-7837-f0ef-be44" typeName="Wargear Item">
+          <characteristics>
+            <characteristic name="Description" typeId="347e-ee4a-764f-6be3">Void armour confers a 4+ Armour Save.</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="cc63-5cc3-212a-3d4c" name="Reinforced Void Armour " hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="e94c-46f0-fa4e-e27b" name="Reinforced Void Armour " publicationId="15a4-fc68-502d-48a9" page="159" hidden="false" typeId="2a1f-7837-f0ef-be44" typeName="Wargear Item">
+          <characteristics>
+            <characteristic name="Description" typeId="347e-ee4a-764f-6be3">Reinforced void armour confers a 4+ Armour Save and any model with reinforced void armour also gains the Heavy Unit Sub-type.</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="523c-d7fb-5288-fe13" name="Heavy Void Armour" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="5ebe-7ce6-f386-530b" name="Heavy Void Armour" publicationId="15a4-fc68-502d-48a9" page="159" hidden="false" typeId="2a1f-7837-f0ef-be44" typeName="Wargear Item">
+          <characteristics>
+            <characteristic name="Description" typeId="347e-ee4a-764f-6be3">Heavy void armour confers a 3+ Armour Save and any model with heavy void armour also gains the Heavy Unit Sub-type.</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="8a41-91cd-666b-3b88" name="Heavy Void Armour" hidden="false" collective="true" import="true" type="upgrade">
+      <infoLinks>
+        <infoLink id="4fd3-f210-d384-15eb" name="Heavy Void Armour" hidden="false" targetId="5ebe-7ce6-f386-530b" type="profile"/>
+      </infoLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="5e45-2a38-759c-3147" name="Reinforced Void Armour " hidden="false" collective="true" import="true" type="upgrade">
+      <infoLinks>
+        <infoLink id="4f0c-0180-7172-c66a" name="Reinforced Void Armour " hidden="false" targetId="e94c-46f0-fa4e-e27b" type="profile"/>
+      </infoLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="499b-b86b-3a44-17c6" name="Void Armour" hidden="false" collective="true" import="true" type="upgrade">
+      <infoLinks>
+        <infoLink id="b8a2-9d63-269f-70d9" name="Void Armour" hidden="false" targetId="1ede-a380-56ce-bd90" type="profile"/>
+      </infoLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="e9d4-7207-71e0-0762" name="Auxilia Tactical Command Tercio" hidden="false" collective="false" import="true" type="unit">
+      <categoryLinks>
+        <categoryLink id="ab79-0133-fa4a-cd86" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="2b04-daec-c616-d6bc" name="Close-order Sub-type" hidden="false" targetId="0af0-ea84-09d7-2b1f" primary="false"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="adca-2009-9ede-8650" name="Tactical Command Section" hidden="false" collective="false" import="true" type="unit">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6d88-f40b-3193-be61" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cac8-3d71-1e24-b2d5" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="5498-5ff9-0191-5ca1" name="Auxilia Companion" hidden="false" collective="false" import="true" type="model">
+              <constraints>
+                <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fcae-a8c2-890d-9a6f" type="min"/>
+                <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9243-1887-3805-994a" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="8e19-2872-df91-2435" name="Auxilia Companion" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
+                  <characteristics>
+                    <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Auxilia Companions: Infantry (Close-order)</characteristic>
+                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">6</characteristic>
+                    <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
+                    <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
+                    <characteristic name="S" typeId="e478-41d4-a092-48a8">3</characteristic>
+                    <characteristic name="T" typeId="c32b-5fdd-3fbe-9b1f">3</characteristic>
+                    <characteristic name="W" typeId="57ee-1126-32a9-5672">2</characteristic>
+                    <characteristic name="I" typeId="62d3-22d7-2d49-52dc">4</characteristic>
+                    <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">2</characteristic>
+                    <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">7</characteristic>
+                    <characteristic name="Save" typeId="e593-6b3c-f169-04f0">4+</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <selectionEntryGroups>
+                <selectionEntryGroup id="2fff-a241-34b8-c4f9" name="May exchange Lasrifle for:" hidden="false" collective="false" import="true" defaultSelectionEntryId="a0e2-cf54-398f-00b1">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dc44-892b-73b5-1361" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2bee-803c-d79a-03af" type="max"/>
+                  </constraints>
+                  <selectionEntries>
+                    <selectionEntry id="a9f7-5c87-7357-09aa" name="Blast Pistols &amp; Power Weapon (Sub-menu)" hidden="false" collective="false" import="true" type="upgrade">
+                      <entryLinks>
+                        <entryLink id="cbe2-7ff4-963a-fb05" name="Blast Pistol" hidden="false" collective="false" import="true" targetId="2460-375d-31f4-4bdf" type="selectionEntry">
+                          <constraints>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8c46-4525-6d0f-2af9" type="min"/>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d2d4-10f9-a5c8-3bfe" type="max"/>
+                          </constraints>
+                        </entryLink>
+                        <entryLink id="8a87-c7c0-e7db-fcc7" name="Power Weapon" hidden="false" collective="false" import="true" targetId="5ff5-48c0-b9f1-5a05" type="selectionEntryGroup">
+                          <constraints>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d375-72e8-a799-8403" type="min"/>
+                          </constraints>
+                        </entryLink>
+                      </entryLinks>
+                      <costs>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                      </costs>
+                    </selectionEntry>
+                    <selectionEntry id="ccaf-e643-0a94-99a3" name="Blast Pilstol and Charnabal Weapon (Sub-menu)" hidden="false" collective="false" import="true" type="upgrade">
+                      <entryLinks>
+                        <entryLink id="9fc5-3176-d4c5-cd9f" name="Blast Pistol" hidden="false" collective="false" import="true" targetId="2460-375d-31f4-4bdf" type="selectionEntry">
+                          <constraints>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e344-dd8b-63e1-30e4" type="min"/>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f7cb-0fbc-b6a7-de37" type="max"/>
+                          </constraints>
+                        </entryLink>
+                        <entryLink id="9d11-0c33-2280-93e3" name="Charnabal Weapon" hidden="false" collective="false" import="true" targetId="f7d1-ad0f-b4cb-dfc1" type="selectionEntryGroup">
+                          <constraints>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ccad-951c-51c0-d525" type="min"/>
+                          </constraints>
+                        </entryLink>
+                      </entryLinks>
+                      <costs>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                      </costs>
+                    </selectionEntry>
+                  </selectionEntries>
+                  <entryLinks>
+                    <entryLink id="a0e2-cf54-398f-00b1" name="Lasrifle" hidden="false" collective="false" import="true" targetId="15f9-817e-275b-c13d" type="selectionEntry"/>
+                    <entryLink id="219d-ad3f-16bb-b1b3" name="Volkite Charger" hidden="false" collective="false" import="true" targetId="6f6e-ad55-e093-6503" type="selectionEntry">
+                      <costs>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="b9e2-1554-feb5-9f7c" name="Bolter" hidden="false" collective="false" import="true" targetId="1ade-0c02-5612-252b" type="selectionEntry"/>
+                    <entryLink id="9038-b3f8-e39c-1ef4" name="Magna Combi-weapon" hidden="false" collective="false" import="true" targetId="4d02-259d-fa50-ef3a" type="selectionEntry">
+                      <costs>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="4563-8243-ea43-d533" name="Minor Combi-weapon" hidden="false" collective="false" import="true" targetId="53c0-b5d7-f001-b816" type="selectionEntry">
+                      <costs>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="ba63-d520-dd54-156f" name="Flamer" hidden="false" collective="false" import="true" targetId="9f41-82e2-90f6-973a" type="selectionEntry">
+                      <costs>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="7937-445f-43bc-a302" name="Plasma Gun" hidden="false" collective="false" import="true" targetId="f0d1-332b-c719-ede7" type="selectionEntry">
+                      <costs>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="7fc9-dfa4-f044-0c1d" name="Meltagun" hidden="false" collective="false" import="true" targetId="4ebd-57e0-3560-e568" type="selectionEntry">
+                      <costs>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="49cd-22b5-af60-c7c2" name="Grenade Launcher" hidden="false" collective="false" import="true" targetId="e0f3-3743-a9d0-f5f1" type="selectionEntry">
+                      <costs>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="a169-8a5c-5466-8330" name="Lasrifle with Bayonet" hidden="false" collective="false" import="true" targetId="2867-ab52-1247-2532" type="selectionEntry">
+                      <costs>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="1.0"/>
+                      </costs>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+              <entryLinks>
+                <entryLink id="a2ed-46fa-63a7-d71c" name="Void Armour" hidden="false" collective="false" import="true" targetId="6112-2c54-ceb5-a24d" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8485-ff72-f466-fd5f" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4d65-99c5-45f8-ea12" type="min"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="12.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="672b-ea90-3efc-dee2" name="Auxilia Captain" hidden="false" collective="false" import="true" type="model">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b350-f9bf-30e3-d40e" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7d43-e939-33e9-3b2e" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="8c6d-cbec-6069-637b" name="Stubborn" hidden="false" targetId="7989-1f2c-a43d-82ae" type="rule"/>
+                <infoLink id="2cb8-fa8e-41ab-3eef" name="Tercio" hidden="false" targetId="6516-f81d-457b-a2cc" type="rule"/>
+              </infoLinks>
+              <categoryLinks>
+                <categoryLink id="e45d-a811-4eef-e5d0" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
+              </categoryLinks>
+              <selectionEntryGroups>
+                <selectionEntryGroup id="853a-fb8f-a344-1c3b" name="Rank" hidden="false" collective="false" import="true" defaultSelectionEntryId="d379-4c35-55cf-5014">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6625-ecd9-72b1-9a84" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2df3-1af7-e3ee-67ba" type="max"/>
+                  </constraints>
+                  <selectionEntries>
+                    <selectionEntry id="d379-4c35-55cf-5014" name="Auxilia Captain" hidden="false" collective="false" import="true" type="upgrade">
+                      <profiles>
+                        <profile id="dd4a-0d18-52a2-3ff3" name="Auxilia Captain" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
+                          <modifiers>
+                            <modifier type="set" field="e593-6b3c-f169-04f0" value="3+">
+                              <conditions>
+                                <condition field="selections" scope="672b-ea90-3efc-dee2" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="523c-d7fb-5288-fe13" type="equalTo"/>
+                              </conditions>
+                            </modifier>
+                            <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Infantry (Close-order, Character, Heavy)">
+                              <conditions>
+                                <condition field="selections" scope="672b-ea90-3efc-dee2" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="523c-d7fb-5288-fe13" type="equalTo"/>
+                              </conditions>
+                            </modifier>
+                          </modifiers>
+                          <characteristics>
+                            <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Close-order, Character)</characteristic>
+                            <characteristic name="Move" typeId="893e-2d76-8f04-44e5">6</characteristic>
+                            <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
+                            <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
+                            <characteristic name="S" typeId="e478-41d4-a092-48a8">3</characteristic>
+                            <characteristic name="T" typeId="c32b-5fdd-3fbe-9b1f">3</characteristic>
+                            <characteristic name="W" typeId="57ee-1126-32a9-5672">3</characteristic>
+                            <characteristic name="I" typeId="62d3-22d7-2d49-52dc">4</characteristic>
+                            <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">3</characteristic>
+                            <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">9</characteristic>
+                            <characteristic name="Save" typeId="e593-6b3c-f169-04f0">4+</characteristic>
+                          </characteristics>
+                        </profile>
+                      </profiles>
+                      <costs>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                      </costs>
+                    </selectionEntry>
+                    <selectionEntry id="cf95-da98-a7df-8543" name="Auxilia Marshall" hidden="false" collective="false" import="true" type="upgrade">
+                      <profiles>
+                        <profile id="eb99-6f6a-5fdf-7b71" name="Auxilia Marshall" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
+                          <modifiers>
+                            <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Infantry (Close-order, Character, Heavy)">
+                              <conditions>
+                                <condition field="selections" scope="672b-ea90-3efc-dee2" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="523c-d7fb-5288-fe13" type="equalTo"/>
+                              </conditions>
+                            </modifier>
+                            <modifier type="set" field="e593-6b3c-f169-04f0" value="3+">
+                              <conditions>
+                                <condition field="selections" scope="672b-ea90-3efc-dee2" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="523c-d7fb-5288-fe13" type="equalTo"/>
+                              </conditions>
+                            </modifier>
+                          </modifiers>
+                          <characteristics>
+                            <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Close-order, Character)</characteristic>
+                            <characteristic name="Move" typeId="893e-2d76-8f04-44e5">6</characteristic>
+                            <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">5</characteristic>
+                            <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
+                            <characteristic name="S" typeId="e478-41d4-a092-48a8">3</characteristic>
+                            <characteristic name="T" typeId="c32b-5fdd-3fbe-9b1f">3</characteristic>
+                            <characteristic name="W" typeId="57ee-1126-32a9-5672">3</characteristic>
+                            <characteristic name="I" typeId="62d3-22d7-2d49-52dc">4</characteristic>
+                            <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">4</characteristic>
+                            <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">9</characteristic>
+                            <characteristic name="Save" typeId="e593-6b3c-f169-04f0">4+</characteristic>
+                          </characteristics>
+                        </profile>
+                      </profiles>
+                      <costs>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                      </costs>
+                    </selectionEntry>
+                  </selectionEntries>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="6084-17fd-ec43-3c69" name="Armour" hidden="false" collective="false" import="true" defaultSelectionEntryId="97d0-4ef1-abe2-d3a9">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7eae-6a57-3367-62c1" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="35f3-090b-238d-0ff4" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="97d0-4ef1-abe2-d3a9" name="Void Armour" hidden="false" collective="false" import="true" targetId="6112-2c54-ceb5-a24d" type="selectionEntry"/>
+                    <entryLink id="e5ef-9492-97e4-0cfc" name="Heavy Void Armour" hidden="false" collective="false" import="true" targetId="523c-d7fb-5288-fe13" type="selectionEntry">
+                      <costs>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                      </costs>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="8fc5-e301-c399-3d7f" name="May exchange Lasrifle for:" hidden="false" collective="false" import="true" defaultSelectionEntryId="8591-c0e5-c959-c458">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="99f6-b070-882a-ac96" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="acb2-df3a-0778-fa97" type="max"/>
+                  </constraints>
+                  <selectionEntries>
+                    <selectionEntry id="d5e9-3a55-d344-d746" name="Blast Pistols &amp; Power Weapon (Sub-menu)" hidden="false" collective="false" import="true" type="upgrade">
+                      <entryLinks>
+                        <entryLink id="5729-8674-fd8f-932f" name="Blast Pistol" hidden="false" collective="false" import="true" targetId="2460-375d-31f4-4bdf" type="selectionEntry">
+                          <constraints>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2284-3fb0-88e6-0bb9" type="min"/>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6673-9000-28e2-74ef" type="max"/>
+                          </constraints>
+                        </entryLink>
+                        <entryLink id="1f2e-6da4-ef37-f91c" name="Power Weapon" hidden="false" collective="false" import="true" targetId="5ff5-48c0-b9f1-5a05" type="selectionEntryGroup">
+                          <constraints>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6e69-dafb-4bbe-fc4c" type="min"/>
+                          </constraints>
+                        </entryLink>
+                      </entryLinks>
+                      <costs>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                      </costs>
+                    </selectionEntry>
+                    <selectionEntry id="b8e6-e450-e7f9-ec25" name="Blast Pilstol and Charnabal Weapon (Sub-menu)" hidden="false" collective="false" import="true" type="upgrade">
+                      <entryLinks>
+                        <entryLink id="bc50-4fad-7aa8-8fc6" name="Blast Pistol" hidden="false" collective="false" import="true" targetId="2460-375d-31f4-4bdf" type="selectionEntry">
+                          <constraints>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3bb4-8d9e-34b0-099c" type="min"/>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cdca-9b64-ffb0-42f1" type="max"/>
+                          </constraints>
+                        </entryLink>
+                        <entryLink id="5249-668b-76b9-6fed" name="Charnabal Weapon" hidden="false" collective="false" import="true" targetId="f7d1-ad0f-b4cb-dfc1" type="selectionEntryGroup">
+                          <constraints>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ab2f-4ab9-74e7-4020" type="min"/>
+                          </constraints>
+                        </entryLink>
+                      </entryLinks>
+                      <costs>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                      </costs>
+                    </selectionEntry>
+                    <selectionEntry id="6051-538e-da26-346c" name="Pistol and Combat weapon (Sub-menu)" hidden="false" collective="false" import="true" type="upgrade">
+                      <selectionEntryGroups>
+                        <selectionEntryGroup id="a6d8-996c-eebe-5d0e" name="Close Combat" hidden="false" collective="false" import="true">
+                          <constraints>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0015-dfde-b057-6a16" type="min"/>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e336-4a32-8987-cbe8" type="max"/>
+                          </constraints>
+                          <entryLinks>
+                            <entryLink id="1064-b69c-1d90-80f5" name="Close Combat Weapon" hidden="false" collective="false" import="true" targetId="3d50-2f85-06ff-6aee" type="selectionEntry"/>
+                            <entryLink id="a9c2-fc2c-2f64-cf75" name="Power Fist" hidden="false" collective="false" import="true" targetId="768d-b89b-7328-d749" type="selectionEntry">
+                              <costs>
+                                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                              </costs>
+                            </entryLink>
+                          </entryLinks>
+                        </selectionEntryGroup>
+                        <selectionEntryGroup id="ac03-bc32-6315-5672" name="Pistol" hidden="false" collective="false" import="true">
+                          <constraints>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0d1c-bef5-f65f-b667" type="min"/>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="97ff-6d72-3d8a-4046" type="max"/>
+                          </constraints>
+                          <entryLinks>
+                            <entryLink id="88eb-1962-0871-26f5" name="Laspistol" hidden="false" collective="false" import="true" targetId="654d-be88-b0a8-7ae5" type="selectionEntry"/>
+                            <entryLink id="32a9-9135-4597-34c9" name="Blast Pistol" hidden="false" collective="false" import="true" targetId="2460-375d-31f4-4bdf" type="selectionEntry">
+                              <costs>
+                                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2.0"/>
+                              </costs>
+                            </entryLink>
+                            <entryLink id="5247-5264-a1b8-f14c" name="Plasma Pistol" hidden="false" collective="false" import="true" targetId="717f-cf0a-1593-4bd8" type="selectionEntry">
+                              <costs>
+                                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                              </costs>
+                            </entryLink>
+                            <entryLink id="b11c-5890-3f18-f4cd" name="Hand Flamer" hidden="false" collective="false" import="true" targetId="e337-adf4-a11f-0280" type="selectionEntry">
+                              <costs>
+                                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2.0"/>
+                              </costs>
+                            </entryLink>
+                            <entryLink id="d3ce-8ec3-5320-348b" name="Needle Pistol" hidden="false" collective="false" import="true" targetId="fdd4-06c7-4608-b07f" type="selectionEntry">
+                              <costs>
+                                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2.0"/>
+                              </costs>
+                            </entryLink>
+                          </entryLinks>
+                        </selectionEntryGroup>
+                      </selectionEntryGroups>
+                      <costs>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                      </costs>
+                    </selectionEntry>
+                  </selectionEntries>
+                  <entryLinks>
+                    <entryLink id="8591-c0e5-c959-c458" name="Lasrifle" hidden="false" collective="false" import="true" targetId="15f9-817e-275b-c13d" type="selectionEntry"/>
+                    <entryLink id="60a8-4182-6239-9f42" name="Volkite Charger" hidden="false" collective="false" import="true" targetId="6f6e-ad55-e093-6503" type="selectionEntry">
+                      <costs>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="1cd9-6a52-f115-d0d8" name="Bolter" hidden="false" collective="false" import="true" targetId="1ade-0c02-5612-252b" type="selectionEntry"/>
+                    <entryLink id="8219-8034-d110-f9ac" name="Magna Combi-weapon" hidden="false" collective="false" import="true" targetId="4d02-259d-fa50-ef3a" type="selectionEntry">
+                      <costs>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="bdd3-1c57-bb50-dca5" name="Minor Combi-weapon" hidden="false" collective="false" import="true" targetId="53c0-b5d7-f001-b816" type="selectionEntry">
+                      <costs>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="6361-0790-5330-f528" name="Flamer" hidden="false" collective="false" import="true" targetId="9f41-82e2-90f6-973a" type="selectionEntry">
+                      <costs>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="39ac-e1ae-de3b-28f9" name="Plasma Gun" hidden="false" collective="false" import="true" targetId="f0d1-332b-c719-ede7" type="selectionEntry">
+                      <costs>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="c813-1fff-3729-719b" name="Meltagun" hidden="false" collective="false" import="true" targetId="4ebd-57e0-3560-e568" type="selectionEntry">
+                      <costs>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="4833-fbaa-83a8-e0a5" name="Grenade Launcher" hidden="false" collective="false" import="true" targetId="e0f3-3743-a9d0-f5f1" type="selectionEntry">
+                      <costs>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="a926-1d13-1647-06cd" name="Lasrifle with Bayonet" hidden="false" collective="false" import="true" targetId="2867-ab52-1247-2532" type="selectionEntry">
+                      <costs>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="1.0"/>
+                      </costs>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="dd1b-b29a-a98d-032d" name="May take:" hidden="false" collective="false" import="true">
+                  <entryLinks>
+                    <entryLink id="1f51-ab4e-93e1-96aa" name="Cortex Controller" hidden="true" collective="false" import="true" targetId="2fda-455f-d34d-97e0" type="selectionEntry">
+                      <modifiers>
+                        <modifier type="set" field="hidden" value="false">
+                          <conditions>
+                            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a09b-28bd-8ffc-f4f0" type="equalTo"/>
+                          </conditions>
+                        </modifier>
+                      </modifiers>
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cd57-9e61-0dae-fdb0" type="max"/>
+                      </constraints>
+                      <costs>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                      </costs>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="575a-927b-c3c7-395f" name="Dedicated Transports" hidden="false" collective="false" import="true">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8d15-36d7-a1ce-2687" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="4d4b-4bd3-10c6-44f4" name="Aurox Transport" hidden="false" collective="false" import="true" targetId="071b-79e5-7b5b-c9cd" type="selectionEntry"/>
+                <entryLink id="ee8e-8f36-5d0c-a2dd" name="Dracosan Armoured Transport " hidden="false" collective="false" import="true" targetId="496b-a01b-3726-0a44" type="selectionEntry"/>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="2117-2813-1879-809d" name="One Auxilia Companion in the unit may be upgraded to have a:" hidden="false" collective="false" import="true">
+              <selectionEntryGroups>
+                <selectionEntryGroup id="954a-518d-4b12-900a" name="Vexilla" hidden="false" collective="false" import="true">
+                  <constraints>
+                    <constraint field="selections" scope="adca-2009-9ede-8650" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="cbdc-9356-f677-cf5d" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7b7d-30fd-c8e9-3d3b" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="ebb9-24b0-7ee1-4cb8" name="Cohorts Vexilla" hidden="false" collective="false" import="true" targetId="b66d-ca3f-b0ea-47ef" type="selectionEntry">
+                      <costs>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="e74b-cb1b-cb7c-fd21" name="Auxilia Vexilla" hidden="false" collective="false" import="true" targetId="6f5a-bf56-4bee-ce7e" type="selectionEntry">
+                      <costs>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                      </costs>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+              <entryLinks>
+                <entryLink id="9fbd-d243-4ae9-dc69" name="Augury Scanner" hidden="false" collective="false" import="true" targetId="67ee-7338-3b74-04b4" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="46fb-6d24-d5df-1b09" type="max"/>
+                    <constraint field="selections" scope="adca-2009-9ede-8650" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3429-6202-8c5c-c7b7" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="fd6a-1bcd-d0bd-c83a" name="Command Vox" hidden="false" collective="false" import="true" targetId="7ac4-c39b-5c48-63cb" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7194-2033-c717-a9f0" type="max"/>
+                    <constraint field="selections" scope="adca-2009-9ede-8650" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8704-40b0-5463-da14" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                  </costs>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks>
+            <entryLink id="dd7b-70a1-dba9-b62c" name="Frag Grenades" hidden="false" collective="false" import="true" targetId="cf9c-327b-3449-00d7" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0681-0336-46a8-764a" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1fbb-3c3e-df3a-525a" type="min"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="4b16-2477-791f-68e7" name="Krak Grenades" hidden="false" collective="false" import="true" targetId="99df-2421-acf7-a5ad" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1fa6-6276-0926-d7ef" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c673-2a3c-b1b2-6b20" type="min"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="11e0-1e27-d1b7-8202" name="Meltabombs" hidden="false" collective="false" import="true" targetId="b9dd-3b21-f3f8-78e3" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="54b9-e9bc-86c6-25ef" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="254a-7502-c513-e650" type="min"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="17ce-f68c-7606-94c7" name="Refractor Field" hidden="false" collective="false" import="true" targetId="a06a-55a5-070b-1d0e" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="daac-7b17-7130-a33c" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3ed9-4997-8b24-72ef" type="min"/>
+              </constraints>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="57.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="637d-9295-181e-9546" name="Companion Sections" hidden="false" collective="false" import="true" type="unit">
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e214-ce2d-5168-3692" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="03d7-59a4-4fa9-96ea" name="Stubborn" hidden="false" targetId="7989-1f2c-a43d-82ae" type="rule"/>
+            <infoLink id="e4ce-c61d-d924-95b6" name="Tercio" hidden="false" targetId="6516-f81d-457b-a2cc" type="rule"/>
+          </infoLinks>
+          <selectionEntries>
+            <selectionEntry id="dfa9-eca3-1edb-7732" name="Auxilia Companion " hidden="false" collective="false" import="true" type="model">
+              <constraints>
+                <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="39d5-56d0-49e3-5e17" type="min"/>
+                <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a8b3-7f42-181b-187b" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="0bc4-075f-3b2d-cbfc" name="Auxilia Companion " hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="true">
+                      <conditions>
+                        <condition field="selections" scope="dfa9-eca3-1edb-7732" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="077d-9853-c2ea-02bf" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <characteristics>
+                    <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Close-order)</characteristic>
+                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">6</characteristic>
+                    <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
+                    <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
+                    <characteristic name="S" typeId="e478-41d4-a092-48a8">3</characteristic>
+                    <characteristic name="T" typeId="c32b-5fdd-3fbe-9b1f">3</characteristic>
+                    <characteristic name="W" typeId="57ee-1126-32a9-5672">2</characteristic>
+                    <characteristic name="I" typeId="62d3-22d7-2d49-52dc">4</characteristic>
+                    <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">2</characteristic>
+                    <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">7</characteristic>
+                    <characteristic name="Save" typeId="e593-6b3c-f169-04f0">4+</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <selectionEntries>
+                <selectionEntry id="077d-9853-c2ea-02bf" name="One Companion may upgrade to Adjutant" hidden="false" collective="false" import="true" type="model">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b3e9-d51d-25e5-683e" type="max"/>
+                    <constraint field="selections" scope="637d-9295-181e-9546" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4453-2d3e-6109-8fcc" type="max"/>
+                  </constraints>
+                  <profiles>
+                    <profile id="ea5a-efab-7414-884a" name="Auxilia Adjutant" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
+                      <characteristics>
+                        <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Close-order, Character)</characteristic>
+                        <characteristic name="Move" typeId="893e-2d76-8f04-44e5">6</characteristic>
+                        <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">5</characteristic>
+                        <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
+                        <characteristic name="S" typeId="e478-41d4-a092-48a8">3</characteristic>
+                        <characteristic name="T" typeId="c32b-5fdd-3fbe-9b1f">3</characteristic>
+                        <characteristic name="W" typeId="57ee-1126-32a9-5672">2</characteristic>
+                        <characteristic name="I" typeId="62d3-22d7-2d49-52dc">4</characteristic>
+                        <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">3</characteristic>
+                        <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">8</characteristic>
+                        <characteristic name="Save" typeId="e593-6b3c-f169-04f0">4+</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+              <selectionEntryGroups>
+                <selectionEntryGroup id="841f-decf-594c-4ce3" name="May exchange Lasrifle for:" hidden="false" collective="false" import="true" defaultSelectionEntryId="1eb7-f212-f216-2dab">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="84eb-ae63-456a-2e52" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="68ac-5dad-10fa-5492" type="max"/>
+                  </constraints>
+                  <selectionEntries>
+                    <selectionEntry id="aa6b-be55-dcf1-ac51" name="Blast Pistols &amp; Power Weapon (Sub-menu)" hidden="false" collective="false" import="true" type="upgrade">
+                      <entryLinks>
+                        <entryLink id="224d-0edf-148c-e9be" name="Blast Pistol" hidden="false" collective="false" import="true" targetId="2460-375d-31f4-4bdf" type="selectionEntry">
+                          <constraints>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4a36-9919-8f93-6c5c" type="min"/>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5ab7-1048-be89-7f68" type="max"/>
+                          </constraints>
+                        </entryLink>
+                        <entryLink id="0524-af6a-7b34-d65d" name="Power Weapon" hidden="false" collective="false" import="true" targetId="5ff5-48c0-b9f1-5a05" type="selectionEntryGroup">
+                          <constraints>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="104c-d597-1c63-4780" type="min"/>
+                          </constraints>
+                        </entryLink>
+                      </entryLinks>
+                      <costs>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                      </costs>
+                    </selectionEntry>
+                    <selectionEntry id="1faf-f4c3-5139-b81a" name="Blast Pilstol and Charnabal Weapon (Sub-menu)" hidden="false" collective="false" import="true" type="upgrade">
+                      <entryLinks>
+                        <entryLink id="4965-a8fb-41b0-d4ed" name="Blast Pistol" hidden="false" collective="false" import="true" targetId="2460-375d-31f4-4bdf" type="selectionEntry">
+                          <constraints>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f1be-431e-951b-8603" type="min"/>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4ca8-b50d-86b9-5d46" type="max"/>
+                          </constraints>
+                        </entryLink>
+                        <entryLink id="48f4-cdd9-ba28-6bde" name="Charnabal Weapon" hidden="false" collective="false" import="true" targetId="f7d1-ad0f-b4cb-dfc1" type="selectionEntryGroup">
+                          <constraints>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f084-f5a4-4fbc-a8e8" type="min"/>
+                          </constraints>
+                        </entryLink>
+                      </entryLinks>
+                      <costs>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                      </costs>
+                    </selectionEntry>
+                    <selectionEntry id="4395-16ba-48e4-1011" name="Pistol and Combat weapon (Sub-menu)" hidden="true" collective="false" import="true" type="upgrade">
+                      <selectionEntryGroups>
+                        <selectionEntryGroup id="57c7-6ab1-dbc5-6565" name="Close Combat" hidden="false" collective="false" import="true">
+                          <constraints>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="66b6-f159-7bc4-979a" type="min"/>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fd29-2101-5755-d3a0" type="max"/>
+                          </constraints>
+                          <entryLinks>
+                            <entryLink id="cf41-dc0e-7e13-ba0e" name="Close Combat Weapon" hidden="false" collective="false" import="true" targetId="3d50-2f85-06ff-6aee" type="selectionEntry"/>
+                            <entryLink id="29a2-2d33-0cab-01ca" name="Power Fist" hidden="false" collective="false" import="true" targetId="768d-b89b-7328-d749" type="selectionEntry">
+                              <modifiers>
+                                <modifier type="set" field="hidden" value="true">
+                                  <conditions>
+                                    <condition field="selections" scope="dfa9-eca3-1edb-7732" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="077d-9853-c2ea-02bf" type="equalTo"/>
+                                  </conditions>
+                                </modifier>
+                              </modifiers>
+                              <costs>
+                                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                              </costs>
+                            </entryLink>
+                            <entryLink id="3b3c-2ab7-166a-b49a" name="Chainsword" hidden="false" collective="false" import="true" targetId="06e7-a6ae-ed1c-eb03" type="selectionEntry">
+                              <costs>
+                                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                              </costs>
+                            </entryLink>
+                          </entryLinks>
+                        </selectionEntryGroup>
+                        <selectionEntryGroup id="7f10-95aa-634f-68df" name="Pistol" hidden="false" collective="false" import="true">
+                          <constraints>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ffc0-97e8-eb27-e104" type="min"/>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2f32-c97e-c90d-2426" type="max"/>
+                          </constraints>
+                          <entryLinks>
+                            <entryLink id="c561-006e-afc2-bed2" name="Laspistol" hidden="false" collective="false" import="true" targetId="654d-be88-b0a8-7ae5" type="selectionEntry"/>
+                            <entryLink id="4c0f-8b1a-470d-fc02" name="Blast Pistol" hidden="false" collective="false" import="true" targetId="2460-375d-31f4-4bdf" type="selectionEntry">
+                              <modifiers>
+                                <modifier type="set" field="hidden" value="true">
+                                  <conditions>
+                                    <condition field="selections" scope="dfa9-eca3-1edb-7732" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="077d-9853-c2ea-02bf" type="equalTo"/>
+                                  </conditions>
+                                </modifier>
+                              </modifiers>
+                              <costs>
+                                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2.0"/>
+                              </costs>
+                            </entryLink>
+                            <entryLink id="d970-68ca-eb12-24e0" name="Plasma Pistol" hidden="false" collective="false" import="true" targetId="717f-cf0a-1593-4bd8" type="selectionEntry">
+                              <modifiers>
+                                <modifier type="set" field="hidden" value="true">
+                                  <conditions>
+                                    <condition field="selections" scope="dfa9-eca3-1edb-7732" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="077d-9853-c2ea-02bf" type="equalTo"/>
+                                  </conditions>
+                                </modifier>
+                              </modifiers>
+                              <costs>
+                                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                              </costs>
+                            </entryLink>
+                            <entryLink id="caf1-3b26-dd28-f88b" name="Hand Flamer" hidden="false" collective="false" import="true" targetId="e337-adf4-a11f-0280" type="selectionEntry">
+                              <modifiers>
+                                <modifier type="set" field="hidden" value="true">
+                                  <conditions>
+                                    <condition field="selections" scope="dfa9-eca3-1edb-7732" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="077d-9853-c2ea-02bf" type="equalTo"/>
+                                  </conditions>
+                                </modifier>
+                              </modifiers>
+                              <costs>
+                                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2.0"/>
+                              </costs>
+                            </entryLink>
+                            <entryLink id="3d18-ea1c-0020-b161" name="Needle Pistol" hidden="false" collective="false" import="true" targetId="fdd4-06c7-4608-b07f" type="selectionEntry">
+                              <modifiers>
+                                <modifier type="set" field="hidden" value="true">
+                                  <conditions>
+                                    <condition field="selections" scope="dfa9-eca3-1edb-7732" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="077d-9853-c2ea-02bf" type="equalTo"/>
+                                  </conditions>
+                                </modifier>
+                              </modifiers>
+                              <costs>
+                                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2.0"/>
+                              </costs>
+                            </entryLink>
+                          </entryLinks>
+                        </selectionEntryGroup>
+                      </selectionEntryGroups>
+                      <costs>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                      </costs>
+                    </selectionEntry>
+                  </selectionEntries>
+                  <entryLinks>
+                    <entryLink id="1eb7-f212-f216-2dab" name="Lasrifle" hidden="false" collective="false" import="true" targetId="15f9-817e-275b-c13d" type="selectionEntry"/>
+                    <entryLink id="0407-b87b-8496-1d68" name="Volkite Charger" hidden="false" collective="false" import="true" targetId="6f6e-ad55-e093-6503" type="selectionEntry">
+                      <costs>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="3772-71f9-6c12-ca51" name="Bolter" hidden="false" collective="false" import="true" targetId="1ade-0c02-5612-252b" type="selectionEntry"/>
+                    <entryLink id="0bc6-c9c5-729d-139d" name="Magna Combi-weapon" hidden="false" collective="false" import="true" targetId="4d02-259d-fa50-ef3a" type="selectionEntry">
+                      <costs>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="bca6-8ff1-3a59-ab03" name="Minor Combi-weapon" hidden="false" collective="false" import="true" targetId="53c0-b5d7-f001-b816" type="selectionEntry">
+                      <costs>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="8d87-0434-6ce5-d7bc" name="Flamer" hidden="false" collective="false" import="true" targetId="9f41-82e2-90f6-973a" type="selectionEntry">
+                      <costs>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="a7da-8d7b-1296-eb61" name="Plasma Gun" hidden="false" collective="false" import="true" targetId="f0d1-332b-c719-ede7" type="selectionEntry">
+                      <costs>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="edd8-bf04-213f-473b" name="Meltagun" hidden="false" collective="false" import="true" targetId="4ebd-57e0-3560-e568" type="selectionEntry">
+                      <costs>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="e08d-c93f-a391-efbc" name="Grenade Launcher" hidden="false" collective="false" import="true" targetId="e0f3-3743-a9d0-f5f1" type="selectionEntry">
+                      <costs>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="72d9-8002-429e-fd79" name="Lasrifle with Bayonet" hidden="false" collective="false" import="true" targetId="2867-ab52-1247-2532" type="selectionEntry">
+                      <costs>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="1.0"/>
+                      </costs>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="12.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="9e8a-f0ff-4130-d5c0" name="Dedicated Transports" hidden="false" collective="false" import="true">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4f01-7bc3-e001-f9a7" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="ed5a-006a-2bd9-3b7a" name="Aurox Transport" hidden="false" collective="false" import="true" targetId="071b-79e5-7b5b-c9cd" type="selectionEntry"/>
+                <entryLink id="0ef4-6f77-7615-2346" name="Dracosan Armoured Transport " hidden="false" collective="false" import="true" targetId="496b-a01b-3726-0a44" type="selectionEntry"/>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="2161-77d2-5365-5423" name="One Auxilia Companion in the unit may be upgraded to have a:" hidden="false" collective="false" import="true">
+              <entryLinks>
+                <entryLink id="55b4-92cb-2160-4452" name="Augury Scanner" hidden="false" collective="false" import="true" targetId="67ee-7338-3b74-04b4" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6487-4c9e-f577-3618" type="max"/>
+                    <constraint field="selections" scope="637d-9295-181e-9546" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6031-4adb-391f-618b" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="ec1e-3d52-1938-b811" name="Auxilia Vexilla" hidden="false" collective="false" import="true" targetId="6f5a-bf56-4bee-ce7e" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="637d-9295-181e-9546" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e0c1-e175-52c0-30fe" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="92c8-5e24-4153-1dd8" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="6c75-3a59-0510-2550" name="Vox Interlock" hidden="false" collective="false" import="true" targetId="c04e-5624-3615-0660" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fab2-6047-5281-69a3" type="max"/>
+                    <constraint field="selections" scope="637d-9295-181e-9546" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0259-6732-65bc-57aa" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                  </costs>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks>
+            <entryLink id="1e72-1a86-cb39-b3a5" name="Frag Grenades" hidden="false" collective="false" import="true" targetId="cf9c-327b-3449-00d7" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ec03-f5db-e0b4-83eb" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="995c-7c68-8920-ed01" type="min"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="2316-ad16-8f52-ca20" name="Krak Grenades" hidden="false" collective="false" import="true" targetId="99df-2421-acf7-a5ad" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f3a7-9ad3-3da7-c492" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6794-88b1-5387-a33a" type="min"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="2178-a367-baa9-1cee" name="Meltabombs" hidden="false" collective="false" import="true" targetId="b9dd-3b21-f3f8-78e3" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d72c-2f90-e1e8-8a62" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a3d5-faae-b921-0434" type="min"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="1460-c3b0-c276-9ce6" name="Refractor Field" hidden="false" collective="false" import="true" targetId="a06a-55a5-070b-1d0e" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c51e-b17a-52ff-19ec" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f452-ca66-1e55-0405" type="min"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="5e73-698c-5725-22d9" name="Void Armour" hidden="false" collective="false" import="true" targetId="6112-2c54-ceb5-a24d" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ca49-8dba-c1ea-93cf" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1cbe-6d0f-e79b-1543" type="min"/>
+              </constraints>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="1905-2087-cffc-4839" name="Auxilia Veletaris Tercio" hidden="false" collective="false" import="true" type="unit">
+      <modifiers>
+        <modifier type="add" field="category" value="6399-5c65-7833-1025">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a09b-28bd-8ffc-f4f0" type="equalTo"/>
+                <condition field="selections" scope="primary-category" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9b5d-fac7-799b-d7e7" type="instanceOf"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+        <modifier type="set" field="ca24-f640-593d-b537" value="1.0">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bfd2-7016-f5fe-be6a" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="parent" value="-1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ca24-f640-593d-b537" type="max"/>
+      </constraints>
+      <categoryLinks>
+        <categoryLink id="4ee4-cb02-24f5-137f" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="43e3-5243-c97d-3eda" name="Close-order Sub-type" hidden="false" targetId="0af0-ea84-09d7-2b1f" primary="false"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="7474-ec3d-98de-d2e0" name="Veletaris Command Section " hidden="false" collective="false" import="true" type="unit">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2e7c-cc82-0b71-2b49" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="1d78-77e6-4fc9-1277" name="Tercio" hidden="false" targetId="6516-f81d-457b-a2cc" type="rule"/>
+          </infoLinks>
+          <selectionEntries>
+            <selectionEntry id="b232-3a78-7275-2fa1" name="Veletarii First Prime" hidden="false" collective="false" import="true" type="model">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7235-781c-a3b9-ba87" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fb9f-a73e-40b8-b198" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="4606-e745-412d-313c" name="Veletarii First Prime" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
+                  <modifiers>
+                    <modifier type="set" field="e593-6b3c-f169-04f0" value="3+">
+                      <conditions>
+                        <condition field="selections" scope="b232-3a78-7275-2fa1" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="523c-d7fb-5288-fe13" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Infantry (Heavy, Character, Line)">
+                      <conditionGroups>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a09b-28bd-8ffc-f4f0" type="equalTo"/>
+                            <condition field="selections" scope="primary-category" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9b5d-fac7-799b-d7e7" type="instanceOf"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                  </modifiers>
+                  <characteristics>
+                    <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Heavy, Character)</characteristic>
+                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">6</characteristic>
+                    <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
+                    <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
+                    <characteristic name="S" typeId="e478-41d4-a092-48a8">3</characteristic>
+                    <characteristic name="T" typeId="c32b-5fdd-3fbe-9b1f">3</characteristic>
+                    <characteristic name="W" typeId="57ee-1126-32a9-5672">1</characteristic>
+                    <characteristic name="I" typeId="62d3-22d7-2d49-52dc">4</characteristic>
+                    <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">2</characteristic>
+                    <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">8</characteristic>
+                    <characteristic name="Save" typeId="e593-6b3c-f169-04f0">4+</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <categoryLinks>
+                <categoryLink id="1278-bf88-ac56-9920" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
+              </categoryLinks>
+              <selectionEntryGroups>
+                <selectionEntryGroup id="1cb1-052d-9cfe-0fc5" name="Armour" hidden="false" collective="false" import="true" defaultSelectionEntryId="09b8-e985-c536-4684">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d23a-c6f3-609c-e6d3" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ff47-cdc2-d411-fc6e" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="09b8-e985-c536-4684" name="Reinforced Void Armour " hidden="false" collective="false" import="true" targetId="cc63-5cc3-212a-3d4c" type="selectionEntry"/>
+                    <entryLink id="c593-dd64-e385-685d" name="Heavy Void Armour" hidden="false" collective="false" import="true" targetId="523c-d7fb-5288-fe13" type="selectionEntry">
+                      <costs>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                      </costs>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="5f6e-e0a3-6584-f494" name="Weapons" hidden="false" collective="false" import="true" defaultSelectionEntryId="c6f7-69d2-456a-b8d9">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e40d-91f3-e8a0-e5ad" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2b13-4a75-39ef-867a" type="max"/>
+                  </constraints>
+                  <selectionEntries>
+                    <selectionEntry id="2483-2a53-a4fc-0bba" name="Pistol and Combat weapon (Sub-menu)" hidden="false" collective="false" import="true" type="upgrade">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a3b3-8bb4-0098-0d34" type="max"/>
+                      </constraints>
+                      <selectionEntryGroups>
+                        <selectionEntryGroup id="8903-0c12-c67c-6c4c" name="Close Combat" hidden="false" collective="false" import="true">
+                          <constraints>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dfe5-99cd-467c-ff16" type="min"/>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e847-9abf-caab-4cf9" type="max"/>
+                          </constraints>
+                          <entryLinks>
+                            <entryLink id="170b-a81a-5a77-0e88" name="Close Combat Weapon" hidden="false" collective="false" import="true" targetId="3d50-2f85-06ff-6aee" type="selectionEntry"/>
+                            <entryLink id="16e5-8246-891f-8de5" name="Power Fist" hidden="false" collective="false" import="true" targetId="768d-b89b-7328-d749" type="selectionEntry">
+                              <costs>
+                                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                              </costs>
+                            </entryLink>
+                            <entryLink id="f1c0-a394-e45d-a4ec" name="Power Sword" hidden="false" collective="false" import="true" targetId="a3cd-aa97-a148-2309" type="selectionEntry">
+                              <costs>
+                                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                              </costs>
+                            </entryLink>
+                            <entryLink id="fc64-47bd-0881-a0ef" name="Power Maul" hidden="false" collective="false" import="true" targetId="0df4-c67e-cf64-82e0" type="selectionEntry">
+                              <costs>
+                                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                              </costs>
+                            </entryLink>
+                            <entryLink id="4288-156c-ce79-201b" name="Power Lance" hidden="false" collective="false" import="true" targetId="a4c8-c8ff-87f2-1ac9" type="selectionEntry">
+                              <costs>
+                                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                              </costs>
+                            </entryLink>
+                            <entryLink id="6297-0651-3479-fd1e" name="Power Axe" hidden="false" collective="false" import="true" targetId="c066-2ace-f68c-e440" type="selectionEntry">
+                              <costs>
+                                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                              </costs>
+                            </entryLink>
+                            <entryLink id="4663-cacd-0e30-b4a8" name="Charnabal Tabar" hidden="false" collective="false" import="true" targetId="4611-c33e-f360-7246" type="selectionEntry">
+                              <costs>
+                                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                              </costs>
+                            </entryLink>
+                            <entryLink id="7e2b-d303-6f50-3a75" name="Charnabal Sabre" hidden="false" collective="false" import="true" targetId="30c2-57eb-5bbe-be0b" type="selectionEntry">
+                              <costs>
+                                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                              </costs>
+                            </entryLink>
+                            <entryLink id="080b-b2d3-eef8-2805" name="Charnabal Glaive" hidden="false" collective="false" import="true" targetId="c07c-35e6-4616-ef25" type="selectionEntry">
+                              <costs>
+                                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                              </costs>
+                            </entryLink>
+                          </entryLinks>
+                        </selectionEntryGroup>
+                        <selectionEntryGroup id="de9f-b846-c818-9e80" name="Pistol" hidden="false" collective="false" import="true">
+                          <constraints>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ba1f-c478-e955-e07a" type="min"/>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fea1-f3b9-7440-3ef3" type="max"/>
+                          </constraints>
+                          <entryLinks>
+                            <entryLink id="3cec-d192-84c1-be5c" name="Blast Pistol" hidden="false" collective="false" import="true" targetId="2460-375d-31f4-4bdf" type="selectionEntry"/>
+                            <entryLink id="756a-9edc-dc66-cb15" name="Plasma Pistol" hidden="false" collective="false" import="true" targetId="717f-cf0a-1593-4bd8" type="selectionEntry">
+                              <costs>
+                                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                              </costs>
+                            </entryLink>
+                            <entryLink id="169e-e211-463c-7c7e" name="Hand Flamer" hidden="false" collective="false" import="true" targetId="e337-adf4-a11f-0280" type="selectionEntry"/>
+                            <entryLink id="beb5-3ca5-021a-2e18" name="Needle Pistol" hidden="false" collective="false" import="true" targetId="fdd4-06c7-4608-b07f" type="selectionEntry"/>
+                          </entryLinks>
+                        </selectionEntryGroup>
+                      </selectionEntryGroups>
+                      <costs>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                      </costs>
+                    </selectionEntry>
+                  </selectionEntries>
+                  <entryLinks>
+                    <entryLink id="c6f7-69d2-456a-b8d9" name="Volkite Charger" hidden="false" collective="false" import="true" targetId="6f6e-ad55-e093-6503" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b14b-febd-135f-7e81" type="max"/>
+                      </constraints>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="d7bc-047c-b7f1-9422" name="Dedicated Transports" hidden="false" collective="false" import="true">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f8a3-daac-d0ed-7e9c" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="c098-ae34-d830-e5c8" name="Aurox Transport" hidden="false" collective="false" import="true" targetId="071b-79e5-7b5b-c9cd" type="selectionEntry"/>
+                <entryLink id="2921-ecce-fcdf-7f51" name="Dracosan Armoured Transport " hidden="false" collective="false" import="true" targetId="496b-a01b-3726-0a44" type="selectionEntry"/>
+                <entryLink id="d762-7404-b6a5-a152" name="Arvus Transport" hidden="true" collective="false" import="true" targetId="5041-9403-02b7-af14" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="false">
+                      <conditions>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a09b-28bd-8ffc-f4f0" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="ff50-83d5-369f-f7ca" name="One Veletarii in the unit may be upgraded to have a:" hidden="false" collective="false" import="true">
+              <entryLinks>
+                <entryLink id="4974-cc0e-dd7a-942d" name="Auxilia Vexilla" hidden="false" collective="false" import="true" targetId="6f5a-bf56-4bee-ce7e" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="7474-ec3d-98de-d2e0" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4a91-f7ee-a5f9-6c26" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="98fe-f299-2629-87f2" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="556b-e589-fcad-8e2d" name="Command Vox" hidden="false" collective="false" import="true" targetId="7ac4-c39b-5c48-63cb" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b250-635e-c7c0-77ca" type="max"/>
+                    <constraint field="selections" scope="7474-ec3d-98de-d2e0" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="385b-529a-0b82-17ed" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                  </costs>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="092d-2397-8f02-c431" name="Veletarii" hidden="false" collective="false" import="true" defaultSelectionEntryId="c39a-711f-3566-712d">
+              <constraints>
+                <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1168-de26-e5bc-3a25" type="min"/>
+                <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="47ed-c168-0aa5-e59a" type="max"/>
+              </constraints>
+              <selectionEntries>
+                <selectionEntry id="0e92-6f2e-8f92-40bf" name="Veletarii w/ Power Sword" hidden="false" collective="false" import="true" type="model">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1011-7d26-c096-6d0c" type="max"/>
+                  </constraints>
+                  <infoLinks>
+                    <infoLink id="d55c-a815-fca3-ee7a" name="Veletarii" hidden="false" targetId="b10f-3847-6c28-0548" type="profile"/>
+                  </infoLinks>
+                  <entryLinks>
+                    <entryLink id="7813-f295-65eb-b35f" name="Reinforced Void Armour " hidden="false" collective="false" import="true" targetId="5e45-2a38-759c-3147" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4c81-045a-711c-ee5f" type="min"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7e45-6a3e-227b-f839" type="max"/>
+                      </constraints>
+                    </entryLink>
+                    <entryLink id="bc0d-4263-e761-362c" name="Power Sword" hidden="false" collective="false" import="true" targetId="fa06-cac0-3d98-125e" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5ee6-ad3d-fbd6-9ce2" type="min"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7b42-c7af-536f-1a12" type="max"/>
+                      </constraints>
+                    </entryLink>
+                  </entryLinks>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="13.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="0fd2-c8e2-45e4-d8e9" name="Veletarii w/ Power Axe" hidden="false" collective="false" import="true" type="model">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6c4a-9416-9e3d-c157" type="max"/>
+                  </constraints>
+                  <profiles>
+                    <profile id="b10f-3847-6c28-0548" name="Veletarii" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
+                      <modifiers>
+                        <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Infantry (Heavy, Line)">
+                          <conditionGroups>
+                            <conditionGroup type="and">
+                              <conditions>
+                                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a09b-28bd-8ffc-f4f0" type="equalTo"/>
+                                <condition field="selections" scope="primary-category" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9b5d-fac7-799b-d7e7" type="instanceOf"/>
+                              </conditions>
+                            </conditionGroup>
+                          </conditionGroups>
+                        </modifier>
+                      </modifiers>
+                      <characteristics>
+                        <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Heavy)</characteristic>
+                        <characteristic name="Move" typeId="893e-2d76-8f04-44e5">6</characteristic>
+                        <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
+                        <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
+                        <characteristic name="S" typeId="e478-41d4-a092-48a8">3</characteristic>
+                        <characteristic name="T" typeId="c32b-5fdd-3fbe-9b1f">3</characteristic>
+                        <characteristic name="W" typeId="57ee-1126-32a9-5672">1</characteristic>
+                        <characteristic name="I" typeId="62d3-22d7-2d49-52dc">4</characteristic>
+                        <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">1</characteristic>
+                        <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">6</characteristic>
+                        <characteristic name="Save" typeId="e593-6b3c-f169-04f0">4+</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <entryLinks>
+                    <entryLink id="d447-2312-0e6e-0290" name="Reinforced Void Armour " hidden="false" collective="false" import="true" targetId="5e45-2a38-759c-3147" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="95e1-7fe4-e7f1-e9f8" type="min"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b622-b1fa-56e3-d17e" type="max"/>
+                      </constraints>
+                    </entryLink>
+                    <entryLink id="e05f-0a93-29c9-e4fb" name="Power Axe" hidden="false" collective="false" import="true" targetId="ef98-66ac-fcaf-c15d" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c9c0-74c4-a591-651d" type="min"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="42d0-a888-160a-7ef1" type="max"/>
+                      </constraints>
+                    </entryLink>
+                  </entryLinks>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="13.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="6e26-de36-1442-bf11" name="Veletarii w/ Power Lance" hidden="false" collective="false" import="true" type="model">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ff05-f5f1-0f4d-d019" type="max"/>
+                  </constraints>
+                  <infoLinks>
+                    <infoLink id="c3fa-1bf1-90fe-5ff3" name="Veletarii" hidden="false" targetId="b10f-3847-6c28-0548" type="profile"/>
+                  </infoLinks>
+                  <entryLinks>
+                    <entryLink id="1b0d-a335-3362-5ab9" name="Reinforced Void Armour " hidden="false" collective="false" import="true" targetId="5e45-2a38-759c-3147" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b850-3d19-2843-f45b" type="min"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9ac9-2bea-a1ac-e521" type="max"/>
+                      </constraints>
+                    </entryLink>
+                    <entryLink id="2df3-e0a8-3bc6-7a98" name="Power Lance" hidden="false" collective="false" import="true" targetId="fca3-4ec1-c581-1ba3" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2e44-4502-dc02-2ac7" type="min"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="43a2-b9b7-ba34-ccc1" type="max"/>
+                      </constraints>
+                    </entryLink>
+                  </entryLinks>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="13.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="2ccc-2dc8-9580-f134" name="Veletarii w/ Power Maul" hidden="false" collective="false" import="true" type="model">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1af2-bcc2-ec38-96e0" type="max"/>
+                  </constraints>
+                  <infoLinks>
+                    <infoLink id="e672-dd79-0784-b7ec" name="Veletarii" hidden="false" targetId="b10f-3847-6c28-0548" type="profile"/>
+                  </infoLinks>
+                  <entryLinks>
+                    <entryLink id="e3c0-8a39-04e0-fcd0" name="Reinforced Void Armour " hidden="false" collective="false" import="true" targetId="5e45-2a38-759c-3147" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4393-23a5-622a-565c" type="min"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="766c-b0dd-63f4-8749" type="max"/>
+                      </constraints>
+                    </entryLink>
+                    <entryLink id="8e07-7cb6-b23b-38c0" name="Power Maul" hidden="false" collective="false" import="true" targetId="98e8-f217-dea9-0493" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1199-a8e3-7d40-6024" type="min"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8056-3f5e-23d8-60f6" type="max"/>
+                      </constraints>
+                    </entryLink>
+                  </entryLinks>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="13.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="c39a-711f-3566-712d" name="Veletarii w/ Volkite Charger" hidden="false" collective="false" import="true" type="model">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="60ff-babf-7da4-a70a" type="max"/>
+                  </constraints>
+                  <infoLinks>
+                    <infoLink id="b46b-492a-7e17-61de" name="Veletarii" hidden="false" targetId="b10f-3847-6c28-0548" type="profile"/>
+                  </infoLinks>
+                  <entryLinks>
+                    <entryLink id="c08b-1081-4d6d-f920" name="Reinforced Void Armour " hidden="false" collective="false" import="true" targetId="5e45-2a38-759c-3147" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1e47-3793-f822-eba7" type="min"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="752c-e144-240e-5882" type="max"/>
+                      </constraints>
+                    </entryLink>
+                    <entryLink id="1194-fd3e-fab0-b679" name="Volkite Charger" hidden="false" collective="false" import="true" targetId="5c82-c306-9c5c-5908" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0cbd-ee32-eb57-dd46" type="min"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b864-28ca-4f90-c6ec" type="max"/>
+                      </constraints>
+                    </entryLink>
+                  </entryLinks>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="8.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks>
+            <entryLink id="e84f-f6d2-80c7-db89" name="Volkite Charger" hidden="false" collective="false" import="true" targetId="6f6e-ad55-e093-6503" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9fb7-613c-30f7-a40a" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="15ce-dbc8-f64d-f873" type="max"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="6bc5-f9e9-44a1-f883" name="Krak Grenades" hidden="false" collective="false" import="true" targetId="99df-2421-acf7-a5ad" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="efba-2f98-ca93-40a1" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8817-bd09-9a91-8456" type="max"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="4207-ba86-a98a-98b2" name="Frag Grenades" hidden="false" collective="false" import="true" targetId="cf9c-327b-3449-00d7" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ebd8-f5f6-d2dc-2e17" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5dfe-f341-dc77-0d07" type="max"/>
+              </constraints>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="58.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="c51e-5dce-2d97-4a99" name="Veletaris Storm Section" hidden="false" collective="false" import="true" type="unit">
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b8d7-d27c-2841-12af" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a8bc-6d7a-6118-1894" type="min"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="2cfb-f9ab-abd0-e95e" name="Tercio" hidden="false" targetId="6516-f81d-457b-a2cc" type="rule"/>
+          </infoLinks>
+          <selectionEntries>
+            <selectionEntry id="06be-2459-ac34-8782" name="Veletarii Prime" hidden="false" collective="false" import="true" type="model">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="642d-bbad-ee60-8168" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8fc2-cd7e-de95-18b5" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="ae88-d4d6-6f08-f4fb" name="Veletarii Prime" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
+                  <modifiers>
+                    <modifier type="set" field="e593-6b3c-f169-04f0" value="3+">
+                      <conditions>
+                        <condition field="selections" scope="06be-2459-ac34-8782" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="523c-d7fb-5288-fe13" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Infantry (Heavy, Character, Line)">
+                      <conditions>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a09b-28bd-8ffc-f4f0" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <characteristics>
+                    <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Heavy, Character)</characteristic>
+                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">6</characteristic>
+                    <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
+                    <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
+                    <characteristic name="S" typeId="e478-41d4-a092-48a8">3</characteristic>
+                    <characteristic name="T" typeId="c32b-5fdd-3fbe-9b1f">3</characteristic>
+                    <characteristic name="W" typeId="57ee-1126-32a9-5672">1</characteristic>
+                    <characteristic name="I" typeId="62d3-22d7-2d49-52dc">4</characteristic>
+                    <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">2</characteristic>
+                    <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">7</characteristic>
+                    <characteristic name="Save" typeId="e593-6b3c-f169-04f0">4+</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <categoryLinks>
+                <categoryLink id="6ba0-d806-4ca8-1add" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
+              </categoryLinks>
+              <selectionEntryGroups>
+                <selectionEntryGroup id="7420-8069-6ac7-b72b" name="Armour" hidden="false" collective="false" import="true" defaultSelectionEntryId="1d16-82e9-d8f6-943e">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="18c7-99ad-9f41-eadc" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3fd4-ea25-c1da-c39d" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="1d16-82e9-d8f6-943e" name="Reinforced Void Armour " hidden="false" collective="false" import="true" targetId="cc63-5cc3-212a-3d4c" type="selectionEntry"/>
+                    <entryLink id="10f6-20a4-55d3-6565" name="Heavy Void Armour" hidden="false" collective="false" import="true" targetId="523c-d7fb-5288-fe13" type="selectionEntry">
+                      <costs>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                      </costs>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="054e-9398-2176-c36e" name="Weapons" hidden="false" collective="false" import="true" defaultSelectionEntryId="0c3c-546a-a159-5ae4">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="903f-32af-4b86-9ee7" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c69e-58eb-fbdb-bb77" type="max"/>
+                  </constraints>
+                  <selectionEntries>
+                    <selectionEntry id="b0be-c9c2-e8a1-8a04" name="Pistol and Combat weapon (Sub-menu)" hidden="false" collective="false" import="true" type="upgrade">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c1ff-7f3f-fbf5-a017" type="max"/>
+                      </constraints>
+                      <selectionEntryGroups>
+                        <selectionEntryGroup id="0582-ef1e-1f15-f504" name="Close Combat" hidden="false" collective="false" import="true">
+                          <constraints>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2d55-d1f5-ccc5-e653" type="min"/>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9d1d-2c20-3aad-d5fe" type="max"/>
+                          </constraints>
+                          <entryLinks>
+                            <entryLink id="7285-fa9b-a0ba-26ce" name="Close Combat Weapon" hidden="false" collective="false" import="true" targetId="3d50-2f85-06ff-6aee" type="selectionEntry"/>
+                            <entryLink id="8442-e1bb-8f7b-ebb1" name="Power Fist" hidden="false" collective="false" import="true" targetId="768d-b89b-7328-d749" type="selectionEntry">
+                              <costs>
+                                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                              </costs>
+                            </entryLink>
+                            <entryLink id="1cfd-0777-a4c9-3f6d" name="Storm Axe" hidden="false" collective="false" import="true" targetId="e09b-73c8-2340-4604" type="selectionEntry">
+                              <costs>
+                                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                              </costs>
+                            </entryLink>
+                            <entryLink id="1203-868c-1ee4-133b" name="Charnabal Glaive" hidden="false" collective="false" import="true" targetId="c07c-35e6-4616-ef25" type="selectionEntry">
+                              <costs>
+                                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                              </costs>
+                            </entryLink>
+                            <entryLink id="d8c0-fb87-038d-6c1d" name="Charnabal Sabre" hidden="false" collective="false" import="true" targetId="30c2-57eb-5bbe-be0b" type="selectionEntry">
+                              <costs>
+                                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                              </costs>
+                            </entryLink>
+                            <entryLink id="cecd-7c8b-50c8-3bbe" name="Charnabal Tabar" hidden="false" collective="false" import="true" targetId="4611-c33e-f360-7246" type="selectionEntry">
+                              <costs>
+                                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                              </costs>
+                            </entryLink>
+                            <entryLink id="12e9-27b3-af59-5530" name="Power Axe" hidden="false" collective="false" import="true" targetId="c066-2ace-f68c-e440" type="selectionEntry">
+                              <costs>
+                                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                              </costs>
+                            </entryLink>
+                            <entryLink id="062e-cbe7-6853-eb05" name="Power Lance" hidden="false" collective="false" import="true" targetId="a4c8-c8ff-87f2-1ac9" type="selectionEntry">
+                              <costs>
+                                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                              </costs>
+                            </entryLink>
+                            <entryLink id="fd68-62d0-decd-9121" name="Power Maul" hidden="false" collective="false" import="true" targetId="0df4-c67e-cf64-82e0" type="selectionEntry">
+                              <costs>
+                                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                              </costs>
+                            </entryLink>
+                            <entryLink id="dfcc-1003-6ecd-5021" name="Power Sword" hidden="false" collective="false" import="true" targetId="a3cd-aa97-a148-2309" type="selectionEntry">
+                              <costs>
+                                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                              </costs>
+                            </entryLink>
+                          </entryLinks>
+                        </selectionEntryGroup>
+                        <selectionEntryGroup id="a9db-cc4a-d2c4-e419" name="Pistol" hidden="false" collective="false" import="true">
+                          <constraints>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b95b-73fa-7c0d-0de2" type="min"/>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e56b-333f-e00b-77b4" type="max"/>
+                          </constraints>
+                          <entryLinks>
+                            <entryLink id="3c62-15f8-c427-a075" name="Blast Pistol" hidden="false" collective="false" import="true" targetId="2460-375d-31f4-4bdf" type="selectionEntry"/>
+                            <entryLink id="0818-8375-670a-dfa7" name="Plasma Pistol" hidden="false" collective="false" import="true" targetId="717f-cf0a-1593-4bd8" type="selectionEntry">
+                              <costs>
+                                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                              </costs>
+                            </entryLink>
+                            <entryLink id="9d01-8c72-f666-e0ef" name="Hand Flamer" hidden="false" collective="false" import="true" targetId="e337-adf4-a11f-0280" type="selectionEntry"/>
+                            <entryLink id="b766-d386-1e55-719b" name="Needle Pistol" hidden="false" collective="false" import="true" targetId="fdd4-06c7-4608-b07f" type="selectionEntry"/>
+                          </entryLinks>
+                        </selectionEntryGroup>
+                      </selectionEntryGroups>
+                      <costs>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                      </costs>
+                    </selectionEntry>
+                  </selectionEntries>
+                  <entryLinks>
+                    <entryLink id="0c3c-546a-a159-5ae4" name="Volkite Charger" hidden="false" collective="false" import="true" targetId="6f6e-ad55-e093-6503" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="26c1-1df0-618a-c436" type="max"/>
+                      </constraints>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="3574-b038-e96e-b6b8" name="One Veletarii in the unit may be upgraded to have a:" hidden="false" collective="false" import="true">
+              <entryLinks>
+                <entryLink id="e07d-482d-e110-3b53" name="Auxilia Vexilla" hidden="false" collective="false" import="true" targetId="6f5a-bf56-4bee-ce7e" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="c51e-5dce-2d97-4a99" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2210-1568-7fdb-417b" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d136-2095-a0a0-0648" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="3824-01fb-b996-4ed8" name="Vox Interlock" hidden="false" collective="false" import="true" targetId="c04e-5624-3615-0660" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="94b6-f2c2-699e-639f" type="max"/>
+                    <constraint field="selections" scope="c51e-5dce-2d97-4a99" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9efb-a913-ba86-58e0" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                  </costs>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="4651-997b-ff30-b4d5" name="Veletarii" hidden="false" collective="false" import="true" defaultSelectionEntryId="9194-cb55-09ee-7817">
+              <constraints>
+                <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b37d-f60a-d458-10a1" type="min"/>
+                <constraint field="selections" scope="parent" value="19.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2bc0-0b6e-c467-60cf" type="max"/>
+              </constraints>
+              <selectionEntries>
+                <selectionEntry id="2b18-d508-d843-fdc5" name="Veletarii w/ Storm axe" hidden="false" collective="false" import="true" type="model">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="19.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f26a-65cc-92b7-799d" type="max"/>
+                  </constraints>
+                  <profiles>
+                    <profile id="9d8f-243d-7020-9043" name="Veletarii" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
+                      <modifiers>
+                        <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Infantry (Heavy, Line)">
+                          <conditions>
+                            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a09b-28bd-8ffc-f4f0" type="equalTo"/>
+                          </conditions>
+                        </modifier>
+                      </modifiers>
+                      <characteristics>
+                        <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Heavy)</characteristic>
+                        <characteristic name="Move" typeId="893e-2d76-8f04-44e5">6</characteristic>
+                        <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
+                        <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
+                        <characteristic name="S" typeId="e478-41d4-a092-48a8">3</characteristic>
+                        <characteristic name="T" typeId="c32b-5fdd-3fbe-9b1f">3</characteristic>
+                        <characteristic name="W" typeId="57ee-1126-32a9-5672">1</characteristic>
+                        <characteristic name="I" typeId="62d3-22d7-2d49-52dc">4</characteristic>
+                        <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">1</characteristic>
+                        <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">6</characteristic>
+                        <characteristic name="Save" typeId="e593-6b3c-f169-04f0">4+</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <entryLinks>
+                    <entryLink id="65ad-96cd-aab3-9e56" name="Reinforced Void Armour " hidden="false" collective="false" import="true" targetId="5e45-2a38-759c-3147" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="09e3-5303-3b5a-b381" type="min"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0358-77f8-81c5-8406" type="max"/>
+                      </constraints>
+                    </entryLink>
+                    <entryLink id="7eba-5376-ba86-c37c" name="Storm Axe" hidden="false" collective="false" import="true" targetId="c305-a3f1-5c2f-ae37" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6c11-7b5c-21bb-35ea" type="min"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eb04-ca4b-ea88-7ddc" type="max"/>
+                      </constraints>
+                    </entryLink>
+                  </entryLinks>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="13.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="9194-cb55-09ee-7817" name="Veletarii w/ Volkite Charger" hidden="false" collective="false" import="true" type="model">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="19.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7830-a3c4-533b-64f9" type="max"/>
+                  </constraints>
+                  <infoLinks>
+                    <infoLink id="5343-2659-8851-807c" name="Veletarii" hidden="false" targetId="9d8f-243d-7020-9043" type="profile"/>
+                  </infoLinks>
+                  <entryLinks>
+                    <entryLink id="c9bf-b8d7-8964-568d" name="Reinforced Void Armour " hidden="false" collective="false" import="true" targetId="5e45-2a38-759c-3147" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="019a-021c-0b4f-e3b7" type="min"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a926-6a19-cb7d-3ec3" type="max"/>
+                      </constraints>
+                    </entryLink>
+                    <entryLink id="0733-55b6-c813-9ad1" name="Volkite Charger" hidden="false" collective="false" import="true" targetId="5c82-c306-9c5c-5908" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8898-6b2f-4134-e2d4" type="min"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a2b2-915b-82e3-7581" type="max"/>
+                      </constraints>
+                    </entryLink>
+                  </entryLinks>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="8.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="ee9d-04a6-b522-4047" name="Dedicated Transports" hidden="false" collective="false" import="true">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="20b7-845c-7c4e-9a24" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="44bd-6025-ca3d-2610" name="Aurox Transport" hidden="false" collective="false" import="true" targetId="071b-79e5-7b5b-c9cd" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="true">
+                      <conditions>
+                        <condition field="selections" scope="c51e-5dce-2d97-4a99" value="10.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="greaterThan"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                </entryLink>
+                <entryLink id="8662-58a1-6d55-4a14" name="Dracosan Armoured Transport " hidden="false" collective="false" import="true" targetId="496b-a01b-3726-0a44" type="selectionEntry"/>
+                <entryLink id="a9b5-fbc5-24f3-4e1f" name="Arvus Transport" hidden="true" collective="false" import="true" targetId="5041-9403-02b7-af14" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="false">
+                      <conditionGroups>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a09b-28bd-8ffc-f4f0" type="equalTo"/>
+                            <condition field="selections" scope="c51e-5dce-2d97-4a99" value="12.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="atMost"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                  </modifiers>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks>
+            <entryLink id="cd2c-65ee-ec87-b0c5" name="Volkite Charger" hidden="false" collective="false" import="true" targetId="6f6e-ad55-e093-6503" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="76b3-ceea-e3cb-51f8" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0c72-1301-3f2e-a57f" type="max"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="3950-d910-eeaa-6dcc" name="Krak Grenades" hidden="false" collective="false" import="true" targetId="99df-2421-acf7-a5ad" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="26f1-eb9d-995d-3c90" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4cbf-7147-4bf7-3226" type="max"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="c04a-fa04-8eff-0c77" name="Frag Grenades" hidden="false" collective="false" import="true" targetId="cf9c-327b-3449-00d7" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d2a6-c1b8-9484-88c9" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="604e-86c2-0c1c-1870" type="max"/>
+              </constraints>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="18.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="0508-f8a6-3996-bf39" name="Veletaris Vanguard Section" hidden="false" collective="false" import="true" type="unit">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="320c-fc49-63d4-126a" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="02e8-2b87-bcad-28b5" name="Tercio" hidden="false" targetId="6516-f81d-457b-a2cc" type="rule"/>
+          </infoLinks>
+          <selectionEntries>
+            <selectionEntry id="8a38-1a5e-e4c7-7b74" name="Veletarii Prime" hidden="false" collective="false" import="true" type="model">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7d95-bd41-cd6d-dbb8" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="21c4-3237-8fd8-6b1a" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="cb33-c30a-4e39-8a83" name="Veletarii Prime" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
+                  <modifiers>
+                    <modifier type="set" field="e593-6b3c-f169-04f0" value="3+">
+                      <conditions>
+                        <condition field="selections" scope="8a38-1a5e-e4c7-7b74" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="523c-d7fb-5288-fe13" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Infantry (Heavy, Character, Line)">
+                      <conditions>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a09b-28bd-8ffc-f4f0" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <characteristics>
+                    <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Heavy, Character)</characteristic>
+                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">6</characteristic>
+                    <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
+                    <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
+                    <characteristic name="S" typeId="e478-41d4-a092-48a8">3</characteristic>
+                    <characteristic name="T" typeId="c32b-5fdd-3fbe-9b1f">3</characteristic>
+                    <characteristic name="W" typeId="57ee-1126-32a9-5672">1</characteristic>
+                    <characteristic name="I" typeId="62d3-22d7-2d49-52dc">4</characteristic>
+                    <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">2</characteristic>
+                    <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">7</characteristic>
+                    <characteristic name="Save" typeId="e593-6b3c-f169-04f0">4+</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <categoryLinks>
+                <categoryLink id="1616-4d93-a1d7-8b9b" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
+              </categoryLinks>
+              <selectionEntryGroups>
+                <selectionEntryGroup id="cb16-77f4-dd20-bb13" name="Armour" hidden="false" collective="false" import="true" defaultSelectionEntryId="76fe-62a6-e1f1-1fe4">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5c13-4982-aa42-5fbd" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b2bb-199f-f6c1-653a" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="76fe-62a6-e1f1-1fe4" name="Reinforced Void Armour " hidden="false" collective="false" import="true" targetId="cc63-5cc3-212a-3d4c" type="selectionEntry"/>
+                    <entryLink id="9568-3bbc-7925-8ede" name="Heavy Void Armour" hidden="false" collective="false" import="true" targetId="523c-d7fb-5288-fe13" type="selectionEntry">
+                      <costs>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                      </costs>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="8209-4fe4-4776-72e1" name="Weapons" hidden="false" collective="false" import="true" defaultSelectionEntryId="6ea0-84ee-7815-bae7">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="db44-9689-19d2-8916" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cdda-c8ec-31aa-dae6" type="max"/>
+                  </constraints>
+                  <selectionEntries>
+                    <selectionEntry id="17f8-33d8-7a8e-d2d3" name="Pistol and Combat weapon (Sub-menu)" hidden="false" collective="false" import="true" type="upgrade">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3141-ace3-17ec-2ccb" type="max"/>
+                      </constraints>
+                      <selectionEntryGroups>
+                        <selectionEntryGroup id="e132-e9a1-d271-c31c" name="Close Combat" hidden="false" collective="false" import="true">
+                          <constraints>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2087-7cbd-fdd5-1967" type="min"/>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3d92-4432-7320-a20e" type="max"/>
+                          </constraints>
+                          <entryLinks>
+                            <entryLink id="db0c-0408-266a-69b8" name="Close Combat Weapon" hidden="false" collective="false" import="true" targetId="3d50-2f85-06ff-6aee" type="selectionEntry"/>
+                            <entryLink id="04d9-5d7c-cc56-c516" name="Power Fist" hidden="false" collective="false" import="true" targetId="768d-b89b-7328-d749" type="selectionEntry">
+                              <costs>
+                                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                              </costs>
+                            </entryLink>
+                            <entryLink id="b387-1955-3a7a-d83e" name="Charnabal Glaive" hidden="false" collective="false" import="true" targetId="c07c-35e6-4616-ef25" type="selectionEntry">
+                              <costs>
+                                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                              </costs>
+                            </entryLink>
+                            <entryLink id="476e-1342-7ad6-6acd" name="Charnabal Sabre" hidden="false" collective="false" import="true" targetId="30c2-57eb-5bbe-be0b" type="selectionEntry">
+                              <costs>
+                                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                              </costs>
+                            </entryLink>
+                            <entryLink id="ba00-b80b-ff5f-454b" name="Charnabal Tabar" hidden="false" collective="false" import="true" targetId="4611-c33e-f360-7246" type="selectionEntry">
+                              <costs>
+                                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                              </costs>
+                            </entryLink>
+                            <entryLink id="f34c-2276-3ca5-ea74" name="Power Axe" hidden="false" collective="false" import="true" targetId="c066-2ace-f68c-e440" type="selectionEntry">
+                              <costs>
+                                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                              </costs>
+                            </entryLink>
+                            <entryLink id="31a6-eb34-633e-b9e9" name="Power Lance" hidden="false" collective="false" import="true" targetId="a4c8-c8ff-87f2-1ac9" type="selectionEntry">
+                              <costs>
+                                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                              </costs>
+                            </entryLink>
+                            <entryLink id="28db-b636-fe67-44c0" name="Power Maul" hidden="false" collective="false" import="true" targetId="0df4-c67e-cf64-82e0" type="selectionEntry">
+                              <costs>
+                                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                              </costs>
+                            </entryLink>
+                            <entryLink id="db7b-030d-71ea-6048" name="Power Sword" hidden="false" collective="false" import="true" targetId="a3cd-aa97-a148-2309" type="selectionEntry">
+                              <costs>
+                                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                              </costs>
+                            </entryLink>
+                          </entryLinks>
+                        </selectionEntryGroup>
+                        <selectionEntryGroup id="7b84-2ff8-147f-3b19" name="Pistol" hidden="false" collective="false" import="true">
+                          <constraints>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a1c8-e9cd-da61-dba7" type="min"/>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="127e-4de8-c90b-7e9d" type="max"/>
+                          </constraints>
+                          <entryLinks>
+                            <entryLink id="cc2e-cd0b-a758-f758" name="Blast Pistol" hidden="false" collective="false" import="true" targetId="2460-375d-31f4-4bdf" type="selectionEntry"/>
+                            <entryLink id="614f-7648-8233-9baa" name="Plasma Pistol" hidden="false" collective="false" import="true" targetId="717f-cf0a-1593-4bd8" type="selectionEntry">
+                              <costs>
+                                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                              </costs>
+                            </entryLink>
+                            <entryLink id="b258-fb3d-4ff0-e1d3" name="Hand Flamer" hidden="false" collective="false" import="true" targetId="e337-adf4-a11f-0280" type="selectionEntry"/>
+                            <entryLink id="ed06-92b3-1104-f2b2" name="Needle Pistol" hidden="false" collective="false" import="true" targetId="fdd4-06c7-4608-b07f" type="selectionEntry"/>
+                          </entryLinks>
+                        </selectionEntryGroup>
+                      </selectionEntryGroups>
+                      <costs>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                      </costs>
+                    </selectionEntry>
+                  </selectionEntries>
+                  <entryLinks>
+                    <entryLink id="6ea0-84ee-7815-bae7" name="Rotor Cannon" hidden="false" collective="false" import="true" targetId="5ce3-3aa5-3f5e-9ead" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="04b9-516e-995e-7f6d" type="max"/>
+                      </constraints>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="198b-a4ad-7b6d-1dc8" name="One Veletarii in the unit may be upgraded to have a:" hidden="false" collective="false" import="true">
+              <entryLinks>
+                <entryLink id="9674-f0d4-f267-7237" name="Auxilia Vexilla" hidden="false" collective="false" import="true" targetId="6f5a-bf56-4bee-ce7e" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="0508-f8a6-3996-bf39" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ecf8-95ff-2a7b-78b7" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="84ff-7828-0759-8d72" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="4a13-7a1a-c494-3778" name="Vox Interlock" hidden="false" collective="false" import="true" targetId="c04e-5624-3615-0660" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c17a-1874-6f13-7ac5" type="max"/>
+                    <constraint field="selections" scope="0508-f8a6-3996-bf39" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c45f-c5bd-291a-35ea" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                  </costs>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="fc3c-5b58-1b10-490c" name="Veletarii" hidden="false" collective="false" import="true" defaultSelectionEntryId="e5b2-9536-03f8-39e2">
+              <constraints>
+                <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a823-12af-48c0-814c" type="min"/>
+                <constraint field="selections" scope="parent" value="19.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="186f-d90b-b0a3-a953" type="max"/>
+              </constraints>
+              <selectionEntries>
+                <selectionEntry id="0f0e-36a9-75e4-e822" name="Veletarii w/ Heavy Flamer" hidden="false" collective="false" import="true" type="model">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="19.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ae4a-69d7-d994-4e44" type="max"/>
+                  </constraints>
+                  <profiles>
+                    <profile id="79eb-30bc-5135-39c2" name="Veletarii" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
+                      <modifiers>
+                        <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Infantry (Heavy, Line)">
+                          <conditions>
+                            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a09b-28bd-8ffc-f4f0" type="equalTo"/>
+                          </conditions>
+                        </modifier>
+                      </modifiers>
+                      <characteristics>
+                        <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Heavy)</characteristic>
+                        <characteristic name="Move" typeId="893e-2d76-8f04-44e5">6</characteristic>
+                        <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
+                        <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
+                        <characteristic name="S" typeId="e478-41d4-a092-48a8">3</characteristic>
+                        <characteristic name="T" typeId="c32b-5fdd-3fbe-9b1f">3</characteristic>
+                        <characteristic name="W" typeId="57ee-1126-32a9-5672">1</characteristic>
+                        <characteristic name="I" typeId="62d3-22d7-2d49-52dc">4</characteristic>
+                        <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">1</characteristic>
+                        <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">6</characteristic>
+                        <characteristic name="Save" typeId="e593-6b3c-f169-04f0">4+</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <entryLinks>
+                    <entryLink id="cff6-2ad3-9b93-06c9" name="Reinforced Void Armour " hidden="false" collective="false" import="true" targetId="5e45-2a38-759c-3147" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="12a9-d57b-b62a-5fe6" type="min"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f56c-38c0-9008-c9db" type="max"/>
+                      </constraints>
+                    </entryLink>
+                    <entryLink id="2e19-2169-3914-ade2" name="Heavy Flamer" hidden="false" collective="false" import="true" targetId="f1d6-ebe1-d236-3f11" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6be6-b728-a83f-eeb3" type="min"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6123-c08d-7ebf-da59" type="max"/>
+                      </constraints>
+                    </entryLink>
+                  </entryLinks>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="8.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="e5b2-9536-03f8-39e2" name="Veletarii w/ Rotor Cannon" hidden="false" collective="false" import="true" type="model">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="19.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8159-a918-f3f2-197e" type="max"/>
+                  </constraints>
+                  <infoLinks>
+                    <infoLink id="ba61-2722-958c-a365" name="Veletarii" hidden="false" targetId="79eb-30bc-5135-39c2" type="profile"/>
+                  </infoLinks>
+                  <entryLinks>
+                    <entryLink id="3521-9e7d-3143-b74d" name="Reinforced Void Armour " hidden="false" collective="false" import="true" targetId="5e45-2a38-759c-3147" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e02f-c48d-a30f-c3e9" type="min"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4be1-117f-a611-624b" type="max"/>
+                      </constraints>
+                    </entryLink>
+                    <entryLink id="f1a6-adb7-32f3-afd8" name="Rotor Cannon" hidden="false" collective="false" import="true" targetId="37ec-a4b4-de7a-acf3" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f2e7-18f8-fb8f-10a4" type="min"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8ee6-77fc-533a-adb9" type="max"/>
+                      </constraints>
+                    </entryLink>
+                  </entryLinks>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="8.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="fff9-2e72-ff3f-0ad1" name="Dedicated Transports" hidden="false" collective="false" import="true">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cf07-414c-ccae-aa89" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="f6c3-f0c8-ca42-3008" name="Aurox Transport" hidden="false" collective="false" import="true" targetId="071b-79e5-7b5b-c9cd" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="true">
+                      <conditions>
+                        <condition field="selections" scope="0508-f8a6-3996-bf39" value="10.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="greaterThan"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                </entryLink>
+                <entryLink id="0283-38af-c423-c5ac" name="Dracosan Armoured Transport " hidden="false" collective="false" import="true" targetId="496b-a01b-3726-0a44" type="selectionEntry"/>
+                <entryLink id="228d-6e69-4957-fa2a" name="Arvus Transport" hidden="true" collective="false" import="true" targetId="5041-9403-02b7-af14" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="false">
+                      <conditionGroups>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a09b-28bd-8ffc-f4f0" type="equalTo"/>
+                            <condition field="selections" scope="0508-f8a6-3996-bf39" value="12.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="atMost"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                  </modifiers>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks>
+            <entryLink id="71a0-bb9d-eacd-c67f" name="Volkite Charger" hidden="false" collective="false" import="true" targetId="6f6e-ad55-e093-6503" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="19fe-6007-3f78-1ff3" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ead7-515d-6319-c795" type="max"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="46bf-4bad-5b67-f596" name="Krak Grenades" hidden="false" collective="false" import="true" targetId="99df-2421-acf7-a5ad" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2834-b30d-f46c-df5e" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9754-bf95-fea0-d512" type="max"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="2312-7a47-525a-0b39" name="Frag Grenades" hidden="false" collective="false" import="true" targetId="cf9c-327b-3449-00d7" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="557e-b345-e27b-e8e5" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="45be-a386-6e50-871e" type="max"/>
+              </constraints>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="18.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="c032-86a2-3757-80e4" name="Surgeon-Primus Aevos Jovan" hidden="false" collective="false" import="true" type="unit">
+      <constraints>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4ebd-4155-56d4-9822" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="2a74-09b1-d73b-4358" name="Bitter Duty" hidden="false" targetId="d1b8-31da-c53c-4fe2" type="rule"/>
+        <infoLink id="acca-a20d-bf8b-82ba" name="Loyalist" hidden="false" targetId="d1de-a45d-2b9b-c878" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="ea45-885f-a928-08b4" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="668d-e66c-dbee-fcaa" name="Aevos Jovan" hidden="false" collective="false" import="true" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2081-6a8a-c72e-b231" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b645-4233-2351-704a" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="9bcb-fa91-d3a2-9554" name="Aevos Jovan" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
+              <characteristics>
+                <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Character, Unique)</characteristic>
+                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">6</characteristic>
+                <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">2</characteristic>
+                <characteristic name="BS" typeId="74ae-c840-0036-d244">2</characteristic>
+                <characteristic name="S" typeId="e478-41d4-a092-48a8">3</characteristic>
+                <characteristic name="T" typeId="c32b-5fdd-3fbe-9b1f">3</characteristic>
+                <characteristic name="W" typeId="57ee-1126-32a9-5672">2</characteristic>
+                <characteristic name="I" typeId="62d3-22d7-2d49-52dc">3</characteristic>
+                <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">1</characteristic>
+                <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">9</characteristic>
+                <characteristic name="Save" typeId="e593-6b3c-f169-04f0">4+</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="bcd3-ad2b-ceb1-ddc6" name="Bloody Infamy" publicationId="15a4-fc68-502d-48a9" page="85" hidden="false">
+              <description>All other units, friendly and enemy, with one or more models within 12&quot; of Aevos Jovan (but not any other models in the same unit) must reduce the Leadership Characteristic of all models in that unit by -1. In addition, Aevos Jovan may never be selected as any army’s Warlord.</description>
+            </rule>
+            <rule id="a3c7-4695-76dc-a752" name="Low-priority Target" publicationId="15a4-fc68-502d-48a9" page="85" hidden="false">
+              <description>Any unit that includes Aevos Jovan may not be targeted by a Shooting Attack by any unit or trigger any Reaction, unless at least one model in the attacking unit is within 12&quot; of one or more models in the same unit as Aevos Jovan. However, if Aevos Jovan, or any model in the same unit, makes a Shooting Attack (including as part of a Reaction) then he loses this special rule for the remainder of the battle.</description>
+            </rule>
+          </rules>
+          <infoLinks>
+            <infoLink id="aefc-565d-d05e-fe39" name="Bulky (X)" hidden="false" targetId="676c-7b75-4b6f-9405" type="rule">
+              <modifiers>
+                <modifier type="set" field="name" value="Bulky (5)"/>
+              </modifiers>
+            </infoLink>
+            <infoLink id="34a0-a3d5-ebbe-3517" name="Fearless" hidden="false" targetId="b48c-d7e1-2a83-2f5b" type="rule"/>
+          </infoLinks>
+          <categoryLinks>
+            <categoryLink id="0b71-539b-8899-6356" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
+          </categoryLinks>
+          <selectionEntries>
+            <selectionEntry id="e08f-f2c7-19eb-9d01" name="Auto-gurney" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d33a-cb5f-4327-77e1" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2ad3-3d2c-f4c9-bfdd" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="9c28-024f-9b09-0da7" name="Auto-gurney" hidden="false" typeId="2a1f-7837-f0ef-be44" typeName="Wargear Item">
+                  <characteristics>
+                    <characteristic name="Description" typeId="347e-ee4a-764f-6be3">Once per player turn, when any friendly model within 12&quot; of Aevos Jovan is removed as a casualty in either the Movement or Shooting phases, the controlling player may choose to roll a D6 and consult the table below:
+D6 Result
+1 Bloody Masterpiece: The model is not removed as a casualty and remains in play with a single Wound – but must be removed from play at the end of the next player turn, at which point neither this special rule nor any Saving Throw or Damage Mitigation roll may be made for it. Until it is removed from play, a model affected by this result gains a bonus of +1 to its Strength and Attacks Characteristic.
+2-5 Mundane Procedure: The model is not removed as a casualty and remains in play with a single Wound.
+6 Inspired Restoration: The model is not removed as a casualty and remains in play with a number of Wounds equal to the Wounds Characteristic listed in its profile.
+If the unit that includes Aevos Jovan also includes one or more Medicae Orderlies, then the controlling player may choose to remove one of those models to make use of this special rule an additional time in a given turn or to add or subtract one from the dice rolled on the table presented as part of this special rule (only one model may be removed as a casualty in this fashion in each player turn). This special rule may only be used on models with the Infantry Unit Type.</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <entryLinks>
+            <entryLink id="3c1e-5e5c-9c17-1aca" name="Needle Pistol" hidden="false" collective="false" import="true" targetId="fdd4-06c7-4608-b07f" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8aef-0e76-af4e-bee1" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e742-de0b-73c4-4fb8" type="max"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="1c72-89c4-af8d-448b" name="Close Combat Weapon" hidden="false" collective="false" import="true" targetId="3d50-2f85-06ff-6aee" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5fcf-131d-51f4-a5dd" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="332a-5236-d320-c550" type="max"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="f632-5501-0cdc-c966" name="Void Armour" hidden="false" collective="false" import="true" targetId="6112-2c54-ceb5-a24d" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9e13-7fa6-2ec1-ac08" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="875b-d3a7-1716-a08a" type="max"/>
+              </constraints>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="60.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="ff07-ca6c-46c8-b8f6" name="Medicae Orderly" hidden="false" collective="false" import="true" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d72e-0e92-cbd2-046f" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="f928-1d15-081c-167b" name="Medicae Orderly" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
+              <characteristics>
+                <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry</characteristic>
+                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">6</characteristic>
+                <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">2</characteristic>
+                <characteristic name="BS" typeId="74ae-c840-0036-d244">2</characteristic>
+                <characteristic name="S" typeId="e478-41d4-a092-48a8">3</characteristic>
+                <characteristic name="T" typeId="c32b-5fdd-3fbe-9b1f">3</characteristic>
+                <characteristic name="W" typeId="57ee-1126-32a9-5672">1</characteristic>
+                <characteristic name="I" typeId="62d3-22d7-2d49-52dc">3</characteristic>
+                <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">1</characteristic>
+                <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">8</characteristic>
+                <characteristic name="Save" typeId="e593-6b3c-f169-04f0">4+</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="f28b-5804-f1fd-c187" name="Medicae Section" hidden="false" collective="false" import="true" type="unit">
+      <selectionEntries>
+        <selectionEntry id="acf1-eb06-5d5d-d36f" name="Auxilia Medicae" hidden="false" collective="false" import="true" type="model">
+          <modifiers>
+            <modifier type="add" field="category" value="0af0-ea84-09d7-2b1f">
+              <conditions>
+                <condition field="selections" scope="acf1-eb06-5d5d-d36f" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="6daa-2169-b0f5-c76c" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e7fe-a5b9-e204-4d34" type="min"/>
+            <constraint field="selections" scope="parent" value="8.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2a66-997d-00b1-2417" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="3873-bb72-8484-5e59" name="Auxilia Medicae" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
+              <modifiers>
+                <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Infantry (Character, Close-Order)">
+                  <conditionGroups>
+                    <conditionGroup type="and">
+                      <conditions>
+                        <condition field="selections" scope="acf1-eb06-5d5d-d36f" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="cc63-5cc3-212a-3d4c" type="equalTo"/>
+                        <condition field="selections" scope="acf1-eb06-5d5d-d36f" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6daa-2169-b0f5-c76c" type="equalTo"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+                <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Infantry (Character, Heavy, Close-Order)">
+                  <conditionGroups>
+                    <conditionGroup type="and">
+                      <conditions>
+                        <condition field="selections" scope="acf1-eb06-5d5d-d36f" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="cc63-5cc3-212a-3d4c" type="equalTo"/>
+                        <condition field="selections" scope="acf1-eb06-5d5d-d36f" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6daa-2169-b0f5-c76c" type="equalTo"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+                <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Infantry (Character, Heavy)">
+                  <conditionGroups>
+                    <conditionGroup type="and">
+                      <conditions>
+                        <condition field="selections" scope="acf1-eb06-5d5d-d36f" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="cc63-5cc3-212a-3d4c" type="equalTo"/>
+                        <condition field="selections" scope="acf1-eb06-5d5d-d36f" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6daa-2169-b0f5-c76c" type="equalTo"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
+              <characteristics>
+                <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Character)</characteristic>
+                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">6</characteristic>
+                <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
+                <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
+                <characteristic name="S" typeId="e478-41d4-a092-48a8">3</characteristic>
+                <characteristic name="T" typeId="c32b-5fdd-3fbe-9b1f">3</characteristic>
+                <characteristic name="W" typeId="57ee-1126-32a9-5672">1</characteristic>
+                <characteristic name="I" typeId="62d3-22d7-2d49-52dc">3</characteristic>
+                <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">2</characteristic>
+                <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">6</characteristic>
+                <characteristic name="Save" typeId="e593-6b3c-f169-04f0">4+</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="8e38-8b21-ccef-d170" name="Medicae Support" publicationId="15a4-fc68-502d-48a9" page="135" hidden="false">
+              <description>An Auxilia Medicae Detachment is selected as any other unit, using up a single Force Organisation slot and bought in the same manner. However, before the first turn begins and any models are deployed to the battlefield, all models in an Auxilia Medicae Detachment must be assigned to another unit from the same Detachment of the army they were selected as part of. Auxilia Medicae may only be assigned to units composed entirely of models with the Infantry Unit Type. No Auxilia Medicae may be assigned to any unit that includes one or more models with the Independent Character special rule or Unique Sub-type (but such models may join a unit that includes an Auxilia Medicae as normal during either deployment or any following turn). No more than one Auxilia Medicae may be assigned to any given unit.
+
+Once assigned to a unit, the Auxilia Medicae is considered part of that unit and may not leave it under any circumstances – if that unit is removed as a casualty then the Auxilia Medicae is removed as well. In games using Victory points, no Victory points are ever scored for removing an Auxilia Medicae as a casualty. When assigned to a unit, an Auxilia Medicae gains all of the special rules (with the exception of those that specifically forbid it, such as the Bitter Duty special rule) and Unit Sub-types listed for the unit to which it is attached, but does not gain access to any additional Wargear options available to the unit to which it is assigned.</description>
+            </rule>
+          </rules>
+          <selectionEntries>
+            <selectionEntry id="6daa-2169-b0f5-c76c" name="Close-order Unit Sub-type" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d74b-6e86-49d7-0b6f" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="c5c5-6455-662a-051f" name="Auto-medicus" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0cb5-a7d7-5211-5b0c" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e15d-afe5-83b8-f01f" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="a675-0a74-798e-cc1e" name="Auto-medicus" publicationId="15a4-fc68-502d-48a9" page="151" hidden="false" typeId="2a1f-7837-f0ef-be44" typeName="Wargear Item">
+                  <characteristics>
+                    <characteristic name="Description" typeId="347e-ee4a-764f-6be3">All models with the Infantry or Cavalry Unit Types in a unit that includes at least one model with an auto-medicus gains the Feel No Pain (6+) special rule. Units that include more than one auto-medicus do not stack the Feel No Pain (X) special rule and gain no additional benefit. Models with the Artillery Sub-type are not affected by this special rule and do not gain the Feel No Pain (X) special rule.</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <infoLinks>
+                <infoLink id="25ca-3721-8f96-fd5a" name="Feel No Pain (X)" hidden="false" targetId="ec46-ff29-32e0-c2aa" type="rule">
+                  <modifiers>
+                    <modifier type="set" field="name" value="Feel No Pain (6+)"/>
+                  </modifiers>
+                </infoLink>
+              </infoLinks>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="54aa-c66c-5acd-5c7f" name="Armour" hidden="false" collective="false" import="true" defaultSelectionEntryId="7c36-da62-e253-d8ca">
+              <entryLinks>
+                <entryLink id="7c36-da62-e253-d8ca" name="Void Armour" hidden="false" collective="false" import="true" targetId="6112-2c54-ceb5-a24d" type="selectionEntry"/>
+                <entryLink id="a1e4-a130-bdab-d918" name="Reinforced Void Armour " hidden="false" collective="false" import="true" targetId="cc63-5cc3-212a-3d4c" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                  </costs>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="63bb-b2e1-9bf2-ff9c" name="May exchange a Laspistol for:" hidden="false" collective="false" import="true" defaultSelectionEntryId="5a58-c3f9-9c1d-46fa">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9dda-e5b6-ec38-a39b" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e38e-694e-d037-0003" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="5a58-c3f9-9c1d-46fa" name="Laspistol" hidden="false" collective="false" import="true" targetId="654d-be88-b0a8-7ae5" type="selectionEntry"/>
+                <entryLink id="df37-90c6-a4ea-64c5" name="Blast Pistol" hidden="false" collective="false" import="true" targetId="2460-375d-31f4-4bdf" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="d883-af91-f2be-a686" name="Needle Pistol" hidden="false" collective="false" import="true" targetId="fdd4-06c7-4608-b07f" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="8a1a-b865-3764-4603" name="Hand Flamer" hidden="false" collective="false" import="true" targetId="e337-adf4-a11f-0280" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="c241-f48c-e549-b1a8" name="Plasma Pistol" hidden="false" collective="false" import="true" targetId="717f-cf0a-1593-4bd8" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                  </costs>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="a3a0-cb63-9a55-cfbd" name="May exchange a Close Combat Weapon for:" hidden="false" collective="false" import="true" defaultSelectionEntryId="8f78-cfce-3634-a3bd">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1ba6-f365-7717-13af" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2739-222c-ea72-09f4" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="8f78-cfce-3634-a3bd" name="Close Combat Weapon" hidden="false" collective="false" import="true" targetId="3d50-2f85-06ff-6aee" type="selectionEntry"/>
+                <entryLink id="89b8-d7cc-f863-3cc5" name="Power Fist" hidden="false" collective="false" import="true" targetId="768d-b89b-7328-d749" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="8939-8c3e-acbb-3cc4" name="Power Weapon" hidden="false" collective="false" import="true" targetId="d2db-7598-f55f-86fe" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="51a5-6ce4-d9a0-4fa8" name="Charnabal Weapon" hidden="false" collective="false" import="true" targetId="e749-ba9b-bb76-a7d9" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                  </costs>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks>
+            <entryLink id="37ec-7a44-0309-8d8c" name="Frag Grenades" hidden="false" collective="false" import="true" targetId="cf9c-327b-3449-00d7" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7d45-d125-72d6-7461" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="38df-1e48-8bf3-95ce" type="max"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="8626-cfce-4bca-2aa5" name="Krak Grenades" hidden="false" collective="false" import="true" targetId="99df-2421-acf7-a5ad" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4cfc-f98c-c2ee-43b3" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dd3d-935b-a403-52d9" type="max"/>
+              </constraints>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="6728-8632-5bf2-79bb" name="Charonite Ogryn Section" hidden="false" collective="false" import="true" type="unit">
+      <selectionEntries>
+        <selectionEntry id="c2a2-f136-696e-5641" name="Charonite Ogryn" hidden="false" collective="false" import="true" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c481-6315-2bf7-e0f5" type="min"/>
+            <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b99d-094c-91ff-5356" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="679a-ab76-d16c-29e7" name="Charonite Ogryn" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
+              <characteristics>
+                <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Monstrous)</characteristic>
+                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7</characteristic>
+                <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
+                <characteristic name="BS" typeId="74ae-c840-0036-d244">2</characteristic>
+                <characteristic name="S" typeId="e478-41d4-a092-48a8">5</characteristic>
+                <characteristic name="T" typeId="c32b-5fdd-3fbe-9b1f">5</characteristic>
+                <characteristic name="W" typeId="57ee-1126-32a9-5672">3</characteristic>
+                <characteristic name="I" typeId="62d3-22d7-2d49-52dc">2</characteristic>
+                <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">4</characteristic>
+                <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">6</characteristic>
+                <characteristic name="Save" typeId="e593-6b3c-f169-04f0">4+</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="6496-831a-2c8a-acee" name="Death Frenzy" publicationId="15a4-fc68-502d-48a9" page="131" hidden="false">
+              <description>A unit composed entirely of models with this special rule that fails a Morale check, due to enemy Shooting Attacks, losing a combat in the Assault phase, or due to a special rule that forces a Morale check, does not Fall Back and is treated as if it had passed the Morale check. However, the unit’s controlling player must immediately select a single model in the unit and remove it from play as a casualty – no Armour Saves or Damage Mitigation rolls may be made for the selected model. After one or more models has been removed from a unit due to this special rule in a given player turn, the unit from which the model was removed increases the Attacks Characteristic of all models in the unit by 1 for the duration of the next player turn.</description>
+            </rule>
+          </rules>
+          <infoLinks>
+            <infoLink id="f738-a229-efaf-1be4" name="Feel No Pain (X)" hidden="false" targetId="ec46-ff29-32e0-c2aa" type="rule">
+              <modifiers>
+                <modifier type="set" field="name" value="Feel No Pain (5+)"/>
+              </modifiers>
+            </infoLink>
+            <infoLink id="9a38-2265-e1a3-3473" name="Hammer of Wrath (X)" hidden="false" targetId="aec0-c3aa-1e4e-1779" type="rule">
+              <modifiers>
+                <modifier type="set" field="name" value="Hammer of Wrath (2)"/>
+              </modifiers>
+            </infoLink>
+            <infoLink id="8556-aea6-be6c-0dee" name="Rage (X)" hidden="false" targetId="564d-3550-ae44-2f99" type="rule">
+              <modifiers>
+                <modifier type="set" field="name" value="Rage (2)"/>
+              </modifiers>
+            </infoLink>
+            <infoLink id="888f-e1cb-0e49-0de4" name="Bitter Duty" hidden="false" targetId="d1b8-31da-c53c-4fe2" type="rule"/>
+            <infoLink id="81d8-da7e-bb8a-2f8f" name="Bulky (X)" hidden="false" targetId="676c-7b75-4b6f-9405" type="rule">
+              <modifiers>
+                <modifier type="set" field="name" value="Bulky (4)"/>
+              </modifiers>
+            </infoLink>
+          </infoLinks>
+          <selectionEntries>
+            <selectionEntry id="8c2a-6820-36b9-8ad0" name="Charonite Claws" hidden="false" collective="true" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f974-f8c4-1293-7967" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3f71-2c3f-0d97-a230" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="6573-9a7d-f256-722e" name="Charonite Claws" publicationId="15a4-fc68-502d-48a9" page="150" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+                  <characteristics>
+                    <characteristic name="Range" typeId="95ba-cda7-b831-6066">-</characteristic>
+                    <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">7</characteristic>
+                    <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">3</characteristic>
+                    <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Melee, Two-handed, Rending (6+)</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <infoLinks>
+                <infoLink id="b3d1-aa5a-19e8-07da" name="Two-handed" hidden="false" targetId="4c23-e863-a569-7617" type="rule"/>
+                <infoLink id="6eed-a41b-73e9-6cd5" name="Rending (X)" hidden="false" targetId="0ac9-fab7-aef3-de1d" type="rule">
+                  <modifiers>
+                    <modifier type="set" field="name" value="Rending (6+)"/>
+                  </modifiers>
+                </infoLink>
+              </infoLinks>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <entryLinks>
+            <entryLink id="cb18-7007-a824-fee8" name="Void Armour" hidden="false" collective="false" import="true" targetId="499b-b86b-3a44-17c6" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="104d-6b2a-7b9c-0887" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7247-390f-dc62-5ee0" type="max"/>
+              </constraints>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="40.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="071b-79e5-7b5b-c9cd" name="Aurox Transport" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="c611-60e5-a7e3-c094" name="Aurox Transport" hidden="false" typeId="2fae-b053-3f78-e7b2" typeName=" Vehicle">
+          <characteristics>
+            <characteristic name="Unit Type" typeId="e555-4aed-dfcc-c0b4">Vehicle (Transport)</characteristic>
+            <characteristic name="Move" typeId="3614-4a2d-bffb-90e4">15</characteristic>
+            <characteristic name="BS" typeId="51fb-b7d9-aa59-863d">3</characteristic>
+            <characteristic name="Front" typeId="0ef8-a648-01d0-08ee">11</characteristic>
+            <characteristic name="Side" typeId="f150-c0dc-c192-9cb3">11</characteristic>
+            <characteristic name="Rear" typeId="8d4e-2aea-fffc-d556">10</characteristic>
+            <characteristic name="HP" typeId="a76c-83b1-602f-9e62">3</characteristic>
+            <characteristic name="Transport Capacity" typeId="0c90-79e2-f768-e547">10</characteristic>
+            <characteristic name="Access Points" typeId="e217-1b1e-9494-3e3e">One Access Point on each side of the hull and one at the rear.</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="2e5a-42c0-cab0-6be5" name="Infantry Transport" hidden="false" targetId="0c6b-9cc1-5801-3e83" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="81d6-a474-3dc4-c9ac" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+      </categoryLinks>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="89bb-3c4f-756f-74a8" name="May take one of the following" hidden="false" collective="false" import="true">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5303-2457-4f28-8f03" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="1b0b-12bb-4f57-2c05" name="Heavy Stubber" hidden="false" collective="false" import="true" targetId="f227-a61a-3215-932b" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="name" value="Pintle Mounted Heavy Stubber"/>
+              </modifiers>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="396e-8024-df29-df74" name="Multi-Laser" hidden="false" collective="false" import="true" targetId="003b-af4b-0094-f5c3" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="name" value="Pintle Mounted Multi-Laser"/>
+              </modifiers>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="6079-3afe-0022-4089" name="Heavy Flamer" hidden="false" collective="false" import="true" targetId="5507-b432-3b4c-df12" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="name" value="Pintle Mounted Heavy Flamer"/>
+              </modifiers>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="386a-7e41-2c22-96fe" name="Searchlights" hidden="false" collective="false" import="true" targetId="4ae3-79b4-6051-505e" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d0a1-e819-2271-e987" type="max"/>
+          </constraints>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+          </costs>
+        </entryLink>
+        <entryLink id="6430-f773-6ee4-760b" name="Smoke Launchers" hidden="false" collective="false" import="true" targetId="0873-34dd-e52d-d33c" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b602-6a30-115d-6b23" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e65e-b0f5-b57a-c72b" type="min"/>
+          </constraints>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="30.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="496b-a01b-3726-0a44" name="Dracosan Armoured Transport " hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="ae05-0bdd-574e-b386" name="Dracosan Armoured Transport " hidden="false" typeId="2fae-b053-3f78-e7b2" typeName=" Vehicle">
+          <modifiers>
+            <modifier type="set" field="0c90-79e2-f768-e547" value="10">
+              <conditions>
+                <condition field="selections" scope="496b-a01b-3726-0a44" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1d4a-05a3-1589-915d" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <characteristics>
+            <characteristic name="Unit Type" typeId="e555-4aed-dfcc-c0b4">Vehicle (Transport, Reinforced)</characteristic>
+            <characteristic name="Move" typeId="3614-4a2d-bffb-90e4">12</characteristic>
+            <characteristic name="BS" typeId="51fb-b7d9-aa59-863d">3</characteristic>
+            <characteristic name="Front" typeId="0ef8-a648-01d0-08ee">13</characteristic>
+            <characteristic name="Side" typeId="f150-c0dc-c192-9cb3">12</characteristic>
+            <characteristic name="Rear" typeId="8d4e-2aea-fffc-d556">11</characteristic>
+            <characteristic name="HP" typeId="a76c-83b1-602f-9e62">5</characteristic>
+            <characteristic name="Transport Capacity" typeId="0c90-79e2-f768-e547">22</characteristic>
+            <characteristic name="Access Points" typeId="e217-1b1e-9494-3e3e">Two Access Points, one on each side</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <categoryLinks>
+        <categoryLink id="31c2-f607-8c09-ec8b" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+        <categoryLink id="f219-feb4-2842-67ad" name="Reinforced Sub-type:" hidden="false" targetId="9b0d-738c-10e4-4ec1" primary="false"/>
+      </categoryLinks>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="ae92-926f-4cc9-a78b" name="May exchange its Hull (Front) Mounted Gravis lascannon for:" hidden="false" collective="false" import="true" defaultSelectionEntryId="a2de-e36e-920f-ed49">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8cc5-fb02-5a00-a2c0" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3671-53b4-b122-d024" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="a2de-e36e-920f-ed49" name="Gravis Lascannon" hidden="false" collective="false" import="true" targetId="1fe0-7c96-5200-0e39" type="selectionEntry"/>
+            <entryLink id="0ac0-2320-b38c-ff37" name="Demolisher Cannon" hidden="false" collective="false" import="true" targetId="1d4a-05a3-1589-915d" type="selectionEntry">
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="50.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="172d-82bd-2e30-e97e" name="May Take:" hidden="false" collective="false" import="true">
+          <entryLinks>
+            <entryLink id="dd8b-449d-54a9-a49c" name="Dozer Blade" hidden="false" collective="false" import="true" targetId="42e1-f6cf-1f2b-a492" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2ff1-f2b3-1d65-2753" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="7849-a608-7988-d2b2" name="Hunter-Killer Missile" hidden="false" collective="false" import="true" targetId="1bf8-72f8-c331-6900" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="name" value="Hull (Front) Mounted hunter-killer missiles"/>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a440-2327-3197-f600" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="1137-616e-a778-1bb1" name="Flare Shield" hidden="false" collective="false" import="true" targetId="0e77-6285-22bb-1534" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a2c4-c575-a513-564e" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="d9e8-e016-e054-6f48" name="May take one of the following" hidden="false" collective="false" import="true">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="99c8-eb73-5fd4-4748" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="24bd-f9be-1088-ae45" name="Heavy Stubber" hidden="false" collective="false" import="true" targetId="f227-a61a-3215-932b" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="name" value="Pintle Mounted Heavy Stubber"/>
+              </modifiers>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="6cbe-d08b-1540-96a3" name="Multi-Laser" hidden="false" collective="false" import="true" targetId="003b-af4b-0094-f5c3" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="name" value="Pintle Mounted Multi-Laser"/>
+              </modifiers>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="3c76-86a0-8e79-bc41" name="Heavy Flamer" hidden="false" collective="false" import="true" targetId="5507-b432-3b4c-df12" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="name" value="Pintle Mounted Heavy Flamer"/>
+              </modifiers>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="2ca1-d62d-c976-c5cd" name="Searchlights" hidden="false" collective="false" import="true" targetId="4ae3-79b4-6051-505e" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f96b-6cff-972a-2544" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b5fd-dbd3-46bf-21a9" type="max"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="ac5a-ebe4-cdd1-9237" name="Smoke Launchers" hidden="false" collective="false" import="true" targetId="0873-34dd-e52d-d33c" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e3c3-5f06-ef0a-d652" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1b8e-c1b1-acb3-572a" type="min"/>
+          </constraints>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="175.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="5041-9403-02b7-af14" name="Arvus Transport" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="6de2-b7e2-60af-304d" name="Arvus Transport" hidden="false" typeId="2fae-b053-3f78-e7b2" typeName=" Vehicle">
+          <characteristics>
+            <characteristic name="Unit Type" typeId="e555-4aed-dfcc-c0b4">Vehicle (Flyer, Hover, Transport)</characteristic>
+            <characteristic name="Move" typeId="3614-4a2d-bffb-90e4">20</characteristic>
+            <characteristic name="BS" typeId="51fb-b7d9-aa59-863d">3</characteristic>
+            <characteristic name="Front" typeId="0ef8-a648-01d0-08ee">11</characteristic>
+            <characteristic name="Side" typeId="f150-c0dc-c192-9cb3">11</characteristic>
+            <characteristic name="Rear" typeId="8d4e-2aea-fffc-d556">10</characteristic>
+            <characteristic name="HP" typeId="a76c-83b1-602f-9e62">2</characteristic>
+            <characteristic name="Transport Capacity" typeId="0c90-79e2-f768-e547">12</characteristic>
+            <characteristic name="Access Points" typeId="e217-1b1e-9494-3e3e">One Access Point at the rear.</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="c798-a7e2-2a5e-d276" name="Deep Strike" hidden="false" targetId="f1e1-986f-c783-ca9e" type="rule"/>
+        <infoLink id="5fe3-cbf6-c53f-c1df" name="Infantry Transport" hidden="false" targetId="0c6b-9cc1-5801-3e83" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="eb18-a40a-57be-dee0" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+        <categoryLink id="075d-87e4-c511-066f" name="Hover Sub-type" hidden="false" targetId="3a7a-8bb7-b0d3-e2e7" primary="false"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="6273-c00c-cbb0-5ffa" name="Smoke Launchers" hidden="false" collective="false" import="true" targetId="0873-34dd-e52d-d33c" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4ba1-c108-b736-df62" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1207-0e83-9645-7f90" type="min"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="41eb-b9d2-03f8-0464" name="Searchlights" hidden="false" collective="false" import="true" targetId="4ae3-79b4-6051-505e" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5c64-2d41-bd11-8125" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e002-31ec-a834-7e98" type="min"/>
+          </constraints>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="75.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="e3d9-ef46-4077-e1f5" name="Auxilia Infantry Tercio" hidden="false" collective="false" import="true" type="unit">
+      <modifiers>
+        <modifier type="set" field="name" value="Ultramar Pattern Auxilia Rifle Tercio">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3624-316b-4ed4-d5d1" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <rules>
+        <rule id="64cf-17ce-bba5-298e" name="Ultramar Pattern Cohort Rifle Section" publicationId="15a4-fc68-502d-48a9" page="70" hidden="false">
+          <description>All Solar Auxilia Rifle Sections and Solar Auxilia Line Command Sections gain a bonus of +1 to all To Hit rolls made during Shooting Attacks when all models in the unit are in base contact with at least one other model from the same unit.</description>
+        </rule>
+      </rules>
+      <categoryLinks>
+        <categoryLink id="7d8a-a782-82d7-4852" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="6513-cab0-be87-36fd" name="Close-order Sub-type" hidden="false" targetId="0af0-ea84-09d7-2b1f" primary="false"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="1b0c-4653-50ad-c99c" name="Line Command Section" hidden="false" collective="false" import="true" type="unit">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6382-5bef-4afd-6471" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="a45d-28b7-3286-f6fa" name="Tercio" hidden="false" targetId="6516-f81d-457b-a2cc" type="rule"/>
+          </infoLinks>
+          <selectionEntries>
+            <selectionEntry id="1a3e-eb00-cced-2abd" name="Auxilia Troop Master" hidden="false" collective="false" import="true" type="model">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b7a7-afa1-130d-846b" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e392-7492-6e50-c967" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="6d7b-be94-6053-1214" name="Auxilia Troop Master" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
+                  <characteristics>
+                    <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Line, Close-order, Character)</characteristic>
+                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">6</characteristic>
+                    <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
+                    <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
+                    <characteristic name="S" typeId="e478-41d4-a092-48a8">3</characteristic>
+                    <characteristic name="T" typeId="c32b-5fdd-3fbe-9b1f">3</characteristic>
+                    <characteristic name="W" typeId="57ee-1126-32a9-5672">2</characteristic>
+                    <characteristic name="I" typeId="62d3-22d7-2d49-52dc">3</characteristic>
+                    <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">3</characteristic>
+                    <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">7</characteristic>
+                    <characteristic name="Save" typeId="e593-6b3c-f169-04f0">4+</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <categoryLinks>
+                <categoryLink id="099b-266a-e368-1e64" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
+              </categoryLinks>
+              <selectionEntryGroups>
+                <selectionEntryGroup id="d7f7-a7a6-c792-ada8" name="Weapons" hidden="false" collective="false" import="true" defaultSelectionEntryId="32ae-3f3b-8b44-9b87">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="aca2-e3ae-9d3f-c43b" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e2e9-dd6a-2e6c-cf04" type="max"/>
+                  </constraints>
+                  <selectionEntries>
+                    <selectionEntry id="7b8a-c3e0-72f0-11a6" name="Pistol and Combat weapon (Sub-menu)" hidden="false" collective="false" import="true" type="upgrade">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dd8c-87f0-b346-192d" type="max"/>
+                      </constraints>
+                      <selectionEntryGroups>
+                        <selectionEntryGroup id="0b6f-e21c-0e81-3769" name="Close Combat" hidden="false" collective="false" import="true">
+                          <constraints>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7b45-26ab-bba5-b433" type="min"/>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8dba-1c2b-d629-ed96" type="max"/>
+                          </constraints>
+                          <entryLinks>
+                            <entryLink id="e4e3-d2c4-76f9-acbf" name="Close Combat Weapon" hidden="false" collective="false" import="true" targetId="3d50-2f85-06ff-6aee" type="selectionEntry"/>
+                            <entryLink id="835d-3c67-c5eb-6eb4" name="Power Fist" hidden="false" collective="false" import="true" targetId="768d-b89b-7328-d749" type="selectionEntry">
+                              <costs>
+                                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                              </costs>
+                            </entryLink>
+                            <entryLink id="dc40-bdf6-8184-36aa" name="Power Sword" hidden="false" collective="false" import="true" targetId="a3cd-aa97-a148-2309" type="selectionEntry">
+                              <costs>
+                                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                              </costs>
+                            </entryLink>
+                            <entryLink id="0c21-9341-c69b-794d" name="Power Maul" hidden="false" collective="false" import="true" targetId="0df4-c67e-cf64-82e0" type="selectionEntry">
+                              <costs>
+                                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                              </costs>
+                            </entryLink>
+                            <entryLink id="cf54-1275-1ce9-a60a" name="Power Lance" hidden="false" collective="false" import="true" targetId="a4c8-c8ff-87f2-1ac9" type="selectionEntry">
+                              <costs>
+                                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                              </costs>
+                            </entryLink>
+                            <entryLink id="725c-3a74-934f-f263" name="Power Axe" hidden="false" collective="false" import="true" targetId="c066-2ace-f68c-e440" type="selectionEntry">
+                              <costs>
+                                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                              </costs>
+                            </entryLink>
+                            <entryLink id="b2a5-91fd-047f-14db" name="Charnabal Tabar" hidden="false" collective="false" import="true" targetId="4611-c33e-f360-7246" type="selectionEntry">
+                              <costs>
+                                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                              </costs>
+                            </entryLink>
+                            <entryLink id="180e-f69b-15a8-2683" name="Charnabal Sabre" hidden="false" collective="false" import="true" targetId="30c2-57eb-5bbe-be0b" type="selectionEntry">
+                              <costs>
+                                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                              </costs>
+                            </entryLink>
+                            <entryLink id="c757-4948-aa11-9495" name="Charnabal Glaive" hidden="false" collective="false" import="true" targetId="c07c-35e6-4616-ef25" type="selectionEntry">
+                              <costs>
+                                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                              </costs>
+                            </entryLink>
+                          </entryLinks>
+                        </selectionEntryGroup>
+                        <selectionEntryGroup id="bace-d70d-0b8e-e465" name="Pistol" hidden="false" collective="false" import="true">
+                          <constraints>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0534-4c78-f5aa-9c4a" type="min"/>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9c0d-072d-bb38-515d" type="max"/>
+                          </constraints>
+                          <entryLinks>
+                            <entryLink id="bd75-b844-7991-1d2a" name="Blast Pistol" hidden="false" collective="false" import="true" targetId="2460-375d-31f4-4bdf" type="selectionEntry">
+                              <costs>
+                                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2.0"/>
+                              </costs>
+                            </entryLink>
+                            <entryLink id="7b77-bf8d-74b9-6518" name="Plasma Pistol" hidden="false" collective="false" import="true" targetId="717f-cf0a-1593-4bd8" type="selectionEntry">
+                              <costs>
+                                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                              </costs>
+                            </entryLink>
+                            <entryLink id="2f32-22ec-6994-487e" name="Hand Flamer" hidden="false" collective="false" import="true" targetId="e337-adf4-a11f-0280" type="selectionEntry">
+                              <costs>
+                                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2.0"/>
+                              </costs>
+                            </entryLink>
+                            <entryLink id="79a2-e8a8-a261-6f53" name="Needle Pistol" hidden="false" collective="false" import="true" targetId="fdd4-06c7-4608-b07f" type="selectionEntry">
+                              <costs>
+                                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2.0"/>
+                              </costs>
+                            </entryLink>
+                            <entryLink id="d4f4-b330-c2ca-36bf" name="Laspistol" hidden="false" collective="false" import="true" targetId="654d-be88-b0a8-7ae5" type="selectionEntry"/>
+                          </entryLinks>
+                        </selectionEntryGroup>
+                      </selectionEntryGroups>
+                      <costs>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                      </costs>
+                    </selectionEntry>
+                  </selectionEntries>
+                  <entryLinks>
+                    <entryLink id="32ae-3f3b-8b44-9b87" name="Lasrifle" hidden="false" collective="false" import="true" targetId="15f9-817e-275b-c13d" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e934-cbf6-3393-e798" type="max"/>
+                      </constraints>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="cd3c-23af-4002-0c2c" name="May take:" hidden="false" collective="false" import="true">
+                  <entryLinks>
+                    <entryLink id="b970-0b01-d66e-df71" name="Refractor Field" hidden="false" collective="false" import="true" targetId="a06a-55a5-070b-1d0e" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6177-e003-3436-4215" type="max"/>
+                      </constraints>
+                      <costs>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="4372-f483-db6e-82ab" name="Meltabombs" hidden="false" collective="false" import="true" targetId="b9dd-3b21-f3f8-78e3" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5b7a-409e-80fc-4bad" type="max"/>
+                      </constraints>
+                      <costs>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                      </costs>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="bf5c-d488-3dcb-5dfe" name="Dedicated Transports" hidden="false" collective="false" import="true">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3624-316b-4ed4-d5d1" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="88c7-302a-dfc8-6521" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="ab7d-4c16-aad9-3d38" name="Aurox Transport" hidden="false" collective="false" import="true" targetId="071b-79e5-7b5b-c9cd" type="selectionEntry"/>
+                <entryLink id="e6d3-88d2-2407-9269" name="Dracosan Armoured Transport " hidden="false" collective="false" import="true" targetId="496b-a01b-3726-0a44" type="selectionEntry"/>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="9eed-3e6d-fa6e-17ef" name="One Auxilia Companion in the unit may be upgraded to have a:" hidden="false" collective="false" import="true">
+              <entryLinks>
+                <entryLink id="b6ed-f950-6900-75b9" name="Augury Scanner" hidden="false" collective="false" import="true" targetId="67ee-7338-3b74-04b4" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ba89-9642-0e46-eb06" type="max"/>
+                    <constraint field="selections" scope="1b0c-4653-50ad-c99c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c3a3-2efe-cac0-c6f9" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="0874-047b-23b3-b886" name="Auxilia Vexilla" hidden="false" collective="false" import="true" targetId="6f5a-bf56-4bee-ce7e" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="1b0c-4653-50ad-c99c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c0df-3769-b755-b85b" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d7ec-da6a-ee5f-3700" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="0b9b-7f40-b293-04b9" name="Command Vox" hidden="false" collective="false" import="true" targetId="7ac4-c39b-5c48-63cb" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8b3e-a4e5-d649-2003" type="max"/>
+                    <constraint field="selections" scope="1b0c-4653-50ad-c99c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="cb26-22b0-df37-f98b" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                  </costs>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="1eaf-bbe0-04a5-22c1" name="Auxilia Veterans" hidden="false" collective="false" import="true" defaultSelectionEntryId="38fa-8a5c-8183-737e">
+              <constraints>
+                <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3215-57f3-1211-43fb" type="min"/>
+                <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8ac8-ebed-57d9-9346" type="max"/>
+              </constraints>
+              <selectionEntries>
+                <selectionEntry id="38fa-8a5c-8183-737e" name="Auxilia Veteran w/ Lasrifle" hidden="false" collective="false" import="true" type="model">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c9a5-bdd1-9156-35d0" type="max"/>
+                  </constraints>
+                  <profiles>
+                    <profile id="1588-db82-569c-00c0" name="Auxilia Veteran" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
+                      <characteristics>
+                        <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Line, Close-order)</characteristic>
+                        <characteristic name="Move" typeId="893e-2d76-8f04-44e5">6</characteristic>
+                        <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">3</characteristic>
+                        <characteristic name="BS" typeId="74ae-c840-0036-d244">3</characteristic>
+                        <characteristic name="S" typeId="e478-41d4-a092-48a8">3</characteristic>
+                        <characteristic name="T" typeId="c32b-5fdd-3fbe-9b1f">3</characteristic>
+                        <characteristic name="W" typeId="57ee-1126-32a9-5672">1</characteristic>
+                        <characteristic name="I" typeId="62d3-22d7-2d49-52dc">3</characteristic>
+                        <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">2</characteristic>
+                        <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">6</characteristic>
+                        <characteristic name="Save" typeId="e593-6b3c-f169-04f0">4+</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <entryLinks>
+                    <entryLink id="e668-5116-edd7-09b8" name="Lasrifle" hidden="false" collective="false" import="true" targetId="2449-dc45-3441-b471" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0136-368b-b3f2-92d9" type="min"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="43cb-43f0-6582-8791" type="max"/>
+                      </constraints>
+                    </entryLink>
+                  </entryLinks>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="8.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="88a5-af55-4a9b-63bf" name="Auxilia Veteran w/ Lasrifle and Bayonet" hidden="false" collective="false" import="true" type="model">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c02b-237d-2b57-034f" type="max"/>
+                  </constraints>
+                  <infoLinks>
+                    <infoLink id="3afc-f5af-1577-970a" name="Auxilia Veteran" hidden="false" targetId="1588-db82-569c-00c0" type="profile"/>
+                  </infoLinks>
+                  <entryLinks>
+                    <entryLink id="f05d-929b-6b20-89f7" name="Lasrifle" hidden="false" collective="false" import="true" targetId="2449-dc45-3441-b471" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dbbb-e699-9c60-a401" type="min"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="687a-0008-4c0f-cafb" type="max"/>
+                      </constraints>
+                    </entryLink>
+                    <entryLink id="7008-99c3-c17a-b2de" name="Bayonet" hidden="false" collective="false" import="true" targetId="8413-55c8-60ce-e9bf" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0934-d608-acb1-8dfb" type="min"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="df1e-d0fc-4e6d-46b3" type="max"/>
+                      </constraints>
+                    </entryLink>
+                  </entryLinks>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="9.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks>
+            <entryLink id="d662-f14c-8a20-db1f" name="Void Armour" hidden="false" collective="false" import="true" targetId="6112-2c54-ceb5-a24d" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2835-e3d1-9f99-4ced" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9f9f-2ed7-43d6-ae6a" type="min"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="099f-46a8-c99c-833d" name="Frag Grenades" hidden="false" collective="false" import="true" targetId="cf9c-327b-3449-00d7" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ab3b-3116-8410-d6db" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1afc-6bf4-6a4d-bb7e" type="min"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="734f-a30e-2f27-1c70" name="Krak Grenades" hidden="false" collective="false" import="true" targetId="99df-2421-acf7-a5ad" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4738-9ae8-2826-45f8" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bdf3-6839-4e12-1e5d" type="min"/>
+              </constraints>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="33.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="a2dc-46c7-3f68-2154" name="Rifle Sections" hidden="false" collective="false" import="true" type="unit">
+          <modifiers>
+            <modifier type="set" field="0108-3f04-fde4-4b5a" value="6.0">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3624-316b-4ed4-d5d1" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2d16-c5a6-07fb-cfe7" type="min"/>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0108-3f04-fde4-4b5a" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="2645-efa9-f220-f5bd" name="Auxilia Sergeant" hidden="false" collective="false" import="true" type="model">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="56a9-0514-f151-f815" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fb50-7a56-3876-79ab" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="c206-c4ad-3ecc-1dd5" name="Auxilia Sergeant" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
+                  <characteristics>
+                    <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Line, Close-order, Character)</characteristic>
+                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">6</characteristic>
+                    <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">3</characteristic>
+                    <characteristic name="BS" typeId="74ae-c840-0036-d244">3</characteristic>
+                    <characteristic name="S" typeId="e478-41d4-a092-48a8">3</characteristic>
+                    <characteristic name="T" typeId="c32b-5fdd-3fbe-9b1f">3</characteristic>
+                    <characteristic name="W" typeId="57ee-1126-32a9-5672">1</characteristic>
+                    <characteristic name="I" typeId="62d3-22d7-2d49-52dc">3</characteristic>
+                    <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">2</characteristic>
+                    <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">7</characteristic>
+                    <characteristic name="Save" typeId="e593-6b3c-f169-04f0">4+</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <categoryLinks>
+                <categoryLink id="e8df-cf83-9688-d89f" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
+              </categoryLinks>
+              <selectionEntryGroups>
+                <selectionEntryGroup id="8db8-4d63-3ff8-0124" name="Weapons" hidden="false" collective="false" import="true" defaultSelectionEntryId="6d17-07d2-d48a-0c7f">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f682-4861-baf5-2aa2" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e986-4567-62a7-10bc" type="max"/>
+                  </constraints>
+                  <selectionEntries>
+                    <selectionEntry id="2a37-dbc1-017c-a2e2" name="Pistol and Combat weapon (Sub-menu)" hidden="false" collective="false" import="true" type="upgrade">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d801-6a80-0870-7bcf" type="max"/>
+                      </constraints>
+                      <selectionEntryGroups>
+                        <selectionEntryGroup id="39bd-4b57-3fa4-d9d7" name="Close Combat" hidden="false" collective="false" import="true">
+                          <constraints>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2d81-2d8d-d503-94ba" type="min"/>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="429c-feca-3aaf-02e5" type="max"/>
+                          </constraints>
+                          <entryLinks>
+                            <entryLink id="75d8-4227-9029-43d9" name="Close Combat Weapon" hidden="false" collective="false" import="true" targetId="3d50-2f85-06ff-6aee" type="selectionEntry"/>
+                            <entryLink id="a7f1-f32b-392b-cd21" name="Power Fist" hidden="false" collective="false" import="true" targetId="768d-b89b-7328-d749" type="selectionEntry">
+                              <costs>
+                                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                              </costs>
+                            </entryLink>
+                            <entryLink id="7ee9-09c8-91f1-4be1" name="Power Sword" hidden="false" collective="false" import="true" targetId="a3cd-aa97-a148-2309" type="selectionEntry">
+                              <costs>
+                                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                              </costs>
+                            </entryLink>
+                            <entryLink id="454b-90c3-4cc3-2c3e" name="Power Maul" hidden="false" collective="false" import="true" targetId="0df4-c67e-cf64-82e0" type="selectionEntry">
+                              <costs>
+                                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                              </costs>
+                            </entryLink>
+                            <entryLink id="1a96-a0f3-3dc4-324c" name="Power Lance" hidden="false" collective="false" import="true" targetId="a4c8-c8ff-87f2-1ac9" type="selectionEntry">
+                              <costs>
+                                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                              </costs>
+                            </entryLink>
+                            <entryLink id="fe33-cc69-233e-2bd7" name="Power Axe" hidden="false" collective="false" import="true" targetId="c066-2ace-f68c-e440" type="selectionEntry">
+                              <costs>
+                                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                              </costs>
+                            </entryLink>
+                            <entryLink id="c6b6-dc26-2768-97be" name="Charnabal Tabar" hidden="false" collective="false" import="true" targetId="4611-c33e-f360-7246" type="selectionEntry">
+                              <costs>
+                                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                              </costs>
+                            </entryLink>
+                            <entryLink id="522f-b4bf-67b9-3c90" name="Charnabal Sabre" hidden="false" collective="false" import="true" targetId="30c2-57eb-5bbe-be0b" type="selectionEntry">
+                              <costs>
+                                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                              </costs>
+                            </entryLink>
+                            <entryLink id="4dfe-b1b4-1b3e-ad75" name="Charnabal Glaive" hidden="false" collective="false" import="true" targetId="c07c-35e6-4616-ef25" type="selectionEntry">
+                              <costs>
+                                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                              </costs>
+                            </entryLink>
+                          </entryLinks>
+                        </selectionEntryGroup>
+                        <selectionEntryGroup id="0544-6f06-ff9a-1fcc" name="Pistol" hidden="false" collective="false" import="true">
+                          <constraints>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2123-64ad-6921-3e20" type="min"/>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1d69-b272-b8bf-b3ec" type="max"/>
+                          </constraints>
+                          <entryLinks>
+                            <entryLink id="1b92-4484-7fc8-71b7" name="Blast Pistol" hidden="false" collective="false" import="true" targetId="2460-375d-31f4-4bdf" type="selectionEntry">
+                              <costs>
+                                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2.0"/>
+                              </costs>
+                            </entryLink>
+                            <entryLink id="6d55-0425-50e9-6858" name="Plasma Pistol" hidden="false" collective="false" import="true" targetId="717f-cf0a-1593-4bd8" type="selectionEntry">
+                              <costs>
+                                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                              </costs>
+                            </entryLink>
+                            <entryLink id="a374-fc26-1c9a-0d31" name="Hand Flamer" hidden="false" collective="false" import="true" targetId="e337-adf4-a11f-0280" type="selectionEntry">
+                              <costs>
+                                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2.0"/>
+                              </costs>
+                            </entryLink>
+                            <entryLink id="a59c-5148-1869-0dc7" name="Needle Pistol" hidden="false" collective="false" import="true" targetId="fdd4-06c7-4608-b07f" type="selectionEntry">
+                              <costs>
+                                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2.0"/>
+                              </costs>
+                            </entryLink>
+                            <entryLink id="98fe-3a8b-1238-702c" name="Laspistol" hidden="false" collective="false" import="true" targetId="654d-be88-b0a8-7ae5" type="selectionEntry"/>
+                          </entryLinks>
+                        </selectionEntryGroup>
+                      </selectionEntryGroups>
+                      <costs>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                      </costs>
+                    </selectionEntry>
+                  </selectionEntries>
+                  <entryLinks>
+                    <entryLink id="6d17-07d2-d48a-0c7f" name="Lasrifle" hidden="false" collective="false" import="true" targetId="15f9-817e-275b-c13d" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5533-f61e-ee44-fbe6" type="max"/>
+                      </constraints>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="5c67-1a24-6d3c-35ef" name="Dedicated Transports" hidden="false" collective="false" import="true">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3624-316b-4ed4-d5d1" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5511-91ae-9847-ab72" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="ed68-0b68-bc85-6db3" name="Aurox Transport" hidden="false" collective="false" import="true" targetId="071b-79e5-7b5b-c9cd" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="true">
+                      <conditions>
+                        <condition field="selections" scope="a2dc-46c7-3f68-2154" value="10.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="greaterThan"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                </entryLink>
+                <entryLink id="77f5-573a-7cdb-c441" name="Dracosan Armoured Transport " hidden="false" collective="false" import="true" targetId="496b-a01b-3726-0a44" type="selectionEntry"/>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="bc4a-9998-2da4-e061" name="Auxilia" hidden="false" collective="false" import="true" defaultSelectionEntryId="516d-d14f-b11d-2879">
+              <constraints>
+                <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c818-7f8c-68a2-984c" type="min"/>
+                <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e8e3-2bed-a77c-30f1" type="max"/>
+              </constraints>
+              <selectionEntries>
+                <selectionEntry id="516d-d14f-b11d-2879" name="Auxilia w/ Lasrifle" hidden="false" collective="false" import="true" type="model">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b000-49ea-15ad-4558" type="max"/>
+                  </constraints>
+                  <profiles>
+                    <profile id="2a5f-4513-e5cf-2e8f" name="Auxilia" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
+                      <characteristics>
+                        <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Line, Close-order)</characteristic>
+                        <characteristic name="Move" typeId="893e-2d76-8f04-44e5">6</characteristic>
+                        <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">3</characteristic>
+                        <characteristic name="BS" typeId="74ae-c840-0036-d244">3</characteristic>
+                        <characteristic name="S" typeId="e478-41d4-a092-48a8">3</characteristic>
+                        <characteristic name="T" typeId="c32b-5fdd-3fbe-9b1f">3</characteristic>
+                        <characteristic name="W" typeId="57ee-1126-32a9-5672">1</characteristic>
+                        <characteristic name="I" typeId="62d3-22d7-2d49-52dc">3</characteristic>
+                        <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">1</characteristic>
+                        <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">6</characteristic>
+                        <characteristic name="Save" typeId="e593-6b3c-f169-04f0">4+</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <entryLinks>
+                    <entryLink id="1e0f-af72-1cf7-a5a5" name="Lasrifle" hidden="false" collective="false" import="true" targetId="2449-dc45-3441-b471" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6cef-2474-b000-d12e" type="min"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ed1f-947d-eb1d-7105" type="max"/>
+                      </constraints>
+                    </entryLink>
+                  </entryLinks>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="d75c-1339-aa85-0b76" name="Auxilia w/ Lasrifle and Bayonet" hidden="false" collective="false" import="true" type="model">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9445-6b39-46c3-8de6" type="max"/>
+                  </constraints>
+                  <infoLinks>
+                    <infoLink id="5fe3-4af6-31d8-3908" name="Auxilia Veteran" hidden="false" targetId="1588-db82-569c-00c0" type="profile"/>
+                  </infoLinks>
+                  <entryLinks>
+                    <entryLink id="f77c-c2d2-0c63-51c5" name="Lasrifle" hidden="false" collective="false" import="true" targetId="2449-dc45-3441-b471" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0046-2ec9-db7c-1a09" type="min"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6aa8-509f-5743-409b" type="max"/>
+                      </constraints>
+                    </entryLink>
+                    <entryLink id="a4ed-4ba3-81c8-d295" name="Bayonet" hidden="false" collective="false" import="true" targetId="8413-55c8-60ce-e9bf" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9ebb-d0d7-b3cc-e4ee" type="min"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="13b1-3cd0-937c-9e6a" type="max"/>
+                      </constraints>
+                    </entryLink>
+                  </entryLinks>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="6.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks>
+            <entryLink id="3c1b-c6fa-5ea9-0af2" name="Frag Grenades" hidden="false" collective="false" import="true" targetId="cf9c-327b-3449-00d7" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4ea8-778f-20bc-8ebf" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="61d3-2594-c279-da42" type="min"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="6f79-b405-f164-ad80" name="Krak Grenades" hidden="false" collective="false" import="true" targetId="99df-2421-acf7-a5ad" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fd24-8c08-1c21-631d" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3817-84d6-cabc-4e67" type="min"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="f18d-188f-6bee-3531" name="Void Armour" hidden="false" collective="false" import="true" targetId="6112-2c54-ceb5-a24d" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9ded-b223-ed0f-2bba" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5550-c38c-a016-7f5e" type="min"/>
+              </constraints>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="40.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="4d02-259d-fa50-ef3a" name="Magna Combi-weapon" hidden="false" collective="false" import="true" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="53c6-c052-4e08-4d2d" type="max"/>
+      </constraints>
+      <entryLinks>
+        <entryLink id="d0d4-8e98-6022-b5bb" name="Manga Combi-weapon" hidden="false" collective="false" import="true" targetId="2286-9fb3-e845-f24a" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="53c0-b5d7-f001-b816" name="Minor Combi-weapon" hidden="false" collective="false" import="true" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="14bd-d324-bfc9-b8a0" type="max"/>
+      </constraints>
+      <entryLinks>
+        <entryLink id="4aec-d447-93d6-f947" name="Minor Combi-weapon" hidden="false" collective="false" import="true" targetId="9b4b-07a4-31bc-fc16" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="d2db-7598-f55f-86fe" name="Power Weapon" hidden="false" collective="false" import="true" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f9ef-d959-f4a3-d4c2" type="max"/>
+      </constraints>
+      <entryLinks>
+        <entryLink id="cf56-2470-b3af-54ab" name="Power Weapon" hidden="false" collective="false" import="true" targetId="5ff5-48c0-b9f1-5a05" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="e749-ba9b-bb76-a7d9" name="Charnabal Weapon" hidden="false" collective="false" import="true" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e94f-e15b-bd54-db57" type="max"/>
+      </constraints>
+      <entryLinks>
+        <entryLink id="2876-3425-8164-1fd4" name="Charnabal Weapon" hidden="false" collective="false" import="true" targetId="f7d1-ad0f-b4cb-dfc1" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="2867-ab52-1247-2532" name="Lasrifle with Bayonet" hidden="false" collective="false" import="true" type="upgrade">
+      <entryLinks>
+        <entryLink id="7216-d901-4f8b-9c7d" name="Lasrifle" hidden="false" collective="false" import="true" targetId="15f9-817e-275b-c13d" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="425f-dffd-473f-c9ce" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6923-3657-a663-3ead" type="max"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="6710-f925-d009-a7cc" name="Bayonet" hidden="false" collective="false" import="true" targetId="6904-6936-d6ca-a0eb" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a869-21f8-caa7-1e90" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cf97-9b75-14d3-b0e6" type="max"/>
+          </constraints>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="df43-1c27-ceea-6d3a" name="Lasrifle with Bayonet" hidden="false" collective="true" import="true" type="upgrade">
+      <entryLinks>
+        <entryLink id="d22b-09fc-d194-9b73" name="Lasrifle" hidden="false" collective="false" import="true" targetId="2449-dc45-3441-b471" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f878-c17d-244a-093e" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fd35-5bd5-3b2c-b200" type="max"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="46a3-45ca-c24e-6b6a" name="Bayonet" hidden="false" collective="false" import="true" targetId="8413-55c8-60ce-e9bf" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="447c-9923-823e-e7da" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ff5f-8ae9-22d6-7a4f" type="max"/>
+          </constraints>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="7ac4-c39b-5c48-63cb" name="Command Vox" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="4eaa-b4e5-6a43-c638" name="Command Vox" publicationId="15a4-fc68-502d-48a9" page="152" hidden="false" typeId="2a1f-7837-f0ef-be44" typeName="Wargear Item">
+          <characteristics>
+            <characteristic name="Description" typeId="347e-ee4a-764f-6be3">Any friendly unit that includes at least one model with a command vox may choose to use the Leadership value of any model in a friendly unit with another command vox when making Pinning tests or Morale checks – this includes any friendly units with command voxs that are in Reserves or Embarked on unit with the Vehicle Unit Type. A unit that includes a command vox also offer benefits to friendly units that include a vox interlock (see page 153).</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="6f5a-bf56-4bee-ce7e" name="Auxilia Vexilla" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="ede3-8f88-276b-7368" name="Auxilia Vexilla" publicationId="15a4-fc68-502d-48a9" page="151" hidden="false" typeId="2a1f-7837-f0ef-be44" typeName="Wargear Item">
+          <characteristics>
+            <characteristic name="Description" typeId="347e-ee4a-764f-6be3">A unit that includes at least one model with an Auxilia vexilla adds +1 to the Wounds score used to decide if they win a Combat in the Assault phase. In addition, a unit that includes at least one model with an Auxilia vexilla may choose to Fall Back only a distance equal to the roll of a D6 instead of 2D6 (or 3D6 if a Cavalry unit) and if forced to move off the edge of the battlefield will instead stop with each model 1&quot; away from the edge of the battlefield.</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="b66d-ca3f-b0ea-47ef" name="Cohorts Vexilla" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="ee86-c0c3-8b6b-76e9" name="Cohorts Vexilla" publicationId="15a4-fc68-502d-48a9" page="152" hidden="false" typeId="2a1f-7837-f0ef-be44" typeName="Wargear Item">
+          <characteristics>
+            <characteristic name="Description" typeId="347e-ee4a-764f-6be3">All of the controlling player’s units that are part of a Detachment chosen from the Solar Auxilia Army List within 6&quot; of a model with a Cohorts vexilla are considered to have a Leadership Characteristic of 9 when resolving Morale checks or Pinning tests (but not Psychic checks). In addition, all models in a unit that includes a Cohorts vexilla gain the Line Sub-type as long as they remain part of that unit – this benefit is lost immediately if the model with the Cohorts vexilla is removed as a casualty.</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="c04e-5624-3615-0660" name="Vox Interlock" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="008b-9e8f-5410-f58b" name="Vox Interlock" publicationId="15a4-fc68-502d-48a9" page="153" hidden="false" typeId="2a1f-7837-f0ef-be44" typeName="Wargear Item">
+          <characteristics>
+            <characteristic name="Description" typeId="347e-ee4a-764f-6be3">Any friendly unit that includes at least one model with a vox interlock may choose to use the Leadership value of any model in a friendly unit with a command vox when making Pinning tests or Morale checks – this includes any friendly units with a command vox that are in Reserves or are Embarked on a model with the Vehicle Unit Type.</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="e09b-73c8-2340-4604" name="Storm Axe" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="593a-b90a-74d1-4159" name="Storm Axe" publicationId="15a4-fc68-502d-48a9" page="149" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="95ba-cda7-b831-6066">-</characteristic>
+            <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">+2</characteristic>
+            <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">2</characteristic>
+            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Melee, Unwieldy, Two-handed, Murderous Strike (6+)</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="ea94-51d9-0b0f-31c9" name="Unwieldy" hidden="false" targetId="1570-c21a-881f-8b8a" type="rule"/>
+        <infoLink id="ee36-f3f0-779a-1022" name="Two-handed" hidden="false" targetId="4c23-e863-a569-7617" type="rule"/>
+        <infoLink id="31c1-9fe6-9258-d422" name="Murderous Strike (X)" hidden="false" targetId="93b9-1454-0e7c-42ae" type="rule">
+          <modifiers>
+            <modifier type="set" field="name" value="Murderous Strike (6+)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="c305-a3f1-5c2f-ae37" name="Storm Axe" hidden="false" collective="true" import="true" type="upgrade">
+      <infoLinks>
+        <infoLink id="e31a-f147-bb81-fe8c" name="Unwieldy" hidden="false" targetId="1570-c21a-881f-8b8a" type="rule"/>
+        <infoLink id="58a3-5b2a-093f-e9f5" name="Two-handed" hidden="false" targetId="4c23-e863-a569-7617" type="rule"/>
+        <infoLink id="4216-7ab6-2560-366c" name="Murderous Strike (X)" hidden="false" targetId="93b9-1454-0e7c-42ae" type="rule">
+          <modifiers>
+            <modifier type="set" field="name" value="Murderous Strike (6+)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="759a-9bff-4841-e716" name="Storm Axe" hidden="false" targetId="593a-b90a-74d1-4159" type="profile"/>
+      </infoLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="37ec-a4b4-de7a-acf3" name="Rotor Cannon" hidden="false" collective="true" import="true" type="upgrade">
+      <infoLinks>
+        <infoLink id="2a23-3690-b10a-5ab4" name="Pinning" hidden="false" targetId="1c96-205c-59a0-3cf2" type="rule"/>
+        <infoLink id="023b-fb8e-d925-0f4c" name="Shell Shock (X)" hidden="false" targetId="46b7-63a1-941c-96a5" type="rule">
+          <modifiers>
+            <modifier type="set" field="name" value="Shell Shock (1)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="610d-65de-9ab7-bd2a" name="Rotor Cannon" hidden="false" targetId="911e-cd25-992e-7a74" type="profile"/>
+      </infoLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="f1d6-ebe1-d236-3f11" name="Heavy Flamer" hidden="false" collective="true" import="true" type="upgrade">
+      <infoLinks>
+        <infoLink id="cd13-1c99-060a-a97c" name="Template Weapons" hidden="false" targetId="5e0e-88e6-db81-5a70" type="rule"/>
+        <infoLink id="55af-d04b-dd9f-9456" name="Heavy Flamer" hidden="false" targetId="a6e9-e2e1-150f-b023" type="profile"/>
+      </infoLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="428d-bd65-c88e-1430" name="Divisio Aeronautica Primaris-Lightning Strike Fighter" hidden="false" collective="false" import="true" type="unit">
+      <profiles>
+        <profile id="b1c3-5171-e456-0210" name="Primaris-Lightning Strike Fighter" publicationId="15a4-fc68-502d-48a9" page="94" hidden="false" typeId="2fae-b053-3f78-e7b2" typeName=" Vehicle">
+          <characteristics>
+            <characteristic name="Unit Type" typeId="e555-4aed-dfcc-c0b4">Vehicle (Flyer)</characteristic>
+            <characteristic name="Move" typeId="3614-4a2d-bffb-90e4">26&quot;</characteristic>
+            <characteristic name="BS" typeId="51fb-b7d9-aa59-863d">3</characteristic>
+            <characteristic name="Front" typeId="0ef8-a648-01d0-08ee">11</characteristic>
+            <characteristic name="Side" typeId="f150-c0dc-c192-9cb3">11</characteristic>
+            <characteristic name="Rear" typeId="8d4e-2aea-fffc-d556">10</characteristic>
+            <characteristic name="HP" typeId="a76c-83b1-602f-9e62">3</characteristic>
+            <characteristic name="Transport Capacity" typeId="0c90-79e2-f768-e547">-</characteristic>
+            <characteristic name="Access Points" typeId="e217-1b1e-9494-3e3e">-</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="8b2b-3c39-588b-a589" name="Deep Strike" hidden="false" targetId="f1e1-986f-c783-ca9e" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="c3c5-09cf-2322-e137" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
+        <categoryLink id="10dd-c4cd-1ae3-e021" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+      </categoryLinks>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="b0fd-50a8-1a40-67fc" name="2) May take:" hidden="false" collective="false" import="true">
+          <entryLinks>
+            <entryLink id="b3b9-258f-2990-ed3b" name="Ramjet Diffraction Grid" hidden="false" collective="false" import="true" targetId="a884-7de7-32c4-3ef6" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2ae6-b6eb-eeea-ab4c" type="max"/>
+                <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d661-cc11-6b03-73ca" type="min"/>
+              </constraints>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="30.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="9440-dfc7-b422-5b4f" name="1) Missile Options:" hidden="false" collective="false" import="true">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e2f3-3c9e-c340-0be1" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="75ae-e1fc-17a5-4a17" name="2x Kraken Penetrator Missiles" hidden="false" collective="false" import="true" type="upgrade">
+              <profiles>
+                <profile id="7e26-902e-9eb5-17bc" name="Kraken Penetrator Missile" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+                  <characteristics>
+                    <characteristic name="Range" typeId="95ba-cda7-b831-6066">36&quot;</characteristic>
+                    <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">8</characteristic>
+                    <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">1</characteristic>
+                    <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Heavy 1, Armourbane (Ranged), One Use</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <infoLinks>
+                <infoLink id="1739-6036-93c6-3850" name="Armourbane (X)" hidden="false" targetId="cb59-f920-f071-7cd4" type="rule">
+                  <modifiers>
+                    <modifier type="set" field="name" value="Armourbane (Ranged)"/>
+                  </modifiers>
+                </infoLink>
+                <infoLink id="b4fd-ac14-4952-f61a" name="One Use/One Shot" hidden="false" targetId="df0c-5423-b892-491e" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="35.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="594e-b67e-ab21-6d5e" name="2x Sunfury Missiles" hidden="false" collective="false" import="true" type="upgrade">
+              <profiles>
+                <profile id="8c28-27cd-4e4f-84d5" name="Sunfury Missile" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+                  <characteristics>
+                    <characteristic name="Range" typeId="95ba-cda7-b831-6066">36&quot;</characteristic>
+                    <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">7</characteristic>
+                    <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">4</characteristic>
+                    <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Heavy 1, Blast (3&quot;), Breaching (4+), Gets Hot, One Use</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <infoLinks>
+                <infoLink id="e266-2003-9a45-0d1d" name="Blast" hidden="false" targetId="1d9a-73ef-5f4f-8bd8" type="rule"/>
+                <infoLink id="b849-7b40-d11e-dbc9" name="Breaching (X)" hidden="false" targetId="a760-f736-1bf3-fa3c" type="rule">
+                  <modifiers>
+                    <modifier type="set" field="name" value="Breaching (4+)"/>
+                  </modifiers>
+                </infoLink>
+              </infoLinks>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="a397-75b8-2cb0-cb36" name="Lascannon" hidden="false" collective="false" import="true" targetId="b252-5a86-6e0f-218b" type="selectionEntry">
+          <modifiers>
+            <modifier type="set" field="name" value="2x Centerline Mounted Lascannons"/>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fbc6-51c2-39cd-dba1" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e94e-250e-4b92-dd63" type="min"/>
+          </constraints>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="150.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="6201-e908-c475-db6b" name="Divisio Aeronautica Thunderbolt Fighter" hidden="false" collective="false" import="true" type="unit">
+      <profiles>
+        <profile id="3179-947f-3d3c-0f2a" name="Thunderbolt Fighter" publicationId="15a4-fc68-502d-48a9" page="95" hidden="false" typeId="2fae-b053-3f78-e7b2" typeName=" Vehicle">
+          <characteristics>
+            <characteristic name="Unit Type" typeId="e555-4aed-dfcc-c0b4">Vehicle (Flyer)</characteristic>
+            <characteristic name="Move" typeId="3614-4a2d-bffb-90e4">22&quot;</characteristic>
+            <characteristic name="BS" typeId="51fb-b7d9-aa59-863d">3</characteristic>
+            <characteristic name="Front" typeId="0ef8-a648-01d0-08ee">12</characteristic>
+            <characteristic name="Side" typeId="f150-c0dc-c192-9cb3">11</characteristic>
+            <characteristic name="Rear" typeId="8d4e-2aea-fffc-d556">10</characteristic>
+            <characteristic name="HP" typeId="a76c-83b1-602f-9e62">3</characteristic>
+            <characteristic name="Transport Capacity" typeId="0c90-79e2-f768-e547">-</characteristic>
+            <characteristic name="Access Points" typeId="e217-1b1e-9494-3e3e">-</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules>
+        <rule id="58eb-a9fb-6c52-7228" name="Divisio Aeronautica Air Superiority" publicationId="15a4-fc68-502d-48a9" page="132" hidden="false">
+          <description>A unit or model with this special rule may be placed into Combat Air Patrol at the beginning of the battle, before any models are deployed onto the table. Models assigned to Combat Air Patrol are not deployed onto the battlefield and remain in Reserves – however, no Reserves rolls are made for these models. Instead, the controlling player gains access to the Combat Air Patrol Advanced Reaction:</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="06b4-6369-4cb7-f5ea" name="Deep Strike" hidden="false" targetId="f1e1-986f-c783-ca9e" type="rule"/>
+        <infoLink id="c787-800e-fdd6-fe90" name="Advanced Reaction: Combat Air Patrol" hidden="false" targetId="0ab2-3765-d019-2730" type="profile"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="4a1d-6ddd-0d6f-346d" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="8bbc-0fe3-3451-81fb" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
+        <categoryLink id="448c-ff0a-e283-4928" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+      </categoryLinks>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="c730-6dc4-302d-fdee" name="2) May take:" hidden="false" collective="false" import="true">
+          <entryLinks>
+            <entryLink id="d6e6-f9b7-75af-be6f" name="Ramjet Diffraction Grid" hidden="false" collective="false" import="true" targetId="a884-7de7-32c4-3ef6" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="99a3-2990-108f-626e" type="max"/>
+                <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9be6-8264-d79f-cb69" type="min"/>
+              </constraints>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="30.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="6ebf-74ec-bd1d-7f48" name="1) Missile Options:" hidden="false" collective="false" import="true">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d4df-41b5-16f0-b526" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="60e3-4240-4775-4e53" name="Skystrike Missile" hidden="false" collective="false" import="true" targetId="423f-5e6d-4427-a348" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="name" value="4x Hull (Front) Mounted Skystrike missiles"/>
+              </modifiers>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="57be-eefc-010c-64bd" name="Hellstrike Missile" hidden="false" collective="false" import="true" targetId="5e24-bdca-a89c-0f40" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="name" value="4x Hull (Front) Mounted Hellstrike Missile"/>
+              </modifiers>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="8bd1-908c-f46e-3bbd" name="Lascannon" hidden="false" collective="false" import="true" targetId="b252-5a86-6e0f-218b" type="selectionEntry">
+          <modifiers>
+            <modifier type="set" field="name" value="2x Centerline (Front) Mounted Lascannons"/>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bb0b-4e3c-4e3e-bdf5" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1e70-7cb2-4442-fb9c" type="min"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="dcef-5ca4-b327-403e" name="Autocannon" hidden="false" collective="false" import="true" targetId="56b3-de09-9fea-deb6" type="selectionEntry">
+          <modifiers>
+            <modifier type="set" field="name" value="4x Centerline (Front) Mounted Autocannons"/>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2780-d1ca-ce8e-fb04" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="874b-d8c4-a1be-cc72" type="max"/>
+          </constraints>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="120.0"/>
+      </costs>
+    </selectionEntry>
+  </sharedSelectionEntries>
+  <sharedSelectionEntryGroups>
+    <selectionEntryGroup id="9da6-635b-fa1d-2c2b" name="Cohort Doctrines (Work in Progress)" hidden="false" collective="false" import="true">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bf99-af3b-5096-cd3c" type="max"/>
+      </constraints>
+      <selectionEntries>
+        <selectionEntry id="fe04-c096-f846-a6fd" name="Reborn Cohorts (Bonus LD and Stubborn &amp;  Limitations need completing)" publicationId="15a4-fc68-502d-48a9" page="71" hidden="false" collective="false" import="true" type="upgrade">
+          <rules>
+            <rule id="05af-452b-0e23-3b16" name="Reborn Cohorts" publicationId="15a4-fc68-502d-48a9" page="71" hidden="false">
+              <description>Effects
+• All models with the Infantry Unit Type in a Detachment using this Cohort Doctrine gain a bonus of +1 to their Leadership Characteristic and the Stubborn special rule.
+• When making a Shooting Attack during any Game Turn in which the attacking unit has not Moved, a unit from a Detachment using this Cohort Doctrine may re-roll all failed To Hit rolls of ‘1’.
+
+Limitations
+• A Detachment using this Cohort Doctrine may not include more than a single Auxilia Armoured Tercio.
+• A Detachment using this Cohort Doctrine may not include more than a single Auxilia Artillery Tercio.
+• All models with the Infantry Unit Type in a Detachment using this Cohort Doctrine count their Initiative as ‘1’ for the purposes of determining the distance moved when Running, when rolling as part of a Sweeping Advance, or when making a Move as part of any Reaction; and when determining which Initiative Step they would attack in during an Assault their Initiative Characteristic is considered to be one lower than normal.</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="3624-316b-4ed4-d5d1" name="Ultramar Pattern Cohorts" publicationId="15a4-fc68-502d-48a9" page="70" hidden="false" collective="false" import="true" type="upgrade">
+          <rules>
+            <rule id="e0ba-7a66-48a3-da09" name="Ultramar Pattern Cohorts" publicationId="15a4-fc68-502d-48a9" page="70" hidden="false">
+              <description>Effects
+• A Detachment using this Cohort Doctrine uses the Organisation chart shown below to select all Auxilia Rifle Sections instead of the one found in the unit profile and may include up to 6 units.
+• All Solar Auxilia Rifle Sections and Solar Auxilia Line Command Sections gain a bonus of +1 to all To Hit rolls made during Shooting Attacks when all models in the unit are in base contact with at least one other model from the same unit.
+
+Ultramar Pattern Auxilia Rifle Tercio Organisation Chart
+An Ultramar Pattern Auxilia Infantry Tercio must include the following units:
+• 0-1 Line Command Section
+• 1-6 Auxilia Rifle Sections
+
+Limitations
+• A Detachment using this Cohort Doctrine may not select Dedicated Transports for any Solar Auxilia Rifle Sections or Solar Auxilia Line Command Sections.</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="1974-9f9a-5b14-e449" name="Armoured Fist Pattern Cohorts (Everything needs completing)" publicationId="15a4-fc68-502d-48a9" page="71" hidden="false" collective="false" import="true" type="upgrade">
+          <rules>
+            <rule id="a28b-aeef-6d88-8985" name="Armoured Fist Pattern Cohorts" publicationId="15a4-fc68-502d-48a9" page="71" hidden="false">
+              <description>Effects
+• A Detachment using this Cohort Doctrine may select Auxilia Armoured Tercios as non-Compulsory Troops choices. An Auxilia Armoured Tercio selected as a Troops choice may only consist of a single unit, which must be a Solar Auxilia Leman Russ Strike Squadron.
+• In a Primary Detachment using this Cohort Doctrine, a single Solar Auxilia Armoured Command Section composed of only a single Leman Russ Command Tank, must be selected as a HQ choice. This Leman Russ Command Tank gains the Cohort Doctrines special rule and must be selected as the army’s Warlord and must use the Armoured Legate Warlord trait (see below). A model with the Vehicle Unit Type must be selected as the Warlord of an army using this Cohort Doctrine, regardless of any rules which would require a model to be selected as the army’s Warlord (note this means that some units and Characters cannot be selected as part of this army):
+
+Warlord Trait: Armoured Legate
+A Warlord with this Warlord Trait gains the Cohort Doctrines special rule, a 5+ Invulnerable Save and increases its BS by +1.
+
+Limitations
+• All units composed entirely of models with the Infantry Unit Type must begin the battle Embarked on a model with the Transport Unit Sub-type or in Reserves.</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="bfd2-7016-f5fe-be6a" name="Penal Pattern Cohorts (Furious Charge, weapon swaps, FnP, remove Close-order to be completed)" publicationId="15a4-fc68-502d-48a9" page="72" hidden="false" collective="false" import="true" type="upgrade">
+          <rules>
+            <rule id="dc68-cb01-b862-110a" name="Penal Pattern Cohorts" publicationId="15a4-fc68-502d-48a9" page="72" hidden="false">
+              <description>Effects
+• All models in a unit from a Detachment using this Cohort Doctrine that include models with the Tercio special rule also gain the Furious Charge (1) special rule.
+• Any model in a Detachment using this Cohort Doctrine may replace a lasrifle or volkite charger with a lascarbine, lasgun, stubcarbine, autorifle or shotgun for no additional points cost. In addition, one Auxilia in any Solar Auxilia Rifle Section may replace a lasrifle with a heavy stubber for +5 points per model.
+• All models selected as part of a Solar Auxilia Rifle Section gain the Feel No Pain (6+) special rule – this does not stack with any other variant of this special rule and if the unit has access to any other Feel No Pain (X) special rule, the controlling player must select one to use.
+
+Limitations
+• All models in a Detachment using this Cohort Doctrine with the Close-order Unit Sub-type lose that Unit Sub-type.
+• A Detachment using this Cohort Doctrine may not include more than one Auxilia Veletaris Tercio.</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="021e-6841-7375-7862" name="Feral Pattern Cohorts (Fear option, Counter attack need completing)" publicationId="15a4-fc68-502d-48a9" page="72" hidden="false" collective="false" import="true" type="upgrade">
+          <rules>
+            <rule id="1a4f-9ea3-092f-f00e" name="Feral Pattern Cohorts" publicationId="15a4-fc68-502d-48a9" page="72" hidden="false">
+              <description>Effects
+• Any unit made up entirely of models with the Infantry Unit Type may be given the Fear (1) special rule for a cost of +25 points per unit.
+• All units that include one or more models with the Tercio special rule gain the Counter-attack (1) special rule while ‘In Formation’.
+
+Limitations
+• All units in a Detachment using this Cohort Doctrine that begin the controlling player’s Assault phase with an enemy unit that is a valid target for a Charge must declare a Charge. If more than one enemy unit is a valid target, the controlling player chooses which enemy unit is the target of the Charge.
+• All other Detachments in an army with the Loyalist Allegiance that includes a Detachment using this Cohort Doctrine will consider the Detachment with this Cohort Doctrine to be Distrusted Allies, regardless of the normal result of the Allies Matrix.</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="d9a0-4875-fb75-f9a9" name="Siege Pattern Cohorts (Everything needs completing)" publicationId="15a4-fc68-502d-48a9" page="73" hidden="false" collective="false" import="true" type="upgrade">
+          <rules>
+            <rule id="bf71-d394-4968-20e3" name="Siege Pattern Cohorts" publicationId="15a4-fc68-502d-48a9" page="73" hidden="false">
+              <description>Effects
+• A Detachment using this Cohort Doctrine may select Auxilia Artillery Tercios and Solar Auxilia Armoured Batteries as both Elites and Heavy Support choices.
+• When a model from a Detachment using this Cohort Doctrine makes a Shooting Attack with any weapon with the Barrage and/or Blast special rules, the controlling player may choose to re-roll the Scatter dice (but not any D6 rolled to determine the distance of any scatter).
+
+Limitations
+• All units in a Detachment using this Cohort Doctrine with the option to select a Dedicated Transport must select that option at the normal cost in points – but do not have to start the battle Embarked on that Dedicated Transport.</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="e0e8-1223-7794-2e95" name="Iron Pattern Cohort (Limitations need completing)" publicationId="15a4-fc68-502d-48a9" page="73" hidden="false" collective="false" import="true" type="upgrade">
+          <rules>
+            <rule id="4d43-43ca-68bb-2608" name="Iron Pattern Cohort" publicationId="15a4-fc68-502d-48a9" page="73" hidden="false">
+              <description>Effects
+• A Detachment using this Cohort Doctrine may select Castellax Maniples* and Thallax Squads* as Elites choices.
+• A Legate Marshal, Auxilia Marshal or Auxilia Captain in a Detachment using this Cohort Doctrine may select a cortex controller* for +15 points each.
+• A Legate Marshal in a Detachment using this Cohort Doctrine gains the Master of Automata special rule.
+*Unit profiles and rules for these can be found in Liber Mechanicum.
+
+Limitations
+• A Detachment using this Cohort Doctrine may not include more than a single Auxilia Armoured Tercio.
+• A Detachment using this Cohort Doctrine may not include more than a single Auxilia Artillery Tercio.</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="a09b-28bd-8ffc-f4f0" name="Solar Pattern Cohorts (Limitations need completing)" publicationId="15a4-fc68-502d-48a9" page="70" hidden="false" collective="false" import="true" type="upgrade">
+          <rules>
+            <rule id="dd51-13b7-cd51-37ef" name="Solar Pattern Cohorts" publicationId="15a4-fc68-502d-48a9" page="70" hidden="false">
+              <description>Effects
+• A Detachment using this Cohort Doctrine may select Auxilia Veletaris Tercios as Troops choices.
+• All units selected as part of an Auxilia Veletaris Tercio in a Detachment using this Cohort Doctrine may select an Arvus Transport as a Dedicated Transport.
+• All units in an Auxilia Veletaris Tercio selected as a Troops choice gain the Line Unit Sub-type.
+
+Limitations
+• A Detachment using this Cohort Doctrine may not include more than a single Auxilia Armoured Tercio.
+• A Detachment using this Cohort Doctrine may not include more than a single Auxilia Artillery Tercio.</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="f7d1-ad0f-b4cb-dfc1" name="Charnabal Weapon" hidden="false" collective="false" import="true">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3813-a033-141b-d875" type="max"/>
+      </constraints>
+      <entryLinks>
+        <entryLink id="a311-a007-7439-9227" name="Charnabal Glaive" hidden="false" collective="false" import="true" targetId="c07c-35e6-4616-ef25" type="selectionEntry"/>
+        <entryLink id="5246-a8e2-96a4-eae4" name="Charnabal Sabre" hidden="false" collective="false" import="true" targetId="30c2-57eb-5bbe-be0b" type="selectionEntry"/>
+        <entryLink id="5fcf-bd2e-46e7-0b09" name="Charnabal Tabar" hidden="false" collective="false" import="true" targetId="4611-c33e-f360-7246" type="selectionEntry"/>
+      </entryLinks>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="5ff5-48c0-b9f1-5a05" name="Power Weapon" hidden="false" collective="false" import="true">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="85ed-fe14-e801-d9ce" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9339-8931-c34c-cecd" type="max"/>
+      </constraints>
+      <entryLinks>
+        <entryLink id="a54d-8d95-708d-c771" name="Power Axe" hidden="false" collective="false" import="true" targetId="c066-2ace-f68c-e440" type="selectionEntry"/>
+        <entryLink id="68ab-655a-32a7-8420" name="Power Lance" hidden="false" collective="false" import="true" targetId="a4c8-c8ff-87f2-1ac9" type="selectionEntry"/>
+        <entryLink id="f81f-0e32-9b97-7c8d" name="Power Maul" hidden="false" collective="false" import="true" targetId="0df4-c67e-cf64-82e0" type="selectionEntry"/>
+        <entryLink id="f6b0-c45f-0288-63f8" name="Power Sword" hidden="false" collective="false" import="true" targetId="a3cd-aa97-a148-2309" type="selectionEntry"/>
+      </entryLinks>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="2286-9fb3-e845-f24a" name="Magna Combi-weapon" hidden="false" collective="false" import="true">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d3ec-1829-0c26-e2f2" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5829-8710-c6d1-774d" type="max"/>
+      </constraints>
+      <entryLinks>
+        <entryLink id="9bc5-919f-7d3a-703e" name="Magna Combi-Weapon - Meltagun" hidden="false" collective="false" import="true" targetId="59c3-2af5-ebe5-d512" type="selectionEntry"/>
+        <entryLink id="0ff2-dd35-7e6a-f83a" name="Magna Combi-Weapon - Plasma Gun" hidden="false" collective="false" import="true" targetId="5ed9-1bc3-4d8f-0826" type="selectionEntry"/>
+      </entryLinks>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="9b4b-07a4-31bc-fc16" name="Minor Combi-weapon" hidden="false" collective="false" import="true">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="64a4-8057-3485-a05e" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b944-00be-d9f1-7025" type="max"/>
+      </constraints>
+      <entryLinks>
+        <entryLink id="0639-e1f6-6e0d-7650" name="Minor Combi-Weapon - Flamer" hidden="false" collective="false" import="true" targetId="8dee-b436-0afd-c70a" type="selectionEntry"/>
+        <entryLink id="7c27-be0d-c946-4c4e" name="Minor Combi-Weapon - Grenade Launcher" hidden="false" collective="false" import="true" targetId="dd06-55b3-1c77-1e1d" type="selectionEntry"/>
+        <entryLink id="1515-78e0-10fa-5223" name="Minor Combi-Weapon - Volkite Charger" hidden="false" collective="false" import="true" targetId="8720-32c4-0099-63f4" type="selectionEntry"/>
+      </entryLinks>
+    </selectionEntryGroup>
+  </sharedSelectionEntryGroups>
+  <sharedRules>
+    <rule id="6516-f81d-457b-a2cc" name="Tercio" publicationId="15a4-fc68-502d-48a9" page="138" hidden="false">
+      <description>Models with this special rule may only be selected as part of a Tercio (see the rules for Tercios on page 68). When a Reaction is declared for a unit with this rule that allows it to make a Shooting Attack or Move, then all units from the same Tercio that are ‘In Formation’ with the Reacting unit may also Move or make a Shooting Attack as described in the Reaction being made (all units that Move or Shoot are counted as having made a Reaction, and thus cannot make further Reactions in the same Phase, and must target the same unit with any Shooting Attacks made). A unit is ‘In Formation’ when that unit is in unit coherency and has at least one model within 3&quot; of a model from a different unit in the same Tercio that is also in unit coherency.</description>
+    </rule>
+  </sharedRules>
+  <catalogueLinks>
+    <catalogueLink id="e048-9e5e-507c-5ba4" name="2022 - Liber Imperium Library" targetId="f3f1-b05f-eefe-4ee4" type="catalogue" importRootEntries="true"/>
+    <catalogueLink id="60d6-cab6-4580-b772" name="2022 - Mech Library" targetId="3129-da35-55e0-642d" type="catalogue" importRootEntries="true"/>
+  </catalogueLinks>
+</catalogue>

--- a/2022 - Legiones Astartes.cat
+++ b/2022 - Legiones Astartes.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="6393-649c-7213-a327" name="(HH V2) Legions Astartes" revision="83" battleScribeVersion="2.03" authorName="Various" authorUrl="https://github.com/BSData/horus-heresy" library="true" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="32" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="6393-649c-7213-a327" name="(HH V2) Legions Astartes" revision="84" battleScribeVersion="2.03" authorName="Various" authorUrl="https://github.com/BSData/horus-heresy" library="true" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="34" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <profileTypes>
     <profileType id="7002-2f9a-59c4-2742" name="Prosperine Arcana">
       <characteristicTypes>
@@ -444,6 +444,146 @@
       <categoryLinks>
         <categoryLink id="6c72-5e9f-a028-aa94" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
         <categoryLink id="b656-a898-3480-f03b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="ccce-f5fd-73be-47df" name="Clade Adamus Assassin" hidden="true" collective="false" import="true" targetId="0510-bd97-e047-88bf" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ccb7-6c5c-76ce-5b77" type="equalTo"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="af06-750f-c801-e3d9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="9a52-9c8b-6540-62f7" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="0f95-3457-d8b3-16c5" name="Clade Callidus Assassin" hidden="true" collective="false" import="true" targetId="aeac-aef4-984e-fe79" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ccb7-6c5c-76ce-5b77" type="equalTo"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="62ab-3a5d-4b85-335f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="07f3-e44b-2b1e-95c3" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="d052-73bf-01d4-5c14" name="Clade Culexus Assassin" hidden="true" collective="false" import="true" targetId="4d3f-0c69-bf50-9076" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ccb7-6c5c-76ce-5b77" type="equalTo"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="c489-f907-bf92-a9b5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="2cc7-6dac-674f-d7bd" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="63a1-7489-1b32-79d5" name="Clade Eversor Assassin" hidden="true" collective="false" import="true" targetId="5d50-77c2-5943-4c3f" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ccb7-6c5c-76ce-5b77" type="equalTo"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="37fe-d0dd-ac30-c0e8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="385d-c382-1cef-ee2f" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="6fc8-e4b1-5134-5a4f" name="Clade Vanus Infocyte Assassin" hidden="true" collective="false" import="true" targetId="3976-8d49-21fc-2633" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ccb7-6c5c-76ce-5b77" type="equalTo"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="0937-64c6-6d2a-83b1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="6665-7637-18c2-2d8d" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="6a66-ca37-fda4-b3be" name="Clade Venenum Assassin" hidden="true" collective="false" import="true" targetId="32f2-1209-7402-4d0d" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ccb7-6c5c-76ce-5b77" type="equalTo"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="bbb6-bee6-d778-c7ca" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="4ca8-1559-619a-1691" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="88bb-a5cd-483d-3549" name="Clade Vindicare Assassin" hidden="true" collective="false" import="true" targetId="abaf-b2fa-1d41-a315" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ccb7-6c5c-76ce-5b77" type="equalTo"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="9956-acfe-202f-54dc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="915b-853e-c601-dde8" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
       </categoryLinks>
     </entryLink>
   </entryLinks>
@@ -46546,5 +46686,6 @@ A unit that includes models with this special rule may only be joined by models 
   </sharedRules>
   <catalogueLinks>
     <catalogueLink id="60d6-cab6-4580-b772" name="2022 - Mech Library" targetId="3129-da35-55e0-642d" type="catalogue" importRootEntries="true"/>
+    <catalogueLink id="e048-9e5e-507c-5ba4" name="2022 - Liber Imperium Library" targetId="f3f1-b05f-eefe-4ee4" type="catalogue" importRootEntries="true"/>
   </catalogueLinks>
 </catalogue>

--- a/2022 - Liber Imperium Library.cat
+++ b/2022 - Liber Imperium Library.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="f3f1-b05f-eefe-4ee4" name="2022 - Liber Imperium Library" revision="1" battleScribeVersion="2.03" library="true" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="30" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="f3f1-b05f-eefe-4ee4" name="2022 - Liber Imperium Library" revision="1" battleScribeVersion="2.03" library="true" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="34" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <categoryEntries>
     <categoryEntry id="7e5d-d73e-8ff4-7345" name="Anathema Sub-type" publicationId="15a4-fc68-502d-48a9" page="129" hidden="false">
       <rules>
@@ -8,6 +8,27 @@
 • A model with the Anathema Sub-type that is allocated Wounds caused by a Psychic Weapon (which is any weapon granted to a unit or model by a Psychic Discipline) will always fail to Wound without any dice being rolled and any special rules attached to that Psychic Weapon will not trigger. Any Wounds allocated to a model with the Anathema Unit Sub-type caused by a Force Weapon gain no benefit from the Force special rules, but are otherwise resolved as normal. These effects do not apply to a model with the Transport Sub-type that has models with the Anathema Sub-type Embarked within, unless the model with the Transport Sub-type also has the Anathema Sub-type.
 • All models that no not have the Anathema Sub-type but are part of a unit that includes one of more models with the Anathema Sub-type, suffer a penalty of -2 to their Leadership Characteristic. Any unit with at least one model within 6&quot; of a model with th eAnathema Sub-type suffers a penalty of -1 to the Leadership of all models in the unit that do not also have the Anathema Sub-type, or -2 if that unit includes one of more models with the Corrupted Unit Sub-type. Note that these two penalties are not cumulative; they apply only the more severe penalty. However, they do stack with other special that modify Leadership (such as Fear (X)).
 • A unit that is Embarked on a Vehicle, Fortification or Building suffers no penalties to its Leadership Characteristic due to the Anathema Sub-type, However, units with the Stubborn special rule do suffer penalties to their Leadership from the effects of this Sub-type (note that this only applies to the Stubborn special rule, and other special rules that ignore panalties to Leadership ignore the effects of the Anathema Sub-type).</description>
+        </rule>
+      </rules>
+    </categoryEntry>
+    <categoryEntry id="b71a-371d-4401-9dc0" name="Silent Sisterhood (Chamber of Judgement)" hidden="false">
+      <rules>
+        <rule id="04a5-fa60-5ebe-aa9d" name="Silent Sisterhood (Chamber of Judgement)" publicationId="15a4-fc68-502d-48a9" page="40" hidden="false">
+          <description>All models with this variant of the Silent Sisterhood (X) special rule gain the Fearless special rule when locked in combat with a unit that includes any models with the Psyker Unit Sub-type.</description>
+        </rule>
+      </rules>
+    </categoryEntry>
+    <categoryEntry id="a7e3-4559-7267-8bf6" name="Silent Sisterhood (Chamber of Obivion)" hidden="false">
+      <rules>
+        <rule id="c4ce-323b-11a5-c9f6" name="Silent Sisterhood (Chamber of Obivion)" publicationId="15a4-fc68-502d-48a9" page="40" hidden="false">
+          <description>All models with this variant of the Silent Sisterhood (X) special rule gain the Fearless special rule when locked in combat with a unit that includes any models with the Daemon Unit Type or Corrupted Unit Sub-type.</description>
+        </rule>
+      </rules>
+    </categoryEntry>
+    <categoryEntry id="b6d7-6924-37fb-dd32" name="Silent Sisterhood (Chamber of Vigilance)" hidden="false">
+      <rules>
+        <rule id="efd8-4a41-bd4b-058b" name="Silent Sisterhood (Chamber of Vigilance)" publicationId="15a4-fc68-502d-48a9" page="40" hidden="false">
+          <description>A unit composed entirely of models with this variant of the Silent Sisterhood (X) special rule may be given one of the following special rules before the start of the battle’s first turn, before any models are deployed: Scout or Infiltrate. When selecting an army using the Sisters of Silence Army List, a unit made up entirely of models with this variant of the Silent Sisterhood (X) special rule may be selected without restriction regardless of which HQ choices are selected for the army.</description>
         </rule>
       </rules>
     </categoryEntry>
@@ -303,6 +324,9 @@
               </characteristics>
             </profile>
           </profiles>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+          </costs>
         </selectionEntry>
         <selectionEntry id="b01d-d89f-1f20-cdd1" name="Neural Shredder" publicationId="15a4-fc68-502d-48a9" page="117" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
@@ -332,6 +356,9 @@
             </infoLink>
             <infoLink id="5db3-abc3-954b-32f4" name="Template Weapons" hidden="false" targetId="5e0e-88e6-db81-5a70" type="rule"/>
           </infoLinks>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+          </costs>
         </selectionEntry>
         <selectionEntry id="5e0c-0168-9fa7-e80a" name="Phase Sword" publicationId="15a4-fc68-502d-48a9" page="117" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
@@ -360,6 +387,9 @@
               </modifiers>
             </infoLink>
           </infoLinks>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+          </costs>
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
@@ -434,6 +464,9 @@
               </modifiers>
             </infoLink>
           </infoLinks>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+          </costs>
         </selectionEntry>
         <selectionEntry id="8770-880b-aeb8-eace" name="Biological Overload" publicationId="15a4-fc68-502d-48a9" page="119" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
@@ -448,6 +481,9 @@
           <infoLinks>
             <infoLink id="9504-18ad-41f1-eac8" name="Fleshbane" hidden="false" targetId="40cd-9505-253c-e76f" type="rule"/>
           </infoLinks>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+          </costs>
         </selectionEntry>
         <selectionEntry id="7611-8f95-f990-ed01" name="Executioner Pistol" publicationId="15a4-fc68-502d-48a9" page="119" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
@@ -463,6 +499,9 @@
             <infoLink id="796a-dac2-c495-85dc" name="Bolt Pistol" hidden="false" targetId="c0d3-c136-ef6e-3ff7" type="profile"/>
             <infoLink id="2c5e-66b8-e31c-1488" name="Needle Pistol" hidden="false" targetId="179e-ff9e-8fd6-8ba5" type="profile"/>
           </infoLinks>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+          </costs>
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
@@ -542,6 +581,9 @@
               </modifiers>
             </infoLink>
           </infoLinks>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+          </costs>
         </selectionEntry>
         <selectionEntry id="33d8-dd7e-0fd4-6bfd" name="Needlespine Blaster" publicationId="15a4-fc68-502d-48a9" page="121" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
@@ -569,6 +611,9 @@
                   </characteristics>
                 </profile>
               </profiles>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+              </costs>
             </selectionEntry>
             <selectionEntry id="6988-a2e1-5542-37b0" name="Needlespine Blaster (Primary)" hidden="false" collective="true" import="true" type="upgrade">
               <constraints>
@@ -589,8 +634,14 @@
                 <infoLink id="708c-27b1-9c25-ffe7" name="Pinning" hidden="false" targetId="1c96-205c-59a0-3cf2" type="rule"/>
                 <infoLink id="6865-b691-7ca6-4af3" name="Poisoned (X)" hidden="false" targetId="e70e-23ea-3251-0edb" type="rule"/>
               </infoLinks>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+              </costs>
             </selectionEntry>
           </selectionEntries>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+          </costs>
         </selectionEntry>
         <selectionEntry id="ada6-3ddf-3009-4dee" name="Decapitation Strike" publicationId="15a4-fc68-502d-48a9" page="121" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
@@ -626,6 +677,9 @@
               </modifiers>
             </infoLink>
           </infoLinks>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+          </costs>
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
@@ -698,6 +752,9 @@
               </modifiers>
             </infoLink>
           </infoLinks>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+          </costs>
         </selectionEntry>
         <selectionEntry id="95d5-e77a-9c27-1648" name="Toxin Ejector" publicationId="15a4-fc68-502d-48a9" page="123" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
@@ -727,6 +784,9 @@
               </modifiers>
             </infoLink>
           </infoLinks>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+          </costs>
         </selectionEntry>
         <selectionEntry id="b060-1ead-cba6-fcfa" name="Poison Globes" publicationId="15a4-fc68-502d-48a9" page="123" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
@@ -740,6 +800,9 @@
               </characteristics>
             </profile>
           </profiles>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+          </costs>
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
@@ -881,7 +944,1433 @@
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
       </costs>
     </selectionEntry>
+    <selectionEntry id="8339-4003-fe88-b536" name="Adrathic Destructor" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="e7e2-d04f-4361-8e89" name="Adrathic Destructor" publicationId="15a4-fc68-502d-48a9" page="145" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="95ba-cda7-b831-6066">12&quot;</characteristic>
+            <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">5</characteristic>
+            <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">3</characteristic>
+            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Assault 1, Instant Death, Armourbane (Ranged), Gets Hot</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="2b71-45bc-1c2a-e19c" name="Instant Death" hidden="false" targetId="9e96-fff1-b916-d9a3" type="rule"/>
+        <infoLink id="20c2-64b3-d0b1-bdc8" name="Armourbane (X)" hidden="false" targetId="cb59-f920-f071-7cd4" type="rule">
+          <modifiers>
+            <modifier type="set" field="name" value="Armourbane (Ranged)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="b1fa-07a0-2176-f6fb" name="Gets Hot" hidden="false" targetId="679f-9d97-5ace-a652" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="6613-a83e-8274-6e06" name="Twin-Linked Adrathic Destructor" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="c176-69ca-f617-127f" name="Twin-linked Adrathic Destructor" publicationId="15a4-fc68-502d-48a9" page="145" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="95ba-cda7-b831-6066">12&quot;</characteristic>
+            <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">5</characteristic>
+            <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">3</characteristic>
+            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Assault 1, Instant Death, Armourbane (Ranged), Gets Hot, Twin-linked</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="1a2c-daf6-0853-9154" name="Armourbane (X)" hidden="false" targetId="cb59-f920-f071-7cd4" type="rule">
+          <modifiers>
+            <modifier type="set" field="name" value="Armourbane (Ranged)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="ce35-dd58-face-518e" name="Gets Hot" hidden="false" targetId="679f-9d97-5ace-a652" type="rule"/>
+        <infoLink id="4daa-26e1-fa26-7235" name="Instant Death" hidden="false" targetId="9e96-fff1-b916-d9a3" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="1887-051d-c262-513b" name="Twin-Linked Adrathic Destructor" hidden="false" collective="true" import="true" type="upgrade">
+      <infoLinks>
+        <infoLink id="62fd-64f2-33a7-65c3" name="Twin-linked Adrathic Destructor" hidden="false" targetId="c176-69ca-f617-127f" type="profile"/>
+        <infoLink id="5e00-7c96-7f31-9d96" name="Armourbane (X)" hidden="false" targetId="cb59-f920-f071-7cd4" type="rule">
+          <modifiers>
+            <modifier type="set" field="name" value="Armourbane (Ranged)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="c617-962f-a9a8-cc64" name="Gets Hot" hidden="false" targetId="679f-9d97-5ace-a652" type="rule"/>
+        <infoLink id="3c22-f365-07f7-2117" name="Instant Death" hidden="false" targetId="9e96-fff1-b916-d9a3" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="6445-e0ea-58ac-ac6c" name="Knight Centura" hidden="false" collective="false" import="true" type="unit">
+      <infoLinks>
+        <infoLink id="e8f3-e1c5-14e8-3db1" name="Silent Sisterhood (X)" hidden="false" targetId="1d8d-3038-9267-6f1b" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="3b60-7e5f-45af-4c86" name="Anathema Sub-type" hidden="false" targetId="7e5d-d73e-8ff4-7345" primary="false"/>
+        <categoryLink id="43a7-a7d4-2954-300a" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="5e7a-fd33-fc06-c2a3" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
+        <categoryLink id="3757-51ca-d9a5-915c" name="Light Sub-type:" hidden="false" targetId="bff2-ae16-74a8-8712" primary="false"/>
+        <categoryLink id="493c-37a2-9320-5dfc" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="1592-b1b2-3d7e-5304" name="Knight Centura" hidden="false" collective="false" import="true" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="36cf-d00c-e952-1e3a" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bd70-499d-c8d9-2de5" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="eb17-053d-db2f-caee" name="Knight Centura" publicationId="15a4-fc68-502d-48a9" page="45" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
+              <characteristics>
+                <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Character, Light, Anathema)</characteristic>
+                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">6</characteristic>
+                <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">5</characteristic>
+                <characteristic name="BS" typeId="74ae-c840-0036-d244">5</characteristic>
+                <characteristic name="S" typeId="e478-41d4-a092-48a8">3</characteristic>
+                <characteristic name="T" typeId="c32b-5fdd-3fbe-9b1f">3</characteristic>
+                <characteristic name="W" typeId="57ee-1126-32a9-5672">3</characteristic>
+                <characteristic name="I" typeId="62d3-22d7-2d49-52dc">5</characteristic>
+                <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">3</characteristic>
+                <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">9</characteristic>
+                <characteristic name="Save" typeId="e593-6b3c-f169-04f0">2+</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <infoLinks>
+            <infoLink id="8c49-467d-22ae-ba2e" name="Fleet (X)" hidden="false" targetId="ddc9-0b4b-78da-bbd2" type="rule">
+              <modifiers>
+                <modifier type="set" field="name" value="Fleet (1)"/>
+              </modifiers>
+            </infoLink>
+            <infoLink id="b3c0-169a-3f77-f02a" name="Stubborn" hidden="false" targetId="7989-1f2c-a43d-82ae" type="rule"/>
+            <infoLink id="79b4-4e2e-84ac-61eb" name="Hatred (X)" hidden="false" targetId="dc0b-fe69-6b71-e0a4" type="rule">
+              <modifiers>
+                <modifier type="set" field="name" value="Hatred (Psykers, Daemons, Corrupted)"/>
+              </modifiers>
+            </infoLink>
+            <infoLink id="2c52-a14d-efcb-1fc5" name="Precision Shots (X)" hidden="false" targetId="4b71-81ee-31f4-fa09" type="rule">
+              <modifiers>
+                <modifier type="set" field="name" value="Precision Strikes (6+)"/>
+              </modifiers>
+            </infoLink>
+            <infoLink id="8ccf-8d4b-5756-f6ee" name="Precision Strikes (X)" hidden="false" targetId="2206-8497-8fe1-e973" type="rule">
+              <modifiers>
+                <modifier type="set" field="name" value="Precision Shots (6+)"/>
+              </modifiers>
+            </infoLink>
+            <infoLink id="083f-a7e6-e796-7cfe" name="Ex-Oblivio" hidden="false" targetId="7982-9292-ef54-8e84" type="rule"/>
+            <infoLink id="afcb-2efd-cac5-c195" name="Loyalist" hidden="false" targetId="d1de-a45d-2b9b-c878" type="rule"/>
+          </infoLinks>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="a1cd-4bf4-795e-54df" name="1) Melee Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="6323-b5b9-e057-3906">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="382a-a649-d6cf-5d8b" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="6323-b5b9-e057-3906" name="Execution Blade" hidden="false" collective="false" import="true" targetId="adc6-3519-204d-2921" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="name" value="Master-crafted Execution Blade"/>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4a1c-51fc-d5e6-b4e1" type="max"/>
+                  </constraints>
+                  <infoLinks>
+                    <infoLink id="a038-1928-ddc4-7880" name="Master-crafted" hidden="false" targetId="6de0-55b0-bf21-48b9" type="rule">
+                      <modifiers>
+                        <modifier type="set" field="hidden" value="true">
+                          <conditions>
+                            <condition field="selections" scope="1592-b1b2-3d7e-5304" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8f79-d31f-9516-367f" type="equalTo"/>
+                          </conditions>
+                        </modifier>
+                      </modifiers>
+                    </infoLink>
+                  </infoLinks>
+                </entryLink>
+                <entryLink id="3db4-c3b1-ad07-d94a" name="Power Axe" hidden="false" collective="false" import="true" targetId="c066-2ace-f68c-e440" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="name" value="Master-crafted Power Axe"/>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a75e-caf7-2367-9263" type="max"/>
+                  </constraints>
+                  <infoLinks>
+                    <infoLink id="ddee-2084-0561-6478" name="Master-crafted" hidden="false" targetId="6de0-55b0-bf21-48b9" type="rule">
+                      <modifiers>
+                        <modifier type="set" field="hidden" value="true">
+                          <conditions>
+                            <condition field="selections" scope="1592-b1b2-3d7e-5304" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8f79-d31f-9516-367f" type="equalTo"/>
+                          </conditions>
+                        </modifier>
+                      </modifiers>
+                    </infoLink>
+                  </infoLinks>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="b8ae-0c67-9815-71a9" name="Power Lance" hidden="false" collective="false" import="true" targetId="a4c8-c8ff-87f2-1ac9" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="name" value="Master-crafted Power Lance"/>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9a4a-b031-7bd0-26dd" type="max"/>
+                  </constraints>
+                  <infoLinks>
+                    <infoLink id="b745-ad21-a500-28af" name="Master-crafted" hidden="false" targetId="6de0-55b0-bf21-48b9" type="rule">
+                      <modifiers>
+                        <modifier type="set" field="hidden" value="true">
+                          <conditions>
+                            <condition field="selections" scope="1592-b1b2-3d7e-5304" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8f79-d31f-9516-367f" type="equalTo"/>
+                          </conditions>
+                        </modifier>
+                      </modifiers>
+                    </infoLink>
+                  </infoLinks>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="75b3-b061-2fda-9aa1" name="Power Maul" hidden="false" collective="false" import="true" targetId="0df4-c67e-cf64-82e0" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="name" value="Master-crafted Power Maul"/>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="af92-a94d-c1bc-324d" type="max"/>
+                  </constraints>
+                  <infoLinks>
+                    <infoLink id="180e-b5dc-c831-8b03" name="Master-crafted" hidden="false" targetId="6de0-55b0-bf21-48b9" type="rule">
+                      <modifiers>
+                        <modifier type="set" field="hidden" value="true">
+                          <conditions>
+                            <condition field="selections" scope="1592-b1b2-3d7e-5304" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8f79-d31f-9516-367f" type="equalTo"/>
+                          </conditions>
+                        </modifier>
+                      </modifiers>
+                    </infoLink>
+                  </infoLinks>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="2810-85de-5657-b564" name="Power Sword" hidden="false" collective="false" import="true" targetId="a3cd-aa97-a148-2309" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="name" value="Master-crafted Power Sword"/>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4d42-c427-b1aa-9bb7" type="max"/>
+                  </constraints>
+                  <infoLinks>
+                    <infoLink id="8db5-237f-daa5-dce8" name="Master-crafted" hidden="false" targetId="6de0-55b0-bf21-48b9" type="rule">
+                      <modifiers>
+                        <modifier type="set" field="hidden" value="true">
+                          <conditions>
+                            <condition field="selections" scope="1592-b1b2-3d7e-5304" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8f79-d31f-9516-367f" type="equalTo"/>
+                          </conditions>
+                        </modifier>
+                      </modifiers>
+                    </infoLink>
+                  </infoLinks>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="ee12-0c73-db62-fad3" name="Charnabal Glaive" hidden="false" collective="false" import="true" targetId="c07c-35e6-4616-ef25" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="name" value="Master-crafted Charnabal Glaive"/>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3627-8841-29aa-1342" type="max"/>
+                  </constraints>
+                  <infoLinks>
+                    <infoLink id="75ed-dc09-19ef-722a" name="Master-crafted" hidden="false" targetId="6de0-55b0-bf21-48b9" type="rule">
+                      <modifiers>
+                        <modifier type="set" field="hidden" value="true">
+                          <conditions>
+                            <condition field="selections" scope="1592-b1b2-3d7e-5304" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8f79-d31f-9516-367f" type="equalTo"/>
+                          </conditions>
+                        </modifier>
+                      </modifiers>
+                    </infoLink>
+                  </infoLinks>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="bb23-dd49-40e5-1004" name="Proteus Neuro-lash" hidden="false" collective="false" import="true" targetId="4d36-dac5-86a1-46cc" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="name" value="Master-crafted Proteus Neuro-lash"/>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9da0-3d8e-a496-e539" type="max"/>
+                  </constraints>
+                  <infoLinks>
+                    <infoLink id="af6a-8486-4469-a9e4" name="Master-crafted" hidden="false" targetId="6de0-55b0-bf21-48b9" type="rule">
+                      <modifiers>
+                        <modifier type="set" field="hidden" value="true">
+                          <conditions>
+                            <condition field="selections" scope="1592-b1b2-3d7e-5304" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8f79-d31f-9516-367f" type="equalTo"/>
+                          </conditions>
+                        </modifier>
+                      </modifiers>
+                    </infoLink>
+                  </infoLinks>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="da79-0214-2c18-af3d" name="Charnabal Sabre" hidden="false" collective="false" import="true" targetId="30c2-57eb-5bbe-be0b" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="name" value="Master-crafted Charnabal Sabre"/>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e662-3649-a753-76dc" type="max"/>
+                  </constraints>
+                  <infoLinks>
+                    <infoLink id="7edd-2c57-fcbe-a595" name="Master-crafted" hidden="false" targetId="6de0-55b0-bf21-48b9" type="rule">
+                      <modifiers>
+                        <modifier type="set" field="hidden" value="true">
+                          <conditions>
+                            <condition field="selections" scope="1592-b1b2-3d7e-5304" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8f79-d31f-9516-367f" type="equalTo"/>
+                          </conditions>
+                        </modifier>
+                      </modifiers>
+                    </infoLink>
+                  </infoLinks>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="9092-8d0a-60aa-cb4d" name="Charnabal Tabar" hidden="false" collective="false" import="true" targetId="4611-c33e-f360-7246" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="name" value="Master-crafted Charnabal Tabar"/>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="87de-2a26-0e5a-2b2e" type="max"/>
+                  </constraints>
+                  <infoLinks>
+                    <infoLink id="b3dc-6565-daf1-e730" name="Master-crafted" hidden="false" targetId="6de0-55b0-bf21-48b9" type="rule">
+                      <modifiers>
+                        <modifier type="set" field="hidden" value="true">
+                          <conditions>
+                            <condition field="selections" scope="1592-b1b2-3d7e-5304" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8f79-d31f-9516-367f" type="equalTo"/>
+                          </conditions>
+                        </modifier>
+                      </modifiers>
+                    </infoLink>
+                  </infoLinks>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                  </costs>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="ef64-2c68-cea4-4bc8" name="2) Ranged Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="e969-93a1-77b8-8e4d">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ac06-3b2b-131e-9858" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="e969-93a1-77b8-8e4d" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="e5ae-6872-37aa-8600" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="name" value="Master-crafted Bolt Pistol"/>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="369c-8d32-24f6-768e" type="max"/>
+                  </constraints>
+                  <infoLinks>
+                    <infoLink id="9ad1-2697-b8d4-5241" name="Master-crafted" hidden="false" targetId="6de0-55b0-bf21-48b9" type="rule">
+                      <modifiers>
+                        <modifier type="set" field="hidden" value="true">
+                          <conditions>
+                            <condition field="selections" scope="1592-b1b2-3d7e-5304" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9739-6bae-baf2-d658" type="equalTo"/>
+                          </conditions>
+                        </modifier>
+                      </modifiers>
+                    </infoLink>
+                  </infoLinks>
+                </entryLink>
+                <entryLink id="25ab-290b-1325-834a" name="Hand Flamer" hidden="false" collective="false" import="true" targetId="e337-adf4-a11f-0280" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="name" value="Master-crafted Hand Flamer"/>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d4c7-dedb-6b89-1e07" type="max"/>
+                  </constraints>
+                  <infoLinks>
+                    <infoLink id="5ce2-ad51-0928-9cd8" name="Master-crafted" hidden="false" targetId="6de0-55b0-bf21-48b9" type="rule">
+                      <modifiers>
+                        <modifier type="set" field="hidden" value="true">
+                          <conditions>
+                            <condition field="selections" scope="1592-b1b2-3d7e-5304" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9739-6bae-baf2-d658" type="equalTo"/>
+                          </conditions>
+                        </modifier>
+                      </modifiers>
+                    </infoLink>
+                  </infoLinks>
+                </entryLink>
+                <entryLink id="b54a-0827-eeda-1c05" name="Needle Pistol" hidden="false" collective="false" import="true" targetId="fdd4-06c7-4608-b07f" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="name" value="Master-crafted Needle Pistol"/>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a8bd-5187-a014-6425" type="max"/>
+                  </constraints>
+                  <infoLinks>
+                    <infoLink id="2a28-7436-8f6d-e997" name="Master-crafted" hidden="false" targetId="6de0-55b0-bf21-48b9" type="rule">
+                      <modifiers>
+                        <modifier type="set" field="hidden" value="true">
+                          <conditions>
+                            <condition field="selections" scope="1592-b1b2-3d7e-5304" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9739-6bae-baf2-d658" type="equalTo"/>
+                          </conditions>
+                        </modifier>
+                      </modifiers>
+                    </infoLink>
+                  </infoLinks>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="f295-eb57-0c3b-6f0d" name="Plasma Pistol" hidden="false" collective="false" import="true" targetId="717f-cf0a-1593-4bd8" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="name" value="Master-crafted Plasma Pistol"/>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="82e5-7cbb-cc10-cb51" type="max"/>
+                  </constraints>
+                  <infoLinks>
+                    <infoLink id="c7e9-7a0d-e283-6851" name="Master-crafted" hidden="false" targetId="6de0-55b0-bf21-48b9" type="rule">
+                      <modifiers>
+                        <modifier type="set" field="hidden" value="true">
+                          <conditions>
+                            <condition field="selections" scope="1592-b1b2-3d7e-5304" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9739-6bae-baf2-d658" type="equalTo"/>
+                          </conditions>
+                        </modifier>
+                      </modifiers>
+                    </infoLink>
+                  </infoLinks>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="26c9-7b84-8331-dba5" name="Archaeotech Pistol" hidden="false" collective="false" import="true" targetId="c22a-ed4d-af68-bf00" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="name" value="Master-crafted Archaeotech Pistol"/>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="688a-0bf4-4397-295b" type="max"/>
+                  </constraints>
+                  <infoLinks>
+                    <infoLink id="d4fb-d122-b366-696f" name="Master-crafted" hidden="false" targetId="6de0-55b0-bf21-48b9" type="rule">
+                      <modifiers>
+                        <modifier type="set" field="hidden" value="true">
+                          <conditions>
+                            <condition field="selections" scope="1592-b1b2-3d7e-5304" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9739-6bae-baf2-d658" type="equalTo"/>
+                          </conditions>
+                        </modifier>
+                      </modifiers>
+                    </infoLink>
+                  </infoLinks>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                  </costs>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="747e-83f2-6c43-4e8a" name="3) May upgrade any one weapon to have the Master-crafted" hidden="false" collective="false" import="true">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="10ad-33b4-602a-a53b" type="max"/>
+              </constraints>
+              <selectionEntries>
+                <selectionEntry id="9739-6bae-baf2-d658" name="Ranged Weapon" hidden="false" collective="false" import="true" type="upgrade">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4274-6067-410b-c72f" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="8f79-d31f-9516-367f" name="Melee Weapon" hidden="false" collective="false" import="true" type="upgrade">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d044-a3ac-c617-c2ec" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="4d55-9f6c-51b2-eef6" name="Retinue" hidden="false" collective="false" import="true">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9c46-a1f5-20c7-66fa" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="29fe-f3d9-aa65-bd03" name="Raptora Cadre" hidden="false" collective="false" import="true" targetId="7117-e1f5-1a14-9716" type="selectionEntry"/>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks>
+            <entryLink id="904f-8bde-5b47-8099" name="Silent Sisterhood (Chamber of Obivion)" hidden="false" collective="false" import="true" targetId="7856-71cb-a1fb-bc43" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5737-9f57-3c96-edee" type="min"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="c3cf-fe6f-47ec-acda" name="Frag Grenades" hidden="false" collective="false" import="true" targetId="cf9c-327b-3449-00d7" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="43dc-a613-24c6-0bbb" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1aa4-43b3-c0da-9ecc" type="max"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="ce56-bcac-8359-1667" name="Krak Grenades" hidden="false" collective="false" import="true" targetId="99df-2421-acf7-a5ad" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="022a-f4e3-e1ae-414d" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8630-0dff-cfd6-fb70" type="max"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="f496-6ae3-7029-6712" name="Psyk-out Granades" hidden="false" collective="false" import="true" targetId="2d34-959c-a93c-888f" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0ea2-6bbb-2550-4cc2" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e10e-21bc-23ed-44de" type="max"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="9c2d-9f76-12e0-6c87" name="Voidscale Cloak" hidden="false" collective="false" import="true" targetId="bd74-a0c5-cee0-bb03" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8d81-dc66-7eb7-501e" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c5e3-2321-2c46-683a" type="max"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="dfe6-87b9-1c98-7159" name="Artificer Armour" hidden="false" collective="false" import="true" targetId="583e-62cb-53f1-f952" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a72a-2310-0003-8858" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="748e-0007-c99e-aec4" type="max"/>
+              </constraints>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="55.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="4d36-dac5-86a1-46cc" name="Proteus Neuro-lash" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="c6af-bab9-ba23-7b87" name="Proteus Neuro-lash" publicationId="15a4-fc68-502d-48a9" page="150" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="95ba-cda7-b831-6066">-</characteristic>
+            <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">+3</characteristic>
+            <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">-</characteristic>
+            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Melee, Two-handed. Deflagerate</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="6ab6-9ce8-338b-3291" name="Two-handed" hidden="false" targetId="4c23-e863-a569-7617" type="rule"/>
+        <infoLink id="5f0d-f662-9b19-6ad0" name="Deflagrate" hidden="false" targetId="60bc-f79a-67ae-be4f" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="d125-c647-343f-16c2" name="Voidscale Cloak" hidden="false" collective="true" import="true" type="upgrade">
+      <infoLinks>
+        <infoLink id="962b-a404-be59-30b7" name="Voidscale Cloak" hidden="false" targetId="21eb-92ea-8c87-7ba3" type="profile"/>
+      </infoLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="adc6-3519-204d-2921" name="Execution Blade" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="e680-1d54-4ca7-c791" name="Execution Blade" publicationId="15a4-fc68-502d-48a9" page="149" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="95ba-cda7-b831-6066">-</characteristic>
+            <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">+2</characteristic>
+            <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">3</characteristic>
+            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Melee, Two-handed, Rending (6+)</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="8f97-9494-d64c-8e45" name="Rending (X)" hidden="false" targetId="0ac9-fab7-aef3-de1d" type="rule">
+          <modifiers>
+            <modifier type="set" field="name" value="Rending (6+)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="3b35-df7d-c283-49d8" name="Two-handed" hidden="false" targetId="4c23-e863-a569-7617" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="9449-eb87-30c1-43c0" name="Voidsheen Cloak" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="7223-c1e4-6d91-8722" name="Voidsheen Cloak" publicationId="15a4-fc68-502d-48a9" page="159" hidden="false" typeId="2a1f-7837-f0ef-be44" typeName="Wargear Item">
+          <characteristics>
+            <characteristic name="Description" typeId="347e-ee4a-764f-6be3">A voidsheen cloak confers a 6+ Invulnerable Save, increasing to 4+ against any Hits from weapons with the Template or Blast special rules.</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="16fa-53b2-b57b-ec25" name="Kharon Pattern Acquistor" hidden="false" collective="false" import="true" type="unit">
+      <profiles>
+        <profile id="3d62-db2c-bfd9-f558" name="Kharon Pattern Acquistor" publicationId="15a4-fc68-502d-48a9" page="56" hidden="false" typeId="2fae-b053-3f78-e7b2" typeName=" Vehicle">
+          <characteristics>
+            <characteristic name="Unit Type" typeId="e555-4aed-dfcc-c0b4">Vehicle (Transport, Antigrav, Fast)</characteristic>
+            <characteristic name="Move" typeId="3614-4a2d-bffb-90e4">16</characteristic>
+            <characteristic name="BS" typeId="51fb-b7d9-aa59-863d">4</characteristic>
+            <characteristic name="Front" typeId="0ef8-a648-01d0-08ee">13</characteristic>
+            <characteristic name="Side" typeId="f150-c0dc-c192-9cb3">12</characteristic>
+            <characteristic name="Rear" typeId="8d4e-2aea-fffc-d556">11</characteristic>
+            <characteristic name="HP" typeId="a76c-83b1-602f-9e62">4</characteristic>
+            <characteristic name="Transport Capacity" typeId="0c90-79e2-f768-e547">16</characteristic>
+            <characteristic name="Access Points" typeId="e217-1b1e-9494-3e3e">A Kharon Pattern Acquisitor has one Access Point at the front.</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="d185-af4f-542b-5372" name="Assault Vehicle" hidden="false" targetId="aa61-11f6-2bb5-7c0e" type="rule"/>
+        <infoLink id="38d9-fd81-82cd-e3e4" name="Night Vision" hidden="false" targetId="683e-b4f2-f032-d31b" type="rule"/>
+        <infoLink id="c784-2eec-e982-b927" name="Deep Strike" hidden="false" targetId="f1e1-986f-c783-ca9e" type="rule"/>
+        <infoLink id="a4c8-a0ae-4166-05aa" name="Outflank" hidden="false" targetId="bfbf-e75c-49a2-0285" type="rule"/>
+        <infoLink id="224b-37f7-3a41-2483" name="Loyalist" hidden="false" targetId="d1de-a45d-2b9b-c878" type="rule"/>
+      </infoLinks>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="7e38-26bb-d5f0-65a3" name="1) Hull (Front) Mounted Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="0142-6796-c6be-c419">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b466-ea01-7642-85a6" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1579-1f91-a64b-7079" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="9cd2-6deb-b860-bacc" name="Multi-Melta" hidden="false" collective="false" import="true" targetId="9332-3834-cf3a-56b4" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="name" value="Twin-linked Multi-Melta"/>
+              </modifiers>
+            </entryLink>
+            <entryLink id="0142-6796-c6be-c419" name="Hellion Heavy Cannon Array" hidden="false" collective="false" import="true" targetId="a17e-c567-c602-892e" type="selectionEntry"/>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="f452-3a10-29a1-ff45" name="2) Two Hull (Front) Mounted Vratine Missile Launchers" hidden="false" collective="false" import="true" defaultSelectionEntryId="b1b8-f434-2b0a-dd01">
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f7b6-04a1-000a-3c07" type="min"/>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dd92-d3b0-55bc-7003" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="b1b8-f434-2b0a-dd01" name="Vratine Missile Launcher" hidden="false" collective="false" import="true" targetId="0ee4-7a2e-804a-a934" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c49c-f286-da87-a195" type="min"/>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9fac-c6a1-f2d9-20bf" type="max"/>
+              </constraints>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="3220-c80e-8952-3df2" name="3) Silent Sisterhood" hidden="false" collective="false" import="true">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="45a0-4358-5e1e-4528" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="86a6-d67a-9082-8fec" name="Silent Sisterhood (Chamber of Obivion)" hidden="true" collective="false" import="true" targetId="7856-71cb-a1fb-bc43" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="50d8-8e4a-6a39-1673" value="1.0">
+                  <conditions>
+                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a7e3-4559-7267-8bf6" type="instanceOf"/>
+                  </conditions>
+                </modifier>
+                <modifier type="set" field="hidden" value="false">
+                  <conditions>
+                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a7e3-4559-7267-8bf6" type="instanceOf"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="50d8-8e4a-6a39-1673" type="min"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="b892-fd2a-47ac-a447" name="Silent Sisterhood (Chamber of Vigilance)" hidden="true" collective="false" import="true" targetId="7b50-6b5d-e6f9-420b" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="d441-b417-eacb-f135" value="1.0">
+                  <conditions>
+                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b6d7-6924-37fb-dd32" type="instanceOf"/>
+                  </conditions>
+                </modifier>
+                <modifier type="set" field="hidden" value="false">
+                  <conditions>
+                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b6d7-6924-37fb-dd32" type="instanceOf"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d441-b417-eacb-f135" type="min"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="8cdc-1f8f-6b2a-4554" name="Silent Sisterhood (Chamber of Judgement)" hidden="true" collective="false" import="true" targetId="ade4-0f3a-c307-9dc2" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="bcf8-f035-c750-a4fc" value="1.0">
+                  <conditions>
+                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b71a-371d-4401-9dc0" type="instanceOf"/>
+                  </conditions>
+                </modifier>
+                <modifier type="set" field="hidden" value="false">
+                  <conditions>
+                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b71a-371d-4401-9dc0" type="instanceOf"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bcf8-f035-c750-a4fc" type="min"/>
+              </constraints>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="1722-d651-7bbc-58fb" name="Spectra Distort Shield" hidden="false" collective="false" import="true" targetId="d11a-3108-ea62-ffac" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fe64-b58f-6716-e1d5" type="min"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="83ef-ccd7-566b-359b" name="Smoke Launchers" hidden="false" collective="false" import="true" targetId="0873-34dd-e52d-d33c" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d6e6-6775-1f7e-0e86" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d82a-3b31-c251-837b" type="min"/>
+          </constraints>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="150.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="7117-e1f5-1a14-9716" name="Raptora Cadre" publicationId="15a4-fc68-502d-48a9" page="50" hidden="false" collective="false" import="true" type="unit">
+      <infoLinks>
+        <infoLink id="571d-048f-aa67-c5fd" name="Silent Sisterhood (X)" hidden="false" targetId="1d8d-3038-9267-6f1b" type="rule"/>
+        <infoLink id="afc5-491b-a9cb-17b7" name="Fleet (X)" hidden="false" targetId="ddc9-0b4b-78da-bbd2" type="rule">
+          <modifiers>
+            <modifier type="set" field="name" value="Fleet (1)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="9e6c-3aae-e8e3-0b17" name="Stubborn" hidden="false" targetId="7989-1f2c-a43d-82ae" type="rule"/>
+        <infoLink id="6f95-d6fc-2eaa-62d9" name="Precision Strikes (X)" hidden="false" targetId="2206-8497-8fe1-e973" type="rule">
+          <modifiers>
+            <modifier type="set" field="name" value="Precision Strikes (6+)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="43c0-07f8-986b-da88" name="Hatred (X)" hidden="false" targetId="dc0b-fe69-6b71-e0a4" type="rule">
+          <modifiers>
+            <modifier type="set" field="name" value="Hatred (Psykers, Daemons, Corrupted)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="d947-3572-0f03-b0ce" name="Chosen Warriors" hidden="false" targetId="13d1-9270-6539-08ed" type="rule"/>
+        <infoLink id="f57f-b796-b020-a382" name="Support Squad" hidden="false" targetId="768e-56d6-ca52-24ae" type="rule"/>
+        <infoLink id="5b25-94e6-b6af-a2eb" name="Loyalist" hidden="false" targetId="d1de-a45d-2b9b-c878" type="rule"/>
+        <infoLink id="02d4-08aa-cda7-7dc0" name="Retinue" hidden="false" targetId="6b79-ac44-4d89-2124" type="rule">
+          <modifiers>
+            <modifier type="set" field="description" value="A Raptora Cadre may only be chosen as a Retinue for a model with both the Silent Sisterhood (Chamber of Oblivion) and Independent Character special rules. This model is referred to as the Raptora Cadre’s Leader for the purposes of this special rule. The Raptora Cadre does not use up a Force Organisation slot and is considered part of the same unit as the model taken as its Leader. The Raptora Cadre must be deployed with the model selected as its Leader deployed as part of the unit and the Leader may not voluntarily leave the Raptora Cadre during play. A Raptora Cadre may not be selected as part of an army without a Leader."/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="2ae6-fc9f-9300-77c7" name="Silent Sisterhood (Chamber of Obivion)" hidden="false" targetId="a7e3-4559-7267-8bf6" primary="false"/>
+        <categoryLink id="72f6-efd8-4b99-9005" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="d3a6-616d-1ed7-510c" name="Light Sub-type:" hidden="false" targetId="bff2-ae16-74a8-8712" primary="false"/>
+        <categoryLink id="65aa-2cac-8a1b-a325" name="Line Sub-type:" hidden="false" targetId="6399-5c65-7833-1025" primary="false"/>
+        <categoryLink id="1464-daad-b4d9-98bb" name="Anathema Sub-type" hidden="false" targetId="7e5d-d73e-8ff4-7345" primary="false"/>
+      </categoryLinks>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="592c-ac85-a052-3988" name="1) Raptora" hidden="false" collective="false" import="true" defaultSelectionEntryId="b36b-03e7-6f3c-c6c6">
+          <constraints>
+            <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="48a0-6f24-dc5a-c3fb" type="max"/>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ab62-06f3-d660-df34" type="min"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="b36b-03e7-6f3c-c6c6" name="Raptora w/ Bolt Pistol &amp; Execution Blade" hidden="false" collective="false" import="true" type="model">
+              <constraints>
+                <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5f5f-d437-fd89-c7c5" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="b248-9879-dec2-1d41" name="Raptora" publicationId="15a4-fc68-502d-48a9" page="50" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
+                  <characteristics>
+                    <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Light, Line, Anathema)</characteristic>
+                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">6</characteristic>
+                    <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">5</characteristic>
+                    <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
+                    <characteristic name="S" typeId="e478-41d4-a092-48a8">3</characteristic>
+                    <characteristic name="T" typeId="c32b-5fdd-3fbe-9b1f">3</characteristic>
+                    <characteristic name="W" typeId="57ee-1126-32a9-5672">2</characteristic>
+                    <characteristic name="I" typeId="62d3-22d7-2d49-52dc">4</characteristic>
+                    <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">2</characteristic>
+                    <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">8</characteristic>
+                    <characteristic name="Save" typeId="e593-6b3c-f169-04f0">3+</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <entryLinks>
+                <entryLink id="e18e-5740-cc0f-dc6b" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="52fe-46cd-520d-9df3" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8635-c1c9-f6a7-03e3" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7188-417d-218a-2341" type="max"/>
+                  </constraints>
+                </entryLink>
+                <entryLink id="e14a-f0ff-e707-6530" name="Execution Blade (Placeholder)" hidden="false" collective="false" import="true" targetId="b902-5e27-e3ec-18ca" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0d26-4911-f5dc-e3de" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c0e7-1805-0bac-168f" type="max"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="2b01-077a-ee75-257b" name="Raptora w/ Hand Flamer &amp; Execution Blade" hidden="false" collective="false" import="true" type="model">
+              <constraints>
+                <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8487-547f-03b4-b896" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="387b-351e-6d8e-2b3a" name="Raptora" hidden="false" targetId="b248-9879-dec2-1d41" type="profile"/>
+              </infoLinks>
+              <entryLinks>
+                <entryLink id="681a-a489-0a68-0ebe" name="Execution Blade (Placeholder)" hidden="false" collective="false" import="true" targetId="b902-5e27-e3ec-18ca" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a428-1dd7-b1e7-f8da" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8078-787b-2e5d-8744" type="max"/>
+                  </constraints>
+                </entryLink>
+                <entryLink id="6511-fa15-814f-2aa1" name="Hand Flamer" hidden="false" collective="false" import="true" targetId="6b5f-d62d-7568-38b6" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1f7b-b4d3-f6cb-523c" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2f02-07e4-e9b1-b738" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                  </costs>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="f238-8c3a-8a31-8aec" name="Raptora w/ Needle Pistol &amp; Execution Blade" hidden="false" collective="false" import="true" type="model">
+              <constraints>
+                <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="108a-9241-6158-e0d2" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="ca4f-aafa-caed-97a3" name="Raptora" hidden="false" targetId="b248-9879-dec2-1d41" type="profile"/>
+              </infoLinks>
+              <entryLinks>
+                <entryLink id="52fd-f6e7-f753-ed05" name="Execution Blade (Placeholder)" hidden="false" collective="false" import="true" targetId="b902-5e27-e3ec-18ca" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c28f-abdb-a76e-489b" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e48f-9743-5031-a4c5" type="max"/>
+                  </constraints>
+                </entryLink>
+                <entryLink id="0a78-e452-65c5-ad19" name="Needle Pistol" hidden="false" collective="false" import="true" targetId="fd59-e665-136c-1172" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c443-0e73-24c8-27e3" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cf8c-82b7-7106-3461" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                  </costs>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="9989-8033-2e76-ef25" name="Raptora w/ Options" hidden="false" collective="false" import="true" type="model">
+              <infoLinks>
+                <infoLink id="4454-98d5-38b2-bcfa" name="Raptora" hidden="false" targetId="b248-9879-dec2-1d41" type="profile"/>
+              </infoLinks>
+              <selectionEntryGroups>
+                <selectionEntryGroup id="cfbd-b5ee-beaf-e9b5" name="May exchange their Execution blades for:" hidden="false" collective="false" import="true" defaultSelectionEntryId="ebca-26a3-2b85-34c2">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2742-aaf5-2e47-ce3e" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="44df-c122-6761-4d71" type="min"/>
+                  </constraints>
+                  <selectionEntryGroups>
+                    <selectionEntryGroup id="5a42-0dfc-7f97-9a53" name="2 models may exchange their Execution blades for:" hidden="false" collective="false" import="true">
+                      <constraints>
+                        <constraint field="selections" scope="7117-e1f5-1a14-9716" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0c72-0579-05a3-4d7a" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3c0a-0f47-c61a-568c" type="max"/>
+                      </constraints>
+                      <entryLinks>
+                        <entryLink id="e53a-3de6-a1b3-6437" name="Power Fist" hidden="false" collective="false" import="true" targetId="768d-b89b-7328-d749" type="selectionEntry">
+                          <constraints>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d4fb-3406-16bc-4c00" type="max"/>
+                          </constraints>
+                          <costs>
+                            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                          </costs>
+                        </entryLink>
+                        <entryLink id="b7ce-484c-0fa5-584e" name="Proteus Neuro-lash" hidden="false" collective="false" import="true" targetId="4d36-dac5-86a1-46cc" type="selectionEntry">
+                          <constraints>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b99e-192b-4543-794f" type="max"/>
+                          </constraints>
+                          <costs>
+                            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                          </costs>
+                        </entryLink>
+                      </entryLinks>
+                    </selectionEntryGroup>
+                  </selectionEntryGroups>
+                  <entryLinks>
+                    <entryLink id="ebca-26a3-2b85-34c2" name="Execution Blade" hidden="false" collective="false" import="true" targetId="adc6-3519-204d-2921" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c58b-4922-b83f-2e7e" type="max"/>
+                      </constraints>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="de37-246c-a1d8-f1e3" name="May take:" hidden="false" collective="false" import="true">
+                  <entryLinks>
+                    <entryLink id="0c0e-35eb-c707-2083" name="Nuncio-Vox" hidden="false" collective="false" import="true" targetId="005e-aae6-ddac-bb45" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="75b7-c59b-e06a-c32d" type="max"/>
+                        <constraint field="selections" scope="7117-e1f5-1a14-9716" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6229-01e1-5575-185a" type="max"/>
+                      </constraints>
+                      <costs>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="13f3-0154-515e-5d6a" name="Augury Scanner" hidden="false" collective="false" import="true" targetId="67ee-7338-3b74-04b4" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8bea-1635-9f6b-3af4" type="max"/>
+                        <constraint field="selections" scope="7117-e1f5-1a14-9716" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="122b-5fb4-7279-054c" type="max"/>
+                      </constraints>
+                      <costs>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                      </costs>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="1709-da98-6548-5bde" name="May exchange a bolt pistol for:" hidden="false" collective="false" import="true" defaultSelectionEntryId="54e9-8c0f-7d0f-c653">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="265f-8029-3adb-100a" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6294-5c1f-2561-8bd3" type="min"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="54e9-8c0f-7d0f-c653" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="e5ae-6872-37aa-8600" type="selectionEntry"/>
+                    <entryLink id="e954-47d5-43ec-17d8" name="Needle Pistol" hidden="false" collective="false" import="true" targetId="fdd4-06c7-4608-b07f" type="selectionEntry">
+                      <costs>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="d325-7190-cf5f-6d5e" name="Hand Flamer" hidden="false" collective="false" import="true" targetId="e337-adf4-a11f-0280" type="selectionEntry">
+                      <costs>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="e4d6-3c35-0d1f-ad15" name="Plasma Pistol" hidden="false" collective="false" import="true" targetId="717f-cf0a-1593-4bd8" type="selectionEntry">
+                      <costs>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                      </costs>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="add5-7f42-e431-86a2" name="2) Dedicated Transport" hidden="false" collective="false" import="true">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2dbd-d760-cbce-83d6" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="848a-edbc-a3f4-0fba" name="Kharon Pattern Acquistor (Placeholder)" hidden="false" collective="false" import="true" targetId="16fa-53b2-b57b-ec25" type="selectionEntry"/>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="d955-855f-2f4b-22db" name="Krak Grenades" hidden="false" collective="false" import="true" targetId="99df-2421-acf7-a5ad" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8b9a-2f76-c6eb-5021" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1bd7-071b-832b-37ad" type="min"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="6cc8-12c3-4a3c-0da9" name="Frag Grenades" hidden="false" collective="false" import="true" targetId="cf9c-327b-3449-00d7" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="461e-8ef7-6b19-4bbf" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ccaa-1f0e-b90c-cbbc" type="max"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="30e3-e295-099b-ff78" name="Psyk-out Granades" hidden="false" collective="false" import="true" targetId="2d34-959c-a93c-888f" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9ac8-097c-6b95-86b7" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="996b-138a-2f28-951c" type="min"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="fd33-1d7c-8a16-7f40" name="Vratine Armour" hidden="false" collective="false" import="true" targetId="d466-63c8-7784-cd84" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6dd6-2ce2-8ea7-ed9c" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b925-a02e-4d98-1a2e" type="min"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="ffb9-6e4a-8612-1c0e" name="Voidsheen Cloak" hidden="false" collective="false" import="true" targetId="9449-eb87-30c1-43c0" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6e4b-cbd7-e2ed-6a9b" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e262-4457-dcc7-fd32" type="min"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="78cc-a61c-1b45-abd1" name="Silent Sisterhood (Chamber of Obivion)" hidden="false" collective="false" import="true" targetId="7856-71cb-a1fb-bc43" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5722-f9f0-71be-89fe" type="min"/>
+          </constraints>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="7bb3-794e-c334-4136" name="Adrathic Destructor" hidden="false" collective="true" import="true" type="upgrade">
+      <infoLinks>
+        <infoLink id="11ef-8068-e1ba-6875" name="Adrathic Destructor" hidden="false" targetId="e7e2-d04f-4361-8e89" type="profile"/>
+        <infoLink id="2411-0a28-63ff-3d71" name="Gets Hot" hidden="false" targetId="679f-9d97-5ace-a652" type="rule"/>
+        <infoLink id="68bf-e3ad-f37e-c71c" name="Instant Death" hidden="false" targetId="9e96-fff1-b916-d9a3" type="rule"/>
+        <infoLink id="1313-d4ac-6cbd-9b6c" name="Armourbane (X)" hidden="false" targetId="cb59-f920-f071-7cd4" type="rule">
+          <modifiers>
+            <modifier type="set" field="name" value="Armourbane (Ranged)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="b902-5e27-e3ec-18ca" name="Execution Blade" hidden="false" collective="true" import="true" type="upgrade">
+      <infoLinks>
+        <infoLink id="52c5-acb7-16d9-bebf" name="Execution Blade" hidden="false" targetId="e680-1d54-4ca7-c791" type="profile"/>
+        <infoLink id="e319-ba4d-1bd2-a9d3" name="Two-handed" hidden="false" targetId="4c23-e863-a569-7617" type="rule"/>
+        <infoLink id="9fa9-17e4-82cd-4ca4" name="Rending (X)" hidden="false" targetId="0ac9-fab7-aef3-de1d" type="rule">
+          <modifiers>
+            <modifier type="set" field="name" value="Rending (6+)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="bd74-a0c5-cee0-bb03" name="Voidscale Cloak" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="21eb-92ea-8c87-7ba3" name="Voidscale Cloak" publicationId="15a4-fc68-502d-48a9" page="159" hidden="false" typeId="2a1f-7837-f0ef-be44" typeName="Wargear Item">
+          <characteristics>
+            <characteristic name="Description" typeId="347e-ee4a-764f-6be3">A voidscale cloak confers a 5+ Invulnerable Save, increasing to 3+ against any Hits from weapons with the Template or Blast special rules.</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="91c6-82e2-3c3e-fe76" name="Vratine Armour" hidden="false" collective="true" import="true" type="upgrade">
+      <infoLinks>
+        <infoLink id="47b7-7aad-2508-c625" name="Vratine Armour" hidden="false" targetId="eaf9-0555-cc91-e313" type="profile"/>
+      </infoLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="d466-63c8-7784-cd84" name="Vratine Armour" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="eaf9-0555-cc91-e313" name="Vratine Armour" publicationId="15a4-fc68-502d-48a9" page="159" hidden="false" typeId="2a1f-7837-f0ef-be44" typeName="Wargear Item">
+          <characteristics>
+            <characteristic name="Description" typeId="347e-ee4a-764f-6be3">Vratine armour confers an 3+ Armour Save</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="65c1-1f76-7b8a-2aa9" name="Voidsheen Cloak" hidden="false" collective="true" import="true" type="upgrade">
+      <infoLinks>
+        <infoLink id="7c22-3219-60bb-da31" name="Voidsheen Cloak" hidden="false" targetId="7223-c1e4-6d91-8722" type="profile"/>
+      </infoLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="d130-4af2-1ea4-e18d" name="Proteus Neuro-lash" hidden="false" collective="true" import="true" type="upgrade">
+      <infoLinks>
+        <infoLink id="efc1-066e-6f16-6443" name="Proteus Neuro-lash" hidden="false" targetId="c6af-bab9-ba23-7b87" type="profile"/>
+        <infoLink id="29f5-30cc-1360-9b39" name="Two-handed" hidden="false" targetId="4c23-e863-a569-7617" type="rule"/>
+        <infoLink id="3b9c-35b5-6338-bebc" name="Deflagrate" hidden="false" targetId="60bc-f79a-67ae-be4f" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="fd59-e665-136c-1172" name="Needle Pistol" publicationId="d0df-7166-5cd3-89fd" page="53" hidden="false" collective="true" import="true" type="upgrade">
+      <infoLinks>
+        <infoLink id="6de7-ad65-0b06-0a26" name="Pinning" hidden="false" targetId="1c96-205c-59a0-3cf2" type="rule"/>
+        <infoLink id="f69f-7ac3-6424-2c10" name="Poisoned (X)" hidden="false" targetId="e70e-23ea-3251-0edb" type="rule">
+          <modifiers>
+            <modifier type="set" field="name" value="Poisoned (3+)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="f467-4c2f-5324-f40d" name="Needle Pistol" hidden="false" targetId="179e-ff9e-8fd6-8ba5" type="profile"/>
+      </infoLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="d11a-3108-ea62-ffac" name="Spectra Distort Shield" hidden="false" collective="false" import="true" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e6ae-d4a7-5bfc-df92" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="3658-e9bd-38cf-4af7" name="Spectra Distort Shield" publicationId="15a4-fc68-502d-48a9" page="158" hidden="false" typeId="2a1f-7837-f0ef-be44" typeName="Wargear Item">
+          <characteristics>
+            <characteristic name="Description" typeId="347e-ee4a-764f-6be3">Whenever targeted by a Shooting Attack, the range between an attacking unit and a model with the Vehicle Unit Type with a spectra distort shield is considered to be 8&quot; further than the actual range between the two units – enemy units with the Night Vision special rule and models with the Primarch Unit Type ignore this effect. In addition, when attacked by a weapon with the Barrage special rule a model with the Vehicle Unit Type and a spectra distort shield is always treated as though it was out of line of sight when scattering any attacks.</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="a17e-c567-c602-892e" name="Hellion Heavy Cannon Array" publicationId="15a4-fc68-502d-48a9" page="140" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="ef57-e1a5-024b-0c5a" name="Hellion Heavy Cannon Array" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="95ba-cda7-b831-6066">24&quot;</characteristic>
+            <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">7</characteristic>
+            <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">4</characteristic>
+            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Heavy 6, Pinning</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="a51a-471e-caa9-e354" name="Pinning" hidden="false" targetId="1c96-205c-59a0-3cf2" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="0ee4-7a2e-804a-a934" name="Vratine Missile Launcher" publicationId="15a4-fc68-502d-48a9" page="144" hidden="false" collective="false" import="true" type="upgrade">
+      <selectionEntries>
+        <selectionEntry id="1394-c3da-ebc1-38c0" name="Vratine Missile Launcher - Frag" hidden="false" collective="true" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7d8c-c470-aee5-b4dd" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="02a1-644b-2ca5-245a" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="5215-16d3-5473-7d8c" name="Vratine Missile Launcher - Frag" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+              <characteristics>
+                <characteristic name="Range" typeId="95ba-cda7-b831-6066">48&quot;</characteristic>
+                <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">4</characteristic>
+                <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">6</characteristic>
+                <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Heavy 1, Blast (3&quot;), Pinning</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="b339-178e-db02-5604" name="Vratine Missile Launcher - Krak" hidden="false" collective="true" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9710-50d9-07b6-b88d" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="347a-d39c-7634-5931" type="min"/>
+          </constraints>
+          <profiles>
+            <profile id="3922-6af4-6555-2e2a" name="Vratine Missile Launcher - Krak" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+              <characteristics>
+                <characteristic name="Range" typeId="95ba-cda7-b831-6066">48&quot;</characteristic>
+                <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">8</characteristic>
+                <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">3</characteristic>
+                <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Heavy 1</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="73c5-06bc-7283-351b" name="Vratine Missile Launcher - Psyk-out" hidden="false" collective="true" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b973-43a5-f1c6-4a2e" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e344-58a4-7059-9b20" type="min"/>
+          </constraints>
+          <profiles>
+            <profile id="3c7f-3e24-05d4-290e" name="Vratine Missile Launcher - Psyk-out" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+              <characteristics>
+                <characteristic name="Range" typeId="95ba-cda7-b831-6066">36&quot;</characteristic>
+                <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">7</characteristic>
+                <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">3</characteristic>
+                <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Heavy 1, Psy-shock</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="3f00-1930-8fcb-41c5" name="Inferno Pistol" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="06f6-f9d8-fa6a-4769" name="Inferno Pistol " hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="95ba-cda7-b831-6066">6&quot;</characteristic>
+            <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">8</characteristic>
+            <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">1</characteristic>
+            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Pistol 1, Armourbane (Melta)</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="d9bb-ec94-4a5a-fe61" name="Armourbane (X)" hidden="false" targetId="cb59-f920-f071-7cd4" type="rule">
+          <modifiers>
+            <modifier type="set" field="name" value="Armourbane (Melta)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="2460-375d-31f4-4bdf" name="Blast Pistol" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="07f3-f3c5-628b-babb" name="Blast Pistol" publicationId="15a4-fc68-502d-48a9" page="143" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="95ba-cda7-b831-6066">9&quot;</characteristic>
+            <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">6</characteristic>
+            <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">4</characteristic>
+            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Pistol 2</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="d68e-ce5a-000c-c322" name="Lascarbine" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="6e5b-6829-41b3-c292" name="Lascarbine" publicationId="15a4-fc68-502d-48a9" page="143" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="95ba-cda7-b831-6066">18&quot;</characteristic>
+            <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">3</characteristic>
+            <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">6</characteristic>
+            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Assault 2</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="3335-928e-aef8-ca0f" name="Lascarbine" hidden="false" collective="true" import="true" type="upgrade">
+      <infoLinks>
+        <infoLink id="6509-f79d-5fba-c9bb" name="Lascarbine" hidden="false" targetId="6e5b-6829-41b3-c292" type="profile"/>
+      </infoLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="376e-c5d6-99c3-49c9" name="Lasgun" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="72c8-ca7d-984d-590d" name="Lasgun" publicationId="15a4-fc68-502d-48a9" page="143" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="95ba-cda7-b831-6066">24&quot;</characteristic>
+            <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">3</characteristic>
+            <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">-</characteristic>
+            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Rapid Fire</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="0b4e-2811-0529-f22f" name="Lasgun" hidden="false" collective="true" import="true" type="upgrade">
+      <infoLinks>
+        <infoLink id="7df1-3b1a-2863-965d" name="Lasgun" hidden="false" targetId="72c8-ca7d-984d-590d" type="profile"/>
+      </infoLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="15f9-817e-275b-c13d" name="Lasrifle" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="f755-3fa4-db2a-9540" name="Lasrifle (Velley)" publicationId="15a4-fc68-502d-48a9" page="143" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="95ba-cda7-b831-6066">30&quot;</characteristic>
+            <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">3</characteristic>
+            <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">6</characteristic>
+            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Heavy 2</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="3eeb-f71b-46e1-f7d4" name="Lasrifle (Blast Charger)" publicationId="15a4-fc68-502d-48a9" page="143" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="95ba-cda7-b831-6066">18&quot;</characteristic>
+            <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">6</characteristic>
+            <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">4</characteristic>
+            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Heavy 1</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="2449-dc45-3441-b471" name="Lasrifle" hidden="false" collective="true" import="true" type="upgrade">
+      <infoLinks>
+        <infoLink id="84c5-6839-17db-f251" name="Lasrifle (Blast Charger)" hidden="false" targetId="3eeb-f71b-46e1-f7d4" type="profile"/>
+        <infoLink id="f024-01ba-e7d4-c537" name="Lasrifle (Velley)" hidden="false" targetId="f755-3fa4-db2a-9540" type="profile"/>
+      </infoLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="57dd-dff6-d173-3bf1" name="Autorifle" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="1d1b-9c50-ad0b-81f6" name="Autorifle" publicationId="15a4-fc68-502d-48a9" page="140" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="95ba-cda7-b831-6066">24&quot;</characteristic>
+            <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">3</characteristic>
+            <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">-</characteristic>
+            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Rapid Fire</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="f3ff-0995-248a-5243" name="Autorifle" hidden="false" collective="true" import="true" type="upgrade">
+      <infoLinks>
+        <infoLink id="2a2b-c2dd-93e3-3434" name="Autorifle" hidden="false" targetId="1d1b-9c50-ad0b-81f6" type="profile"/>
+      </infoLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="a7cc-88cb-c6e8-6d4c" name="Stubcarbine" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="a832-5bff-ad61-066a" name="Stubcarbine" publicationId="15a4-fc68-502d-48a9" page="140" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="95ba-cda7-b831-6066">12&quot;</characteristic>
+            <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">3</characteristic>
+            <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">-</characteristic>
+            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Assault 3</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="090f-d3b8-9e92-40e3" name="Stubcarbine" hidden="false" collective="true" import="true" type="upgrade">
+      <infoLinks>
+        <infoLink id="d291-0acf-32ec-d74b" name="Stubcarbine" hidden="false" targetId="a832-5bff-ad61-066a" type="profile"/>
+      </infoLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="e0f3-3743-a9d0-f5f1" name="Grenade Launcher" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="9edf-5b4f-f269-c98e" name="Grenade launcher - Krak" publicationId="a716-c1c4-7b26-8424" page="130" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="95ba-cda7-b831-6066">24&quot;</characteristic>
+            <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">5</characteristic>
+            <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">4</characteristic>
+            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Assault 1</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="7223-39b1-9ee8-bbc0" name="Grenade launcher - Frag" publicationId="a716-c1c4-7b26-8424" page="130" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="95ba-cda7-b831-6066">24&quot;</characteristic>
+            <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">3</characteristic>
+            <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">6</characteristic>
+            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Assault 1, Blast (3&quot;), Pinning</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="eb7a-1305-afa8-6362" name="Blast" hidden="false" targetId="1d9a-73ef-5f4f-8bd8" type="rule"/>
+        <infoLink id="40e8-b20c-77ad-0282" name="Pinning" hidden="false" targetId="1c96-205c-59a0-3cf2" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="e27d-6534-ec82-dcd2" name="Grenade Launcher" hidden="false" collective="true" import="true" type="upgrade">
+      <infoLinks>
+        <infoLink id="a07c-976c-787c-7e39" name="Blast" hidden="false" targetId="1d9a-73ef-5f4f-8bd8" type="rule"/>
+        <infoLink id="2013-d374-760f-d5e6" name="Pinning" hidden="false" targetId="1c96-205c-59a0-3cf2" type="rule"/>
+        <infoLink id="76f0-c871-4618-dc2a" name="Grenade launcher - Frag" hidden="false" targetId="7223-39b1-9ee8-bbc0" type="profile"/>
+        <infoLink id="b1e5-639f-5e03-46d4" name="Grenade launcher - Krak" hidden="false" targetId="9edf-5b4f-f269-c98e" type="profile"/>
+      </infoLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
   </sharedSelectionEntries>
+  <sharedSelectionEntryGroups>
+    <selectionEntryGroup id="a329-aa45-a45c-f92a" name="Silent Sisterhood (X)" hidden="false" collective="false" import="true">
+      <selectionEntries>
+        <selectionEntry id="ade4-0f3a-c307-9dc2" name="Silent Sisterhood (Chamber of Judgement)" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="f43a-8973-e1ac-2c14" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="d7f2-9a15-c98c-ecbc" name="Silent Sisterhood (Chamber of Judgement)" hidden="false" targetId="04a5-fa60-5ebe-aa9d" type="rule"/>
+          </infoLinks>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="7856-71cb-a1fb-bc43" name="Silent Sisterhood (Chamber of Obivion)" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="b763-bcf8-1a91-3b90" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="81c2-6d1a-6520-7924" name="Silent Sisterhood (Chamber of Obivion)" hidden="false" targetId="c4ce-323b-11a5-c9f6" type="rule"/>
+          </infoLinks>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="7b50-6b5d-e6f9-420b" name="Silent Sisterhood (Chamber of Vigilance)" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="ce01-c675-57d8-a4a1" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="ba10-8eb6-4a3b-669a" name="Silent Sisterhood (Chamber of Vigilance)" hidden="false" targetId="efd8-4a41-bd4b-058b" type="rule"/>
+          </infoLinks>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+    </selectionEntryGroup>
+  </sharedSelectionEntryGroups>
+  <sharedRules>
+    <rule id="7982-9292-ef54-8e84" name="Ex-Oblivio" publicationId="15a4-fc68-502d-48a9" page="132" hidden="false">
+      <description>At the start of any combat in the Assault phase, before the beginning of Initiative step 10, the controlling player of a model with this special rule may declare its use. When used, roll a D6 and select a single enemy model in base contact with the model that has this special rule (including a model that is Engaged in a Challenge with that model) – that enemy model must reduce its Weapon Skill to 1 for the remainder of the current player turn. If the dice roll results in a result of 2-6 then there is no further effect, but if the dice roll results in a result of 1 then the model with this special rule suffers a single Wound against which no Armour Saves, Cover Saves or Invulnerable Saves may be taken (Damage Mitigation rolls may be taken as normal).</description>
+    </rule>
+    <rule id="1d8d-3038-9267-6f1b" name="Silent Sisterhood (X)" publicationId="15a4-fc68-502d-48a9" page="39" hidden="false">
+      <description>The notation in brackets that is included as part of the Silent Sisterhood (X) special rule defines which Chamber Militant the model belongs to. This Chamber Militant may grant the model some additional rules or effects and influences how it may be selected when building an army that incorporates a Detachment with the Sisters of Silence Faction. 
+When selecting a Detachment using the Sisters of Silence Army List, the number of units of Chambers Militant other than the Chamber of Vigilance is limited. For each HQ choice with a given Chamber Militant, the Detachment may include up to three other choices of the same Chamber Militant (except for units with the Chamber of Vigilance variant of the Silent Sisterhood (X) special rule, of which an army may include any number, limited only by available Force Organisation slots). Note that Dedicated Transports and units selected using the Retinue special rule do not count against these limits regardless of their variant of the Silent Sisterhood (X) special rule.
+For example, a Sisters of Silence Detachment includes three HQ choices – two Knights Centura (Chamber of Oblivion) and a Silent Judge (Chamber of Judgement). This army may include any number of units from the Chamber of Vigilance, up to six units from the Chamber of Oblivion, and up to three units from the Chamber of Judgement.</description>
+    </rule>
+  </sharedRules>
   <sharedProfiles>
     <profile id="71d4-b924-c931-1b45" name="Advanced Reaction: Tactical Displacement" publicationId="15a4-fc68-502d-48a9" page="113" hidden="false" typeId="90b9-7fab-87db-aed3" typeName="Reactions">
       <characteristics>

--- a/2022 - Mechanicum.cat
+++ b/2022 - Mechanicum.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="c247-da79-1654-d39e" name="2022 - Mechanicum" revision="14" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="32" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="c247-da79-1654-d39e" name="2022 - Mechanicum" revision="16" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="34" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entryLinks>
     <entryLink id="29c6-0ec7-0162-e817" name="Mechanicum" hidden="false" collective="false" import="false" targetId="ddf5-d792-3146-6e9a" type="selectionEntry">
       <constraints>
@@ -395,6 +395,125 @@
       <categoryLinks>
         <categoryLink id="6b3d-b497-866a-d8a0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="a12c-791f-fbf5-c999" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="4463-b650-886c-ccdf" name="Clade Adamus Assassin" hidden="true" collective="false" import="false" targetId="0510-bd97-e047-88bf" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="8833-3e66-3151-2887" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="a6f8-a668-7218-e406" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="fd65-5e88-a411-841e" name="Clade Callidus Assassin" hidden="true" collective="false" import="false" targetId="aeac-aef4-984e-fe79" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="2b00-1299-dfe4-bf1d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="06e5-5200-ae1d-5f95" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="cbd3-1799-1a28-cd10" name="Clade Culexus Assassin" hidden="true" collective="false" import="false" targetId="4d3f-0c69-bf50-9076" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="e993-cf16-dc5e-39a4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="6a3d-cb27-0d0a-8e37" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="1099-28b4-f975-37d3" name="Clade Eversor Assassin" hidden="true" collective="false" import="false" targetId="5d50-77c2-5943-4c3f" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="e1dd-9263-7f49-3cb1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="1543-6c30-604c-6047" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="ce9d-8409-92d3-501d" name="Clade Vanus Infocyte Assassin" hidden="true" collective="false" import="false" targetId="3976-8d49-21fc-2633" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="4390-5192-d06b-a0d4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="24a0-1f7c-d6ac-e8bf" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="50f8-abcc-a3d1-34d2" name="Clade Venenum Assassin" hidden="true" collective="false" import="false" targetId="32f2-1209-7402-4d0d" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="f526-14c5-c41b-f32a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="7708-6dc6-bc56-d4a6" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="bb43-7503-1b2c-0305" name="Clade Vindicare Assassin" hidden="true" collective="false" import="false" targetId="abaf-b2fa-1d41-a315" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="e7db-682d-7cd1-db0e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="537f-65db-34ff-789a" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
       </categoryLinks>
     </entryLink>
   </entryLinks>
@@ -4823,12 +4942,6 @@ removed as a casualty.�</characteristic>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="90fc-4de7-a2db-ab4b" type="max"/>
           </constraints>
         </entryLink>
-        <entryLink id="f00e-042e-cb53-305d" name="Las-lock" hidden="false" collective="false" import="true" targetId="6491-5e10-ba7e-e0d3" type="selectionEntry">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5e89-b350-d474-b2c4" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0153-5180-71f7-0eaa" type="max"/>
-          </constraints>
-        </entryLink>
       </entryLinks>
       <costs>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
@@ -6550,5 +6663,6 @@ Additionally, each time Inar Satarael makes a successful Invulnable Save on a ro
   </sharedSelectionEntries>
   <catalogueLinks>
     <catalogueLink id="5f24-4626-71c3-0547" name="2022 - Mech Library" targetId="3129-da35-55e0-642d" type="catalogue" importRootEntries="true"/>
+    <catalogueLink id="e048-9e5e-507c-5ba4" name="2022 - Liber Imperium Library" targetId="f3f1-b05f-eefe-4ee4" type="catalogue" importRootEntries="true"/>
   </catalogueLinks>
 </catalogue>

--- a/2022 - Titan Legions.cat
+++ b/2022 - Titan Legions.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="c01b-0224-f806-0d23" name="2022 - Titan Legions" revision="5" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="22" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="c01b-0224-f806-0d23" name="2022 - Titan Legions" revision="6" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="33" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <forceEntries>
     <forceEntry id="aebe-bed9-b32f-a8ea" name="Titan Maniple" hidden="false">
       <categoryLinks>
@@ -84,6 +84,125 @@
       <categoryLinks>
         <categoryLink id="8940-f885-bcc9-b74f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="a270-c7de-cbbf-fd44" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="4a1b-0084-e1f6-92d5" name="Clade Adamus Assassin" hidden="true" collective="false" import="false" targetId="0510-bd97-e047-88bf" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="e2ac-74e1-a0da-b8e2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="c312-68da-28d6-bbd7" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="13ed-56d5-3cb5-cb63" name="Clade Callidus Assassin" hidden="true" collective="false" import="false" targetId="aeac-aef4-984e-fe79" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="aa82-72a3-edba-19ba" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="3d1c-86b1-e68b-e165" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="8050-e965-f8ec-eacd" name="Clade Culexus Assassin" hidden="true" collective="false" import="false" targetId="4d3f-0c69-bf50-9076" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="e16b-37ae-e39a-14b8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="a850-e521-5a6a-c014" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="056d-5474-ac39-eb5d" name="Clade Eversor Assassin" hidden="true" collective="false" import="false" targetId="5d50-77c2-5943-4c3f" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="f820-109d-d205-1965" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="5ac9-de0c-0793-bc36" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="8c13-e001-31c6-03a1" name="Clade Vanus Infocyte Assassin" hidden="true" collective="false" import="false" targetId="3976-8d49-21fc-2633" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="b52c-96db-9852-71c3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="2acd-5cff-c975-1b4f" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="b756-8767-b52b-b6d1" name="Clade Venenum Assassin" hidden="true" collective="false" import="false" targetId="32f2-1209-7402-4d0d" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="1f4e-e8dc-2472-a311" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="0b14-19f7-06ad-7a3e" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="d991-3819-a524-12a1" name="Clade Vindicare Assassin" hidden="true" collective="false" import="false" targetId="abaf-b2fa-1d41-a315" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="236c-6158-89b4-8021" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="d601-d692-d3cb-a06c" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
       </categoryLinks>
     </entryLink>
   </entryLinks>
@@ -737,5 +856,6 @@
   </sharedSelectionEntries>
   <catalogueLinks>
     <catalogueLink id="de74-d2a5-d0be-55c8" name="2022 - Mech Library" targetId="3129-da35-55e0-642d" type="catalogue" importRootEntries="true"/>
+    <catalogueLink id="e048-9e5e-507c-5ba4" name="2022 - Liber Imperium Library" targetId="f3f1-b05f-eefe-4ee4" type="catalogue" importRootEntries="true"/>
   </catalogueLinks>
 </catalogue>


### PR DESCRIPTION
This should:
Added components to GST to allow Custodes, SoS and SA to work.
Add assassins for all (into LA, Mech, Titans) & linked to the LI library.
Give Solmon Khan his Sister of silence option and unit. Have HQ/Elite/Troops/Fast and a part done Cohorts for Solar Auxilia. A Placeholder only list for Custodes.

Please set a title for the PR describing your changes,
fill out the information below, and delete this heading.

