### PR TITLE
Deathwing Companions Primarch Retinue & Consul Bug

### DIFF
--- a/2022 - LA - Dark Angels.cat
+++ b/2022 - LA - Dark Angels.cat
@@ -2685,6 +2685,24 @@
         <categoryLink id="8411-1862-5232-cf37" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
+    <entryLink id="3eda-15e2-e4e7-bf3f" name="Deathwing Companion Detachment" hidden="false" collective="false" import="true" targetId="a9b5-ef4c-31db-4104" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="fe6b-5937-4498-074e" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true"/>
+        <categoryLink id="3807-ebca-b93d-3e84" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="d38e-7277-5dd4-8dd5" name="Deathwing Terminator Cataphractii Companions" hidden="false" collective="false" import="true" targetId="0f58-8273-a8b5-196e" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="c2cd-5e6c-4a00-f3d4" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true"/>
+        <categoryLink id="2761-5121-e1c4-34e2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="f1da-c433-8744-4d77" name="Deathwing Terminator Tartaros Companions" hidden="false" collective="false" import="true" targetId="3053-608b-d111-6fd7" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="00ea-853a-67d8-3a01" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true"/>
+        <categoryLink id="39df-9018-7ec3-3ca2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+      </categoryLinks>
+    </entryLink>
   </entryLinks>
   <sharedSelectionEntries>
     <selectionEntry id="4097-b2b4-d9da-da99" name="Corswain" hidden="false" collective="false" import="true" type="unit">

--- a/2022 - Legiones Astartes.cat
+++ b/2022 - Legiones Astartes.cat
@@ -44765,7 +44765,7 @@ Hit rolls for each attack, for a total of 24 To Hit rolls over the full 6 attack
             </modifier>
             <modifier type="set" field="1817-1a25-72ab-6fc9" value="1.0">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6e1e-8616-6e4a-173d" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6e1e-8616-6e4a-173d" type="equalTo"/>
               </conditions>
             </modifier>
           </modifiers>


### PR DESCRIPTION
# Deathwing Companions Primarch Retinue & Consularis Issue

## Fixed Units
- Deathwing companions now appear as an option for Primarch Retinue when Lion El'Jonson is selected.
-  Fixed an issue where Siege Breaker was a mandatory upgrade for Centurions.

### Related Issues

* closes #2626, #2609 

## Test Case
![deathwing companions](https://user-images.githubusercontent.com/47039299/205417757-bc1c34a8-e6f4-4b68-b65f-a17d076560dc.png)


