### PR TITLE
Patches for row   toreador

### DIFF
--- a/2022 - Horus Heresy.gst
+++ b/2022 - Horus Heresy.gst
@@ -405,6 +405,7 @@ During Reactions made in any Phase, a unit equipped with Jump PAcks may not acti
               <conditions>
                 <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="12f2-df1a-525f-7957" type="equalTo"/>
                 <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="64a2-0d7a-e716-e67f" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7a43-6793-013b-1af6" type="equalTo"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
@@ -861,6 +862,7 @@ In addition, when a Fast Vehicle moves, it may choose to move at Flat-out:</desc
               <conditions>
                 <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="12f2-df1a-525f-7957" type="equalTo"/>
                 <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="64a2-0d7a-e716-e67f" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7a43-6793-013b-1af6" type="equalTo"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
@@ -6975,10 +6977,10 @@ In addition, a model with the Paragon of Metal special rule may not be targeted 
             <conditionGroup type="or">
               <conditions>
                 <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="64a2-0d7a-e716-e67f" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0fa2-d71c-9cdb-86cb" type="equalTo"/>
                 <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e864-ddc1-da3a-138e" type="equalTo"/>
                 <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="12f2-df1a-525f-7957" type="equalTo"/>
                 <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e20d-6f02-d7d5-395f" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0fa2-d71c-9cdb-86cb" type="equalTo"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
@@ -11477,6 +11479,13 @@ Limitations
 • A Detachment using this Rite of War may include only a single Heavy Support choice.</description>
             </rule>
           </rules>
+          <infoLinks>
+            <infoLink id="af91-a308-9b5e-80d1" name="It Will Not Die (X)" hidden="false" targetId="2784-d0be-a4e2-890f" type="rule">
+              <modifiers>
+                <modifier type="set" field="name" value="It Will Not Die (5+)"/>
+              </modifiers>
+            </infoLink>
+          </infoLinks>
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
           </costs>
@@ -11603,8 +11612,8 @@ Limitations
               <conditionGroups>
                 <conditionGroup type="or">
                   <conditions>
-                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c0df-c1fa-5ddc-9ee5" type="equalTo"/>
                     <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="21c3-2f28-7820-e51a" type="equalTo"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c0df-c1fa-5ddc-9ee5" type="equalTo"/>
                     <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d82b-1980-74f8-5dac" type="equalTo"/>
                   </conditions>
                 </conditionGroup>

--- a/2022 - Horus Heresy.gst
+++ b/2022 - Horus Heresy.gst
@@ -405,7 +405,6 @@ During Reactions made in any Phase, a unit equipped with Jump PAcks may not acti
               <conditions>
                 <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="12f2-df1a-525f-7957" type="equalTo"/>
                 <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="64a2-0d7a-e716-e67f" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7a43-6793-013b-1af6" type="equalTo"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
@@ -862,7 +861,6 @@ In addition, when a Fast Vehicle moves, it may choose to move at Flat-out:</desc
               <conditions>
                 <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="12f2-df1a-525f-7957" type="equalTo"/>
                 <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="64a2-0d7a-e716-e67f" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7a43-6793-013b-1af6" type="equalTo"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
@@ -897,7 +895,7 @@ In addition, when a Fast Vehicle moves, it may choose to move at Flat-out:</desc
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="fa4b-a703-9dbf-bb6a" type="max"/>
           </constraints>
         </categoryLink>
-        <categoryLink id="4240-0870-e7ec-839e" name="Rite of Warzz:" hidden="false" targetId="d494-e450-d4aa-579a" primary="false"/>
+        <categoryLink id="4240-0870-e7ec-839e" name="Rite of War:" hidden="false" targetId="d494-e450-d4aa-579a" primary="false"/>
         <categoryLink id="cb59-2a42-9e16-fbe7" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="false">
           <modifiers>
             <modifier type="set" field="1db1-1803-cee1-86cb" value="5.0">
@@ -1164,6 +1162,7 @@ In addition, when a Fast Vehicle moves, it may choose to move at Flat-out:</desc
                 <conditionGroup type="or">
                   <conditions>
                     <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4ca1-b02c-e2c7-5f09" type="equalTo"/>
+                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="12f2-df1a-525f-7957" type="equalTo"/>
                   </conditions>
                 </conditionGroup>
               </conditionGroups>
@@ -6963,19 +6962,23 @@ In addition, a model with the Paragon of Metal special rule may not be targeted 
           </conditions>
         </modifier>
         <modifier type="set" field="7ae6-be12-f22c-f977" value="1.0">
-          <conditions>
-            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="12f2-df1a-525f-7957" type="equalTo"/>
-          </conditions>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="12f2-df1a-525f-7957" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
         </modifier>
         <modifier type="set" field="ba40-62e6-2111-e938" value="0.0">
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
                 <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="64a2-0d7a-e716-e67f" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0fa2-d71c-9cdb-86cb" type="equalTo"/>
                 <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e864-ddc1-da3a-138e" type="equalTo"/>
                 <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="12f2-df1a-525f-7957" type="equalTo"/>
                 <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e20d-6f02-d7d5-395f" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0fa2-d71c-9cdb-86cb" type="equalTo"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
@@ -11474,13 +11477,6 @@ Limitations
 • A Detachment using this Rite of War may include only a single Heavy Support choice.</description>
             </rule>
           </rules>
-          <infoLinks>
-            <infoLink id="af91-a308-9b5e-80d1" name="It Will Not Die (X)" hidden="false" targetId="2784-d0be-a4e2-890f" type="rule">
-              <modifiers>
-                <modifier type="set" field="name" value="It Will Not Die (5+)"/>
-              </modifiers>
-            </infoLink>
-          </infoLinks>
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
           </costs>
@@ -11607,8 +11603,9 @@ Limitations
               <conditionGroups>
                 <conditionGroup type="or">
                   <conditions>
-                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="21c3-2f28-7820-e51a" type="equalTo"/>
                     <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c0df-c1fa-5ddc-9ee5" type="equalTo"/>
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="21c3-2f28-7820-e51a" type="equalTo"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d82b-1980-74f8-5dac" type="equalTo"/>
                   </conditions>
                 </conditionGroup>
               </conditionGroups>

--- a/2022 - LA - Thousand Sons.cat
+++ b/2022 - LA - Thousand Sons.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="abac-8dd1-df65-e253" name="LA -  XV: Thousand Sons" revision="19" battleScribeVersion="2.03" authorName="Arkangelmark5" authorContact="BSData Developers Discord" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="32" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="abac-8dd1-df65-e253" name="LA -  XV: Thousand Sons" revision="20" battleScribeVersion="2.03" authorName="Arkangelmark5" authorContact="BSData Developers Discord" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="38" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="f743-7ff9-a2f3-01c7" name="Exemplary Battles of the Age of Darkness: The Axandria IV Incident" shortName="Axandria IV" publisher="Exemplary Battles of the Age of Darkness: The Axandria IV Incident" publicationDate="9/16/2022" publisherUrl="https://www.warhammer-community.com/wp-content/uploads/2022/09/3mVvZrTG9XOWeVxv.pdf"/>
   </publications>
@@ -2840,8 +2840,8 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="2606-d746-7f52-0386" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="d2fa-c058-6b0d-94e7" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="6454-4a82-a8bd-af34" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
+        <categoryLink id="084a-976c-4fd9-2d0a" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="9459-1bbc-25cc-935f" name="Thallax Cohort" hidden="true" collective="false" import="false" targetId="25c8-3e0f-e22d-a7eb" type="selectionEntry">
@@ -2868,6 +2868,41 @@
       <categoryLinks>
         <categoryLink id="b216-3ea3-7fc8-276f" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="cefe-d1eb-7654-615c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="6e01-6d4c-dc55-5c19" name="Sekhmet Terminator Cabal" hidden="true" collective="false" import="true" targetId="dda2-bdd0-3ced-b427" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_eafb-5453-4dd9-8623</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_41ad-3585-4031-9b76</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0fa2-d71c-9cdb-86cb" type="equalTo">
+                  <comment>    node_id_a02c-8632-499f-827c</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="a81e-5122-d99f-96a6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="6a2d-4b5c-d2c1-d604" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="ff08-0f1b-ad0f-f01b" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="4a53-e786-ad53-0b9d" name="Castellax-Achea Automata" hidden="true" collective="false" import="true" targetId="95cb-9366-295e-f10d" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="373b-ce5a-ddc5-cf8f" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="f268-8e53-5ac0-a435" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="2a59-d380-e882-32a7" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
       </categoryLinks>
     </entryLink>
   </entryLinks>
@@ -3142,7 +3177,7 @@
         </rule>
       </rules>
       <infoLinks>
-        <infoLink id="e9dd-447e-a8de-1ddb" name="Legiones Astartes (Thousand Sons) " hidden="false" targetId="2377-1d73-44bc-fee2" type="rule"/>
+        <infoLink id="e9dd-447e-a8de-1ddb" name="Legiones Astartes (Thousand Sons)" hidden="false" targetId="2377-1d73-44bc-fee2" type="rule"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="c1ad-3434-2f99-5b24" name="Automata Unit-type:" hidden="false" targetId="d8ab-8e21-e193-63ba" primary="false"/>
@@ -3155,6 +3190,16 @@
               <conditions>
                 <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="da46-48b5-6cc5-9d8b" type="equalTo"/>
               </conditions>
+            </modifier>
+            <modifier type="set" field="c355-0b58-7786-486c" value="2.0">
+              <conditionGroups>
+                <conditionGroup type="and">
+                  <conditions>
+                    <condition field="selections" scope="primary-category" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9b5d-fac7-799b-d7e7" type="instanceOf"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="373b-ce5a-ddc5-cf8f" type="equalTo"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
             </modifier>
           </modifiers>
           <constraints>
@@ -3517,7 +3562,7 @@
         <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d75d-fcad-c8ca-0a77" type="max"/>
       </constraints>
       <infoLinks>
-        <infoLink id="003c-d933-e89e-dc9c" name="Legiones Astartes (Thousand Sons) " hidden="false" targetId="2377-1d73-44bc-fee2" type="rule"/>
+        <infoLink id="003c-d933-e89e-dc9c" name="Legiones Astartes (Thousand Sons)" hidden="false" targetId="2377-1d73-44bc-fee2" type="rule"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="68e3-d5fc-41b5-8cf7" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
@@ -3743,6 +3788,13 @@
       </costs>
     </selectionEntry>
     <selectionEntry id="f1d9-5c86-f496-61f0" name="Ahzek Ahriman" hidden="false" collective="false" import="true" type="unit">
+      <modifiers>
+        <modifier type="add" field="category" value="350d-03ac-0da9-0c8b">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0fa2-d71c-9cdb-86cb" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <constraints>
         <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a3eb-f7d1-c04f-1aff" type="max"/>
       </constraints>
@@ -3930,6 +3982,17 @@
       </costs>
     </selectionEntry>
     <selectionEntry id="dda2-bdd0-3ced-b427" name="Sekhmet Terminator Cabal" hidden="false" collective="false" import="true" type="unit">
+      <modifierGroups>
+        <modifierGroup>
+          <modifiers>
+            <modifier type="add" field="category" value="9b5d-fac7-799b-d7e7">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0fa2-d71c-9cdb-86cb" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </modifierGroup>
+      </modifierGroups>
       <infoLinks>
         <infoLink id="f574-03d6-2b3b-01bc" name="Stubborn" hidden="false" targetId="7989-1f2c-a43d-82ae" type="rule"/>
         <infoLink id="ef2c-8b12-6630-5961" name="Bulky (X)" hidden="false" targetId="676c-7b75-4b6f-9405" type="rule">
@@ -4541,6 +4604,13 @@
       </costs>
     </selectionEntry>
     <selectionEntry id="07f4-98a2-a371-5191" name="Magnus the Red" hidden="false" collective="false" import="true" type="model">
+      <modifiers>
+        <modifier type="add" field="category" value="350d-03ac-0da9-0c8b">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0fa2-d71c-9cdb-86cb" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <constraints>
         <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6898-f9fe-d35a-e601" type="max"/>
       </constraints>
@@ -4578,7 +4648,7 @@
             <modifier type="set" field="name" value="Shrouded (5+)"/>
           </modifiers>
         </infoLink>
-        <infoLink id="414e-3741-48f2-7114" name="Legiones Astartes (Thousand Sons) " hidden="false" targetId="2377-1d73-44bc-fee2" type="rule"/>
+        <infoLink id="414e-3741-48f2-7114" name="Legiones Astartes (Thousand Sons)" hidden="false" targetId="2377-1d73-44bc-fee2" type="rule"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="45af-d7ac-39f4-2234" name="Primarch:" hidden="false" targetId="ad5f-31db-8bc7-5c46" primary="false"/>

--- a/2022 - LA - World Eaters.cat
+++ b/2022 - LA - World Eaters.cat
@@ -2889,6 +2889,30 @@
         <categoryLink id="fe51-d88d-c607-9870" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
+    <entryLink id="46db-1103-afec-c13d" name="Rampager Squad" hidden="false" collective="false" import="false" targetId="2fb9-74a8-43b0-dd00" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="c293-1a6e-3287-c8bd" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="7d74-ff42-876f-f0d0" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="09e5-f24c-2719-d2c4" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="c204-0901-2005-7cba" name="Predator Squadron " hidden="true" collective="false" import="false" targetId="45fd-df3e-9bc4-60b6" type="selectionEntry">
+      <comment>    template_id_59c9-be20-4f7c-b91d</comment>
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_7f87-6d3e-4738-b3ee</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="50cf-edf5-d39a-8943" type="equalTo">
+              <comment>    node_id_cd74-309d-4d08-825e</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="928b-f08c-a155-8962" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="f0dc-4c8f-c31e-9bfb" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+      </categoryLinks>
+    </entryLink>
   </entryLinks>
   <sharedSelectionEntries>
     <selectionEntry id="7a04-bc44-70bb-cb98" name="Red Hand Destroyer Assault Squad" hidden="false" collective="false" import="true" type="unit">
@@ -3942,16 +3966,6 @@
         <modifier type="add" field="category" value="eee8-3c7c-2762-e33e">
           <conditions>
             <condition field="selections" scope="2fb9-74a8-43b0-dd00" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a298-8584-70ed-18ce" type="equalTo"/>
-          </conditions>
-        </modifier>
-        <modifier type="add" field="category" value="9b5d-fac7-799b-d7e7">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="50cf-edf5-d39a-8943" type="equalTo"/>
-          </conditions>
-        </modifier>
-        <modifier type="add" field="category" value="8f42-a824-fb5f-8fea">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="50cf-edf5-d39a-8943" type="equalTo"/>
           </conditions>
         </modifier>
         <modifier type="add" field="category" value="6399-5c65-7833-1025">

--- a/2022 - LA - World Eaters.cat
+++ b/2022 - LA - World Eaters.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="d901-0eca-48b5-304a" name="LA -  XII: World Eaters" revision="18" battleScribeVersion="2.03" authorName="UrsinePatriarch" authorContact="BSData Developers Discord" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="36" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="d901-0eca-48b5-304a" name="LA -  XII: World Eaters" revision="20" battleScribeVersion="2.03" authorName="UrsinePatriarch" authorContact="BSData Developers Discord" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="38" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entryLinks>
     <entryLink id="d647-fd99-73e0-bd57" name="Angron" hidden="false" collective="false" import="false" targetId="6352-8efa-0cc4-cfa7" type="selectionEntry">
       <modifiers>
@@ -491,6 +491,11 @@
               </conditions>
             </conditionGroup>
           </conditionGroups>
+        </modifier>
+        <modifier type="add" field="category" value="2bcf-6bbe-58a1-e082">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c83-69fb-8066-a773" type="equalTo"/>
+          </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
@@ -1500,6 +1505,11 @@
             </conditionGroup>
           </conditionGroups>
         </modifier>
+        <modifier type="add" field="category" value="2bcf-6bbe-58a1-e082">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c83-69fb-8066-a773" type="equalTo"/>
+          </conditions>
+        </modifier>
       </modifiers>
       <categoryLinks>
         <categoryLink id="fb58-4d27-43f3-9937" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1676,6 +1686,11 @@
               </conditions>
             </conditionGroup>
           </conditionGroups>
+        </modifier>
+        <modifier type="add" field="category" value="2bcf-6bbe-58a1-e082">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c83-69fb-8066-a773" type="equalTo"/>
+          </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
@@ -1867,6 +1882,11 @@
             </conditionGroup>
           </conditionGroups>
         </modifier>
+        <modifier type="add" field="category" value="2bcf-6bbe-58a1-e082">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c83-69fb-8066-a773" type="equalTo"/>
+          </conditions>
+        </modifier>
       </modifiers>
       <categoryLinks>
         <categoryLink id="8312-1f0d-4b26-b881" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
@@ -1999,6 +2019,11 @@
               </conditions>
             </conditionGroup>
           </conditionGroups>
+        </modifier>
+        <modifier type="add" field="category" value="2bcf-6bbe-58a1-e082">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c83-69fb-8066-a773" type="equalTo"/>
+          </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
@@ -2850,6 +2875,11 @@
             <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="62c8-8f27-9673-8450" type="greaterThan"/>
           </conditions>
         </modifier>
+        <modifier type="add" field="category" value="db6f-0311-834c-e6ff">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c83-69fb-8066-a773" type="equalTo"/>
+          </conditions>
+        </modifier>
       </modifiers>
       <constraints>
         <constraint field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8d79-887f-d9af-b6b1" type="max"/>
@@ -2862,6 +2892,13 @@
   </entryLinks>
   <sharedSelectionEntries>
     <selectionEntry id="7a04-bc44-70bb-cb98" name="Red Hand Destroyer Assault Squad" hidden="false" collective="false" import="true" type="unit">
+      <modifiers>
+        <modifier type="add" field="category" value="db6f-0311-834c-e6ff">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c83-69fb-8066-a773" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <rules>
         <rule id="9f63-cb32-73a5-840e" name="Bearers of the Blood Hand" hidden="false">
           <description>A unit that contains at least one model with this special rule must declare a Charge if able when they begin the Assault phase within 12&quot; of an enemy unit. If there is more than one eligible target, the controlling player chooses the target of any Charges made. Note that this does not allow models with this special rule to Charge a different unit to one that they made a Shooting Attack against in the previous Shooting phase.</description>
@@ -2883,7 +2920,6 @@
       <categoryLinks>
         <categoryLink id="5c3d-505d-be3a-0021" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="ee5e-db50-34f8-2da8" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="b191-5eb3-1a15-b3df" name="Infantry Only" hidden="false" targetId="db6f-0311-834c-e6ff" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="bb97-5922-24bd-d6ca" name=" Blood Bonded" hidden="false" collective="false" import="true" type="model">
@@ -3409,6 +3445,13 @@
       </costs>
     </selectionEntry>
     <selectionEntry id="aa6d-c70a-199f-1db5" name="Shabran Darr" hidden="false" collective="false" import="true" type="unit">
+      <modifiers>
+        <modifier type="add" field="category" value="db6f-0311-834c-e6ff">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c83-69fb-8066-a773" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <constraints>
         <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c6f2-ce96-4619-a14e" type="max"/>
       </constraints>
@@ -3456,7 +3499,6 @@
         <categoryLink id="82c7-7ee7-c815-1285" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
         <categoryLink id="6018-e91b-ef03-2ee3" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="66fc-9632-84b0-aa90" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="f4b9-64c7-5660-a0c6" name="Infantry Only" hidden="false" targetId="db6f-0311-834c-e6ff" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="912e-502f-2838-ef01" name="The Liberator" hidden="false" collective="false" import="true" type="upgrade">
@@ -3550,6 +3592,32 @@
       </costs>
     </selectionEntry>
     <selectionEntry id="1987-2aa5-929b-979e" name="Red Butchers" hidden="false" collective="false" import="true" type="unit">
+      <modifierGroups>
+        <modifierGroup>
+          <modifiers>
+            <modifier type="add" field="category" value="db6f-0311-834c-e6ff">
+              <conditionGroups>
+                <conditionGroup type="and">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c83-69fb-8066-a773" type="equalTo"/>
+                    <condition field="selections" scope="1987-2aa5-929b-979e" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5b3d-cf2e-8db7-3218" type="equalTo"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+            <modifier type="add" field="category" value="2bcf-6bbe-58a1-e082">
+              <conditionGroups>
+                <conditionGroup type="and">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c83-69fb-8066-a773" type="equalTo"/>
+                    <condition field="selections" scope="1987-2aa5-929b-979e" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5b3d-cf2e-8db7-3218" type="greaterThan"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
+        </modifierGroup>
+      </modifierGroups>
       <infoLinks>
         <infoLink id="6fdb-6571-8b27-1cee" name="Legiones Astartes (World Eaters) " hidden="false" targetId="405d-019f-9ef6-423c" type="rule"/>
         <infoLink id="b122-34c7-eea2-8d6f" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule"/>
@@ -3571,7 +3639,6 @@
         <categoryLink id="cf1c-50e5-11f5-a5c0" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="080b-8aab-b802-323a" name="Terminators:" hidden="false" targetId="bab3-f50d-3e5f-2f78" primary="false"/>
         <categoryLink id="4259-2c1a-9160-12f3" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="59d9-9df2-1e14-403f" name="Infantry Only" hidden="false" targetId="db6f-0311-834c-e6ff" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="0ef2-9852-5b60-2ff2" name="Devoured" hidden="false" collective="false" import="true" type="model">
@@ -3893,6 +3960,32 @@
           </conditions>
         </modifier>
       </modifiers>
+      <modifierGroups>
+        <modifierGroup>
+          <modifiers>
+            <modifier type="add" field="category" value="db6f-0311-834c-e6ff">
+              <conditionGroups>
+                <conditionGroup type="and">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c83-69fb-8066-a773" type="equalTo"/>
+                    <condition field="selections" scope="2fb9-74a8-43b0-dd00" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8e28-2360-9d87-061e" type="equalTo"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+            <modifier type="add" field="category" value="2bcf-6bbe-58a1-e082">
+              <conditionGroups>
+                <conditionGroup type="and">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c83-69fb-8066-a773" type="equalTo"/>
+                    <condition field="selections" scope="2fb9-74a8-43b0-dd00" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8e28-2360-9d87-061e" type="greaterThan"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
+        </modifierGroup>
+      </modifierGroups>
       <infoLinks>
         <infoLink id="a803-4071-5d85-92c7" name="Legiones Astartes (World Eaters) " hidden="false" targetId="405d-019f-9ef6-423c" type="rule"/>
         <infoLink id="ed22-c7f9-5c36-1e71" name="Furious Charge (X)" hidden="false" targetId="2821-9269-862f-0554" type="rule">
@@ -4299,6 +4392,13 @@
       </costs>
     </selectionEntry>
     <selectionEntry id="6352-8efa-0cc4-cfa7" name="Angron" hidden="false" collective="false" import="true" type="model">
+      <modifiers>
+        <modifier type="add" field="category" value="2bcf-6bbe-58a1-e082">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c83-69fb-8066-a773" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <constraints>
         <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="426b-a3da-a898-7dd8" type="max"/>
       </constraints>
@@ -4347,7 +4447,6 @@
         <categoryLink id="8d69-ffc8-873e-2e42" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
         <categoryLink id="b990-1902-a070-c6d2" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="a500-e244-4c25-e4aa" name="Primarch:" hidden="false" targetId="ad5f-31db-8bc7-5c46" primary="true"/>
-        <categoryLink id="ea0e-4517-cd33-58ea" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="646c-85f5-7755-cc45" name="Gorefather &amp; Gorechild" hidden="false" collective="false" import="true" type="upgrade">
@@ -4465,6 +4564,13 @@
       </costs>
     </selectionEntry>
     <selectionEntry id="e812-10d1-b911-90c5" name="Gahlan Surlak" hidden="false" collective="false" import="true" type="model">
+      <modifiers>
+        <modifier type="add" field="category" value="db6f-0311-834c-e6ff">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c83-69fb-8066-a773" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <constraints>
         <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0606-8335-857a-a6d4" type="max"/>
       </constraints>
@@ -4494,7 +4600,6 @@
         <categoryLink id="9218-c0cc-8dc7-a683" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="6456-b9f2-a391-2c29" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
         <categoryLink id="58d8-8eda-8902-2a74" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="432a-61cf-580c-fde5" name="Infantry Only" hidden="false" targetId="db6f-0311-834c-e6ff" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="01fb-10e7-0c43-2b0d" name="Fleshripper" hidden="false" collective="false" import="true" type="upgrade">
@@ -4577,6 +4682,13 @@
       </costs>
     </selectionEntry>
     <selectionEntry id="e726-7208-d919-a4a1" name="Khârn the Bloody" hidden="false" collective="false" import="true" type="model">
+      <modifiers>
+        <modifier type="add" field="category" value="db6f-0311-834c-e6ff">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c83-69fb-8066-a773" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <constraints>
         <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="40b6-ae71-99d5-3c02" type="max"/>
       </constraints>
@@ -4615,7 +4727,6 @@
         <categoryLink id="6d76-7591-3f6a-4f2c" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="2e2e-a670-504f-7861" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="a72b-1dd1-a0d9-f099" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
-        <categoryLink id="cf2d-efb2-71d6-4848" name="Infantry Only" hidden="false" targetId="db6f-0311-834c-e6ff" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="3017-90ed-f8d5-20fb" name="Melee Weapon" hidden="false" collective="false" import="true">

--- a/2022 - Legiones Astartes.cat
+++ b/2022 - Legiones Astartes.cat
@@ -49,31 +49,43 @@
     </categoryEntry>
     <categoryEntry id="db6f-0311-834c-e6ff" name="Infantry Only" hidden="false">
       <modifiers>
-        <modifier type="set" field="80e6-cb32-4c9f-9518" value="1.0">
+        <modifier type="increment" field="80e6-cb32-4c9f-9518" value="1.0">
+          <repeats>
+            <repeat field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2bcf-6bbe-58a1-e082" repeats="1" roundUp="false"/>
+          </repeats>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c83-69fb-8066-a773" type="equalTo"/>
+          </conditions>
+        </modifier>
+        <modifier type="increment" field="80e6-cb32-4c9f-9518" value="1.0">
           <conditions>
             <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c83-69fb-8066-a773" type="equalTo"/>
           </conditions>
         </modifier>
       </modifiers>
       <constraints>
-        <constraint field="selections" scope="force" value="-1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="80e6-cb32-4c9f-9518" type="min"/>
+        <constraint field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="80e6-cb32-4c9f-9518" type="min"/>
       </constraints>
     </categoryEntry>
     <categoryEntry id="2bcf-6bbe-58a1-e082" name="Non-Infantry Only" hidden="false">
       <modifiers>
-        <modifier type="set" field="8292-97e1-be59-de75" value="-1.0">
+        <modifier type="set" field="8292-97e1-be59-de75" value="0.0">
           <conditions>
             <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c83-69fb-8066-a773" type="lessThan"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c83-69fb-8066-a773" type="equalTo"/>
           </conditions>
         </modifier>
         <modifier type="increment" field="8292-97e1-be59-de75" value="1.0">
           <repeats>
             <repeat field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="db6f-0311-834c-e6ff" repeats="1" roundUp="false"/>
           </repeats>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c83-69fb-8066-a773" type="equalTo"/>
+          </conditions>
         </modifier>
       </modifiers>
       <constraints>
-        <constraint field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8292-97e1-be59-de75" type="max"/>
+        <constraint field="selections" scope="force" value="-1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8292-97e1-be59-de75" type="max"/>
       </constraints>
     </categoryEntry>
     <categoryEntry id="5472-b476-dcbd-c215" name="The Guard Of The Crimson King (TS) Compulsory HQ" hidden="false">
@@ -256,6 +268,11 @@
             </conditionGroup>
           </conditionGroups>
         </modifier>
+        <modifier type="add" field="category" value="2bcf-6bbe-58a1-e082">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c83-69fb-8066-a773" type="equalTo"/>
+          </conditions>
+        </modifier>
       </modifiers>
       <categoryLinks>
         <categoryLink id="2f91-acc5-328b-d376" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
@@ -275,6 +292,11 @@
               </conditions>
             </conditionGroup>
           </conditionGroups>
+        </modifier>
+        <modifier type="add" field="category" value="2bcf-6bbe-58a1-e082">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c83-69fb-8066-a773" type="equalTo"/>
+          </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
@@ -296,6 +318,11 @@
             </conditionGroup>
           </conditionGroups>
         </modifier>
+        <modifier type="add" field="category" value="2bcf-6bbe-58a1-e082">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c83-69fb-8066-a773" type="equalTo"/>
+          </conditions>
+        </modifier>
       </modifiers>
       <categoryLinks>
         <categoryLink id="73f6-f624-9bb9-4b8e" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
@@ -315,6 +342,11 @@
               </conditions>
             </conditionGroup>
           </conditionGroups>
+        </modifier>
+        <modifier type="add" field="category" value="2bcf-6bbe-58a1-e082">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c83-69fb-8066-a773" type="equalTo"/>
+          </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
@@ -336,6 +368,11 @@
             </conditionGroup>
           </conditionGroups>
         </modifier>
+        <modifier type="add" field="category" value="2bcf-6bbe-58a1-e082">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c83-69fb-8066-a773" type="equalTo"/>
+          </conditions>
+        </modifier>
       </modifiers>
       <categoryLinks>
         <categoryLink id="e8b5-e501-541a-3432" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
@@ -355,6 +392,11 @@
               </conditions>
             </conditionGroup>
           </conditionGroups>
+        </modifier>
+        <modifier type="add" field="category" value="2bcf-6bbe-58a1-e082">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c83-69fb-8066-a773" type="equalTo"/>
+          </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
@@ -376,6 +418,11 @@
             </conditionGroup>
           </conditionGroups>
         </modifier>
+        <modifier type="add" field="category" value="2bcf-6bbe-58a1-e082">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c83-69fb-8066-a773" type="equalTo"/>
+          </conditions>
+        </modifier>
       </modifiers>
       <categoryLinks>
         <categoryLink id="6849-516b-9701-6e33" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
@@ -395,6 +442,11 @@
               </conditions>
             </conditionGroup>
           </conditionGroups>
+        </modifier>
+        <modifier type="add" field="category" value="2bcf-6bbe-58a1-e082">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c83-69fb-8066-a773" type="equalTo"/>
+          </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
@@ -416,6 +468,11 @@
             </conditionGroup>
           </conditionGroups>
         </modifier>
+        <modifier type="add" field="category" value="2bcf-6bbe-58a1-e082">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c83-69fb-8066-a773" type="equalTo"/>
+          </conditions>
+        </modifier>
       </modifiers>
       <categoryLinks>
         <categoryLink id="a7f9-aa17-ef6d-061b" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
@@ -436,6 +493,11 @@
             </conditionGroup>
           </conditionGroups>
         </modifier>
+        <modifier type="add" field="category" value="2bcf-6bbe-58a1-e082">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c83-69fb-8066-a773" type="equalTo"/>
+          </conditions>
+        </modifier>
       </modifiers>
       <categoryLinks>
         <categoryLink id="e768-2478-84ab-b7f7" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
@@ -454,6 +516,11 @@
               </conditions>
             </conditionGroup>
           </conditionGroups>
+        </modifier>
+        <modifier type="add" field="category" value="2bcf-6bbe-58a1-e082">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c83-69fb-8066-a773" type="equalTo"/>
+          </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
@@ -474,6 +541,11 @@
             </conditionGroup>
           </conditionGroups>
         </modifier>
+        <modifier type="add" field="category" value="2bcf-6bbe-58a1-e082">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c83-69fb-8066-a773" type="equalTo"/>
+          </conditions>
+        </modifier>
       </modifiers>
       <categoryLinks>
         <categoryLink id="39c6-006d-c8de-0cee" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
@@ -492,6 +564,11 @@
               </conditions>
             </conditionGroup>
           </conditionGroups>
+        </modifier>
+        <modifier type="add" field="category" value="2bcf-6bbe-58a1-e082">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c83-69fb-8066-a773" type="equalTo"/>
+          </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
@@ -513,6 +590,11 @@
               </conditions>
             </conditionGroup>
           </conditionGroups>
+        </modifier>
+        <modifier type="add" field="category" value="2bcf-6bbe-58a1-e082">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c83-69fb-8066-a773" type="equalTo"/>
+          </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
@@ -3758,6 +3840,32 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
       </costs>
     </selectionEntry>
     <selectionEntry id="aa72-63e4-bc60-4611" name="Tactical Squad" hidden="false" collective="false" import="true" type="unit">
+      <modifierGroups>
+        <modifierGroup>
+          <modifiers>
+            <modifier type="add" field="category" value="db6f-0311-834c-e6ff">
+              <conditionGroups>
+                <conditionGroup type="and">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c83-69fb-8066-a773" type="equalTo"/>
+                    <condition field="selections" scope="aa72-63e4-bc60-4611" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0531-85dd-feb0-116d" type="equalTo"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+            <modifier type="add" field="category" value="2bcf-6bbe-58a1-e082">
+              <conditionGroups>
+                <conditionGroup type="and">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c83-69fb-8066-a773" type="equalTo"/>
+                    <condition field="selections" scope="aa72-63e4-bc60-4611" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0531-85dd-feb0-116d" type="greaterThan"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
+        </modifierGroup>
+      </modifierGroups>
       <infoLinks>
         <infoLink id="5af3-9ace-5f52-ec8b" name="Fury of the Legion" hidden="false" targetId="56e4-5bbb-91bd-13e0" type="rule"/>
         <infoLink id="95f0-d144-1ce5-89c1" name="Heart of the Legion" hidden="false" targetId="c0dd-9002-2ebd-f96d" type="rule"/>
@@ -3780,7 +3888,6 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
         <categoryLink id="240b-61e9-f6cc-56fa" name="New CategoryLink" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="1571-4b68-f416-00ea" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="4138-d106-960e-94e0" name="Line Sub-type:" hidden="false" targetId="6399-5c65-7833-1025" primary="false"/>
-        <categoryLink id="9b4e-df25-fe2b-90be" name="Infantry Only" hidden="false" targetId="db6f-0311-834c-e6ff" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="638c-a192-24e6-1604" name=" Legion Tactical Sergeant" hidden="false" collective="false" import="true" type="model">
@@ -4930,7 +5037,6 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
         <categoryLink id="e07d-b552-90ef-c096" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="4048-d50e-f863-8094" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
         <categoryLink id="02a0-025a-fc68-8e2a" name="Transport" hidden="false" targetId="7b0a-a743-a8da-3a39" primary="false"/>
-        <categoryLink id="4e96-d77d-532c-741e" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="fffa-369b-8a93-c728" name="2) May take:" hidden="false" collective="false" import="true">
@@ -5122,6 +5228,32 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
       </costs>
     </selectionEntry>
     <selectionEntry id="50ed-5869-643d-1ac5" name="Tactical Support Squad" hidden="false" collective="false" import="true" type="unit">
+      <modifierGroups>
+        <modifierGroup>
+          <modifiers>
+            <modifier type="add" field="category" value="db6f-0311-834c-e6ff">
+              <conditionGroups>
+                <conditionGroup type="and">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c83-69fb-8066-a773" type="equalTo"/>
+                    <condition field="selections" scope="50ed-5869-643d-1ac5" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fdf4-6e43-0b7c-ab6b" type="equalTo"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+            <modifier type="add" field="category" value="2bcf-6bbe-58a1-e082">
+              <conditionGroups>
+                <conditionGroup type="and">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c83-69fb-8066-a773" type="equalTo"/>
+                    <condition field="selections" scope="50ed-5869-643d-1ac5" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fdf4-6e43-0b7c-ab6b" type="greaterThan"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
+        </modifierGroup>
+      </modifierGroups>
       <infoLinks>
         <infoLink id="2bbb-0037-4d96-a82b" name="Support Squad" hidden="false" targetId="768e-56d6-ca52-24ae" type="rule"/>
         <infoLink id="3d2f-694b-bcdf-b3ac" name="Outflank" hidden="false" targetId="bfbf-e75c-49a2-0285" type="rule">
@@ -5142,7 +5274,6 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
       <categoryLinks>
         <categoryLink id="09bf-3b6b-fba1-8fae" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="566e-8e1f-ea26-51e1" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="305f-f9b4-05bd-c9a9" name="Infantry Only" hidden="false" targetId="db6f-0311-834c-e6ff" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="846e-c9da-5b90-861d" name=" Legion Tactical Support Sergeant" hidden="false" collective="false" import="true" type="model">
@@ -6007,6 +6138,11 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
             <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
           </conditions>
         </modifier>
+        <modifier type="add" field="category" value="2bcf-6bbe-58a1-e082">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c83-69fb-8066-a773" type="equalTo"/>
+          </conditions>
+        </modifier>
       </modifiers>
       <infoLinks>
         <infoLink id="ea28-4e70-3907-dd03" name="Scout" hidden="false" targetId="aacf-9a7e-982d-b793" type="rule"/>
@@ -6031,7 +6167,6 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
         <categoryLink id="2a0a-16f7-36a7-f414" name="Skirmish:" hidden="false" targetId="59a4-7b61-600a-c457" primary="false"/>
         <categoryLink id="ca35-8e83-c135-9eaf" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="ed2e-e758-859f-2c45" name="Cavalry Sub-type:" hidden="false" targetId="6d79-a3e4-381f-7b0f" primary="false"/>
-        <categoryLink id="8019-98fe-157c-594d" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="97b6-65f8-df73-9551" name="Legion Outriders" hidden="false" collective="false" import="true" type="model">
@@ -6544,11 +6679,15 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
             <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
           </conditions>
         </modifier>
+        <modifier type="add" field="category" value="2bcf-6bbe-58a1-e082">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c83-69fb-8066-a773" type="equalTo"/>
+          </conditions>
+        </modifier>
       </modifiers>
       <categoryLinks>
         <categoryLink id="08b4-0dc4-d272-47f7" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="7ee1-e5c8-570a-223d" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
-        <categoryLink id="36f7-406d-40f1-3472" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="e11b-4170-0afd-b025" name="Sicaran Omega" hidden="false" collective="false" import="true" type="model">
@@ -6800,6 +6939,11 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
             <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
           </conditions>
         </modifier>
+        <modifier type="add" field="category" value="2bcf-6bbe-58a1-e082">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c83-69fb-8066-a773" type="equalTo"/>
+          </conditions>
+        </modifier>
       </modifiers>
       <categoryLinks>
         <categoryLink id="5fe4-5ce9-cf62-2d10" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
@@ -6828,7 +6972,6 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
           </profiles>
           <categoryLinks>
             <categoryLink id="e659-8bae-056e-7bf3" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
-            <categoryLink id="9f9e-aaa0-df6a-0535" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="9fba-1911-69f1-4077" name="4) May Take:" hidden="false" collective="false" import="true">
@@ -7160,6 +7303,11 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
             <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
           </conditions>
         </modifier>
+        <modifier type="add" field="category" value="2bcf-6bbe-58a1-e082">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c83-69fb-8066-a773" type="equalTo"/>
+          </conditions>
+        </modifier>
       </modifiers>
       <infoLinks>
         <infoLink id="2985-d6a8-ea11-0c40" name="Power of the Machine Spirit" hidden="false" targetId="5a93-13e0-809d-782a" type="rule"/>
@@ -7177,7 +7325,6 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
         <categoryLink id="cec9-0cba-c60c-7a82" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="002c-703f-e5f8-7705" name="Flyer" hidden="false" targetId="4e84-2d57-4986-2b23" primary="false"/>
         <categoryLink id="c857-29a3-277a-f9bb" name="Hover Sub-type" hidden="false" targetId="3a7a-8bb7-b0d3-e2e7" primary="false"/>
-        <categoryLink id="3769-fd6f-8878-eaf4" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="52b1-1b7c-90bf-eed2" name="Legion Fire Raptor Gunship" hidden="false" collective="false" import="true" type="model">
@@ -7313,6 +7460,13 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
       </costs>
     </selectionEntry>
     <selectionEntry id="bfdf-831f-2171-c1e7" name="Deredeo Dreadnought Talon" hidden="false" collective="false" import="true" type="unit">
+      <modifiers>
+        <modifier type="add" field="category" value="2bcf-6bbe-58a1-e082">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c83-69fb-8066-a773" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="9d47-a878-735c-c251" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
         <categoryLink id="7b1c-14d3-0084-fc4a" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
@@ -7346,7 +7500,6 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
           </infoLinks>
           <categoryLinks>
             <categoryLink id="6a3f-598c-9862-c796" name="Dreadnought:" hidden="false" targetId="4280-4963-02b5-e31d" primary="false"/>
-            <categoryLink id="0151-0251-1f64-1500" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="331d-145d-cd22-0f4e" name="1) Arm Weapon Choice:" hidden="false" collective="false" import="true" defaultSelectionEntryId="bf48-29c5-e0d0-56d0">
@@ -7583,7 +7736,6 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
         <categoryLink id="243d-5b6e-2794-2a35" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="2a7a-c446-f5fa-4eed" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="6165-b9b2-438c-a1a8" name="Transport" hidden="false" targetId="7b0a-a743-a8da-3a39" primary="false"/>
-        <categoryLink id="4ef6-6fa5-0abb-db97" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="dcd4-4e45-52d9-09b3" name="1) Pintle-mounted weapons:" hidden="false" collective="false" import="true">
@@ -7802,7 +7954,6 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
         <categoryLink id="5dfa-b331-6bee-1fc7" name="Transport" hidden="false" targetId="7b0a-a743-a8da-3a39" primary="false"/>
         <categoryLink id="a8b7-3e8a-2180-6644" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="100e-fe74-c5a5-3a07" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
-        <categoryLink id="19f3-25a9-c5b5-1ac4" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="216c-1984-d1a7-f3b1" name="Drop Pod" hidden="false" collective="false" import="true" type="model">
@@ -7909,7 +8060,6 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
         <categoryLink id="9430-425d-f0a1-3055" name="Transport" hidden="false" targetId="7b0a-a743-a8da-3a39" primary="false"/>
         <categoryLink id="ca1f-0918-3532-f963" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="1966-a329-a6b5-94e9" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
-        <categoryLink id="7299-7f9e-9882-8f97" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="2a23-d677-62c5-ed1d" name="Dreadnought Drop Pod" hidden="false" collective="false" import="true" type="model">
@@ -8016,7 +8166,6 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
         <categoryLink id="3856-c687-8257-b20c" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
         <categoryLink id="905b-c1d8-b585-daaf" name="Transport" hidden="false" targetId="7b0a-a743-a8da-3a39" primary="false"/>
         <categoryLink id="2cbe-41c5-7149-b2a6" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
-        <categoryLink id="6b8c-c94a-b2ea-fa02" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="ede9-4deb-570d-70c0" name="Termite Assault Drill" hidden="false" collective="false" import="true" type="model">
@@ -8159,6 +8308,11 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
             <condition field="selections" scope="d664-5692-cd41-f9be" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="555f-3998-a06e-f415" type="equalTo"/>
           </conditions>
         </modifier>
+        <modifier type="add" field="category" value="2bcf-6bbe-58a1-e082">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c83-69fb-8066-a773" type="equalTo"/>
+          </conditions>
+        </modifier>
       </modifiers>
       <categoryLinks>
         <categoryLink id="6cb7-533a-0bf3-29b0" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
@@ -8235,7 +8389,6 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
           </infoLinks>
           <categoryLinks>
             <categoryLink id="9df9-9e61-2785-d561" name="Dreadnought Unit-type:" hidden="false" targetId="4280-4963-02b5-e31d" primary="false"/>
-            <categoryLink id="bb4b-677f-5c22-6db5" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="9c64-0cf1-b27c-e84e" name="1) Weapon Option 1" hidden="false" collective="false" import="true" defaultSelectionEntryId="e636-ec3d-89ce-8cf5">
@@ -8669,7 +8822,6 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
         <categoryLink id="9c02-a9fe-a9c9-039f" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="8631-1aaf-e375-221c" name="Transport" hidden="false" targetId="7b0a-a743-a8da-3a39" primary="false"/>
         <categoryLink id="9ed7-53ba-9190-1c22" name="Reinforced Sub-type:" hidden="false" targetId="9b0d-738c-10e4-4ec1" primary="false"/>
-        <categoryLink id="34ac-1d95-e869-3f51" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="305c-37ae-3cda-349b" name="Land Raider Spartan" hidden="false" collective="false" import="true" type="upgrade">
@@ -8941,6 +9093,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                     <condition field="selections" scope="03be-5d55-d05a-771d" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e254-77a1-6dae-14a0" type="equalTo"/>
                     <condition field="selections" scope="03be-5d55-d05a-771d" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3952-66ed-93ea-27ee" type="equalTo"/>
                     <condition field="selections" scope="03be-5d55-d05a-771d" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4108-5f37-0b50-b419" type="equalTo"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c83-69fb-8066-a773" type="equalTo"/>
                   </conditions>
                 </conditionGroup>
               </conditionGroups>
@@ -8984,12 +9137,19 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
             </modifier>
             <modifier type="add" field="category" value="2bcf-6bbe-58a1-e082">
               <conditionGroups>
-                <conditionGroup type="or">
+                <conditionGroup type="and">
                   <conditions>
-                    <condition field="selections" scope="03be-5d55-d05a-771d" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3952-66ed-93ea-27ee" type="atLeast"/>
-                    <condition field="selections" scope="03be-5d55-d05a-771d" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4108-5f37-0b50-b419" type="atLeast"/>
-                    <condition field="selections" scope="03be-5d55-d05a-771d" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e254-77a1-6dae-14a0" type="atLeast"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c83-69fb-8066-a773" type="equalTo"/>
                   </conditions>
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="03be-5d55-d05a-771d" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3952-66ed-93ea-27ee" type="atLeast"/>
+                        <condition field="selections" scope="03be-5d55-d05a-771d" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4108-5f37-0b50-b419" type="atLeast"/>
+                        <condition field="selections" scope="03be-5d55-d05a-771d" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e254-77a1-6dae-14a0" type="atLeast"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
                 </conditionGroup>
               </conditionGroups>
             </modifier>
@@ -9959,6 +10119,11 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
             </conditionGroup>
           </conditionGroups>
         </modifier>
+        <modifier type="add" field="category" value="db6f-0311-834c-e6ff">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c83-69fb-8066-a773" type="equalTo"/>
+          </conditions>
+        </modifier>
       </modifiers>
       <infoLinks>
         <infoLink id="efe7-1f05-d369-32b4" name="Outflank" hidden="false" targetId="bfbf-e75c-49a2-0285" type="rule">
@@ -9994,7 +10159,6 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
         <categoryLink id="e1e8-360b-92f0-10e3" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
         <categoryLink id="e6ff-3685-f0a8-be34" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="a60b-1cf4-5ab4-bbff" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="e1f4-5100-9250-f86a" name="Infantry Only" hidden="false" targetId="db6f-0311-834c-e6ff" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="de73-2d79-156f-6f64" name="Legion Cataphractii Praetor" hidden="false" collective="false" import="true" type="model">
@@ -10374,6 +10538,11 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
             </conditionGroup>
           </conditionGroups>
         </modifier>
+        <modifier type="add" field="category" value="db6f-0311-834c-e6ff">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c83-69fb-8066-a773" type="equalTo"/>
+          </conditions>
+        </modifier>
       </modifiers>
       <infoLinks>
         <infoLink id="24dc-79b7-16f5-6db3" name="Outflank" hidden="false" targetId="bfbf-e75c-49a2-0285" type="rule">
@@ -10408,7 +10577,6 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
       <categoryLinks>
         <categoryLink id="9d49-2d09-dd7c-30c3" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="5225-7937-685c-e9db" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="94f4-55bb-a038-7394" name="Infantry Only" hidden="false" targetId="db6f-0311-834c-e6ff" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="a2f0-15d9-2b7a-2204" name="Legion Tartaros Praetor" hidden="false" collective="false" import="true" type="model">
@@ -10806,23 +10974,39 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
             </modifier>
             <modifier type="add" field="category" value="db6f-0311-834c-e6ff">
               <conditionGroups>
-                <conditionGroup type="or">
+                <conditionGroup type="and">
                   <conditions>
-                    <condition field="selections" scope="25a2-7a52-632a-6b2c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a8ac-7465-70fb-70fb" type="lessThan"/>
-                    <condition field="selections" scope="25a2-7a52-632a-6b2c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f152-51f5-b509-2d9c" type="lessThan"/>
-                    <condition field="selections" scope="25a2-7a52-632a-6b2c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9924-004c-e683-877b" type="lessThan"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c83-69fb-8066-a773" type="equalTo"/>
+                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ea5b-25e4-9c56-38dd" type="equalTo"/>
+                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5951-8d5c-dde7-b704" type="equalTo"/>
                   </conditions>
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="25a2-7a52-632a-6b2c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f152-51f5-b509-2d9c" type="lessThan"/>
+                        <condition field="selections" scope="25a2-7a52-632a-6b2c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9924-004c-e683-877b" type="lessThan"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
                 </conditionGroup>
               </conditionGroups>
             </modifier>
             <modifier type="add" field="category" value="2bcf-6bbe-58a1-e082">
               <conditionGroups>
-                <conditionGroup type="or">
+                <conditionGroup type="and">
                   <conditions>
-                    <condition field="selections" scope="25a2-7a52-632a-6b2c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a8ac-7465-70fb-70fb" type="atLeast"/>
-                    <condition field="selections" scope="25a2-7a52-632a-6b2c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f152-51f5-b509-2d9c" type="atLeast"/>
-                    <condition field="selections" scope="25a2-7a52-632a-6b2c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9924-004c-e683-877b" type="atLeast"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c83-69fb-8066-a773" type="equalTo"/>
                   </conditions>
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="25a2-7a52-632a-6b2c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f152-51f5-b509-2d9c" type="atLeast"/>
+                        <condition field="selections" scope="25a2-7a52-632a-6b2c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9924-004c-e683-877b" type="atLeast"/>
+                        <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5951-8d5c-dde7-b704" type="greaterThan"/>
+                        <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ea5b-25e4-9c56-38dd" type="greaterThan"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
                 </conditionGroup>
               </conditionGroups>
             </modifier>
@@ -12242,6 +12426,32 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
           </conditions>
         </modifier>
       </modifiers>
+      <modifierGroups>
+        <modifierGroup>
+          <modifiers>
+            <modifier type="add" field="category" value="db6f-0311-834c-e6ff">
+              <conditionGroups>
+                <conditionGroup type="and">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c83-69fb-8066-a773" type="equalTo"/>
+                    <condition field="selections" scope="1a8e-0ded-a4dc-2b4e" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c2cf-d802-a680-c352" type="equalTo"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+            <modifier type="add" field="category" value="2bcf-6bbe-58a1-e082">
+              <conditionGroups>
+                <conditionGroup type="and">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c83-69fb-8066-a773" type="equalTo"/>
+                    <condition field="selections" scope="1a8e-0ded-a4dc-2b4e" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c2cf-d802-a680-c352" type="greaterThan"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
+        </modifierGroup>
+      </modifierGroups>
       <infoLinks>
         <infoLink id="b8e8-c9dc-7677-8cd8" name="Bulky (X)" hidden="false" targetId="676c-7b75-4b6f-9405" type="rule">
           <modifiers>
@@ -12283,7 +12493,6 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
         <categoryLink id="9c7a-acc7-9230-fcc4" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="6901-e4b0-c5cc-a02b" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="a872-59ee-deae-90b7" name="Terminators:" hidden="false" targetId="bab3-f50d-3e5f-2f78" primary="false"/>
-        <categoryLink id="74d5-6f1c-2d5e-23df" name="Infantry Only" hidden="false" targetId="db6f-0311-834c-e6ff" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="87b7-091d-4bc3-9164" name="One Legion Tartaros may take:" hidden="false" collective="false" import="true">
@@ -12972,6 +13181,32 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
           </conditions>
         </modifier>
       </modifiers>
+      <modifierGroups>
+        <modifierGroup>
+          <modifiers>
+            <modifier type="add" field="category" value="db6f-0311-834c-e6ff">
+              <conditionGroups>
+                <conditionGroup type="and">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c83-69fb-8066-a773" type="equalTo"/>
+                    <condition field="selections" scope="d91a-a3c7-d7be-4293" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6766-d205-3ee9-7543" type="equalTo"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+            <modifier type="add" field="category" value="2bcf-6bbe-58a1-e082">
+              <conditionGroups>
+                <conditionGroup type="and">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c83-69fb-8066-a773" type="equalTo"/>
+                    <condition field="selections" scope="d91a-a3c7-d7be-4293" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6766-d205-3ee9-7543" type="greaterThan"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
+        </modifierGroup>
+      </modifierGroups>
       <infoLinks>
         <infoLink id="9369-a4cc-c1fa-0baf" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule"/>
         <infoLink id="a864-610c-7dc3-64c2" name="Inexorable" hidden="false" targetId="d863-8a5e-ddb6-d5a4" type="rule"/>
@@ -13014,7 +13249,6 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
         <categoryLink id="d924-8839-45ef-d725" name="Terminators:" hidden="false" targetId="bab3-f50d-3e5f-2f78" primary="false"/>
         <categoryLink id="30ff-487a-51ee-62ce" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="8cc9-9b8f-dc8b-183f" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
-        <categoryLink id="3353-4c41-7567-bc88" name="Infantry Only" hidden="false" targetId="db6f-0311-834c-e6ff" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="b908-ada3-76ab-8d4d" name="2) One Legion Cataphractii may take:" hidden="false" collective="false" import="true">
@@ -13589,6 +13823,32 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
       </costs>
     </selectionEntry>
     <selectionEntry id="4357-930e-165a-a6e3" name="Despoiler Squad" publicationId="a716-c1c4-7b26-8424" hidden="false" collective="false" import="true" type="unit">
+      <modifierGroups>
+        <modifierGroup>
+          <modifiers>
+            <modifier type="add" field="category" value="db6f-0311-834c-e6ff">
+              <conditionGroups>
+                <conditionGroup type="and">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c83-69fb-8066-a773" type="equalTo"/>
+                    <condition field="selections" scope="4357-930e-165a-a6e3" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ef54-aab4-53ae-d96c" type="equalTo"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+            <modifier type="add" field="category" value="2bcf-6bbe-58a1-e082">
+              <conditionGroups>
+                <conditionGroup type="and">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c83-69fb-8066-a773" type="equalTo"/>
+                    <condition field="selections" scope="4357-930e-165a-a6e3" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ef54-aab4-53ae-d96c" type="greaterThan"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
+        </modifierGroup>
+      </modifierGroups>
       <infoLinks>
         <infoLink id="757d-1944-7229-0b85" name="Spite of the Legion" hidden="false" targetId="ed9b-1320-335f-aa10" type="rule"/>
         <infoLink id="3b31-08b6-4b8a-cd83" name="Heart of the Legion" hidden="false" targetId="c0dd-9002-2ebd-f96d" type="rule"/>
@@ -13611,7 +13871,6 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
         <categoryLink id="176f-2693-896f-9748" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="3a70-5ba0-7914-683a" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="3cfb-f16e-35b6-c89d" name="Line Sub-type:" hidden="false" targetId="6399-5c65-7833-1025" primary="false"/>
-        <categoryLink id="7bab-24c0-89e7-7898" name="Infantry Only" hidden="false" targetId="db6f-0311-834c-e6ff" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="ef23-ca32-6fe5-b736" name="  Legion Despoiler Sergeant" hidden="false" collective="false" import="true" type="model">
@@ -14527,6 +14786,32 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
       </costs>
     </selectionEntry>
     <selectionEntry id="ad97-c090-fa67-696f" name="Breacher Squad" hidden="false" collective="false" import="true" type="unit">
+      <modifierGroups>
+        <modifierGroup>
+          <modifiers>
+            <modifier type="add" field="category" value="db6f-0311-834c-e6ff">
+              <conditionGroups>
+                <conditionGroup type="and">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c83-69fb-8066-a773" type="equalTo"/>
+                    <condition field="selections" scope="ad97-c090-fa67-696f" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="50b4-b5ef-c95f-ab51" type="equalTo"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+            <modifier type="add" field="category" value="2bcf-6bbe-58a1-e082">
+              <conditionGroups>
+                <conditionGroup type="and">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c83-69fb-8066-a773" type="equalTo"/>
+                    <condition field="selections" scope="ad97-c090-fa67-696f" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="50b4-b5ef-c95f-ab51" type="greaterThan"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
+        </modifierGroup>
+      </modifierGroups>
       <infoLinks>
         <infoLink id="6915-e215-a41f-1c9f" name="Outflank" hidden="false" targetId="bfbf-e75c-49a2-0285" type="rule">
           <modifiers>
@@ -14548,7 +14833,6 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
         <categoryLink id="d5a1-47f5-0e3c-716d" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="ad69-ee1e-ec47-c17e" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
         <categoryLink id="39df-bd14-1a10-1f88" name="Line Sub-type:" hidden="false" targetId="6399-5c65-7833-1025" primary="false"/>
-        <categoryLink id="e462-1349-3629-f34d" name="Infantry Only" hidden="false" targetId="db6f-0311-834c-e6ff" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="8725-b9d1-1e86-0364" name="  Legion Breacher Sergeant" hidden="false" collective="false" import="true" type="model">
@@ -15367,6 +15651,11 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
             <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
           </conditions>
         </modifier>
+        <modifier type="add" field="category" value="2bcf-6bbe-58a1-e082">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c83-69fb-8066-a773" type="equalTo"/>
+          </conditions>
+        </modifier>
       </modifiers>
       <categoryLinks>
         <categoryLink id="6ca2-562a-dfaa-1587" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
@@ -15406,6 +15695,32 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
       </costs>
     </selectionEntry>
     <selectionEntry id="6db7-6e88-877e-35ca" name="Reconnaissance Squad" hidden="false" collective="false" import="true" type="unit">
+      <modifierGroups>
+        <modifierGroup>
+          <modifiers>
+            <modifier type="add" field="category" value="db6f-0311-834c-e6ff">
+              <conditionGroups>
+                <conditionGroup type="and">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c83-69fb-8066-a773" type="equalTo"/>
+                    <condition field="selections" scope="6db7-6e88-877e-35ca" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="77e9-4e14-63c6-fad7" type="equalTo"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+            <modifier type="add" field="category" value="2bcf-6bbe-58a1-e082">
+              <conditionGroups>
+                <conditionGroup type="and">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c83-69fb-8066-a773" type="equalTo"/>
+                    <condition field="selections" scope="6db7-6e88-877e-35ca" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="77e9-4e14-63c6-fad7" type="greaterThan"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
+        </modifierGroup>
+      </modifierGroups>
       <infoLinks>
         <infoLink id="9660-4ebf-fe5a-7582" name="Support Squad" hidden="false" targetId="768e-56d6-ca52-24ae" type="rule">
           <modifiers>
@@ -15437,7 +15752,6 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
         <categoryLink id="78f2-3b93-045e-9fff" name="Infantry" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="da59-0c31-03f1-ae38" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="95f4-7bc2-449f-5dd3" name="Line Sub-type:" hidden="false" targetId="6399-5c65-7833-1025" primary="false"/>
-        <categoryLink id="0802-5786-4bf3-c07b" name="Infantry Only" hidden="false" targetId="db6f-0311-834c-e6ff" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="4d0d-06f9-4989-439e" name=" Legion Recon Sergeant" hidden="false" collective="false" import="true" type="model">
@@ -16120,6 +16434,13 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
       </costs>
     </selectionEntry>
     <selectionEntry id="9b10-b657-a65a-9d60" name="Scout Squad" publicationId="a716-c1c4-7b26-8424" hidden="false" collective="false" import="true" type="unit">
+      <modifiers>
+        <modifier type="add" field="category" value="db6f-0311-834c-e6ff">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c83-69fb-8066-a773" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <infoLinks>
         <infoLink id="1e59-9bd4-20c6-6183" name="Scout" hidden="false" targetId="aacf-9a7e-982d-b793" type="rule"/>
         <infoLink id="3ae1-247d-2b45-ed67" name="Infiltrate" hidden="false" targetId="0e32-5b92-a95a-8464" type="rule"/>
@@ -16151,7 +16472,6 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
       <categoryLinks>
         <categoryLink id="1b9e-4e93-3914-a6e1" name="New CategoryLink" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="f887-300a-daae-7e57" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="49b4-8dc9-6457-dc3a" name="Infantry Only" hidden="false" targetId="db6f-0311-834c-e6ff" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="8867-1af4-01f7-da72" name="Legion Scout" hidden="false" collective="false" import="true" type="model">
@@ -16739,16 +17059,18 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
               <conditions>
                 <condition field="selections" scope="0aca-632d-1642-8af9" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6fb4-adf6-dbe8-86af" type="equalTo"/>
                 <condition field="selections" scope="0aca-632d-1642-8af9" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e8a8-b526-beab-bb82" type="equalTo"/>
+                <condition field="selections" scope="0aca-632d-1642-8af9" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8c76-b52e-b055-5ff5" type="greaterThan"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
         <modifier type="add" field="category" value="db6f-0311-834c-e6ff">
           <conditionGroups>
-            <conditionGroup type="or">
+            <conditionGroup type="and">
               <conditions>
                 <condition field="selections" scope="0aca-632d-1642-8af9" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6fb4-adf6-dbe8-86af" type="lessThan"/>
                 <condition field="selections" scope="0aca-632d-1642-8af9" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e8a8-b526-beab-bb82" type="lessThan"/>
+                <condition field="selections" scope="0aca-632d-1642-8af9" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8c76-b52e-b055-5ff5" type="equalTo"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
@@ -17578,6 +17900,13 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
       </costs>
     </selectionEntry>
     <selectionEntry id="3766-ea98-0aa7-62d0" name="Centurion, Cataphractii " publicationId="a716-c1c4-7b26-8424" hidden="false" collective="false" import="true" type="unit">
+      <modifiers>
+        <modifier type="add" field="category" value="db6f-0311-834c-e6ff">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c83-69fb-8066-a773" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <infoLinks>
         <infoLink id="d8d6-da89-2c24-d032" name="Stubborn" hidden="false" targetId="7989-1f2c-a43d-82ae" type="rule">
           <modifiers>
@@ -18202,6 +18531,28 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
       </costs>
     </selectionEntry>
     <selectionEntry id="58d0-a0fd-d20b-cb1b" name="Command Squad, Tartaros " publicationId="a716-c1c4-7b26-8424" hidden="false" collective="false" import="true" type="unit">
+      <modifiers>
+        <modifier type="add" field="category" value="2bcf-6bbe-58a1-e082">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c83-69fb-8066-a773" type="equalTo"/>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f059-2405-bfa0-11cf" type="greaterThan"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+        <modifier type="add" field="category" value="db6f-0311-834c-e6ff">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c83-69fb-8066-a773" type="equalTo"/>
+                <condition field="selections" scope="58d0-a0fd-d20b-cb1b" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f059-2405-bfa0-11cf" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <infoLinks>
         <infoLink id="12f2-b3b7-fe0d-ff56" name="Chosen Warriors" hidden="false" targetId="13d1-9270-6539-08ed" type="rule"/>
         <infoLink id="01f9-6381-a13d-64c6" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule"/>
@@ -18230,7 +18581,6 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
       <categoryLinks>
         <categoryLink id="6815-a77d-f59b-632f" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="480a-471d-9c29-a920" name="Terminators:" hidden="false" targetId="bab3-f50d-3e5f-2f78" primary="false"/>
-        <categoryLink id="79ca-0d38-d631-8f29" name="Infantry Only" hidden="false" targetId="db6f-0311-834c-e6ff" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="f059-2405-bfa0-11cf" name="Dedicated Transport" hidden="false" collective="false" import="true">
@@ -18531,6 +18881,32 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
           </conditions>
         </modifier>
       </modifiers>
+      <modifierGroups>
+        <modifierGroup>
+          <modifiers>
+            <modifier type="add" field="category" value="db6f-0311-834c-e6ff">
+              <conditionGroups>
+                <conditionGroup type="and">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c83-69fb-8066-a773" type="equalTo"/>
+                    <condition field="selections" scope="a423-7dd8-3f1b-3e28" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8fbf-dba5-5b44-1875" type="equalTo"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+            <modifier type="add" field="category" value="2bcf-6bbe-58a1-e082">
+              <conditionGroups>
+                <conditionGroup type="and">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c83-69fb-8066-a773" type="equalTo"/>
+                    <condition field="selections" scope="a423-7dd8-3f1b-3e28" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8fbf-dba5-5b44-1875" type="greaterThan"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
+        </modifierGroup>
+      </modifierGroups>
       <infoLinks>
         <infoLink id="18b6-f65d-5d60-d317" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule"/>
         <infoLink id="297d-7e23-67dd-a0e5" name="Chosen Warriors" hidden="false" targetId="13d1-9270-6539-08ed" type="rule"/>
@@ -18566,7 +18942,6 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
       <categoryLinks>
         <categoryLink id="028b-dfb1-e521-2745" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="cea8-a6fe-2e41-d8ff" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="b9ec-1b6f-0509-0e5e" name="Infantry Only" hidden="false" targetId="db6f-0311-834c-e6ff" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="2dde-c679-4d2d-e928" name="0) Legiones Unit Upgrades:" hidden="false" collective="false" import="true">
@@ -20044,7 +20419,6 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
       </infoLinks>
       <categoryLinks>
         <categoryLink id="bb97-be52-aa75-a4d0" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="a1e2-f519-dbbb-da61" name="Infantry Only" hidden="false" targetId="db6f-0311-834c-e6ff" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="415c-6834-f4d2-d967" name="Apothecary" publicationId="a716-c1c4-7b26-8424" hidden="false" collective="false" import="true" type="model">
@@ -20436,6 +20810,30 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
             </modifier>
           </modifiers>
         </modifierGroup>
+        <modifierGroup>
+          <modifiers>
+            <modifier type="add" field="category" value="db6f-0311-834c-e6ff">
+              <conditionGroups>
+                <conditionGroup type="and">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c83-69fb-8066-a773" type="equalTo"/>
+                    <condition field="selections" scope="58e6-f9cc-4c46-e258" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8988-7c51-7802-2ca5" type="equalTo"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+            <modifier type="add" field="category" value="2bcf-6bbe-58a1-e082">
+              <conditionGroups>
+                <conditionGroup type="and">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c83-69fb-8066-a773" type="equalTo"/>
+                    <condition field="selections" scope="58e6-f9cc-4c46-e258" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8988-7c51-7802-2ca5" type="greaterThan"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
+        </modifierGroup>
       </modifierGroups>
       <infoLinks>
         <infoLink id="df2d-b66a-8e2d-98b5" name="Infiltrate" hidden="false" targetId="0e32-5b92-a95a-8464" type="rule"/>
@@ -20463,7 +20861,6 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
       <categoryLinks>
         <categoryLink id="13fc-715d-8968-5d54" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="129e-3d72-2602-afcd" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="defe-34ad-aa73-cce7" name="Infantry Only" hidden="false" targetId="db6f-0311-834c-e6ff" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="53c3-7eec-4676-996e" name="Legion Seeker" hidden="false" collective="false" import="true" type="model">
@@ -21193,7 +21590,6 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
       </infoLinks>
       <categoryLinks>
         <categoryLink id="bba9-768a-89c6-84ba" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="b902-b743-ba1b-0ec7" name="Infantry Only" hidden="false" targetId="db6f-0311-834c-e6ff" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="fc32-089e-1c59-70bd" name="Techmarine" publicationId="a716-c1c4-7b26-8424" hidden="false" collective="false" import="true" type="model">
@@ -21871,6 +22267,13 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
       </costs>
     </selectionEntry>
     <selectionEntry id="f806-8a4e-d0d6-beaa" name="Centurion, Tartaros " publicationId="a716-c1c4-7b26-8424" hidden="false" collective="false" import="true" type="unit">
+      <modifiers>
+        <modifier type="add" field="category" value="db6f-0311-834c-e6ff">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c83-69fb-8066-a773" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <infoLinks>
         <infoLink id="535e-fd1a-eee8-43d0" name="Outflank" hidden="false" targetId="bfbf-e75c-49a2-0285" type="rule">
           <modifiers>
@@ -22477,6 +22880,13 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
       </costs>
     </selectionEntry>
     <selectionEntry id="c2a7-9e2c-fc65-1b78" name="Leviathan Dreadnought Talon" hidden="false" collective="false" import="true" type="unit">
+      <modifiers>
+        <modifier type="add" field="category" value="2bcf-6bbe-58a1-e082">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c83-69fb-8066-a773" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="c543-976f-ef9d-d41e" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="9152-5697-6c00-ca89" name="Dreadnought Unit-type:" hidden="false" targetId="4280-4963-02b5-e31d" primary="false"/>
@@ -22527,9 +22937,6 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
               </modifiers>
             </infoLink>
           </infoLinks>
-          <categoryLinks>
-            <categoryLink id="bf8f-6c7c-ed20-00bd" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
-          </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="5f5a-bc15-c9d5-e890" name="4) May take:" hidden="false" collective="false" import="true">
               <constraints>
@@ -22801,6 +23208,11 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
             <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="50cf-edf5-d39a-8943" type="equalTo"/>
           </conditions>
         </modifier>
+        <modifier type="add" field="category" value="2bcf-6bbe-58a1-e082">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c83-69fb-8066-a773" type="equalTo"/>
+          </conditions>
+        </modifier>
       </modifiers>
       <categoryLinks>
         <categoryLink id="0ea3-c6cc-f348-2226" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
@@ -22829,7 +23241,6 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
           </profiles>
           <categoryLinks>
             <categoryLink id="8b77-ae5c-8bac-f9e0" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
-            <categoryLink id="1254-e8a0-4ef4-a552" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="5b1e-5fa8-bf4c-9339" name="4) May take:" hidden="false" collective="false" import="true">
@@ -23188,6 +23599,11 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
             <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
           </conditions>
         </modifier>
+        <modifier type="add" field="category" value="2bcf-6bbe-58a1-e082">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c83-69fb-8066-a773" type="equalTo"/>
+          </conditions>
+        </modifier>
       </modifiers>
       <categoryLinks>
         <categoryLink id="4558-d6c5-a85f-a7b9" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
@@ -23216,7 +23632,6 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
           </profiles>
           <categoryLinks>
             <categoryLink id="86f7-68a5-edfa-df3a" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
-            <categoryLink id="f07f-3132-ba77-6566" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="030d-69f8-d9af-d6f6" name="1) Arcus Launcher" hidden="false" collective="false" import="true">
@@ -23461,6 +23876,11 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
             <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
           </conditions>
         </modifier>
+        <modifier type="add" field="category" value="2bcf-6bbe-58a1-e082">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c83-69fb-8066-a773" type="equalTo"/>
+          </conditions>
+        </modifier>
       </modifiers>
       <categoryLinks>
         <categoryLink id="7a3a-cf7f-7e0f-50ec" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
@@ -23489,7 +23909,6 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
           </profiles>
           <categoryLinks>
             <categoryLink id="532a-184b-6633-a933" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
-            <categoryLink id="5cf1-62e8-6511-3de0" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="ea31-6d06-3a9a-8bf8" name="2) Sponson Mounted Weapons:" hidden="false" collective="false" import="true" defaultSelectionEntryId="50f8-01b2-554c-f3c8">
@@ -23829,6 +24248,11 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
             <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
           </conditions>
         </modifier>
+        <modifier type="add" field="category" value="2bcf-6bbe-58a1-e082">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c83-69fb-8066-a773" type="equalTo"/>
+          </conditions>
+        </modifier>
       </modifiers>
       <categoryLinks>
         <categoryLink id="4456-9ae8-88cc-ba12" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
@@ -23860,7 +24284,6 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
           </infoLinks>
           <categoryLinks>
             <categoryLink id="4161-d5a7-0d9e-6234" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
-            <categoryLink id="67b4-d4b8-eed0-a0e4" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="0d3c-a988-5a78-4077" name="3) May take:" hidden="false" collective="false" import="true">
@@ -24062,6 +24485,11 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
             <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
           </conditions>
         </modifier>
+        <modifier type="add" field="category" value="2bcf-6bbe-58a1-e082">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c83-69fb-8066-a773" type="equalTo"/>
+          </conditions>
+        </modifier>
       </modifiers>
       <profiles>
         <profile id="2289-894c-5b9c-87cd" name="Land Raider Proteus Explorator" publicationId="a716-c1c4-7b26-8424" page="76" hidden="false" typeId="2fae-b053-3f78-e7b2" typeName=" Vehicle">
@@ -24088,7 +24516,6 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
         <categoryLink id="8cda-e93d-10a1-8cbc" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
         <categoryLink id="b1af-aba1-ebba-987b" name="Transport" hidden="false" targetId="7b0a-a743-a8da-3a39" primary="false"/>
         <categoryLink id="d8cd-3887-6695-d480" name="Reinforced Sub-type:" hidden="false" targetId="9b0d-738c-10e4-4ec1" primary="false"/>
-        <categoryLink id="5da8-4d96-2cdf-5328" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="94f8-f071-903e-a4f9" name="2) Pintle mounted Weapon:" hidden="false" collective="false" import="true">
@@ -24330,6 +24757,11 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
             <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
           </conditions>
         </modifier>
+        <modifier type="add" field="category" value="2bcf-6bbe-58a1-e082">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c83-69fb-8066-a773" type="equalTo"/>
+          </conditions>
+        </modifier>
       </modifiers>
       <categoryLinks>
         <categoryLink id="50cb-c9fb-ba26-1fe8" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
@@ -24360,7 +24792,6 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
           <categoryLinks>
             <categoryLink id="a3a3-24e2-ecd4-38fa" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
             <categoryLink id="328a-a860-4be3-e6c8" name="Reinforced Sub-type:" hidden="false" targetId="9b0d-738c-10e4-4ec1" primary="false"/>
-            <categoryLink id="9809-ace4-bae3-3375" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="c99e-c96d-5c57-7215" name="1) Centreline Mounted Weapon:" hidden="false" collective="false" import="true" defaultSelectionEntryId="646f-5064-f0b0-3a83">
@@ -24624,6 +25055,11 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
             <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
           </conditions>
         </modifier>
+        <modifier type="add" field="category" value="2bcf-6bbe-58a1-e082">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c83-69fb-8066-a773" type="equalTo"/>
+          </conditions>
+        </modifier>
       </modifiers>
       <infoLinks>
         <infoLink id="40d0-4a80-7e2c-62bc" name="Move Through Cover" hidden="false" targetId="2b6f-bfec-759e-1746" type="rule"/>
@@ -24656,7 +25092,6 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
           </profiles>
           <categoryLinks>
             <categoryLink id="c2f1-cd11-ca0c-0d3b" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
-            <categoryLink id="4cad-f81a-fda5-1703" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="ad38-0891-7db4-3528" name="1) Sponson Mounted Weapons:" hidden="false" collective="false" import="true" defaultSelectionEntryId="2f89-a5d7-94b6-6868">
@@ -24954,6 +25389,28 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
       </costs>
     </selectionEntry>
     <selectionEntry id="1b17-dcd6-0153-3efe" name="Command Squad, Cataphractii" publicationId="a716-c1c4-7b26-8424" page="28" hidden="false" collective="false" import="true" type="unit">
+      <modifiers>
+        <modifier type="add" field="category" value="db6f-0311-834c-e6ff">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c83-69fb-8066-a773" type="equalTo"/>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9fa9-d220-698d-8220" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+        <modifier type="add" field="category" value="2bcf-6bbe-58a1-e082">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c83-69fb-8066-a773" type="equalTo"/>
+                <condition field="selections" scope="1b17-dcd6-0153-3efe" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9fa9-d220-698d-8220" type="greaterThan"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <infoLinks>
         <infoLink id="9979-d687-399a-d9fd" name="Chosen Warriors" hidden="false" targetId="13d1-9270-6539-08ed" type="rule"/>
         <infoLink id="e54e-9f64-26ec-67ad" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule"/>
@@ -24983,7 +25440,6 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
         <categoryLink id="2b45-00e1-5c3d-c2e5" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="c33e-fa91-93da-9bc9" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
         <categoryLink id="d4ab-bc77-4c9d-1887" name="Terminators:" hidden="false" targetId="bab3-f50d-3e5f-2f78" primary="false"/>
-        <categoryLink id="b5b0-a064-0704-2107" name="Infantry Only" hidden="false" targetId="db6f-0311-834c-e6ff" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="9fa9-d220-698d-8220" name="Dedicated Transport" hidden="false" collective="false" import="true">
@@ -25328,7 +25784,6 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
         <categoryLink id="ae9b-5609-d742-a57c" name="Flyer" hidden="false" targetId="4e84-2d57-4986-2b23" primary="false"/>
         <categoryLink id="9f22-19aa-22ca-5dbf" name="Hover Sub-type" hidden="false" targetId="3a7a-8bb7-b0d3-e2e7" primary="false"/>
         <categoryLink id="c289-9171-f7d9-d94a" name="Transport" hidden="false" targetId="7b0a-a743-a8da-3a39" primary="false"/>
-        <categoryLink id="d758-b63f-aa59-86e8" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="1b10-460e-e75a-3ffd" name="Dreadclaw Drop Pod" hidden="false" collective="false" import="true" type="upgrade">
@@ -25414,6 +25869,32 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
           </conditions>
         </modifier>
       </modifiers>
+      <modifierGroups>
+        <modifierGroup>
+          <modifiers>
+            <modifier type="add" field="category" value="db6f-0311-834c-e6ff">
+              <conditionGroups>
+                <conditionGroup type="and">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c83-69fb-8066-a773" type="equalTo"/>
+                    <condition field="selections" scope="bac9-5389-e2e7-0b1f" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f20c-0dc7-e4bd-d795" type="equalTo"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+            <modifier type="add" field="category" value="2bcf-6bbe-58a1-e082">
+              <conditionGroups>
+                <conditionGroup type="and">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c83-69fb-8066-a773" type="equalTo"/>
+                    <condition field="selections" scope="bac9-5389-e2e7-0b1f" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f20c-0dc7-e4bd-d795" type="greaterThan"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
+        </modifierGroup>
+      </modifierGroups>
       <infoLinks>
         <infoLink id="20f6-e319-6939-4a3d" name="Outflank" hidden="false" targetId="bfbf-e75c-49a2-0285" type="rule">
           <modifiers>
@@ -25428,7 +25909,6 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
       <categoryLinks>
         <categoryLink id="156c-ae25-48d5-1e9d" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="1ef8-f347-84e3-b054" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="8cda-288b-945f-9e62" name="Infantry Only" hidden="false" targetId="db6f-0311-834c-e6ff" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="8aea-b995-e957-0c42" name=" Legion Support Sergeant" hidden="false" collective="false" import="true" type="model">
@@ -26107,6 +26587,11 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
             <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
           </conditions>
         </modifier>
+        <modifier type="add" field="category" value="2bcf-6bbe-58a1-e082">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c83-69fb-8066-a773" type="equalTo"/>
+          </conditions>
+        </modifier>
       </modifiers>
       <categoryLinks>
         <categoryLink id="5af8-d955-210c-10a3" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
@@ -26136,10 +26621,9 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
           </profiles>
           <categoryLinks>
             <categoryLink id="5101-eca4-4a32-4c77" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
-            <categoryLink id="472b-1cc7-49b5-86f3" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
-            <selectionEntryGroup id="6261-4456-2d7b-82b0" name="1) Centreline Mounted Weapon" hidden="false" collective="false" import="true">
+            <selectionEntryGroup id="6261-4456-2d7b-82b0" name="1) Centreline Mounted Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="71fe-26fc-a174-6387">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3792-783d-c54e-b25c" type="min"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="55a5-c49c-fa68-c212" type="max"/>
@@ -26154,7 +26638,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                 <entryLink id="916e-a274-7d08-5ee5" name="Volkite Saker" hidden="false" collective="false" import="true" targetId="8aec-80a1-667a-cc15" type="selectionEntry"/>
               </entryLinks>
             </selectionEntryGroup>
-            <selectionEntryGroup id="96ec-222d-31e1-d124" name="2) Hull (Front) Weapon" hidden="false" collective="false" import="true">
+            <selectionEntryGroup id="96ec-222d-31e1-d124" name="2) Hull (Front) Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="81f2-9232-3dd6-24fa">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6d90-adeb-e792-6c3b" type="max"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f393-d7cd-938d-17c1" type="min"/>
@@ -26348,6 +26832,11 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
             <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
           </conditions>
         </modifier>
+        <modifier type="add" field="category" value="2bcf-6bbe-58a1-e082">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c83-69fb-8066-a773" type="equalTo"/>
+          </conditions>
+        </modifier>
       </modifiers>
       <infoLinks>
         <infoLink id="ff8e-99c2-a83a-246d" name="Deep Strike" hidden="false" targetId="f1e1-986f-c783-ca9e" type="rule"/>
@@ -26382,7 +26871,6 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
         <categoryLink id="6b9a-cce1-8d40-60e4" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="c641-0dd3-091e-e12d" name="Cavalry Sub-type:" hidden="false" targetId="6d79-a3e4-381f-7b0f" primary="false"/>
         <categoryLink id="d231-48d4-4a7e-88c4" name="Antigrav Sub-type" hidden="false" targetId="4303-1348-cce4-9501" primary="false"/>
-        <categoryLink id="a611-26f8-993e-8b71" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="d0b2-a77a-a4f4-0ae1" name="Legion Sky-Hunter" hidden="false" collective="false" import="true" type="model">
@@ -26871,7 +27359,6 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
         <categoryLink id="8179-34af-db8c-7a20" name="Flyer" hidden="false" targetId="4e84-2d57-4986-2b23" primary="false"/>
         <categoryLink id="ef8f-3fb2-f2d5-3e57" name="Hover Sub-type" hidden="false" targetId="3a7a-8bb7-b0d3-e2e7" primary="false"/>
         <categoryLink id="075f-3971-715b-a9a2" name="Transport" hidden="false" targetId="7b0a-a743-a8da-3a39" primary="false"/>
-        <categoryLink id="8d10-f5b1-a3bb-6206" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="1d23-3f85-0a01-95b9" name="Hull (Front) Mounted Vengeance launcher" hidden="false" collective="false" import="true" type="upgrade">
@@ -27003,6 +27490,11 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
             <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
           </conditions>
         </modifier>
+        <modifier type="add" field="category" value="2bcf-6bbe-58a1-e082">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c83-69fb-8066-a773" type="equalTo"/>
+          </conditions>
+        </modifier>
       </modifiers>
       <profiles>
         <profile id="29f8-c56d-4902-5d23" name="Xiphon Interceptor" hidden="false" typeId="2fae-b053-3f78-e7b2" typeName=" Vehicle">
@@ -27028,7 +27520,6 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
         <categoryLink id="faad-a55f-fe5f-79ba" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="c58b-a48e-6286-c40d" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
         <categoryLink id="7123-b060-2ff0-00d4" name="Flyer" hidden="false" targetId="4e84-2d57-4986-2b23" primary="false"/>
-        <categoryLink id="1930-fffd-00e1-3db8" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="68ac-5612-184b-904d" name="Hull (Front) Mounted Rotary Missile Launcher" hidden="false" collective="false" import="true" type="upgrade">
@@ -27120,6 +27611,11 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
             <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
           </conditions>
         </modifier>
+        <modifier type="add" field="category" value="2bcf-6bbe-58a1-e082">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c83-69fb-8066-a773" type="equalTo"/>
+          </conditions>
+        </modifier>
       </modifiers>
       <infoLinks>
         <infoLink id="26e5-42ae-300b-82e5" name="Deep Strike" hidden="false" targetId="f1e1-986f-c783-ca9e" type="rule"/>
@@ -27170,7 +27666,6 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
           </profiles>
           <categoryLinks>
             <categoryLink id="04bb-9232-6cae-47f2" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
-            <categoryLink id="fab9-12fe-9e83-6faa" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="f24c-7b68-d78c-11e2" name="1) Heavy Bolter Options" hidden="false" collective="false" import="true" defaultSelectionEntryId="e8ee-9957-bb72-3155">
@@ -27393,6 +27888,11 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
             <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
           </conditions>
         </modifier>
+        <modifier type="add" field="category" value="2bcf-6bbe-58a1-e082">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c83-69fb-8066-a773" type="equalTo"/>
+          </conditions>
+        </modifier>
       </modifiers>
       <infoLinks>
         <infoLink id="6688-04fe-0ef8-ff29" name="Deep Strike" hidden="false" targetId="f1e1-986f-c783-ca9e" type="rule"/>
@@ -27442,9 +27942,6 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
               </characteristics>
             </profile>
           </profiles>
-          <categoryLinks>
-            <categoryLink id="bba5-15e2-0342-6847" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
-          </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="8e58-3e53-6466-d844" name="1) Cyclone Missile Launcher Options" hidden="false" collective="false" import="true" defaultSelectionEntryId="eae6-b0e3-f61d-7ed0">
               <constraints>
@@ -27631,6 +28128,11 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
             <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo"/>
           </conditions>
         </modifier>
+        <modifier type="add" field="category" value="2bcf-6bbe-58a1-e082">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c83-69fb-8066-a773" type="equalTo"/>
+          </conditions>
+        </modifier>
       </modifiers>
       <infoLinks>
         <infoLink id="a976-a8c0-c396-da7f" name="Reactor Blast" hidden="false" targetId="85c2-d84d-6a4f-ab64" type="rule"/>
@@ -27664,7 +28166,6 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
           </profiles>
           <categoryLinks>
             <categoryLink id="3c86-f984-9801-c6ad" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
-            <categoryLink id="f5d8-3a3b-d955-9664" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="6c2c-6557-be98-903a" name="3) May take:" hidden="false" collective="false" import="true">
@@ -27975,6 +28476,11 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
             <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo"/>
           </conditions>
         </modifier>
+        <modifier type="add" field="category" value="2bcf-6bbe-58a1-e082">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c83-69fb-8066-a773" type="equalTo"/>
+          </conditions>
+        </modifier>
       </modifiers>
       <infoLinks>
         <infoLink id="195a-ea3e-6ddd-377e" name="Crushing Weight" hidden="false" targetId="9eb0-9165-e000-818a" type="rule"/>
@@ -28008,7 +28514,6 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
           </profiles>
           <categoryLinks>
             <categoryLink id="c3fb-b663-3e8c-fac8" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
-            <categoryLink id="6eb8-767e-2988-9f20" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="8ebc-e1b7-eee0-81bc" name="3) May take:" hidden="false" collective="false" import="true">
@@ -28276,6 +28781,11 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
             <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo"/>
           </conditions>
         </modifier>
+        <modifier type="add" field="category" value="2bcf-6bbe-58a1-e082">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c83-69fb-8066-a773" type="equalTo"/>
+          </conditions>
+        </modifier>
       </modifiers>
       <profiles>
         <profile id="0b05-2dc7-b9e1-5a3e" name="Glaive" hidden="false" typeId="2fae-b053-3f78-e7b2" typeName=" Vehicle">
@@ -28297,7 +28807,6 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
         <categoryLink id="ae99-700e-db56-fc27" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="7852-636a-6edc-9978" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
         <categoryLink id="5a6b-0473-e1ba-1a6e" name="Super-heavy" hidden="false" targetId="7381-1130-ca6e-1806" primary="false"/>
-        <categoryLink id="b5cd-403c-68c2-de62" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="43d4-8f65-a666-b6e3" name="May take:" hidden="false" collective="false" import="true">
@@ -28559,6 +29068,13 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
       </costs>
     </selectionEntry>
     <selectionEntry id="8754-3a4f-213b-bdc0" name="Thunderhawk Gunship" hidden="false" collective="false" import="true" type="unit">
+      <modifiers>
+        <modifier type="add" field="category" value="2bcf-6bbe-58a1-e082">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c83-69fb-8066-a773" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile id="f471-f5a8-001a-2a5e" name="Thunderhawk Gunship" hidden="false" typeId="2fae-b053-3f78-e7b2" typeName=" Vehicle">
           <characteristics>
@@ -28586,7 +29102,6 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
         <categoryLink id="ea22-733c-649a-1077" name="Hover Sub-type" hidden="false" targetId="3a7a-8bb7-b0d3-e2e7" primary="false"/>
         <categoryLink id="d4f2-aa4f-0399-dcfe" name="Lumbering" hidden="false" targetId="7f9b-c5ed-7edb-02dc" primary="false"/>
         <categoryLink id="0b61-29b5-1887-5b88" name="Transport" hidden="false" targetId="7b0a-a743-a8da-3a39" primary="false"/>
-        <categoryLink id="d918-0e6b-6844-4953" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="fb46-e14c-0a38-320b" name="1) Main Gun Options" hidden="false" collective="false" import="true" defaultSelectionEntryId="8df2-f6fb-f564-4c74">
@@ -28740,6 +29255,11 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
             <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo"/>
           </conditions>
         </modifier>
+        <modifier type="add" field="category" value="2bcf-6bbe-58a1-e082">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c83-69fb-8066-a773" type="equalTo"/>
+          </conditions>
+        </modifier>
       </modifiers>
       <profiles>
         <profile id="09eb-b5e9-6ceb-86f6" name="Fellblade" hidden="false" typeId="2fae-b053-3f78-e7b2" typeName=" Vehicle">
@@ -28758,7 +29278,6 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
       </profiles>
       <categoryLinks>
         <categoryLink id="9bac-bc2a-2c38-ab28" name="Super-heavy" hidden="false" targetId="7381-1130-ca6e-1806" primary="false"/>
-        <categoryLink id="abd4-40bc-eb55-33b5" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="2dbd-13c2-ed9e-c395" name="1) Hull Weapon Options" hidden="false" collective="false" import="true" defaultSelectionEntryId="f831-4ab5-a7ea-f1d5">
@@ -29040,6 +29559,11 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
             <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo"/>
           </conditions>
         </modifier>
+        <modifier type="add" field="category" value="2bcf-6bbe-58a1-e082">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c83-69fb-8066-a773" type="equalTo"/>
+          </conditions>
+        </modifier>
       </modifiers>
       <profiles>
         <profile id="b7fb-1e71-e236-0be2" name="Mastodon" hidden="false" typeId="2fae-b053-3f78-e7b2" typeName=" Vehicle">
@@ -29071,7 +29595,6 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
         <categoryLink id="231c-19d1-0097-c872" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
         <categoryLink id="35a4-7e73-f5a8-c7a8" name="Super-heavy" hidden="false" targetId="7381-1130-ca6e-1806" primary="false"/>
         <categoryLink id="9168-20ed-1639-2373" name="Transport" hidden="false" targetId="7b0a-a743-a8da-3a39" primary="false"/>
-        <categoryLink id="121d-8ef3-ef67-d18d" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="c830-8055-5fad-7768" name="1) Turret Mounted Equipment" hidden="false" collective="false" import="true" defaultSelectionEntryId="17eb-0577-023d-3735">
@@ -29226,6 +29749,11 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
         <modifier type="add" field="category" value="a335-d5b0-79b6-8117">
           <conditions>
             <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo"/>
+          </conditions>
+        </modifier>
+        <modifier type="add" field="category" value="2bcf-6bbe-58a1-e082">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c83-69fb-8066-a773" type="equalTo"/>
           </conditions>
         </modifier>
       </modifiers>
@@ -29499,6 +30027,13 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
       </costs>
     </selectionEntry>
     <selectionEntry id="f403-630f-71ae-5a7d" name="Sokar Stormbird" hidden="false" collective="false" import="true" type="model">
+      <modifiers>
+        <modifier type="add" field="category" value="2bcf-6bbe-58a1-e082">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c83-69fb-8066-a773" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile id="5fb3-5546-93f0-c504" name="Sokar Stormbird" hidden="false" typeId="2fae-b053-3f78-e7b2" typeName=" Vehicle">
           <characteristics>
@@ -29530,7 +30065,6 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
         <categoryLink id="b8c4-671b-9a5f-eb6b" name="Hover Sub-type" hidden="false" targetId="3a7a-8bb7-b0d3-e2e7" primary="false"/>
         <categoryLink id="853a-8e69-b900-48c9" name="Lumbering" hidden="false" targetId="7f9b-c5ed-7edb-02dc" primary="false"/>
         <categoryLink id="4d3e-f11e-f213-f158" name="Transport" hidden="false" targetId="7b0a-a743-a8da-3a39" primary="false"/>
-        <categoryLink id="c5be-01dc-c977-d4f3" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="110f-5a27-f7d4-0302" name="1) Left Side Weapon Options" hidden="false" collective="false" import="true" defaultSelectionEntryId="a0f9-7e15-88f2-eef0">
@@ -29693,6 +30227,11 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
             <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo"/>
           </conditions>
         </modifier>
+        <modifier type="add" field="category" value="2bcf-6bbe-58a1-e082">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c83-69fb-8066-a773" type="equalTo"/>
+          </conditions>
+        </modifier>
       </modifiers>
       <profiles>
         <profile id="4edb-4679-a1c3-5786" name="Shadowsword" hidden="false" typeId="2fae-b053-3f78-e7b2" typeName=" Vehicle">
@@ -29713,7 +30252,6 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
         <categoryLink id="4346-61f7-6ddb-7db4" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="0163-3f12-80b9-2221" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="eb3d-4f92-8ccb-b662" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
-        <categoryLink id="3fa2-6d9b-66ca-29f3" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="985f-caea-1e37-8ac2" name="May take:" hidden="false" collective="false" import="true">
@@ -29962,7 +30500,6 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
         <categoryLink id="8775-c7f6-d071-55c9" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="1bb7-7735-8c97-b799" name="Transport" hidden="false" targetId="7b0a-a743-a8da-3a39" primary="false"/>
         <categoryLink id="d320-d9a9-315c-2b0c" name="Reinforced Sub-type:" hidden="false" targetId="9b0d-738c-10e4-4ec1" primary="false"/>
-        <categoryLink id="4fd1-ce55-689e-1af2" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="e097-5c31-84dd-dc26" name="1) Hull Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="9d6b-4a72-62ea-1317">
@@ -30180,11 +30717,17 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
       </costs>
     </selectionEntry>
     <selectionEntry id="23e4-c64b-65b4-c8a5" name="Rapier Battery" hidden="false" collective="false" import="true" type="unit">
+      <modifiers>
+        <modifier type="add" field="category" value="db6f-0311-834c-e6ff">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c83-69fb-8066-a773" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="6beb-8854-14dd-3db9" name="Artillery Sub-type:" hidden="false" targetId="6f99-c178-6f9d-fb63" primary="false"/>
         <categoryLink id="fbe0-eca3-2aa2-eecc" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="5a2f-2252-bba0-e052" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
-        <categoryLink id="a165-29f0-1617-b437" name="Infantry Only" hidden="false" targetId="db6f-0311-834c-e6ff" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="975a-c83c-1f06-b4c8" name="1) Battery Weapon Options" hidden="false" collective="false" import="true" defaultSelectionEntryId="beaa-2d73-874a-0897">
@@ -30625,6 +31168,32 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
           </conditions>
         </modifier>
       </modifiers>
+      <modifierGroups>
+        <modifierGroup>
+          <modifiers>
+            <modifier type="add" field="category" value="db6f-0311-834c-e6ff">
+              <conditionGroups>
+                <conditionGroup type="and">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c83-69fb-8066-a773" type="equalTo"/>
+                    <condition field="selections" scope="954d-cf8e-eefd-27a6" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="16a0-0aeb-974a-33a9" type="equalTo"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+            <modifier type="add" field="category" value="2bcf-6bbe-58a1-e082">
+              <conditionGroups>
+                <conditionGroup type="and">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c83-69fb-8066-a773" type="equalTo"/>
+                    <condition field="selections" scope="954d-cf8e-eefd-27a6" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="16a0-0aeb-974a-33a9" type="greaterThan"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
+        </modifierGroup>
+      </modifierGroups>
       <constraints>
         <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="06d8-ea57-0a19-b93a" type="max"/>
       </constraints>
@@ -30671,7 +31240,6 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
         <categoryLink id="f0cb-e19d-2d73-aa3f" name="Terminators:" hidden="false" targetId="bab3-f50d-3e5f-2f78" primary="false"/>
         <categoryLink id="a888-0301-9c87-ae58" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
         <categoryLink id="94de-62fb-73ee-229d" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="9ae2-1bcd-de39-c704" name="Infantry Only" hidden="false" targetId="db6f-0311-834c-e6ff" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="0740-a851-4e97-fced" name="Nullificator" hidden="false" collective="false" import="true" type="model">
@@ -31007,6 +31575,11 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
             <condition field="selections" scope="daf7-b23b-5474-5836" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="555f-3998-a06e-f415" type="equalTo"/>
           </conditions>
         </modifier>
+        <modifier type="add" field="category" value="2bcf-6bbe-58a1-e082">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c83-69fb-8066-a773" type="equalTo"/>
+          </conditions>
+        </modifier>
       </modifiers>
       <infoLinks>
         <infoLink id="a87a-f9bb-ddda-a09b" name="Dreadnought Talon" hidden="false" targetId="a924-2634-73fd-aa96" type="rule"/>
@@ -31082,7 +31655,6 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
           </profiles>
           <categoryLinks>
             <categoryLink id="f292-0604-29fa-a71e" name="Dreadnought Unit-type:" hidden="false" targetId="4280-4963-02b5-e31d" primary="false"/>
-            <categoryLink id="ad69-8717-dba6-9001" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="cdb1-bf93-df94-2bf9" name="4) May take:" hidden="false" collective="false" import="true">
@@ -31431,6 +32003,32 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
           </conditions>
         </modifier>
       </modifiers>
+      <modifierGroups>
+        <modifierGroup>
+          <modifiers>
+            <modifier type="add" field="category" value="db6f-0311-834c-e6ff">
+              <conditionGroups>
+                <conditionGroup type="and">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c83-69fb-8066-a773" type="equalTo"/>
+                    <condition field="selections" scope="aa7f-bd4c-5231-d459" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5372-67ef-f594-305b" type="equalTo"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+            <modifier type="add" field="category" value="2bcf-6bbe-58a1-e082">
+              <conditionGroups>
+                <conditionGroup type="and">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c83-69fb-8066-a773" type="equalTo"/>
+                    <condition field="selections" scope="aa7f-bd4c-5231-d459" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5372-67ef-f594-305b" type="greaterThan"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
+        </modifierGroup>
+      </modifierGroups>
       <rules>
         <rule id="89b9-6f89-73a2-4e98" name="Pride of the Legion" publicationId="d0df-7166-5cd3-89fd" page="18" hidden="false">
           <description>Any Legion Terminator Indomitus Squads taken in a Detachment with the Pride of the Legion Rite of War lose the Support Squad special rule and gain the Line Sub-type.</description>
@@ -31473,7 +32071,6 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
         <categoryLink id="ba6c-bb79-909d-33f1" name="Terminators:" hidden="false" targetId="bab3-f50d-3e5f-2f78" primary="false"/>
         <categoryLink id="0a43-ec27-0c1e-4c5b" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="5ff7-87f5-f921-d1c4" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
-        <categoryLink id="c416-8484-3d86-bc26" name="Infantry Only" hidden="false" targetId="db6f-0311-834c-e6ff" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="23e2-4e21-6229-2444" name="3) One Legion Indomitus may take:" hidden="false" collective="false" import="true">
@@ -32321,6 +32918,11 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
             <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
           </conditions>
         </modifier>
+        <modifier type="add" field="category" value="2bcf-6bbe-58a1-e082">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c83-69fb-8066-a773" type="equalTo"/>
+          </conditions>
+        </modifier>
       </modifiers>
       <categoryLinks>
         <categoryLink id="2112-2112-a19d-f2d6" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
@@ -32349,7 +32951,6 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
           </profiles>
           <categoryLinks>
             <categoryLink id="5e23-61e4-47a0-0e3e" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
-            <categoryLink id="383c-a4a3-8fc6-af0e" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="ae74-5d4e-7532-84ac" name="2) May Take:" hidden="false" collective="false" import="true">
@@ -32609,6 +33210,11 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
             <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
           </conditions>
         </modifier>
+        <modifier type="add" field="category" value="2bcf-6bbe-58a1-e082">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c83-69fb-8066-a773" type="equalTo"/>
+          </conditions>
+        </modifier>
       </modifiers>
       <categoryLinks>
         <categoryLink id="ba88-571f-1c64-4f5b" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
@@ -32638,7 +33244,6 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
           </profiles>
           <categoryLinks>
             <categoryLink id="a0e0-36ae-f8cc-a99d" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
-            <categoryLink id="8185-3d0d-5b63-df53" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="0c4f-3ecb-4134-314d" name="1) Turret Mounted Weapon:" hidden="false" collective="false" import="true" defaultSelectionEntryId="270d-03a1-1122-8540">
@@ -33260,7 +33865,6 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
           </infoLinks>
           <categoryLinks>
             <categoryLink id="38b0-7f4d-7fa6-5d5a" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
-            <categoryLink id="88f4-2c3d-4f9c-3842" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="7865-513b-43f6-7ba3" name="May take:" hidden="false" collective="false" import="true">
@@ -33481,6 +34085,11 @@ Additionally, at the end of any Phase in which a model with Gorgon Terminator ar
             <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
           </conditions>
         </modifier>
+        <modifier type="add" field="category" value="2bcf-6bbe-58a1-e082">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c83-69fb-8066-a773" type="equalTo"/>
+          </conditions>
+        </modifier>
       </modifiers>
       <infoLinks>
         <infoLink id="4e5f-ff66-6b18-54e4" name="Hammer of Wrath (X)" hidden="false" targetId="aec0-c3aa-1e4e-1779" type="rule">
@@ -33513,7 +34122,6 @@ Additionally, at the end of any Phase in which a model with Gorgon Terminator ar
         <categoryLink id="995e-aa85-478b-de47" name="Skirmish:" hidden="false" targetId="59a4-7b61-600a-c457" primary="false"/>
         <categoryLink id="1b08-e6e5-3d06-e1a1" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="1256-af1a-9a11-bd3b" name="Cavalry Sub-type:" hidden="false" targetId="6d79-a3e4-381f-7b0f" primary="false"/>
-        <categoryLink id="0f11-e290-4c84-1c95" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="a0ea-afcb-5c88-a699" name="Legion Spatha Attack Bike" hidden="false" collective="false" import="true" type="model">
@@ -33711,6 +34319,13 @@ Additionally, at the end of any Phase in which a model with Gorgon Terminator ar
       </costs>
     </selectionEntry>
     <selectionEntry id="0583-258d-f0a0-2170" name="Nathaniel Garro" hidden="false" collective="false" import="true" type="model">
+      <modifiers>
+        <modifier type="add" field="category" value="db6f-0311-834c-e6ff">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c83-69fb-8066-a773" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile id="cbd5-d543-c2a9-fbe7" name="Nathaniel Garro" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
           <characteristics>
@@ -33739,7 +34354,6 @@ Additionally, at the end of any Phase in which a model with Gorgon Terminator ar
       <categoryLinks>
         <categoryLink id="04e3-a81a-89b2-5f49" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
         <categoryLink id="793a-67fe-8731-7c9f" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="a266-5b5f-670e-df4c" name="Infantry Only" hidden="false" targetId="db6f-0311-834c-e6ff" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="e353-952c-5733-c446" name="Libertas" hidden="false" collective="false" import="true" type="upgrade">
@@ -33836,6 +34450,13 @@ Garro is fighting in a Challenge</characteristic>
       </costs>
     </selectionEntry>
     <selectionEntry id="56bf-2c6d-a0fa-a145" name="Tylos Rubio" publicationId="d0df-7166-5cd3-89fd" page="6" hidden="false" collective="false" import="true" type="model">
+      <modifiers>
+        <modifier type="add" field="category" value="db6f-0311-834c-e6ff">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c83-69fb-8066-a773" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile id="21fb-5fb4-7430-24c7" name="Tylos Rubio" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
           <characteristics>
@@ -33865,7 +34486,6 @@ Garro is fighting in a Challenge</characteristic>
         <categoryLink id="b8cf-ff1a-662e-6f72" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
         <categoryLink id="e2a6-00ad-2796-c89b" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="0528-07cf-ec83-bdab" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="93b2-1197-7163-cc43" name="Infantry Only" hidden="false" targetId="db6f-0311-834c-e6ff" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="7a6e-ff13-9c39-ff1d" name="The Aegis Argentum" publicationId="d0df-7166-5cd3-89fd" page="7" hidden="false" collective="false" import="true" type="upgrade">
@@ -33965,6 +34585,11 @@ containing the model that failed its Check. If the Psyker survives Perils of the
             <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo"/>
           </conditions>
         </modifier>
+        <modifier type="add" field="category" value="2bcf-6bbe-58a1-e082">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c83-69fb-8066-a773" type="equalTo"/>
+          </conditions>
+        </modifier>
       </modifiers>
       <profiles>
         <profile id="2054-6e80-540c-fd7f" name="Banehammer" hidden="false" typeId="2fae-b053-3f78-e7b2" typeName=" Vehicle">
@@ -33985,7 +34610,6 @@ containing the model that failed its Check. If the Psyker survives Perils of the
         <categoryLink id="12f4-8864-ab57-f9f9" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="c519-b6ff-7f40-4d69" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="7f7a-19de-90a2-4c95" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
-        <categoryLink id="9c9b-f85a-e481-2931" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="0bf0-559f-72b9-cfa9" name="4) May take:" hidden="false" collective="false" import="true">
@@ -34209,6 +34833,11 @@ containing the model that failed its Check. If the Psyker survives Perils of the
             <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo"/>
           </conditions>
         </modifier>
+        <modifier type="add" field="category" value="2bcf-6bbe-58a1-e082">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c83-69fb-8066-a773" type="equalTo"/>
+          </conditions>
+        </modifier>
       </modifiers>
       <profiles>
         <profile id="054d-bad1-5823-a55e" name="Baneblade" hidden="false" typeId="2fae-b053-3f78-e7b2" typeName=" Vehicle">
@@ -34229,7 +34858,6 @@ containing the model that failed its Check. If the Psyker survives Perils of the
         <categoryLink id="46f1-e90b-bf1d-882c" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="5f4a-4ffd-a8a7-2c3e" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="9823-f559-b33c-66e6" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
-        <categoryLink id="5efe-4091-635b-6181" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="123c-539a-dca4-5fb2" name="May take:" hidden="false" collective="false" import="true">
@@ -34471,6 +35099,11 @@ containing the model that failed its Check. If the Psyker survives Perils of the
             <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo"/>
           </conditions>
         </modifier>
+        <modifier type="add" field="category" value="2bcf-6bbe-58a1-e082">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c83-69fb-8066-a773" type="equalTo"/>
+          </conditions>
+        </modifier>
       </modifiers>
       <profiles>
         <profile id="ea3f-b365-8ddb-d484" name="Stormblade" hidden="false" typeId="2fae-b053-3f78-e7b2" typeName=" Vehicle">
@@ -34491,7 +35124,6 @@ containing the model that failed its Check. If the Psyker survives Perils of the
         <categoryLink id="6730-3426-65c4-b313" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="2c58-a573-56d4-ec73" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="d6e3-8a15-0d26-6d93" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
-        <categoryLink id="876b-182e-5279-0ad9" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="6534-8d4a-6593-2806" name="May take:" hidden="false" collective="false" import="true">
@@ -34671,6 +35303,11 @@ containing the model that failed its Check. If the Psyker survives Perils of the
             <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo"/>
           </conditions>
         </modifier>
+        <modifier type="add" field="category" value="2bcf-6bbe-58a1-e082">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c83-69fb-8066-a773" type="equalTo"/>
+          </conditions>
+        </modifier>
       </modifiers>
       <profiles>
         <profile id="6706-c4ba-06ba-bda3" name="Stormlord" hidden="false" typeId="2fae-b053-3f78-e7b2" typeName=" Vehicle">
@@ -34691,7 +35328,6 @@ containing the model that failed its Check. If the Psyker survives Perils of the
         <categoryLink id="3218-f8aa-2242-3c25" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="40ad-88a5-9830-de8c" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
         <categoryLink id="b90d-8751-2096-6845" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="c115-dbdb-1896-1db4" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="baa5-fc7e-f925-4a5d" name="May take:" hidden="false" collective="false" import="true">
@@ -34886,6 +35522,11 @@ containing the model that failed its Check. If the Psyker survives Perils of the
             <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo"/>
           </conditions>
         </modifier>
+        <modifier type="add" field="category" value="2bcf-6bbe-58a1-e082">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c83-69fb-8066-a773" type="equalTo"/>
+          </conditions>
+        </modifier>
       </modifiers>
       <profiles>
         <profile id="b40a-4fa3-7b99-6518" name="Stormsword" hidden="false" typeId="2fae-b053-3f78-e7b2" typeName=" Vehicle">
@@ -34906,7 +35547,6 @@ containing the model that failed its Check. If the Psyker survives Perils of the
         <categoryLink id="0051-5fd8-4005-30c2" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="cb74-1081-9d7d-ec9c" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="c703-dfd8-1371-b64a" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
-        <categoryLink id="7460-4132-50f4-e879" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="00c0-3a7c-15d7-3788" name="May take:" hidden="false" collective="false" import="true">
@@ -35120,6 +35760,11 @@ containing the model that failed its Check. If the Psyker survives Perils of the
             <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
           </conditions>
         </modifier>
+        <modifier type="add" field="category" value="2bcf-6bbe-58a1-e082">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c83-69fb-8066-a773" type="equalTo"/>
+          </conditions>
+        </modifier>
       </modifiers>
       <profiles>
         <profile id="caa5-278d-5d8f-c074" name="Whirlwind" publicationId="d0df-7166-5cd3-89fd" page="27" hidden="false" typeId="2fae-b053-3f78-e7b2" typeName=" Vehicle">
@@ -35141,7 +35786,6 @@ containing the model that failed its Check. If the Psyker survives Perils of the
         <categoryLink id="5907-22d5-cb57-2222" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="1bfc-4442-f18b-c57b" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="f3aa-c912-cb85-0629" name="Bombard Sub-type:" hidden="false" targetId="d5df-57ac-8f3c-097b" primary="false"/>
-        <categoryLink id="55d8-5a2b-cdf8-ab98" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="b4f4-a12a-e7da-3341" name="Pintle mounted Weapon Options" hidden="false" collective="false" import="true">
@@ -35307,6 +35951,11 @@ containing the model that failed its Check. If the Psyker survives Perils of the
             <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
           </conditions>
         </modifier>
+        <modifier type="add" field="category" value="2bcf-6bbe-58a1-e082">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c83-69fb-8066-a773" type="equalTo"/>
+          </conditions>
+        </modifier>
       </modifiers>
       <categoryLinks>
         <categoryLink id="22a2-27bf-4393-a373" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
@@ -35336,7 +35985,6 @@ containing the model that failed its Check. If the Psyker survives Perils of the
           </profiles>
           <categoryLinks>
             <categoryLink id="9e86-a1f3-a85e-737c" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
-            <categoryLink id="b0ea-e29a-2db5-7417" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="f661-cf57-5135-4146" name="May take:" hidden="false" collective="false" import="true">
@@ -35600,6 +36248,11 @@ containing the model that failed its Check. If the Psyker survives Perils of the
             <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
           </conditions>
         </modifier>
+        <modifier type="add" field="category" value="2bcf-6bbe-58a1-e082">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c83-69fb-8066-a773" type="equalTo"/>
+          </conditions>
+        </modifier>
       </modifiers>
       <categoryLinks>
         <categoryLink id="94ed-969e-a5ce-0329" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
@@ -35629,7 +36282,6 @@ containing the model that failed its Check. If the Psyker survives Perils of the
           </profiles>
           <categoryLinks>
             <categoryLink id="359b-fa5f-391b-96ba" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
-            <categoryLink id="d8dd-7b4f-0879-f745" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="3640-9400-1ca4-403e" name="May take:" hidden="false" collective="false" import="true">
@@ -35882,6 +36534,11 @@ containing the model that failed its Check. If the Psyker survives Perils of the
             <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
           </conditions>
         </modifier>
+        <modifier type="add" field="category" value="2bcf-6bbe-58a1-e082">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c83-69fb-8066-a773" type="equalTo"/>
+          </conditions>
+        </modifier>
       </modifiers>
       <profiles>
         <profile id="8319-4d8b-93a8-53d9" name="Thunderbolt Fighter" hidden="false" typeId="2fae-b053-3f78-e7b2" typeName=" Vehicle">
@@ -35905,7 +36562,6 @@ containing the model that failed its Check. If the Psyker survives Perils of the
         <categoryLink id="992a-101e-f1c0-2b6f" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="53cc-a648-20ea-e349" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="32f2-4ab0-d1cd-7cf0" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
-        <categoryLink id="e09b-159a-e9a4-8697" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="ee7e-a739-4575-9ad9" name="2) May take:" hidden="false" collective="false" import="true">
@@ -35997,6 +36653,11 @@ containing the model that failed its Check. If the Psyker survives Perils of the
             <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
           </conditions>
         </modifier>
+        <modifier type="add" field="category" value="2bcf-6bbe-58a1-e082">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c83-69fb-8066-a773" type="equalTo"/>
+          </conditions>
+        </modifier>
       </modifiers>
       <profiles>
         <profile id="7734-ee3f-d6f4-ed4b" name="Avenger Strike Fighter" hidden="false" typeId="2fae-b053-3f78-e7b2" typeName=" Vehicle">
@@ -36020,7 +36681,6 @@ containing the model that failed its Check. If the Psyker survives Perils of the
         <categoryLink id="b39e-518d-9b15-bc14" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="56be-a381-5681-4467" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="2a64-c9fa-2381-f3f9" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
-        <categoryLink id="5292-b6e9-f677-dc5e" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="b870-bb30-dc67-fce8" name="Hull (Front) Mounted Avenger bolt cannon" hidden="false" collective="false" import="true" type="upgrade">
@@ -36158,6 +36818,11 @@ containing the model that failed its Check. If the Psyker survives Perils of the
             <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
           </conditions>
         </modifier>
+        <modifier type="add" field="category" value="2bcf-6bbe-58a1-e082">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c83-69fb-8066-a773" type="equalTo"/>
+          </conditions>
+        </modifier>
       </modifiers>
       <profiles>
         <profile id="cf86-91cb-432a-176b" name="Primaris-Lightning Strike Fighter" hidden="false" typeId="2fae-b053-3f78-e7b2" typeName=" Vehicle">
@@ -36181,7 +36846,6 @@ containing the model that failed its Check. If the Psyker survives Perils of the
         <categoryLink id="8d00-8a0b-d3d5-58a7" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="5822-e87b-5749-5a7d" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="ad65-dae6-bb16-edb5" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
-        <categoryLink id="fd66-e86c-83e4-8aba" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="aa79-1382-6a4d-d728" name="2) May take:" hidden="false" collective="false" import="true">
@@ -36293,6 +36957,11 @@ containing the model that failed its Check. If the Psyker survives Perils of the
         <modifier type="add" field="category" value="fee9-d520-fed6-fb6f">
           <conditions>
             <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
+          </conditions>
+        </modifier>
+        <modifier type="add" field="category" value="db6f-0311-834c-e6ff">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c83-69fb-8066-a773" type="equalTo"/>
           </conditions>
         </modifier>
       </modifiers>
@@ -36617,11 +37286,15 @@ containing the model that failed its Check. If the Psyker survives Perils of the
             <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
           </conditions>
         </modifier>
+        <modifier type="add" field="category" value="2bcf-6bbe-58a1-e082">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c83-69fb-8066-a773" type="equalTo"/>
+          </conditions>
+        </modifier>
       </modifiers>
       <categoryLinks>
         <categoryLink id="b053-4b8e-8514-cb3f" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="c478-ab4e-1a65-2daa" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
-        <categoryLink id="493f-a6eb-f171-2ab4" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="8bf3-9b8d-578a-38f1" name="Land Raider Phobos " hidden="false" collective="false" import="true" type="model">
@@ -36889,6 +37562,11 @@ containing the model that failed its Check. If the Psyker survives Perils of the
             <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
           </conditions>
         </modifier>
+        <modifier type="add" field="category" value="2bcf-6bbe-58a1-e082">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c83-69fb-8066-a773" type="equalTo"/>
+          </conditions>
+        </modifier>
       </modifiers>
       <categoryLinks>
         <categoryLink id="29c9-1260-337f-9318" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
@@ -36931,7 +37609,6 @@ containing the model that failed its Check. If the Psyker survives Perils of the
           <categoryLinks>
             <categoryLink id="c3af-f5d6-2210-9218" name="Reinforced Sub-type:" hidden="false" targetId="9b0d-738c-10e4-4ec1" primary="false"/>
             <categoryLink id="8d73-a0a0-a804-6122" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
-            <categoryLink id="7173-ee4b-f48d-a125" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
           </categoryLinks>
           <selectionEntries>
             <selectionEntry id="b44b-a321-7724-b2b6" name="1) Hull (Front) Mounted Achillus Quad Launcher" hidden="false" collective="false" import="true" type="upgrade">
@@ -37175,6 +37852,11 @@ containing the model that failed its Check. If the Psyker survives Perils of the
             </conditionGroup>
           </conditionGroups>
         </modifier>
+        <modifier type="add" field="category" value="2bcf-6bbe-58a1-e082">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c83-69fb-8066-a773" type="equalTo"/>
+          </conditions>
+        </modifier>
       </modifiers>
       <profiles>
         <profile id="63f9-a8e5-ab16-deaf" name="Caestus Assault Ram" hidden="false" typeId="2fae-b053-3f78-e7b2" typeName=" Vehicle">
@@ -37199,7 +37881,6 @@ containing the model that failed its Check. If the Psyker survives Perils of the
         <categoryLink id="7230-f0b9-a9e3-1a41" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="f4b6-841c-0647-e523" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="54c6-4521-16ef-9033" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
-        <categoryLink id="9f7f-312c-0e0a-042a" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="9efc-950b-d435-50ce" name="Havoc Launcher Options" hidden="false" collective="false" import="true" defaultSelectionEntryId="e050-2037-d90c-6db3">
@@ -37270,6 +37951,11 @@ containing the model that failed its Check. If the Psyker survives Perils of the
             <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo"/>
           </conditions>
         </modifier>
+        <modifier type="add" field="category" value="2bcf-6bbe-58a1-e082">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c83-69fb-8066-a773" type="equalTo"/>
+          </conditions>
+        </modifier>
       </modifiers>
       <categoryLinks>
         <categoryLink id="4740-ca67-2937-0722" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
@@ -37298,7 +37984,6 @@ containing the model that failed its Check. If the Psyker survives Perils of the
           </profiles>
           <categoryLinks>
             <categoryLink id="b72e-0f0e-30be-2ae8" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
-            <categoryLink id="9d49-4562-bee0-395a" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="06bc-e5bc-15a2-0ac3" name="1) Main Cannon" hidden="false" collective="false" import="true" defaultSelectionEntryId="9d4c-0f3b-54f2-5940">
@@ -37589,6 +38274,11 @@ containing the model that failed its Check. If the Psyker survives Perils of the
             <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
           </conditions>
         </modifier>
+        <modifier type="add" field="category" value="2bcf-6bbe-58a1-e082">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c83-69fb-8066-a773" type="equalTo"/>
+          </conditions>
+        </modifier>
       </modifiers>
       <categoryLinks>
         <categoryLink id="ddec-50ef-3b4b-2ecc" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
@@ -37623,7 +38313,6 @@ containing the model that failed its Check. If the Psyker survives Perils of the
           <categoryLinks>
             <categoryLink id="3d15-4b03-3990-a801" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
             <categoryLink id="27f0-cd3d-9fbe-c047" name="Reinforced Sub-type:" hidden="false" targetId="9b0d-738c-10e4-4ec1" primary="false"/>
-            <categoryLink id="38e5-55aa-ecbf-f51d" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="2b42-c375-8d00-e27f" name="May take:" hidden="false" collective="false" import="true">
@@ -37737,6 +38426,11 @@ containing the model that failed its Check. If the Psyker survives Perils of the
             <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
           </conditions>
         </modifier>
+        <modifier type="add" field="category" value="2bcf-6bbe-58a1-e082">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c83-69fb-8066-a773" type="equalTo"/>
+          </conditions>
+        </modifier>
       </modifiers>
       <categoryLinks>
         <categoryLink id="bd2a-3b6a-6bc2-faf2" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
@@ -37769,7 +38463,6 @@ containing the model that failed its Check. If the Psyker survives Perils of the
           <categoryLinks>
             <categoryLink id="e8e4-d91a-160f-5f98" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
             <categoryLink id="0148-0faf-a575-11eb" name="Reinforced Sub-type:" hidden="false" targetId="9b0d-738c-10e4-4ec1" primary="false"/>
-            <categoryLink id="d79e-c4fc-7093-37e4" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="a082-432f-a77f-6c34" name="5) May take:" hidden="false" collective="false" import="true">
@@ -38065,6 +38758,13 @@ containing the model that failed its Check. If the Psyker survives Perils of the
       </costs>
     </selectionEntry>
     <selectionEntry id="d30b-59bb-8ae0-36d1" name="Destroyer Assault Squad" publicationId="a716-c1c4-7b26-8424" hidden="false" collective="false" import="true" type="unit">
+      <modifiers>
+        <modifier type="add" field="category" value="db6f-0311-834c-e6ff">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c83-69fb-8066-a773" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <infoLinks>
         <infoLink id="3821-3eb2-2940-2179" name="Bitter Duty" hidden="false" targetId="d1b8-31da-c53c-4fe2" type="rule"/>
         <infoLink id="3db5-2f63-6179-7c14" name="Counter-Attack (X)" hidden="false" targetId="fd6d-2a76-10e0-936a" type="rule">
@@ -38090,7 +38790,6 @@ containing the model that failed its Check. If the Psyker survives Perils of the
       </infoLinks>
       <categoryLinks>
         <categoryLink id="96a4-abb8-aa87-c97a" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="97df-92e2-b5be-c45c" name="Infantry Only" hidden="false" targetId="db6f-0311-834c-e6ff" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="a58b-3293-d55c-ebc2" name="  Destroyer Sergeant" hidden="false" collective="false" import="true" type="model">
@@ -39669,6 +40368,13 @@ During a Reaction made in any Phase, a player may not choose to activate a model
       </costs>
     </selectionEntry>
     <selectionEntry id="a8e9-70e1-b8bc-8ee2" name="Assault Squad" publicationId="a716-c1c4-7b26-8424" hidden="false" collective="false" import="true" type="unit">
+      <modifiers>
+        <modifier type="add" field="category" value="db6f-0311-834c-e6ff">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c83-69fb-8066-a773" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <infoLinks>
         <infoLink id="5854-b9b7-2fec-4911" name="Outflank" hidden="false" targetId="bfbf-e75c-49a2-0285" type="rule">
           <modifiers>
@@ -39690,7 +40396,6 @@ During a Reaction made in any Phase, a player may not choose to activate a model
         <categoryLink id="b857-6717-ae82-50fc" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="45c3-04df-2fcc-c0e5" name="Jump Infantry:" hidden="false" targetId="eee8-3c7c-2762-e33e" primary="false"/>
         <categoryLink id="c531-9282-85ea-930a" name="Line Sub-type:" hidden="false" targetId="6399-5c65-7833-1025" primary="false"/>
-        <categoryLink id="099f-44b6-75c1-ac5b" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="e6b7-06f3-c392-64c0" name=" Legion Assault Sergeant" hidden="false" collective="false" import="true" type="model">
@@ -40538,6 +41243,32 @@ During a Reaction made in any Phase, a player may not choose to activate a model
       </costs>
     </selectionEntry>
     <selectionEntry id="dbd4-930e-e003-9449" name="Mortalis Destroyer Squad" publicationId="a716-c1c4-7b26-8424" hidden="false" collective="false" import="true" type="unit">
+      <modifierGroups>
+        <modifierGroup>
+          <modifiers>
+            <modifier type="add" field="category" value="db6f-0311-834c-e6ff">
+              <conditionGroups>
+                <conditionGroup type="and">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c83-69fb-8066-a773" type="equalTo"/>
+                    <condition field="selections" scope="dbd4-930e-e003-9449" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3351-b5ea-4b0d-fd29" type="equalTo"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+            <modifier type="add" field="category" value="2bcf-6bbe-58a1-e082">
+              <conditionGroups>
+                <conditionGroup type="and">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c83-69fb-8066-a773" type="equalTo"/>
+                    <condition field="selections" scope="dbd4-930e-e003-9449" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3351-b5ea-4b0d-fd29" type="greaterThan"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
+        </modifierGroup>
+      </modifierGroups>
       <infoLinks>
         <infoLink id="1845-6dea-afaa-9c05" name="Bitter Duty" hidden="false" targetId="d1b8-31da-c53c-4fe2" type="rule"/>
         <infoLink id="9533-4e59-9981-83e1" name="Counter-Attack (X)" hidden="false" targetId="fd6d-2a76-10e0-936a" type="rule">
@@ -40564,7 +41295,6 @@ During a Reaction made in any Phase, a player may not choose to activate a model
       <categoryLinks>
         <categoryLink id="ce73-ce2e-305f-269d" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="7aae-5c6b-5782-4d71" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="a643-ac25-74fa-48c7" name="Infantry Only" hidden="false" targetId="db6f-0311-834c-e6ff" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="2515-c6a7-16d6-ac9e" name="  Destroyer Sergeant" hidden="false" collective="false" import="true" type="model">
@@ -42214,7 +42944,6 @@ During a Reaction made in any Phase, a player may not choose to activate a model
       </profiles>
       <categoryLinks>
         <categoryLink id="7516-dfe2-fcc7-c51f" name="Dreadnought Unit-type:" hidden="false" targetId="4280-4963-02b5-e31d" primary="false"/>
-        <categoryLink id="f4be-c2b4-e26e-9b8c" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="ac7d-4ee1-1a5f-ab7e" name="1) Weapon Option 1" hidden="false" collective="false" import="true" defaultSelectionEntryId="b892-eb06-ab29-e738">
@@ -42621,6 +43350,13 @@ During a Reaction made in any Phase, a player may not choose to activate a model
       </costs>
     </selectionEntry>
     <selectionEntry id="5b94-a916-9864-8d15" name="Thunderhawk Transporter" hidden="false" collective="false" import="true" type="unit">
+      <modifiers>
+        <modifier type="add" field="category" value="2bcf-6bbe-58a1-e082">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c83-69fb-8066-a773" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile id="8926-acf6-9983-dd9c" name="Thunderhawk Transporter" hidden="false" typeId="2fae-b053-3f78-e7b2" typeName=" Vehicle">
           <characteristics>
@@ -42647,9 +43383,6 @@ During a Reaction made in any Phase, a player may not choose to activate a model
         <infoLink id="5916-3eef-ebd6-8340" name="Auxiliary Vehicle Bay" hidden="false" targetId="8837-14e8-344a-1f39" type="rule"/>
         <infoLink id="2cbf-6343-0385-6fd7" name="Transport Bay" hidden="false" targetId="0662-8b8d-38e8-60f8" type="rule"/>
       </infoLinks>
-      <categoryLinks>
-        <categoryLink id="3745-6766-beef-1ac5" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
-      </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="888e-2e77-4caf-9925" name="1) Wing Weapon Options" hidden="false" collective="false" import="true" defaultSelectionEntryId="4d67-aa4e-a987-f780">
           <constraints>
@@ -42743,6 +43476,13 @@ During a Reaction made in any Phase, a player may not choose to activate a model
       </costs>
     </selectionEntry>
     <selectionEntry id="6879-98bf-7e9c-7093" name="Legion Marauder Bomber" hidden="false" collective="false" import="true" type="unit">
+      <modifiers>
+        <modifier type="add" field="category" value="2bcf-6bbe-58a1-e082">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c83-69fb-8066-a773" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile id="790f-7fc8-2d03-d8f7" name="Marauder Bomber" hidden="false" typeId="2fae-b053-3f78-e7b2" typeName=" Vehicle">
           <characteristics>
@@ -42761,9 +43501,6 @@ During a Reaction made in any Phase, a player may not choose to activate a model
       <infoLinks>
         <infoLink id="6535-5aa6-6722-753a" name="Deep Strike" hidden="false" targetId="f1e1-986f-c783-ca9e" type="rule"/>
       </infoLinks>
-      <categoryLinks>
-        <categoryLink id="a465-dde8-7b28-f028" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
-      </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="29cc-8d9e-f6dc-66f2" name="3) May take:" hidden="false" collective="false" import="true">
           <entryLinks>
@@ -42874,6 +43611,11 @@ During a Reaction made in any Phase, a player may not choose to activate a model
             <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo"/>
           </conditions>
         </modifier>
+        <modifier type="add" field="category" value="2bcf-6bbe-58a1-e082">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c83-69fb-8066-a773" type="equalTo"/>
+          </conditions>
+        </modifier>
       </modifiers>
       <profiles>
         <profile id="8142-7d14-75d1-89b7" name="Macharius Omega Heavy Tank" hidden="false" typeId="2fae-b053-3f78-e7b2" typeName=" Vehicle">
@@ -42898,9 +43640,6 @@ During a Reaction made in any Phase, a player may not choose to activate a model
       <infoLinks>
         <infoLink id="afde-172b-93dd-3f84" name="Volatile Plasma Containment" hidden="false" targetId="564b-25f0-6bae-949e" type="rule"/>
       </infoLinks>
-      <categoryLinks>
-        <categoryLink id="04d1-2509-3ca2-8294" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
-      </categoryLinks>
       <selectionEntries>
         <selectionEntry id="ba7f-1983-eb26-3761" name="Omega-pattern Plasma Blastgun" hidden="false" collective="false" import="true" type="upgrade">
           <modifiers>
@@ -43019,6 +43758,11 @@ During a Reaction made in any Phase, a player may not choose to activate a model
             <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo"/>
           </conditions>
         </modifier>
+        <modifier type="add" field="category" value="2bcf-6bbe-58a1-e082">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c83-69fb-8066-a773" type="equalTo"/>
+          </conditions>
+        </modifier>
       </modifiers>
       <profiles>
         <profile id="0938-7d9a-d992-a5ac" name="Crassus Armoured Assault Transport" hidden="false" typeId="2fae-b053-3f78-e7b2" typeName=" Vehicle">
@@ -43035,9 +43779,6 @@ During a Reaction made in any Phase, a player may not choose to activate a model
           </characteristics>
         </profile>
       </profiles>
-      <categoryLinks>
-        <categoryLink id="ec79-ca96-6e14-adc3" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
-      </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="584c-1391-dc26-2454" name="3) May take:" hidden="false" collective="false" import="true">
           <entryLinks>
@@ -43247,6 +43988,11 @@ During a Reaction made in any Phase, a player may not choose to activate a model
             <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo"/>
           </conditions>
         </modifier>
+        <modifier type="add" field="category" value="2bcf-6bbe-58a1-e082">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c83-69fb-8066-a773" type="equalTo"/>
+          </conditions>
+        </modifier>
       </modifiers>
       <profiles>
         <profile id="b405-c7a4-2b77-b9c1" name="Praetor Armoured Assault Transport" hidden="false" typeId="2fae-b053-3f78-e7b2" typeName=" Vehicle">
@@ -43263,9 +44009,6 @@ During a Reaction made in any Phase, a player may not choose to activate a model
           </characteristics>
         </profile>
       </profiles>
-      <categoryLinks>
-        <categoryLink id="7f60-9530-6ca1-4d05" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
-      </categoryLinks>
       <selectionEntries>
         <selectionEntry id="597b-12c7-3a14-cf77" name="Praetor Launcher" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
@@ -43425,6 +44168,13 @@ During a Reaction made in any Phase, a player may not choose to activate a model
       </costs>
     </selectionEntry>
     <selectionEntry id="cf51-6d23-8764-af94" name="Legion Marauder Destroyer" hidden="false" collective="false" import="true" type="unit">
+      <modifiers>
+        <modifier type="add" field="category" value="2bcf-6bbe-58a1-e082">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c83-69fb-8066-a773" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile id="c27f-0ac1-1410-4946" name="Marauder Destroyer" hidden="false" typeId="2fae-b053-3f78-e7b2" typeName=" Vehicle">
           <characteristics>
@@ -43443,9 +44193,6 @@ During a Reaction made in any Phase, a player may not choose to activate a model
       <infoLinks>
         <infoLink id="6a90-76f9-404a-d5f0" name="Deep Strike" hidden="false" targetId="f1e1-986f-c783-ca9e" type="rule"/>
       </infoLinks>
-      <categoryLinks>
-        <categoryLink id="a052-258f-f41d-79b7" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
-      </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="1089-f39e-058e-636c" name="3) May take:" hidden="false" collective="false" import="true">
           <entryLinks>
@@ -44575,7 +45322,6 @@ Invulnerable saves granted by a combat shield or boarding shield do not stack wi
       </infoLinks>
       <categoryLinks>
         <categoryLink id="b7a0-67ed-9fdb-1187" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="9706-3749-5fae-0300" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="b2f2-ebdf-0ced-fe23" name="Legiones Unit Upgrades:" hidden="false" collective="false" import="true">

--- a/2022 - Legiones Astartes.cat
+++ b/2022 - Legiones Astartes.cat
@@ -23166,20 +23166,32 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
-      </selectionEntryGroups>
-      <entryLinks>
-        <entryLink id="a2de-4a73-b105-d318" name="Dreadnought Drop Pod" hidden="false" collective="false" import="true" targetId="1ffe-82e4-12db-538d" type="selectionEntry">
+        <selectionEntryGroup id="0f0f-b23a-f95c-6ace" name="Drop Pods" hidden="false" collective="false" import="true">
           <modifiers>
-            <modifier type="set" field="86cd-d61a-ba38-fb08" value="0.0">
+            <modifier type="set" field="91f9-f7a3-c45d-8b85" value="0.0">
               <conditions>
                 <condition field="selections" scope="c2a7-9e2c-fc65-1b78" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ac2d-77a1-ecd7-a555" type="greaterThan"/>
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="86cd-d61a-ba38-fb08" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="91f9-f7a3-c45d-8b85" type="max"/>
           </constraints>
-        </entryLink>
+          <entryLinks>
+            <entryLink id="cdb3-a358-6b7b-fbc8" name="Dreadnought Drop Pod" hidden="false" collective="false" import="true" targetId="1ffe-82e4-12db-538d" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9c6e-b30e-6599-abbc" type="max"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="f451-50e9-034e-166b" name="Dreadnought Drop Pod" hidden="false" collective="false" import="true" targetId="1ffe-82e4-12db-538d" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="458c-0002-e097-caa5" type="max"/>
+              </constraints>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
         <entryLink id="ed4d-9a6d-3ddc-ac29" name="Hexagrammaton Choice:" hidden="false" collective="false" import="true" targetId="61a2-7005-1e6c-c08e" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
@@ -23201,11 +23213,6 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
         <modifier type="add" field="category" value="9edf-ad4f-0fe2-9b73">
           <conditions>
             <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
-          </conditions>
-        </modifier>
-        <modifier type="add" field="category" value="20ef-cd01-a8da-376e">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="50cf-edf5-d39a-8943" type="equalTo"/>
           </conditions>
         </modifier>
         <modifier type="add" field="category" value="2bcf-6bbe-58a1-e082">

--- a/2022 - Legiones Astartes.cat
+++ b/2022 - Legiones Astartes.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="6393-649c-7213-a327" name="(HH V2) Legions Astartes" revision="88" battleScribeVersion="2.03" authorName="Various" authorUrl="https://github.com/BSData/horus-heresy" library="true" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="36" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="6393-649c-7213-a327" name="(HH V2) Legions Astartes" revision="88" battleScribeVersion="2.03" authorName="Various" authorUrl="https://github.com/BSData/horus-heresy" library="true" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="38" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <profileTypes>
     <profileType id="7002-2f9a-59c4-2742" name="Prosperine Arcana">
       <characteristicTypes>
@@ -47,33 +47,28 @@
         <constraint field="selections" scope="force" value="-1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f1eb-cf2a-8611-faad" type="max"/>
       </constraints>
     </categoryEntry>
-    <categoryEntry id="db6f-0311-834c-e6ff" name="Infantry Only" hidden="false">
+    <categoryEntry id="350d-03ac-0da9-0c8b" name="The Guard Of The Crimson King (TS) Compulsory HQ" hidden="false">
       <modifiers>
-        <modifier type="set" field="80e6-cb32-4c9f-9518" value="1.0">
+        <modifier type="set" field="a0c7-dc64-dc1b-07d3" value="1.0">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c83-69fb-8066-a773" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0fa2-d71c-9cdb-86cb" type="equalTo"/>
           </conditions>
         </modifier>
       </modifiers>
       <constraints>
-        <constraint field="selections" scope="force" value="-1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="80e6-cb32-4c9f-9518" type="min"/>
+        <constraint field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a0c7-dc64-dc1b-07d3" type="min"/>
       </constraints>
     </categoryEntry>
-    <categoryEntry id="2bcf-6bbe-58a1-e082" name="Non-Infantry Only" hidden="false">
+    <categoryEntry id="14bd-5f53-021b-a0f3" name="Praevian Consul (The Achaean Configuration Requirment)" hidden="false">
       <modifiers>
-        <modifier type="set" field="8292-97e1-be59-de75" value="-1.0">
+        <modifier type="set" field="8e06-18ee-9523-a43d" value="1.0">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c83-69fb-8066-a773" type="lessThan"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="373b-ce5a-ddc5-cf8f" type="equalTo"/>
           </conditions>
-        </modifier>
-        <modifier type="increment" field="8292-97e1-be59-de75" value="1.0">
-          <repeats>
-            <repeat field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="db6f-0311-834c-e6ff" repeats="1" roundUp="false"/>
-          </repeats>
         </modifier>
       </modifiers>
       <constraints>
-        <constraint field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8292-97e1-be59-de75" type="max"/>
+        <constraint field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8e06-18ee-9523-a43d" type="min"/>
       </constraints>
     </categoryEntry>
   </categoryEntries>
@@ -3756,7 +3751,6 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
         <categoryLink id="240b-61e9-f6cc-56fa" name="New CategoryLink" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="1571-4b68-f416-00ea" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="4138-d106-960e-94e0" name="Line Sub-type:" hidden="false" targetId="6399-5c65-7833-1025" primary="false"/>
-        <categoryLink id="9b4e-df25-fe2b-90be" name="Infantry Only" hidden="false" targetId="db6f-0311-834c-e6ff" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="638c-a192-24e6-1604" name=" Legion Tactical Sergeant" hidden="false" collective="false" import="true" type="model">
@@ -4221,21 +4215,11 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
               <modifiers>
                 <modifier type="set" field="hidden" value="false">
                   <conditionGroups>
-                    <conditionGroup type="or">
-                      <conditionGroups>
-                        <conditionGroup type="and">
-                          <conditions>
-                            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1977-49f2-7910-f177" type="equalTo"/>
-                            <condition field="selections" scope="aa72-63e4-bc60-4611" value="10.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f115-cfc4-4199-f8be" type="lessThan"/>
-                          </conditions>
-                        </conditionGroup>
-                        <conditionGroup type="and">
-                          <conditions>
-                            <condition field="selections" scope="aa72-63e4-bc60-4611" value="10.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f115-cfc4-4199-f8be" type="lessThan"/>
-                            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e864-ddc1-da3a-138e" type="equalTo"/>
-                          </conditions>
-                        </conditionGroup>
-                      </conditionGroups>
+                    <conditionGroup type="and">
+                      <conditions>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1977-49f2-7910-f177" type="equalTo"/>
+                        <condition field="selections" scope="aa72-63e4-bc60-4611" value="10.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f115-cfc4-4199-f8be" type="lessThan"/>
+                      </conditions>
                     </conditionGroup>
                   </conditionGroups>
                 </modifier>
@@ -4906,7 +4890,6 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
         <categoryLink id="e07d-b552-90ef-c096" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="4048-d50e-f863-8094" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
         <categoryLink id="02a0-025a-fc68-8e2a" name="Transport" hidden="false" targetId="7b0a-a743-a8da-3a39" primary="false"/>
-        <categoryLink id="4e96-d77d-532c-741e" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="fffa-369b-8a93-c728" name="2) May take:" hidden="false" collective="false" import="true">
@@ -5118,7 +5101,6 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
       <categoryLinks>
         <categoryLink id="09bf-3b6b-fba1-8fae" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="566e-8e1f-ea26-51e1" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="305f-f9b4-05bd-c9a9" name="Infantry Only" hidden="false" targetId="db6f-0311-834c-e6ff" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="846e-c9da-5b90-861d" name=" Legion Tactical Support Sergeant" hidden="false" collective="false" import="true" type="model">
@@ -5595,7 +5577,6 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                     <conditionGroup type="or">
                       <conditions>
                         <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1977-49f2-7910-f177" type="equalTo"/>
-                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e864-ddc1-da3a-138e" type="equalTo"/>
                       </conditions>
                     </conditionGroup>
                   </conditionGroups>
@@ -6007,7 +5988,6 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
         <categoryLink id="2a0a-16f7-36a7-f414" name="Skirmish:" hidden="false" targetId="59a4-7b61-600a-c457" primary="false"/>
         <categoryLink id="ca35-8e83-c135-9eaf" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="ed2e-e758-859f-2c45" name="Cavalry Sub-type:" hidden="false" targetId="6d79-a3e4-381f-7b0f" primary="false"/>
-        <categoryLink id="8019-98fe-157c-594d" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="97b6-65f8-df73-9551" name="Legion Outriders" hidden="false" collective="false" import="true" type="model">
@@ -6524,7 +6504,6 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
       <categoryLinks>
         <categoryLink id="08b4-0dc4-d272-47f7" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="7ee1-e5c8-570a-223d" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
-        <categoryLink id="36f7-406d-40f1-3472" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="e11b-4170-0afd-b025" name="Sicaran Omega" hidden="false" collective="false" import="true" type="model">
@@ -6804,7 +6783,6 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
           </profiles>
           <categoryLinks>
             <categoryLink id="e659-8bae-056e-7bf3" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
-            <categoryLink id="9f9e-aaa0-df6a-0535" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="9fba-1911-69f1-4077" name="4) May Take:" hidden="false" collective="false" import="true">
@@ -7153,7 +7131,6 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
         <categoryLink id="cec9-0cba-c60c-7a82" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="002c-703f-e5f8-7705" name="Flyer" hidden="false" targetId="4e84-2d57-4986-2b23" primary="false"/>
         <categoryLink id="c857-29a3-277a-f9bb" name="Hover Sub-type" hidden="false" targetId="3a7a-8bb7-b0d3-e2e7" primary="false"/>
-        <categoryLink id="3769-fd6f-8878-eaf4" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="52b1-1b7c-90bf-eed2" name="Legion Fire Raptor Gunship" hidden="false" collective="false" import="true" type="model">
@@ -7322,7 +7299,6 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
           </infoLinks>
           <categoryLinks>
             <categoryLink id="6a3f-598c-9862-c796" name="Dreadnought:" hidden="false" targetId="4280-4963-02b5-e31d" primary="false"/>
-            <categoryLink id="0151-0251-1f64-1500" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="331d-145d-cd22-0f4e" name="1) Arm Weapon Choice:" hidden="false" collective="false" import="true" defaultSelectionEntryId="bf48-29c5-e0d0-56d0">
@@ -7559,7 +7535,6 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
         <categoryLink id="243d-5b6e-2794-2a35" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="2a7a-c446-f5fa-4eed" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="6165-b9b2-438c-a1a8" name="Transport" hidden="false" targetId="7b0a-a743-a8da-3a39" primary="false"/>
-        <categoryLink id="4ef6-6fa5-0abb-db97" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="dcd4-4e45-52d9-09b3" name="1) Pintle-mounted weapons:" hidden="false" collective="false" import="true">
@@ -7756,16 +7731,6 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
       </costs>
     </selectionEntry>
     <selectionEntry id="83ac-f9cf-cc29-00a3" name="Drop Pod" hidden="false" collective="false" import="true" type="upgrade">
-      <modifiers>
-        <modifier type="set" field="9a6e-8133-d94a-1f5c" value="0.0">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7a43-6793-013b-1af6" type="equalTo"/>
-          </conditions>
-        </modifier>
-      </modifiers>
-      <constraints>
-        <constraint field="selections" scope="force" value="-1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9a6e-8133-d94a-1f5c" type="max"/>
-      </constraints>
       <infoLinks>
         <infoLink id="febd-7328-3ea8-fc2f" name="Inertial Guidance System" hidden="false" targetId="d222-fde9-51b8-8739" type="rule"/>
         <infoLink id="7278-a30b-5237-7829" name="Impact-reactive Doors" hidden="false" targetId="6c21-dd77-4c93-eeed" type="rule"/>
@@ -7778,7 +7743,6 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
         <categoryLink id="5dfa-b331-6bee-1fc7" name="Transport" hidden="false" targetId="7b0a-a743-a8da-3a39" primary="false"/>
         <categoryLink id="a8b7-3e8a-2180-6644" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="100e-fe74-c5a5-3a07" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
-        <categoryLink id="19f3-25a9-c5b5-1ac4" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="216c-1984-d1a7-f3b1" name="Drop Pod" hidden="false" collective="false" import="true" type="model">
@@ -7863,16 +7827,6 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
       </costs>
     </selectionEntry>
     <selectionEntry id="1ffe-82e4-12db-538d" name="Dreadnought Drop Pod" hidden="false" collective="false" import="true" type="unit">
-      <modifiers>
-        <modifier type="set" field="ad98-c5b7-344a-b2d2" value="0.0">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7a43-6793-013b-1af6" type="equalTo"/>
-          </conditions>
-        </modifier>
-      </modifiers>
-      <constraints>
-        <constraint field="selections" scope="force" value="-1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ad98-c5b7-344a-b2d2" type="max"/>
-      </constraints>
       <infoLinks>
         <infoLink id="440d-1b43-e5d0-4e98" name="Inertial Guidance System" hidden="false" targetId="d222-fde9-51b8-8739" type="rule"/>
         <infoLink id="4ab2-0edb-0296-12eb" name="Impact-reactive Doors" hidden="false" targetId="6c21-dd77-4c93-eeed" type="rule"/>
@@ -7885,7 +7839,6 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
         <categoryLink id="9430-425d-f0a1-3055" name="Transport" hidden="false" targetId="7b0a-a743-a8da-3a39" primary="false"/>
         <categoryLink id="ca1f-0918-3532-f963" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="1966-a329-a6b5-94e9" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
-        <categoryLink id="7299-7f9e-9882-8f97" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="2a23-d677-62c5-ed1d" name="Dreadnought Drop Pod" hidden="false" collective="false" import="true" type="model">
@@ -7992,7 +7945,6 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
         <categoryLink id="3856-c687-8257-b20c" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
         <categoryLink id="905b-c1d8-b585-daaf" name="Transport" hidden="false" targetId="7b0a-a743-a8da-3a39" primary="false"/>
         <categoryLink id="2cbe-41c5-7149-b2a6" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
-        <categoryLink id="6b8c-c94a-b2ea-fa02" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="ede9-4deb-570d-70c0" name="Termite Assault Drill" hidden="false" collective="false" import="true" type="model">
@@ -8211,7 +8163,6 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
           </infoLinks>
           <categoryLinks>
             <categoryLink id="9df9-9e61-2785-d561" name="Dreadnought Unit-type:" hidden="false" targetId="4280-4963-02b5-e31d" primary="false"/>
-            <categoryLink id="bb4b-677f-5c22-6db5" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="9c64-0cf1-b27c-e84e" name="1) Weapon Option 1" hidden="false" collective="false" import="true" defaultSelectionEntryId="e636-ec3d-89ce-8cf5">
@@ -8645,7 +8596,6 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
         <categoryLink id="9c02-a9fe-a9c9-039f" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="8631-1aaf-e375-221c" name="Transport" hidden="false" targetId="7b0a-a743-a8da-3a39" primary="false"/>
         <categoryLink id="9ed7-53ba-9190-1c22" name="Reinforced Sub-type:" hidden="false" targetId="9b0d-738c-10e4-4ec1" primary="false"/>
-        <categoryLink id="34ac-1d95-e869-3f51" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="305c-37ae-3cda-349b" name="Land Raider Spartan" hidden="false" collective="false" import="true" type="upgrade">
@@ -8896,6 +8846,18 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
       </costs>
     </selectionEntry>
     <selectionEntry id="03be-5d55-d05a-771d" name="Praetor" hidden="false" collective="false" import="true" type="unit">
+      <modifiers>
+        <modifier type="add" field="category" value="350d-03ac-0da9-0c8b">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0fa2-d71c-9cdb-86cb" type="equalTo"/>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2aa6-ed38-ddc9-60fa" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <modifierGroups>
         <modifierGroup>
           <comment>Add Category (X)</comment>
@@ -8910,7 +8872,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                 </conditionGroup>
               </conditionGroups>
             </modifier>
-            <modifier type="add" field="category" value="db6f-0311-834c-e6ff">
+            <modifier type="add" field="category" value="8b4f-bfe2-ce7b-f1b1">
               <conditionGroups>
                 <conditionGroup type="and">
                   <conditions>
@@ -8946,28 +8908,6 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
               <conditions>
                 <condition field="selections" scope="03be-5d55-d05a-771d" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="cb35-21a5-c296-ddd9" type="equalTo"/>
               </conditions>
-            </modifier>
-            <modifier type="add" field="category" value="8b4f-bfe2-ce7b-f1b1">
-              <conditionGroups>
-                <conditionGroup type="and">
-                  <conditions>
-                    <condition field="selections" scope="03be-5d55-d05a-771d" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e254-77a1-6dae-14a0" type="equalTo"/>
-                    <condition field="selections" scope="03be-5d55-d05a-771d" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3952-66ed-93ea-27ee" type="equalTo"/>
-                    <condition field="selections" scope="03be-5d55-d05a-771d" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4108-5f37-0b50-b419" type="equalTo"/>
-                  </conditions>
-                </conditionGroup>
-              </conditionGroups>
-            </modifier>
-            <modifier type="add" field="category" value="2bcf-6bbe-58a1-e082">
-              <conditionGroups>
-                <conditionGroup type="or">
-                  <conditions>
-                    <condition field="selections" scope="03be-5d55-d05a-771d" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3952-66ed-93ea-27ee" type="atLeast"/>
-                    <condition field="selections" scope="03be-5d55-d05a-771d" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4108-5f37-0b50-b419" type="atLeast"/>
-                    <condition field="selections" scope="03be-5d55-d05a-771d" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e254-77a1-6dae-14a0" type="atLeast"/>
-                  </conditions>
-                </conditionGroup>
-              </conditionGroups>
             </modifier>
           </modifiers>
         </modifierGroup>
@@ -9012,7 +8952,6 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
       </infoLinks>
       <categoryLinks>
         <categoryLink id="555c-4c0c-29a0-082a" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="7a63-714c-8d20-c004" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="d862-5767-da41-cff0" name="Legion Praetor" hidden="false" collective="false" import="true" type="model">
@@ -9571,10 +9510,6 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
               </entryLinks>
             </selectionEntryGroup>
             <selectionEntryGroup id="f662-22a4-b0b4-3f15" name="0) Legion-specific upgrades" hidden="false" collective="false" import="true">
-              <categoryLinks>
-                <categoryLink id="ebe8-05b8-8ce2-ad96" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
-                <categoryLink id="eaa1-a718-303d-3a67" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
-              </categoryLinks>
               <entryLinks>
                 <entryLink id="ab3a-707f-7f67-8804" name="Dragonscale Shield" hidden="true" collective="false" import="true" targetId="489d-88d0-a0d8-b3e6" type="selectionEntry">
                   <modifiers>
@@ -9600,7 +9535,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="35.0"/>
                   </costs>
                 </entryLink>
-                <entryLink id="63e4-7f4f-70e7-64fd" name="Surgical Augment" hidden="true" collective="false" import="true" targetId="ffa3-1a57-1eb4-1818" type="selectionEntryGroup">
+                <entryLink id="63e4-7f4f-70e7-64fd" name="Surgical Augment" hidden="true" collective="false" import="true" targetId="aeb3-6a73-da1d-2b90" type="selectionEntryGroup">
                   <modifiers>
                     <modifier type="set" field="hidden" value="false">
                       <conditionGroups>
@@ -9915,6 +9850,16 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
             <condition field="selections" scope="1b79-1951-5a63-4b9e" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fd55-9459-b3b3-5d20" type="equalTo"/>
           </conditions>
         </modifier>
+        <modifier type="add" field="category" value="350d-03ac-0da9-0c8b">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0fa2-d71c-9cdb-86cb" type="equalTo"/>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2aa6-ed38-ddc9-60fa" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
       </modifiers>
       <infoLinks>
         <infoLink id="efe7-1f05-d369-32b4" name="Outflank" hidden="false" targetId="bfbf-e75c-49a2-0285" type="rule">
@@ -9950,7 +9895,6 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
         <categoryLink id="e1e8-360b-92f0-10e3" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
         <categoryLink id="e6ff-3685-f0a8-be34" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="a60b-1cf4-5ab4-bbff" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="e1f4-5100-9250-f86a" name="Infantry Only" hidden="false" targetId="db6f-0311-834c-e6ff" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="de73-2d79-156f-6f64" name="Legion Cataphractii Praetor" hidden="false" collective="false" import="true" type="model">
@@ -10052,7 +9996,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="35.0"/>
                   </costs>
                 </entryLink>
-                <entryLink id="b8e0-dc95-36b4-0a3f" name="Surgical Augment" hidden="true" collective="false" import="true" targetId="ffa3-1a57-1eb4-1818" type="selectionEntryGroup">
+                <entryLink id="b8e0-dc95-36b4-0a3f" name="Surgical Augment" hidden="true" collective="false" import="true" targetId="aeb3-6a73-da1d-2b90" type="selectionEntryGroup">
                   <modifiers>
                     <modifier type="set" field="hidden" value="false">
                       <conditionGroups>
@@ -10320,6 +10264,16 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
             <condition field="selections" scope="3760-204e-444c-1044" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fd55-9459-b3b3-5d20" type="equalTo"/>
           </conditions>
         </modifier>
+        <modifier type="add" field="category" value="350d-03ac-0da9-0c8b">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0fa2-d71c-9cdb-86cb" type="equalTo"/>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2aa6-ed38-ddc9-60fa" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
       </modifiers>
       <infoLinks>
         <infoLink id="24dc-79b7-16f5-6db3" name="Outflank" hidden="false" targetId="bfbf-e75c-49a2-0285" type="rule">
@@ -10354,7 +10308,6 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
       <categoryLinks>
         <categoryLink id="9d49-2d09-dd7c-30c3" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="5225-7937-685c-e9db" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="94f4-55bb-a038-7394" name="Infantry Only" hidden="false" targetId="db6f-0311-834c-e6ff" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="a2f0-15d9-2b7a-2204" name="Legion Tartaros Praetor" hidden="false" collective="false" import="true" type="model">
@@ -10456,7 +10409,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="35.0"/>
                   </costs>
                 </entryLink>
-                <entryLink id="3a9d-a0b7-4e30-3f78" name="Surgical Augment" hidden="false" collective="false" import="true" targetId="ffa3-1a57-1eb4-1818" type="selectionEntryGroup">
+                <entryLink id="3a9d-a0b7-4e30-3f78" name="Surgical Augment" hidden="false" collective="false" import="true" targetId="aeb3-6a73-da1d-2b90" type="selectionEntryGroup">
                   <modifiers>
                     <modifier type="set" field="hidden" value="false">
                       <conditionGroups>
@@ -10702,6 +10655,13 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
       </costs>
     </selectionEntry>
     <selectionEntry id="25a2-7a52-632a-6b2c" name="Centurion" hidden="false" collective="false" import="true" type="model">
+      <modifiers>
+        <modifier type="set" field="7e1a-0f0a-6d7f-1f19" value="1.0">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="373b-ce5a-ddc5-cf8f" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <modifierGroups>
         <modifierGroup>
           <comment>Add Category (X)</comment>
@@ -10743,31 +10703,12 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                 </conditionGroup>
               </conditionGroups>
             </modifier>
-            <modifier type="add" field="category" value="db6f-0311-834c-e6ff">
-              <conditionGroups>
-                <conditionGroup type="or">
-                  <conditions>
-                    <condition field="selections" scope="25a2-7a52-632a-6b2c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a8ac-7465-70fb-70fb" type="lessThan"/>
-                    <condition field="selections" scope="25a2-7a52-632a-6b2c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f152-51f5-b509-2d9c" type="lessThan"/>
-                    <condition field="selections" scope="25a2-7a52-632a-6b2c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9924-004c-e683-877b" type="lessThan"/>
-                  </conditions>
-                </conditionGroup>
-              </conditionGroups>
-            </modifier>
-            <modifier type="add" field="category" value="2bcf-6bbe-58a1-e082">
-              <conditionGroups>
-                <conditionGroup type="or">
-                  <conditions>
-                    <condition field="selections" scope="25a2-7a52-632a-6b2c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a8ac-7465-70fb-70fb" type="atLeast"/>
-                    <condition field="selections" scope="25a2-7a52-632a-6b2c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f152-51f5-b509-2d9c" type="atLeast"/>
-                    <condition field="selections" scope="25a2-7a52-632a-6b2c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9924-004c-e683-877b" type="atLeast"/>
-                  </conditions>
-                </conditionGroup>
-              </conditionGroups>
-            </modifier>
           </modifiers>
         </modifierGroup>
       </modifierGroups>
+      <constraints>
+        <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7e1a-0f0a-6d7f-1f19" type="min"/>
+      </constraints>
       <infoLinks>
         <infoLink id="5e6c-bc4c-3c23-15d2" name="Outflank" hidden="false" targetId="bfbf-e75c-49a2-0285" type="rule">
           <modifiers>
@@ -11946,7 +11887,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                     </modifier>
                   </modifiers>
                 </entryLink>
-                <entryLink id="a0ce-7130-54f7-edc5" name="Surgical Augment" hidden="true" collective="false" import="true" targetId="ffa3-1a57-1eb4-1818" type="selectionEntryGroup">
+                <entryLink id="a0ce-7130-54f7-edc5" name="Surgical Augment" hidden="true" collective="false" import="true" targetId="aeb3-6a73-da1d-2b90" type="selectionEntryGroup">
                   <modifiers>
                     <modifier type="set" field="hidden" value="false">
                       <conditionGroups>
@@ -12219,7 +12160,6 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
         <categoryLink id="9c7a-acc7-9230-fcc4" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="6901-e4b0-c5cc-a02b" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="a872-59ee-deae-90b7" name="Terminators:" hidden="false" targetId="bab3-f50d-3e5f-2f78" primary="false"/>
-        <categoryLink id="74d5-6f1c-2d5e-23df" name="Infantry Only" hidden="false" targetId="db6f-0311-834c-e6ff" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="87b7-091d-4bc3-9164" name="One Legion Tartaros may take:" hidden="false" collective="false" import="true">
@@ -12950,7 +12890,6 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
         <categoryLink id="d924-8839-45ef-d725" name="Terminators:" hidden="false" targetId="bab3-f50d-3e5f-2f78" primary="false"/>
         <categoryLink id="30ff-487a-51ee-62ce" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="8cc9-9b8f-dc8b-183f" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
-        <categoryLink id="3353-4c41-7567-bc88" name="Infantry Only" hidden="false" targetId="db6f-0311-834c-e6ff" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="b908-ada3-76ab-8d4d" name="2) One Legion Cataphractii may take:" hidden="false" collective="false" import="true">
@@ -13547,7 +13486,6 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
         <categoryLink id="176f-2693-896f-9748" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="3a70-5ba0-7914-683a" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="3cfb-f16e-35b6-c89d" name="Line Sub-type:" hidden="false" targetId="6399-5c65-7833-1025" primary="false"/>
-        <categoryLink id="7bab-24c0-89e7-7898" name="Infantry Only" hidden="false" targetId="db6f-0311-834c-e6ff" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="ef23-ca32-6fe5-b736" name="  Legion Despoiler Sergeant" hidden="false" collective="false" import="true" type="model">
@@ -14034,7 +13972,6 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                     <conditionGroup type="or">
                       <conditions>
                         <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1977-49f2-7910-f177" type="equalTo"/>
-                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e864-ddc1-da3a-138e" type="equalTo"/>
                       </conditions>
                     </conditionGroup>
                   </conditionGroups>
@@ -14484,7 +14421,6 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
         <categoryLink id="d5a1-47f5-0e3c-716d" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="ad69-ee1e-ec47-c17e" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
         <categoryLink id="39df-bd14-1a10-1f88" name="Line Sub-type:" hidden="false" targetId="6399-5c65-7833-1025" primary="false"/>
-        <categoryLink id="e462-1349-3629-f34d" name="Infantry Only" hidden="false" targetId="db6f-0311-834c-e6ff" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="8725-b9d1-1e86-0364" name="  Legion Breacher Sergeant" hidden="false" collective="false" import="true" type="model">
@@ -14915,7 +14851,6 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                     <conditionGroup type="or">
                       <conditions>
                         <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1977-49f2-7910-f177" type="equalTo"/>
-                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e864-ddc1-da3a-138e" type="equalTo"/>
                       </conditions>
                     </conditionGroup>
                   </conditionGroups>
@@ -15373,7 +15308,6 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
         <categoryLink id="78f2-3b93-045e-9fff" name="Infantry" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="da59-0c31-03f1-ae38" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="95f4-7bc2-449f-5dd3" name="Line Sub-type:" hidden="false" targetId="6399-5c65-7833-1025" primary="false"/>
-        <categoryLink id="0802-5786-4bf3-c07b" name="Infantry Only" hidden="false" targetId="db6f-0311-834c-e6ff" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="4d0d-06f9-4989-439e" name=" Legion Recon Sergeant" hidden="false" collective="false" import="true" type="model">
@@ -15978,7 +15912,6 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                     <conditionGroup type="or">
                       <conditions>
                         <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1977-49f2-7910-f177" type="equalTo"/>
-                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e864-ddc1-da3a-138e" type="equalTo"/>
                       </conditions>
                     </conditionGroup>
                   </conditionGroups>
@@ -16087,7 +16020,6 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
       <categoryLinks>
         <categoryLink id="1b9e-4e93-3914-a6e1" name="New CategoryLink" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="f887-300a-daae-7e57" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="49b4-8dc9-6457-dc3a" name="Infantry Only" hidden="false" targetId="db6f-0311-834c-e6ff" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="8867-1af4-01f7-da72" name="Legion Scout" hidden="false" collective="false" import="true" type="model">
@@ -16665,26 +16597,6 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
               <conditions>
                 <condition field="selections" scope="0aca-632d-1642-8af9" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6fb4-adf6-dbe8-86af" type="equalTo"/>
                 <condition field="selections" scope="0aca-632d-1642-8af9" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e8a8-b526-beab-bb82" type="equalTo"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-        <modifier type="add" field="category" value="2bcf-6bbe-58a1-e082">
-          <conditionGroups>
-            <conditionGroup type="or">
-              <conditions>
-                <condition field="selections" scope="0aca-632d-1642-8af9" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6fb4-adf6-dbe8-86af" type="equalTo"/>
-                <condition field="selections" scope="0aca-632d-1642-8af9" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e8a8-b526-beab-bb82" type="equalTo"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-        <modifier type="add" field="category" value="db6f-0311-834c-e6ff">
-          <conditionGroups>
-            <conditionGroup type="or">
-              <conditions>
-                <condition field="selections" scope="0aca-632d-1642-8af9" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6fb4-adf6-dbe8-86af" type="lessThan"/>
-                <condition field="selections" scope="0aca-632d-1642-8af9" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e8a8-b526-beab-bb82" type="lessThan"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
@@ -17437,7 +17349,6 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                     <conditionGroup type="or">
                       <conditions>
                         <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1977-49f2-7910-f177" type="equalTo"/>
-                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e864-ddc1-da3a-138e" type="equalTo"/>
                       </conditions>
                     </conditionGroup>
                   </conditionGroups>
@@ -17549,7 +17460,6 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
         <categoryLink id="b8e8-4253-0c09-b2ef" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
         <categoryLink id="4448-0829-a17f-5502" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="b7b3-57a1-d3d8-2be0" name="Terminators:" hidden="false" targetId="bab3-f50d-3e5f-2f78" primary="false"/>
-        <categoryLink id="4971-18c0-7a6f-b3e6" name="Infantry Only" hidden="false" targetId="db6f-0311-834c-e6ff" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="da79-9588-cc7f-e02f" name="Legion Cataphractii Centurion" hidden="false" collective="false" import="true" type="model">
@@ -17957,7 +17867,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                     </modifier>
                   </modifiers>
                 </entryLink>
-                <entryLink id="0fc9-8d7b-c87d-ef5f" name="Surgical Augment" hidden="true" collective="false" import="true" targetId="ffa3-1a57-1eb4-1818" type="selectionEntryGroup">
+                <entryLink id="0fc9-8d7b-c87d-ef5f" name="Surgical Augment" hidden="true" collective="false" import="true" targetId="aeb3-6a73-da1d-2b90" type="selectionEntryGroup">
                   <modifiers>
                     <modifier type="set" field="hidden" value="false">
                       <conditionGroups>
@@ -18125,7 +18035,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
-        <entryLink id="00f3-a40a-f289-9fc1" name="0) Legiones Consularis" hidden="false" collective="false" import="true" targetId="3cbf-9466-2558-2c22" type="selectionEntryGroup"/>
+        <entryLink id="00f3-a40a-f289-9fc1" name=" Legiones Consularis" hidden="false" collective="false" import="true" targetId="3cbf-9466-2558-2c22" type="selectionEntryGroup"/>
         <entryLink id="8a18-8470-ccc2-0a97" name="0) Consul Additional Wargear and Options" hidden="false" collective="false" import="true" targetId="244a-2a7c-1349-94e7" type="selectionEntryGroup"/>
         <entryLink id="36be-ca67-c929-4725" name="Warlord" hidden="false" collective="false" import="true" targetId="0176-56a3-d590-b103" type="selectionEntry">
           <constraints>
@@ -18166,7 +18076,6 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
       <categoryLinks>
         <categoryLink id="6815-a77d-f59b-632f" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="480a-471d-9c29-a920" name="Terminators:" hidden="false" targetId="bab3-f50d-3e5f-2f78" primary="false"/>
-        <categoryLink id="79ca-0d38-d631-8f29" name="Infantry Only" hidden="false" targetId="db6f-0311-834c-e6ff" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="f059-2405-bfa0-11cf" name="Dedicated Transport" hidden="false" collective="false" import="true">
@@ -18502,7 +18411,6 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
       <categoryLinks>
         <categoryLink id="028b-dfb1-e521-2745" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="cea8-a6fe-2e41-d8ff" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="b9ec-1b6f-0509-0e5e" name="Infantry Only" hidden="false" targetId="db6f-0311-834c-e6ff" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="2dde-c679-4d2d-e928" name="0) Legiones Unit Upgrades:" hidden="false" collective="false" import="true">
@@ -19980,7 +19888,6 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
       </infoLinks>
       <categoryLinks>
         <categoryLink id="bb97-be52-aa75-a4d0" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="a1e2-f519-dbbb-da61" name="Infantry Only" hidden="false" targetId="db6f-0311-834c-e6ff" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="415c-6834-f4d2-d967" name="Apothecary" publicationId="a716-c1c4-7b26-8424" hidden="false" collective="false" import="true" type="model">
@@ -20399,7 +20306,6 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
       <categoryLinks>
         <categoryLink id="13fc-715d-8968-5d54" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="129e-3d72-2602-afcd" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="defe-34ad-aa73-cce7" name="Infantry Only" hidden="false" targetId="db6f-0311-834c-e6ff" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="53c3-7eec-4676-996e" name="Legion Seeker" hidden="false" collective="false" import="true" type="model">
@@ -21066,7 +20972,6 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                     <conditionGroup type="or">
                       <conditions>
                         <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1977-49f2-7910-f177" type="equalTo"/>
-                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e864-ddc1-da3a-138e" type="equalTo"/>
                       </conditions>
                     </conditionGroup>
                   </conditionGroups>
@@ -21107,8 +21012,16 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
       </costs>
     </selectionEntry>
     <selectionEntry id="d39f-99d5-f7a4-7b86" name="Techmarine Covenant" publicationId="a716-c1c4-7b26-8424" hidden="false" collective="false" import="true" type="unit">
+      <modifiers>
+        <modifier type="set" field="ff7e-29e9-15ce-eb81" value="1.0">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="373b-ce5a-ddc5-cf8f" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <constraints>
-        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ff7e-29e9-15ce-eb81" type="max"/>
+        <constraint field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ff7e-29e9-15ce-eb81" type="min"/>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8d60-d1f0-a95c-8b26" type="max"/>
       </constraints>
       <infoLinks>
         <infoLink id="ad67-cade-eb63-f8c5" name="Techmarine Covenant" hidden="false" targetId="93e9-2806-e822-bfaf" type="rule"/>
@@ -21121,7 +21034,6 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
       </infoLinks>
       <categoryLinks>
         <categoryLink id="bba9-768a-89c6-84ba" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="b902-b743-ba1b-0ec7" name="Infantry Only" hidden="false" targetId="db6f-0311-834c-e6ff" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="fc32-089e-1c59-70bd" name="Techmarine" publicationId="a716-c1c4-7b26-8424" hidden="false" collective="false" import="true" type="model">
@@ -21833,7 +21745,6 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
         <categoryLink id="cccf-e162-2ea4-885a" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="1237-8d7a-91b2-1565" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="9db9-a73f-ccf4-06a3" name="Terminators:" hidden="false" targetId="bab3-f50d-3e5f-2f78" primary="false"/>
-        <categoryLink id="8eb4-6b99-d451-bbae" name="Infantry Only" hidden="false" targetId="db6f-0311-834c-e6ff" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="69fc-a6ab-d7a8-0e83" name="Legion Tartaros Centurion" hidden="false" collective="false" import="true" type="model">
@@ -22228,7 +22139,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                     </modifier>
                   </modifiers>
                 </entryLink>
-                <entryLink id="2973-fa28-948b-8797" name="Surgical Augment" hidden="true" collective="false" import="true" targetId="ffa3-1a57-1eb4-1818" type="selectionEntryGroup">
+                <entryLink id="2973-fa28-948b-8797" name="Surgical Augment" hidden="true" collective="false" import="true" targetId="aeb3-6a73-da1d-2b90" type="selectionEntryGroup">
                   <modifiers>
                     <modifier type="set" field="hidden" value="false">
                       <conditionGroups>
@@ -22455,9 +22366,6 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
               </modifiers>
             </infoLink>
           </infoLinks>
-          <categoryLinks>
-            <categoryLink id="bf8f-6c7c-ed20-00bd" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
-          </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="5f5a-bc15-c9d5-e890" name="4) May take:" hidden="false" collective="false" import="true">
               <constraints>
@@ -22724,11 +22632,6 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
             <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
           </conditions>
         </modifier>
-        <modifier type="add" field="category" value="20ef-cd01-a8da-376e">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="50cf-edf5-d39a-8943" type="equalTo"/>
-          </conditions>
-        </modifier>
       </modifiers>
       <categoryLinks>
         <categoryLink id="0ea3-c6cc-f348-2226" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
@@ -22757,7 +22660,6 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
           </profiles>
           <categoryLinks>
             <categoryLink id="8b77-ae5c-8bac-f9e0" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
-            <categoryLink id="1254-e8a0-4ef4-a552" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="5b1e-5fa8-bf4c-9339" name="4) May take:" hidden="false" collective="false" import="true">
@@ -23144,7 +23046,6 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
           </profiles>
           <categoryLinks>
             <categoryLink id="86f7-68a5-edfa-df3a" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
-            <categoryLink id="f07f-3132-ba77-6566" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="030d-69f8-d9af-d6f6" name="1) Arcus Launcher" hidden="false" collective="false" import="true">
@@ -23417,7 +23318,6 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
           </profiles>
           <categoryLinks>
             <categoryLink id="532a-184b-6633-a933" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
-            <categoryLink id="5cf1-62e8-6511-3de0" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="ea31-6d06-3a9a-8bf8" name="2) Sponson Mounted Weapons:" hidden="false" collective="false" import="true" defaultSelectionEntryId="50f8-01b2-554c-f3c8">
@@ -23788,7 +23688,6 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
           </infoLinks>
           <categoryLinks>
             <categoryLink id="4161-d5a7-0d9e-6234" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
-            <categoryLink id="67b4-d4b8-eed0-a0e4" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="0d3c-a988-5a78-4077" name="3) May take:" hidden="false" collective="false" import="true">
@@ -24016,7 +23915,6 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
         <categoryLink id="8cda-e93d-10a1-8cbc" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
         <categoryLink id="b1af-aba1-ebba-987b" name="Transport" hidden="false" targetId="7b0a-a743-a8da-3a39" primary="false"/>
         <categoryLink id="d8cd-3887-6695-d480" name="Reinforced Sub-type:" hidden="false" targetId="9b0d-738c-10e4-4ec1" primary="false"/>
-        <categoryLink id="5da8-4d96-2cdf-5328" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="94f8-f071-903e-a4f9" name="2) Pintle mounted Weapon:" hidden="false" collective="false" import="true">
@@ -24288,7 +24186,6 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
           <categoryLinks>
             <categoryLink id="a3a3-24e2-ecd4-38fa" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
             <categoryLink id="328a-a860-4be3-e6c8" name="Reinforced Sub-type:" hidden="false" targetId="9b0d-738c-10e4-4ec1" primary="false"/>
-            <categoryLink id="9809-ace4-bae3-3375" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="c99e-c96d-5c57-7215" name="1) Centreline Mounted Weapon:" hidden="false" collective="false" import="true" defaultSelectionEntryId="646f-5064-f0b0-3a83">
@@ -24584,7 +24481,6 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
           </profiles>
           <categoryLinks>
             <categoryLink id="c2f1-cd11-ca0c-0d3b" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
-            <categoryLink id="4cad-f81a-fda5-1703" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="ad38-0891-7db4-3528" name="1) Sponson Mounted Weapons:" hidden="false" collective="false" import="true" defaultSelectionEntryId="2f89-a5d7-94b6-6868">
@@ -24911,7 +24807,6 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
         <categoryLink id="2b45-00e1-5c3d-c2e5" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="c33e-fa91-93da-9bc9" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
         <categoryLink id="d4ab-bc77-4c9d-1887" name="Terminators:" hidden="false" targetId="bab3-f50d-3e5f-2f78" primary="false"/>
-        <categoryLink id="b5b0-a064-0704-2107" name="Infantry Only" hidden="false" targetId="db6f-0311-834c-e6ff" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="9fa9-d220-698d-8220" name="Dedicated Transport" hidden="false" collective="false" import="true">
@@ -25256,7 +25151,6 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
         <categoryLink id="ae9b-5609-d742-a57c" name="Flyer" hidden="false" targetId="4e84-2d57-4986-2b23" primary="false"/>
         <categoryLink id="9f22-19aa-22ca-5dbf" name="Hover Sub-type" hidden="false" targetId="3a7a-8bb7-b0d3-e2e7" primary="false"/>
         <categoryLink id="c289-9171-f7d9-d94a" name="Transport" hidden="false" targetId="7b0a-a743-a8da-3a39" primary="false"/>
-        <categoryLink id="d758-b63f-aa59-86e8" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="1b10-460e-e75a-3ffd" name="Dreadclaw Drop Pod" hidden="false" collective="false" import="true" type="upgrade">
@@ -25356,7 +25250,6 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
       <categoryLinks>
         <categoryLink id="156c-ae25-48d5-1e9d" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="1ef8-f347-84e3-b054" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="8cda-288b-945f-9e62" name="Infantry Only" hidden="false" targetId="db6f-0311-834c-e6ff" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="8aea-b995-e957-0c42" name=" Legion Support Sergeant" hidden="false" collective="false" import="true" type="model">
@@ -25772,7 +25665,6 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                     <conditionGroup type="or">
                       <conditions>
                         <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1977-49f2-7910-f177" type="equalTo"/>
-                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e864-ddc1-da3a-138e" type="equalTo"/>
                       </conditions>
                     </conditionGroup>
                   </conditionGroups>
@@ -26064,7 +25956,6 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
           </profiles>
           <categoryLinks>
             <categoryLink id="5101-eca4-4a32-4c77" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
-            <categoryLink id="472b-1cc7-49b5-86f3" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="6261-4456-2d7b-82b0" name="1) Centreline Mounted Weapon" hidden="false" collective="false" import="true">
@@ -26310,7 +26201,6 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
         <categoryLink id="6b9a-cce1-8d40-60e4" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="c641-0dd3-091e-e12d" name="Cavalry Sub-type:" hidden="false" targetId="6d79-a3e4-381f-7b0f" primary="false"/>
         <categoryLink id="d231-48d4-4a7e-88c4" name="Antigrav Sub-type" hidden="false" targetId="4303-1348-cce4-9501" primary="false"/>
-        <categoryLink id="a611-26f8-993e-8b71" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="d0b2-a77a-a4f4-0ae1" name="Legion Sky-Hunter" hidden="false" collective="false" import="true" type="model">
@@ -26799,7 +26689,6 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
         <categoryLink id="8179-34af-db8c-7a20" name="Flyer" hidden="false" targetId="4e84-2d57-4986-2b23" primary="false"/>
         <categoryLink id="ef8f-3fb2-f2d5-3e57" name="Hover Sub-type" hidden="false" targetId="3a7a-8bb7-b0d3-e2e7" primary="false"/>
         <categoryLink id="075f-3971-715b-a9a2" name="Transport" hidden="false" targetId="7b0a-a743-a8da-3a39" primary="false"/>
-        <categoryLink id="8d10-f5b1-a3bb-6206" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="1d23-3f85-0a01-95b9" name="Hull (Front) Mounted Vengeance launcher" hidden="false" collective="false" import="true" type="upgrade">
@@ -26956,7 +26845,6 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
         <categoryLink id="faad-a55f-fe5f-79ba" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="c58b-a48e-6286-c40d" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
         <categoryLink id="7123-b060-2ff0-00d4" name="Flyer" hidden="false" targetId="4e84-2d57-4986-2b23" primary="false"/>
-        <categoryLink id="1930-fffd-00e1-3db8" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="68ac-5612-184b-904d" name="Hull (Front) Mounted Rotary Missile Launcher" hidden="false" collective="false" import="true" type="upgrade">
@@ -27098,7 +26986,6 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
           </profiles>
           <categoryLinks>
             <categoryLink id="04bb-9232-6cae-47f2" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
-            <categoryLink id="fab9-12fe-9e83-6faa" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="f24c-7b68-d78c-11e2" name="1) Heavy Bolter Options" hidden="false" collective="false" import="true" defaultSelectionEntryId="e8ee-9957-bb72-3155">
@@ -27370,9 +27257,6 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
               </characteristics>
             </profile>
           </profiles>
-          <categoryLinks>
-            <categoryLink id="bba5-15e2-0342-6847" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
-          </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="8e58-3e53-6466-d844" name="1) Cyclone Missile Launcher Options" hidden="false" collective="false" import="true" defaultSelectionEntryId="eae6-b0e3-f61d-7ed0">
               <constraints>
@@ -27592,7 +27476,6 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
           </profiles>
           <categoryLinks>
             <categoryLink id="3c86-f984-9801-c6ad" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
-            <categoryLink id="f5d8-3a3b-d955-9664" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="6c2c-6557-be98-903a" name="3) May take:" hidden="false" collective="false" import="true">
@@ -27936,7 +27819,6 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
           </profiles>
           <categoryLinks>
             <categoryLink id="c3fb-b663-3e8c-fac8" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
-            <categoryLink id="6eb8-767e-2988-9f20" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="8ebc-e1b7-eee0-81bc" name="3) May take:" hidden="false" collective="false" import="true">
@@ -28225,7 +28107,6 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
         <categoryLink id="ae99-700e-db56-fc27" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="7852-636a-6edc-9978" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
         <categoryLink id="5a6b-0473-e1ba-1a6e" name="Super-heavy" hidden="false" targetId="7381-1130-ca6e-1806" primary="false"/>
-        <categoryLink id="b5cd-403c-68c2-de62" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="43d4-8f65-a666-b6e3" name="May take:" hidden="false" collective="false" import="true">
@@ -28514,7 +28395,6 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
         <categoryLink id="ea22-733c-649a-1077" name="Hover Sub-type" hidden="false" targetId="3a7a-8bb7-b0d3-e2e7" primary="false"/>
         <categoryLink id="d4f2-aa4f-0399-dcfe" name="Lumbering" hidden="false" targetId="7f9b-c5ed-7edb-02dc" primary="false"/>
         <categoryLink id="0b61-29b5-1887-5b88" name="Transport" hidden="false" targetId="7b0a-a743-a8da-3a39" primary="false"/>
-        <categoryLink id="d918-0e6b-6844-4953" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="fb46-e14c-0a38-320b" name="1) Main Gun Options" hidden="false" collective="false" import="true" defaultSelectionEntryId="8df2-f6fb-f564-4c74">
@@ -28686,7 +28566,6 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
       </profiles>
       <categoryLinks>
         <categoryLink id="9bac-bc2a-2c38-ab28" name="Super-heavy" hidden="false" targetId="7381-1130-ca6e-1806" primary="false"/>
-        <categoryLink id="abd4-40bc-eb55-33b5" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="2dbd-13c2-ed9e-c395" name="1) Hull Weapon Options" hidden="false" collective="false" import="true" defaultSelectionEntryId="f831-4ab5-a7ea-f1d5">
@@ -28999,7 +28878,6 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
         <categoryLink id="231c-19d1-0097-c872" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
         <categoryLink id="35a4-7e73-f5a8-c7a8" name="Super-heavy" hidden="false" targetId="7381-1130-ca6e-1806" primary="false"/>
         <categoryLink id="9168-20ed-1639-2373" name="Transport" hidden="false" targetId="7b0a-a743-a8da-3a39" primary="false"/>
-        <categoryLink id="121d-8ef3-ef67-d18d" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="c830-8055-5fad-7768" name="1) Turret Mounted Equipment" hidden="false" collective="false" import="true" defaultSelectionEntryId="17eb-0577-023d-3735">
@@ -29458,7 +29336,6 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
         <categoryLink id="b8c4-671b-9a5f-eb6b" name="Hover Sub-type" hidden="false" targetId="3a7a-8bb7-b0d3-e2e7" primary="false"/>
         <categoryLink id="853a-8e69-b900-48c9" name="Lumbering" hidden="false" targetId="7f9b-c5ed-7edb-02dc" primary="false"/>
         <categoryLink id="4d3e-f11e-f213-f158" name="Transport" hidden="false" targetId="7b0a-a743-a8da-3a39" primary="false"/>
-        <categoryLink id="c5be-01dc-c977-d4f3" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="110f-5a27-f7d4-0302" name="1) Left Side Weapon Options" hidden="false" collective="false" import="true" defaultSelectionEntryId="a0f9-7e15-88f2-eef0">
@@ -29641,7 +29518,6 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
         <categoryLink id="4346-61f7-6ddb-7db4" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="0163-3f12-80b9-2221" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="eb3d-4f92-8ccb-b662" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
-        <categoryLink id="3fa2-6d9b-66ca-29f3" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="985f-caea-1e37-8ac2" name="May take:" hidden="false" collective="false" import="true">
@@ -29890,7 +29766,6 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
         <categoryLink id="8775-c7f6-d071-55c9" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="1bb7-7735-8c97-b799" name="Transport" hidden="false" targetId="7b0a-a743-a8da-3a39" primary="false"/>
         <categoryLink id="d320-d9a9-315c-2b0c" name="Reinforced Sub-type:" hidden="false" targetId="9b0d-738c-10e4-4ec1" primary="false"/>
-        <categoryLink id="4fd1-ce55-689e-1af2" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="e097-5c31-84dd-dc26" name="1) Hull Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="9d6b-4a72-62ea-1317">
@@ -30112,7 +29987,6 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
         <categoryLink id="6beb-8854-14dd-3db9" name="Artillery Sub-type:" hidden="false" targetId="6f99-c178-6f9d-fb63" primary="false"/>
         <categoryLink id="fbe0-eca3-2aa2-eecc" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="5a2f-2252-bba0-e052" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
-        <categoryLink id="a165-29f0-1617-b437" name="Infantry Only" hidden="false" targetId="db6f-0311-834c-e6ff" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="975a-c83c-1f06-b4c8" name="1) Battery Weapon Options" hidden="false" collective="false" import="true" defaultSelectionEntryId="beaa-2d73-874a-0897">
@@ -30212,56 +30086,6 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
           </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="b59d-e5b8-7f73-c6f8" name="Legiones Unit Upgrades:" hidden="false" collective="false" import="true">
-          <selectionEntryGroups>
-            <selectionEntryGroup id="c99d-7474-b00c-17f6" name="Surgical Augment (unit)" hidden="true" collective="false" import="true">
-              <modifiers>
-                <modifier type="set" field="hidden" value="false">
-                  <conditionGroups>
-                    <conditionGroup type="and">
-                      <conditions>
-                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3edc-a1b9-6dc6-b1ea" type="equalTo"/>
-                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo"/>
-                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e221-0a54-9f94-988f" type="equalTo"/>
-                      </conditions>
-                    </conditionGroup>
-                  </conditionGroups>
-                </modifier>
-              </modifiers>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4b3f-7eff-88df-678c" type="max"/>
-                <constraint field="selections" scope="parent" value="-1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c0bf-00ad-da84-fa3c" type="min"/>
-              </constraints>
-              <entryLinks>
-                <entryLink id="e96d-7d0a-05fe-a833" name="Sonic Shriekers (Unit)" hidden="false" collective="false" import="true" targetId="7200-efa6-c232-eb74" type="selectionEntry">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d3e5-14d5-869b-411b" type="max"/>
-                  </constraints>
-                  <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="30.0"/>
-                  </costs>
-                </entryLink>
-                <entryLink id="93e6-e918-f10d-639f" name="Sonic Lance (Unit)" hidden="false" collective="false" import="true" targetId="b8b5-3d56-8f42-4b4d" type="selectionEntry">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9f0c-f848-b052-6668" type="max"/>
-                  </constraints>
-                  <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="30.0"/>
-                  </costs>
-                </entryLink>
-                <entryLink id="5f12-c462-0cff-417d" name="Sub-sonic Pulser Unit)" hidden="false" collective="false" import="true" targetId="a3c0-860a-2b71-c53e" type="selectionEntry">
-                  <modifiers>
-                    <modifier type="set" field="name" value="Sub-sonic Pulser (Unit)"/>
-                  </modifiers>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7f68-ac49-f51a-7cd0" type="max"/>
-                  </constraints>
-                  <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="30.0"/>
-                  </costs>
-                </entryLink>
-              </entryLinks>
-            </selectionEntryGroup>
-          </selectionEntryGroups>
           <entryLinks>
             <entryLink id="b7ac-fadc-079e-b45e" name="Preysight" hidden="false" collective="false" import="true" targetId="b905-4d78-c141-4e63" type="selectionEntry">
               <constraints>
@@ -30599,7 +30423,6 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
         <categoryLink id="f0cb-e19d-2d73-aa3f" name="Terminators:" hidden="false" targetId="bab3-f50d-3e5f-2f78" primary="false"/>
         <categoryLink id="a888-0301-9c87-ae58" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
         <categoryLink id="94de-62fb-73ee-229d" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="9ae2-1bcd-de39-c704" name="Infantry Only" hidden="false" targetId="db6f-0311-834c-e6ff" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="0740-a851-4e97-fced" name="Nullificator" hidden="false" collective="false" import="true" type="model">
@@ -31010,7 +30833,6 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
           </profiles>
           <categoryLinks>
             <categoryLink id="f292-0604-29fa-a71e" name="Dreadnought Unit-type:" hidden="false" targetId="4280-4963-02b5-e31d" primary="false"/>
-            <categoryLink id="ad69-8717-dba6-9001" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="cdb1-bf93-df94-2bf9" name="4) May take:" hidden="false" collective="false" import="true">
@@ -31401,7 +31223,6 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
         <categoryLink id="ba6c-bb79-909d-33f1" name="Terminators:" hidden="false" targetId="bab3-f50d-3e5f-2f78" primary="false"/>
         <categoryLink id="0a43-ec27-0c1e-4c5b" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="5ff7-87f5-f921-d1c4" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
-        <categoryLink id="c416-8484-3d86-bc26" name="Infantry Only" hidden="false" targetId="db6f-0311-834c-e6ff" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="23e2-4e21-6229-2444" name="3) One Legion Indomitus may take:" hidden="false" collective="false" import="true">
@@ -32277,7 +32098,6 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
           </profiles>
           <categoryLinks>
             <categoryLink id="5e23-61e4-47a0-0e3e" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
-            <categoryLink id="383c-a4a3-8fc6-af0e" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="ae74-5d4e-7532-84ac" name="2) May Take:" hidden="false" collective="false" import="true">
@@ -32566,7 +32386,6 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
           </profiles>
           <categoryLinks>
             <categoryLink id="a0e0-36ae-f8cc-a99d" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
-            <categoryLink id="8185-3d0d-5b63-df53" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="0c4f-3ecb-4134-314d" name="1) Turret Mounted Weapon:" hidden="false" collective="false" import="true" defaultSelectionEntryId="270d-03a1-1122-8540">
@@ -33088,7 +32907,6 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
         <categoryLink id="f9a5-3777-fc4c-4dba" name="Flyer" hidden="false" targetId="4e84-2d57-4986-2b23" primary="false"/>
         <categoryLink id="cec9-319f-7118-7cf8" name="Hover Sub-type" hidden="false" targetId="3a7a-8bb7-b0d3-e2e7" primary="false"/>
         <categoryLink id="9111-2535-4dc3-ad8e" name="Transport" hidden="false" targetId="7b0a-a743-a8da-3a39" primary="false"/>
-        <categoryLink id="23fd-cf06-d154-63db" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="50f2-4e31-2b38-674a" name="Turret Mounted Deathstorm Missile Launcher" hidden="false" collective="false" import="true" type="upgrade">
@@ -33144,16 +32962,6 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
       </costs>
     </selectionEntry>
     <selectionEntry id="af13-fb4e-b792-61a3" name="Deathstorm Drop Pod Squadron" hidden="false" collective="false" import="true" type="unit">
-      <modifiers>
-        <modifier type="set" field="7050-1866-b0b5-030e" value="0.0">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7a43-6793-013b-1af6" type="equalTo"/>
-          </conditions>
-        </modifier>
-      </modifiers>
-      <constraints>
-        <constraint field="selections" scope="force" value="-1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7050-1866-b0b5-030e" type="max"/>
-      </constraints>
       <categoryLinks>
         <categoryLink id="7f67-e0ca-2b9d-4b1c" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="false"/>
         <categoryLink id="5d80-eb88-5146-595d" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
@@ -33188,7 +32996,6 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
           </infoLinks>
           <categoryLinks>
             <categoryLink id="38b0-7f4d-7fa6-5d5a" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
-            <categoryLink id="88f4-2c3d-4f9c-3842" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="7865-513b-43f6-7ba3" name="May take:" hidden="false" collective="false" import="true">
@@ -33362,9 +33169,6 @@ Additionally, at the end of any Phase in which a model with Gorgon Terminator ar
         </infoLink>
         <infoLink id="cc20-196a-4ebc-7e1e" name="Master of Automata" hidden="false" targetId="8eef-f84b-37cb-554b" type="rule"/>
       </infoLinks>
-      <categoryLinks>
-        <categoryLink id="cbc7-7866-ccfb-b2df" name="Infantry Only" hidden="false" targetId="db6f-0311-834c-e6ff" primary="false"/>
-      </categoryLinks>
       <entryLinks>
         <entryLink id="7d01-2d81-485f-25aa" name="Servo-Arm" hidden="false" collective="false" import="true" targetId="4168-fc85-8912-7188" type="selectionEntry">
           <constraints>
@@ -33441,7 +33245,6 @@ Additionally, at the end of any Phase in which a model with Gorgon Terminator ar
         <categoryLink id="995e-aa85-478b-de47" name="Skirmish:" hidden="false" targetId="59a4-7b61-600a-c457" primary="false"/>
         <categoryLink id="1b08-e6e5-3d06-e1a1" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="1256-af1a-9a11-bd3b" name="Cavalry Sub-type:" hidden="false" targetId="6d79-a3e4-381f-7b0f" primary="false"/>
-        <categoryLink id="0f11-e290-4c84-1c95" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="a0ea-afcb-5c88-a699" name="Legion Spatha Attack Bike" hidden="false" collective="false" import="true" type="model">
@@ -33667,7 +33470,6 @@ Additionally, at the end of any Phase in which a model with Gorgon Terminator ar
       <categoryLinks>
         <categoryLink id="04e3-a81a-89b2-5f49" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
         <categoryLink id="793a-67fe-8731-7c9f" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="a266-5b5f-670e-df4c" name="Infantry Only" hidden="false" targetId="db6f-0311-834c-e6ff" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="e353-952c-5733-c446" name="Libertas" hidden="false" collective="false" import="true" type="upgrade">
@@ -33793,7 +33595,6 @@ Garro is fighting in a Challenge</characteristic>
         <categoryLink id="b8cf-ff1a-662e-6f72" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
         <categoryLink id="e2a6-00ad-2796-c89b" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="0528-07cf-ec83-bdab" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="93b2-1197-7163-cc43" name="Infantry Only" hidden="false" targetId="db6f-0311-834c-e6ff" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="7a6e-ff13-9c39-ff1d" name="The Aegis Argentum" publicationId="d0df-7166-5cd3-89fd" page="7" hidden="false" collective="false" import="true" type="upgrade">
@@ -33913,7 +33714,6 @@ containing the model that failed its Check. If the Psyker survives Perils of the
         <categoryLink id="12f4-8864-ab57-f9f9" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="c519-b6ff-7f40-4d69" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="7f7a-19de-90a2-4c95" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
-        <categoryLink id="9c9b-f85a-e481-2931" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="0bf0-559f-72b9-cfa9" name="4) May take:" hidden="false" collective="false" import="true">
@@ -34157,7 +33957,6 @@ containing the model that failed its Check. If the Psyker survives Perils of the
         <categoryLink id="46f1-e90b-bf1d-882c" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="5f4a-4ffd-a8a7-2c3e" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="9823-f559-b33c-66e6" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
-        <categoryLink id="5efe-4091-635b-6181" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="123c-539a-dca4-5fb2" name="May take:" hidden="false" collective="false" import="true">
@@ -34419,7 +34218,6 @@ containing the model that failed its Check. If the Psyker survives Perils of the
         <categoryLink id="6730-3426-65c4-b313" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="2c58-a573-56d4-ec73" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="d6e3-8a15-0d26-6d93" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
-        <categoryLink id="876b-182e-5279-0ad9" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="6534-8d4a-6593-2806" name="May take:" hidden="false" collective="false" import="true">
@@ -34619,7 +34417,6 @@ containing the model that failed its Check. If the Psyker survives Perils of the
         <categoryLink id="3218-f8aa-2242-3c25" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="40ad-88a5-9830-de8c" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
         <categoryLink id="b90d-8751-2096-6845" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="c115-dbdb-1896-1db4" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="baa5-fc7e-f925-4a5d" name="May take:" hidden="false" collective="false" import="true">
@@ -34834,7 +34631,6 @@ containing the model that failed its Check. If the Psyker survives Perils of the
         <categoryLink id="0051-5fd8-4005-30c2" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="cb74-1081-9d7d-ec9c" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="c703-dfd8-1371-b64a" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
-        <categoryLink id="7460-4132-50f4-e879" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="00c0-3a7c-15d7-3788" name="May take:" hidden="false" collective="false" import="true">
@@ -35069,7 +34865,6 @@ containing the model that failed its Check. If the Psyker survives Perils of the
         <categoryLink id="5907-22d5-cb57-2222" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="1bfc-4442-f18b-c57b" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="f3aa-c912-cb85-0629" name="Bombard Sub-type:" hidden="false" targetId="d5df-57ac-8f3c-097b" primary="false"/>
-        <categoryLink id="55d8-5a2b-cdf8-ab98" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="b4f4-a12a-e7da-3341" name="Pintle mounted Weapon Options" hidden="false" collective="false" import="true">
@@ -35264,7 +35059,6 @@ containing the model that failed its Check. If the Psyker survives Perils of the
           </profiles>
           <categoryLinks>
             <categoryLink id="9e86-a1f3-a85e-737c" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
-            <categoryLink id="b0ea-e29a-2db5-7417" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="f661-cf57-5135-4146" name="May take:" hidden="false" collective="false" import="true">
@@ -35557,7 +35351,6 @@ containing the model that failed its Check. If the Psyker survives Perils of the
           </profiles>
           <categoryLinks>
             <categoryLink id="359b-fa5f-391b-96ba" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
-            <categoryLink id="d8dd-7b4f-0879-f745" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="3640-9400-1ca4-403e" name="May take:" hidden="false" collective="false" import="true">
@@ -35833,7 +35626,6 @@ containing the model that failed its Check. If the Psyker survives Perils of the
         <categoryLink id="992a-101e-f1c0-2b6f" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="53cc-a648-20ea-e349" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="32f2-4ab0-d1cd-7cf0" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
-        <categoryLink id="e09b-159a-e9a4-8697" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="ee7e-a739-4575-9ad9" name="2) May take:" hidden="false" collective="false" import="true">
@@ -35948,7 +35740,6 @@ containing the model that failed its Check. If the Psyker survives Perils of the
         <categoryLink id="b39e-518d-9b15-bc14" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="56be-a381-5681-4467" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="2a64-c9fa-2381-f3f9" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
-        <categoryLink id="5292-b6e9-f677-dc5e" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="b870-bb30-dc67-fce8" name="Hull (Front) Mounted Avenger bolt cannon" hidden="false" collective="false" import="true" type="upgrade">
@@ -36109,7 +35900,6 @@ containing the model that failed its Check. If the Psyker survives Perils of the
         <categoryLink id="8d00-8a0b-d3d5-58a7" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="5822-e87b-5749-5a7d" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="ad65-dae6-bb16-edb5" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
-        <categoryLink id="fd66-e86c-83e4-8aba" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="aa79-1382-6a4d-d728" name="2) May take:" hidden="false" collective="false" import="true">
@@ -36549,7 +36339,6 @@ containing the model that failed its Check. If the Psyker survives Perils of the
       <categoryLinks>
         <categoryLink id="b053-4b8e-8514-cb3f" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="c478-ab4e-1a65-2daa" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
-        <categoryLink id="493f-a6eb-f171-2ab4" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="8bf3-9b8d-578a-38f1" name="Land Raider Phobos " hidden="false" collective="false" import="true" type="model">
@@ -36859,7 +36648,6 @@ containing the model that failed its Check. If the Psyker survives Perils of the
           <categoryLinks>
             <categoryLink id="c3af-f5d6-2210-9218" name="Reinforced Sub-type:" hidden="false" targetId="9b0d-738c-10e4-4ec1" primary="false"/>
             <categoryLink id="8d73-a0a0-a804-6122" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
-            <categoryLink id="7173-ee4b-f48d-a125" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
           </categoryLinks>
           <selectionEntries>
             <selectionEntry id="b44b-a321-7724-b2b6" name="1) Hull (Front) Mounted Achillus Quad Launcher" hidden="false" collective="false" import="true" type="upgrade">
@@ -37127,7 +36915,6 @@ containing the model that failed its Check. If the Psyker survives Perils of the
         <categoryLink id="7230-f0b9-a9e3-1a41" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="f4b6-841c-0647-e523" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="54c6-4521-16ef-9033" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
-        <categoryLink id="9f7f-312c-0e0a-042a" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="9efc-950b-d435-50ce" name="Havoc Launcher Options" hidden="false" collective="false" import="true" defaultSelectionEntryId="e050-2037-d90c-6db3">
@@ -37226,7 +37013,6 @@ containing the model that failed its Check. If the Psyker survives Perils of the
           </profiles>
           <categoryLinks>
             <categoryLink id="b72e-0f0e-30be-2ae8" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
-            <categoryLink id="9d49-4562-bee0-395a" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="06bc-e5bc-15a2-0ac3" name="1) Main Cannon" hidden="false" collective="false" import="true" defaultSelectionEntryId="9d4c-0f3b-54f2-5940">
@@ -37551,7 +37337,6 @@ containing the model that failed its Check. If the Psyker survives Perils of the
           <categoryLinks>
             <categoryLink id="3d15-4b03-3990-a801" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
             <categoryLink id="27f0-cd3d-9fbe-c047" name="Reinforced Sub-type:" hidden="false" targetId="9b0d-738c-10e4-4ec1" primary="false"/>
-            <categoryLink id="38e5-55aa-ecbf-f51d" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="2b42-c375-8d00-e27f" name="May take:" hidden="false" collective="false" import="true">
@@ -37697,7 +37482,6 @@ containing the model that failed its Check. If the Psyker survives Perils of the
           <categoryLinks>
             <categoryLink id="e8e4-d91a-160f-5f98" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
             <categoryLink id="0148-0faf-a575-11eb" name="Reinforced Sub-type:" hidden="false" targetId="9b0d-738c-10e4-4ec1" primary="false"/>
-            <categoryLink id="d79e-c4fc-7093-37e4" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="a082-432f-a77f-6c34" name="5) May take:" hidden="false" collective="false" import="true">
@@ -38018,7 +37802,6 @@ containing the model that failed its Check. If the Psyker survives Perils of the
       </infoLinks>
       <categoryLinks>
         <categoryLink id="96a4-abb8-aa87-c97a" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="97df-92e2-b5be-c45c" name="Infantry Only" hidden="false" targetId="db6f-0311-834c-e6ff" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="a58b-3293-d55c-ebc2" name="  Destroyer Sergeant" hidden="false" collective="false" import="true" type="model">
@@ -39618,7 +39401,6 @@ During a Reaction made in any Phase, a player may not choose to activate a model
         <categoryLink id="b857-6717-ae82-50fc" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="45c3-04df-2fcc-c0e5" name="Jump Infantry:" hidden="false" targetId="eee8-3c7c-2762-e33e" primary="false"/>
         <categoryLink id="c531-9282-85ea-930a" name="Line Sub-type:" hidden="false" targetId="6399-5c65-7833-1025" primary="false"/>
-        <categoryLink id="099f-44b6-75c1-ac5b" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="e6b7-06f3-c392-64c0" name=" Legion Assault Sergeant" hidden="false" collective="false" import="true" type="model">
@@ -40492,7 +40274,6 @@ During a Reaction made in any Phase, a player may not choose to activate a model
       <categoryLinks>
         <categoryLink id="ce73-ce2e-305f-269d" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="7aae-5c6b-5782-4d71" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="a643-ac25-74fa-48c7" name="Infantry Only" hidden="false" targetId="db6f-0311-834c-e6ff" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="2515-c6a7-16d6-ac9e" name="  Destroyer Sergeant" hidden="false" collective="false" import="true" type="model">
@@ -41853,7 +41634,6 @@ During a Reaction made in any Phase, a player may not choose to activate a model
                     <conditionGroup type="or">
                       <conditions>
                         <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1977-49f2-7910-f177" type="equalTo"/>
-                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e864-ddc1-da3a-138e" type="equalTo"/>
                       </conditions>
                     </conditionGroup>
                   </conditionGroups>
@@ -42142,7 +41922,6 @@ During a Reaction made in any Phase, a player may not choose to activate a model
       </profiles>
       <categoryLinks>
         <categoryLink id="7516-dfe2-fcc7-c51f" name="Dreadnought Unit-type:" hidden="false" targetId="4280-4963-02b5-e31d" primary="false"/>
-        <categoryLink id="f4be-c2b4-e26e-9b8c" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="ac7d-4ee1-1a5f-ab7e" name="1) Weapon Option 1" hidden="false" collective="false" import="true" defaultSelectionEntryId="b892-eb06-ab29-e738">
@@ -42487,9 +42266,6 @@ During a Reaction made in any Phase, a player may not choose to activate a model
           </modifiers>
         </infoLink>
       </infoLinks>
-      <categoryLinks>
-        <categoryLink id="9f39-8e7d-5922-80a5" name="Infantry Only" hidden="false" targetId="db6f-0311-834c-e6ff" primary="false"/>
-      </categoryLinks>
       <entryLinks>
         <entryLink id="a9ca-16b0-72a2-74da" name="Cyber-Familiar" hidden="false" collective="false" import="true" targetId="6c85-4601-cf58-7b35" type="selectionEntry">
           <constraints>
@@ -42575,9 +42351,6 @@ During a Reaction made in any Phase, a player may not choose to activate a model
         <infoLink id="5916-3eef-ebd6-8340" name="Auxiliary Vehicle Bay" hidden="false" targetId="8837-14e8-344a-1f39" type="rule"/>
         <infoLink id="2cbf-6343-0385-6fd7" name="Transport Bay" hidden="false" targetId="0662-8b8d-38e8-60f8" type="rule"/>
       </infoLinks>
-      <categoryLinks>
-        <categoryLink id="3745-6766-beef-1ac5" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
-      </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="888e-2e77-4caf-9925" name="1) Wing Weapon Options" hidden="false" collective="false" import="true" defaultSelectionEntryId="4d67-aa4e-a987-f780">
           <constraints>
@@ -42689,9 +42462,6 @@ During a Reaction made in any Phase, a player may not choose to activate a model
       <infoLinks>
         <infoLink id="6535-5aa6-6722-753a" name="Deep Strike" hidden="false" targetId="f1e1-986f-c783-ca9e" type="rule"/>
       </infoLinks>
-      <categoryLinks>
-        <categoryLink id="a465-dde8-7b28-f028" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
-      </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="29cc-8d9e-f6dc-66f2" name="3) May take:" hidden="false" collective="false" import="true">
           <entryLinks>
@@ -42826,9 +42596,6 @@ During a Reaction made in any Phase, a player may not choose to activate a model
       <infoLinks>
         <infoLink id="afde-172b-93dd-3f84" name="Volatile Plasma Containment" hidden="false" targetId="564b-25f0-6bae-949e" type="rule"/>
       </infoLinks>
-      <categoryLinks>
-        <categoryLink id="04d1-2509-3ca2-8294" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
-      </categoryLinks>
       <selectionEntries>
         <selectionEntry id="ba7f-1983-eb26-3761" name="Omega-pattern Plasma Blastgun" hidden="false" collective="false" import="true" type="upgrade">
           <modifiers>
@@ -42963,9 +42730,6 @@ During a Reaction made in any Phase, a player may not choose to activate a model
           </characteristics>
         </profile>
       </profiles>
-      <categoryLinks>
-        <categoryLink id="ec79-ca96-6e14-adc3" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
-      </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="584c-1391-dc26-2454" name="3) May take:" hidden="false" collective="false" import="true">
           <entryLinks>
@@ -43191,9 +42955,6 @@ During a Reaction made in any Phase, a player may not choose to activate a model
           </characteristics>
         </profile>
       </profiles>
-      <categoryLinks>
-        <categoryLink id="7f60-9530-6ca1-4d05" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
-      </categoryLinks>
       <selectionEntries>
         <selectionEntry id="597b-12c7-3a14-cf77" name="Praetor Launcher" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
@@ -43371,9 +43132,6 @@ During a Reaction made in any Phase, a player may not choose to activate a model
       <infoLinks>
         <infoLink id="6a90-76f9-404a-d5f0" name="Deep Strike" hidden="false" targetId="f1e1-986f-c783-ca9e" type="rule"/>
       </infoLinks>
-      <categoryLinks>
-        <categoryLink id="a052-258f-f41d-79b7" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
-      </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="1089-f39e-058e-636c" name="3) May take:" hidden="false" collective="false" import="true">
           <entryLinks>
@@ -44503,7 +44261,6 @@ Invulnerable saves granted by a combat shield or boarding shield do not stack wi
       </infoLinks>
       <categoryLinks>
         <categoryLink id="b7a0-67ed-9fdb-1187" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="9706-3749-5fae-0300" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="b2f2-ebdf-0ced-fe23" name="Legiones Unit Upgrades:" hidden="false" collective="false" import="true">
@@ -44963,80 +44720,6 @@ Invulnerable saves granted by a combat shield or boarding shield do not stack wi
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="b8b5-3d56-8f42-4b4d" name="Sonic Lance (Unit)" hidden="false" collective="false" import="true" type="upgrade">
-      <profiles>
-        <profile id="9e08-c99e-cdb5-250d" name="Sonic Lance " hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
-          <characteristics>
-            <characteristic name="Range" typeId="95ba-cda7-b831-6066">Template </characteristic>
-            <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">2</characteristic>
-            <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">-</characteristic>
-            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Assault 1, Breaching (6+), Pinning</characteristic>
-          </characteristics>
-        </profile>
-      </profiles>
-      <infoLinks>
-        <infoLink id="da94-fac3-4d7a-ba15" name="Breaching (X)" hidden="false" targetId="a760-f736-1bf3-fa3c" type="rule">
-          <modifiers>
-            <modifier type="set" field="name" value="Breaching (6+)"/>
-          </modifiers>
-        </infoLink>
-        <infoLink id="cae9-14ab-72a5-ba54" name="Pinning" hidden="false" targetId="1c96-205c-59a0-3cf2" type="rule"/>
-      </infoLinks>
-      <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="7200-efa6-c232-eb74" name="Sonic Shriekers (Unit)" hidden="false" collective="false" import="true" type="upgrade">
-      <profiles>
-        <profile id="0247-367b-9758-715f" name="Sonic Shriekers " page="154" hidden="false" typeId="2a1f-7837-f0ef-be44" typeName="Wargear Item">
-          <characteristics>
-            <characteristic name="Description" typeId="347e-ee4a-764f-6be3">During a turn in which a unit with at least one model equipped with sonic shriekers Successfully Charges, or themselves successfully Charged, all models in any enemy unit(s) locked in combat with them suffer a -1 penalty to all To Hit rolls, Models which are immunte to the effect of the Fear (X) special rule are not affected by this modifier.</characteristic>
-          </characteristics>
-        </profile>
-      </profiles>
-      <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="a3c0-860a-2b71-c53e" name="Sub-sonic Pulser Unit)" hidden="false" collective="false" import="true" type="upgrade">
-      <profiles>
-        <profile id="d8f9-5f16-cb56-5d54" name="Sub-sonic Pulser " hidden="false" typeId="2a1f-7837-f0ef-be44" typeName="Wargear Item">
-          <characteristics>
-            <characteristic name="Description" typeId="347e-ee4a-764f-6be3">A model equipped with this upgrade, and any unit it joins, ignores the penalties to Leadership and Ballistic Skill imposed by the Night Fighting special rules.</characteristic>
-          </characteristics>
-        </profile>
-      </profiles>
-      <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="fdb9-b132-5012-2f30" name="Maru Skara HQ (Champion or Phoenix Warden)" hidden="true" collective="false" import="true" type="upgrade">
-      <modifiers>
-        <modifier type="set" field="b5c8-3596-2cbb-1761" value="1.0">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7a43-6793-013b-1af6" type="equalTo"/>
-          </conditions>
-        </modifier>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7a43-6793-013b-1af6" type="equalTo"/>
-          </conditions>
-        </modifier>
-        <modifier type="set" field="8f77-0642-c5b9-9df0" value="1.0">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7a43-6793-013b-1af6" type="equalTo"/>
-          </conditions>
-        </modifier>
-      </modifiers>
-      <constraints>
-        <constraint field="selections" scope="force" value="-1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b5c8-3596-2cbb-1761" type="min"/>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ab6b-6529-2ced-5244" type="max"/>
-        <constraint field="selections" scope="parent" value="-1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8f77-0642-c5b9-9df0" type="min"/>
-      </constraints>
-      <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
-      </costs>
-    </selectionEntry>
   </sharedSelectionEntries>
   <sharedSelectionEntryGroups>
     <selectionEntryGroup id="61a2-7005-1e6c-c08e" name="Hexagrammaton Choice:" hidden="true" collective="false" import="true">
@@ -45243,7 +44926,7 @@ Invulnerable saves granted by a combat shield or boarding shield do not stack wi
         <entryLink id="78be-935f-1458-e8fd" name="Pavoni" hidden="false" collective="false" import="true" targetId="5532-04aa-8302-2038" type="selectionEntry"/>
       </entryLinks>
     </selectionEntryGroup>
-    <selectionEntryGroup id="aeb3-6a73-da1d-2b90" name="Surgical Augment (unit)" hidden="true" collective="false" import="true">
+    <selectionEntryGroup id="aeb3-6a73-da1d-2b90" name="Surgical Augment" hidden="true" collective="false" import="true">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditionGroups>
@@ -45255,25 +44938,12 @@ Invulnerable saves granted by a combat shield or boarding shield do not stack wi
             </conditionGroup>
           </conditionGroups>
         </modifier>
-        <modifier type="set" field="9eb6-371d-de44-c12b" value="1.0">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e221-0a54-9f94-988f" type="equalTo"/>
-          </conditions>
-        </modifier>
       </modifiers>
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="25f0-6d13-3ccb-ec05" type="max"/>
-        <constraint field="selections" scope="parent" value="-1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9eb6-371d-de44-c12b" type="min"/>
       </constraints>
       <entryLinks>
         <entryLink id="4852-ee62-1f85-3dc2" name="Sonic Lance" hidden="false" collective="false" import="true" targetId="5007-1732-6ad5-ce36" type="selectionEntry">
-          <modifiers>
-            <modifier type="set" field="hidden" value="true">
-              <conditions>
-                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="6f99-c178-6f9d-fb63" type="greaterThan"/>
-              </conditions>
-            </modifier>
-          </modifiers>
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="93a5-1699-4b06-c31a" type="max"/>
           </constraints>
@@ -45281,12 +44951,12 @@ Invulnerable saves granted by a combat shield or boarding shield do not stack wi
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0"/>
           </costs>
         </entryLink>
-        <entryLink id="e855-5157-0264-17c1" name="Sonic Shriekers (Unit)" hidden="false" collective="false" import="true" targetId="7200-efa6-c232-eb74" type="selectionEntry">
+        <entryLink id="e855-5157-0264-17c1" name="Sonic Shriekers" hidden="false" collective="false" import="true" targetId="3f61-86fe-eecf-aed7" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fe5e-6f5c-cf7b-4148" type="max"/>
           </constraints>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="30.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0"/>
           </costs>
         </entryLink>
         <entryLink id="bb4c-2ee2-3b1d-c799" name="Sub-sonic Pulser" hidden="false" collective="false" import="true" targetId="ddd0-22b3-ea96-680d" type="selectionEntry">
@@ -45295,33 +44965,6 @@ Invulnerable saves granted by a combat shield or boarding shield do not stack wi
           </constraints>
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0"/>
-          </costs>
-        </entryLink>
-        <entryLink id="cec6-a6f4-378f-07a4" name="Sonic Lance (Unit)" hidden="false" collective="false" import="true" targetId="b8b5-3d56-8f42-4b4d" type="selectionEntry">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5e5b-072a-3b18-6788" type="max"/>
-          </constraints>
-          <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="30.0"/>
-          </costs>
-        </entryLink>
-        <entryLink id="ed2b-8971-e7e8-809d" name="Sonic Shriekers" hidden="false" collective="false" import="true" targetId="3f61-86fe-eecf-aed7" type="selectionEntry">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dbb0-4253-1dbe-599c" type="max"/>
-          </constraints>
-          <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0"/>
-          </costs>
-        </entryLink>
-        <entryLink id="b22b-99c8-2c03-62da" name="Sub-sonic Pulser Unit)" hidden="false" collective="false" import="true" targetId="a3c0-860a-2b71-c53e" type="selectionEntry">
-          <modifiers>
-            <modifier type="set" field="name" value="Sub-sonic Pulser (Unit)"/>
-          </modifiers>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2e5c-c9e3-9e0a-cd41" type="max"/>
-          </constraints>
-          <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="30.0"/>
           </costs>
         </entryLink>
       </entryLinks>
@@ -45450,24 +45093,17 @@ Legion Only: Paladin of Hekatonystika (Dark Angels), Phoenix Warden (Emperor&apo
         </selectionEntry>
         <selectionEntry id="35ac-992e-97a7-1612" name="Master of Signals" publicationId="a716-c1c4-7b26-8424" page="105" hidden="false" collective="false" import="true" type="upgrade">
           <modifiers>
-            <modifier type="set" field="8f5a-e3ec-734d-23ab" value="1.0">
-              <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fbe5-123b-cb17-6049" type="equalTo"/>
-              </conditions>
-            </modifier>
             <modifier type="set" field="hidden" value="true">
               <conditionGroups>
                 <conditionGroup type="or">
                   <conditions>
+                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="25a2-7a52-632a-6b2c" type="notInstanceOf"/>
                     <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
                   </conditions>
                 </conditionGroup>
               </conditionGroups>
             </modifier>
           </modifiers>
-          <constraints>
-            <constraint field="selections" scope="force" value="-1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8f5a-e3ec-734d-23ab" type="min"/>
-          </constraints>
           <rules>
             <rule id="5fb1-c000-121c-b16e" name="Strategic Comms" publicationId="a716-c1c4-7b26-8424" page="105" hidden="false">
               <description>At the start of each Game Turn you can declare whether each vox disruptor array in your army is turned on or turned off. While there is at least one model on the battlefield with a vox disruptor array turned on, regardless of whether that model is enemy or friendly, any attempt to perform a Deep Strike Assault, Drop Pod Assault, Area Denial Drop or Subterranean Assault during that turn is Disordered on the roll of a &apos;1&apos;, &apos;2&apos; or &apos;3&apos; instead of iust on a 1&apos;</description>
@@ -45880,7 +45516,6 @@ Legion Only: Paladin of Hekatonystika (Dark Angels), Phoenix Warden (Emperor&apo
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4a57-7b36-258e-096c" type="min"/>
               </constraints>
             </entryLink>
-            <entryLink id="58b4-dc5e-e68d-35d3" name="Maru Skara HQ (Champion or Phoenix Warden)" hidden="false" collective="false" import="true" targetId="fdb9-b132-5012-2f30" type="selectionEntry"/>
           </entryLinks>
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="30.0"/>
@@ -46111,6 +45746,9 @@ A Legion Primus Nullificator Consul gains the Psyker Sub-type and has only the P
             <infoLink id="328e-31c9-9aa5-89ed" name="Legiones Cybernetica" hidden="false" targetId="a2ef-63a4-3531-db91" type="rule"/>
             <infoLink id="6c18-66c0-7c82-ed9b" name="Master of Automata" hidden="false" targetId="8eef-f84b-37cb-554b" type="rule"/>
           </infoLinks>
+          <categoryLinks>
+            <categoryLink id="5954-d075-a735-1999" name="Praevian Consul (The Achaean Configuration Requirment)" hidden="false" targetId="14bd-5f53-021b-a0f3" primary="false"/>
+          </categoryLinks>
           <entryLinks>
             <entryLink id="3322-e7ba-5d2e-6bf4" name="Cortex Controller" hidden="false" collective="false" import="true" targetId="2fda-455f-d34d-97e0" type="selectionEntry">
               <constraints>
@@ -46190,10 +45828,16 @@ Hit rolls for each attack, for a total of 24 To Hit rolls over the full 6 attack
           </categoryLinks>
           <entryLinks>
             <entryLink id="fdc2-d401-2510-d453" name="Astartes Shotgun" hidden="false" collective="false" import="true" targetId="6f79-5cf4-a689-7269" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="name" value="Master-crafted Astartes Shotgun"/>
+              </modifiers>
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2c86-504a-ea5c-33fa" type="max"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e93a-c6a3-e263-8791" type="min"/>
               </constraints>
+              <infoLinks>
+                <infoLink id="7b97-24be-0e39-3c50" name="Master-crafted" hidden="false" targetId="6de0-55b0-bf21-48b9" type="rule"/>
+              </infoLinks>
             </entryLink>
             <entryLink id="2f93-d2e2-553f-670b" name="Scout Armour" hidden="false" collective="false" import="true" targetId="b282-55aa-d1e2-ebe7" type="selectionEntry">
               <constraints>
@@ -46252,10 +45896,36 @@ Hit rolls for each attack, for a total of 24 To Hit rolls over the full 6 attack
           <infoLinks>
             <infoLink id="598d-8c9f-e5a4-f2a4" name="Marked For Death" hidden="false" targetId="4f41-4c04-9cd8-c5a1" type="rule"/>
           </infoLinks>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="1830-db0c-3c9f-788a" name="Special Rules" hidden="false" collective="false" import="true">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="86c0-37d4-1381-be9d" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="75cb-3194-4ae6-d8b0" type="max"/>
+              </constraints>
+              <selectionEntries>
+                <selectionEntry id="ee9b-5275-8627-1861" name="Scout" hidden="false" collective="false" import="true" type="upgrade">
+                  <infoLinks>
+                    <infoLink id="b014-b991-5932-714d" name="Scout" hidden="false" targetId="aacf-9a7e-982d-b793" type="rule"/>
+                  </infoLinks>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="d2fb-7bb1-d577-9b98" name="Infilitrate" hidden="false" collective="false" import="true" type="upgrade">
+                  <infoLinks>
+                    <infoLink id="f5d1-8ea8-9c4b-2e98" name="Infiltrate" hidden="false" targetId="0e32-5b92-a95a-8464" type="rule"/>
+                  </infoLinks>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
           <entryLinks>
             <entryLink id="ab85-af17-b1bf-63b4" name="Nemesis Bolter" hidden="false" collective="false" import="true" targetId="c10a-61f8-9c33-fe8a" type="selectionEntry">
               <modifiers>
-                <modifier type="append" field="name" value="(master-crafted)"/>
+                <modifier type="set" field="name" value="Master-crafted Nemesis Bolter"/>
               </modifiers>
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e352-e639-5c55-982b" type="max"/>
@@ -46418,7 +46088,6 @@ Hit rolls for each attack, for a total of 24 To Hit rolls over the full 6 attack
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="971f-26aa-10df-fbb4" type="max"/>
               </constraints>
             </entryLink>
-            <entryLink id="f1c3-7e93-64f1-a1b5" name="Maru Skara HQ (Champion or Phoenix Warden)" hidden="false" collective="false" import="true" targetId="fdb9-b132-5012-2f30" type="selectionEntry"/>
           </entryLinks>
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="35.0"/>
@@ -47899,55 +47568,6 @@ Hit rolls for each attack, for a total of 24 To Hit rolls over the full 6 attack
           </costs>
         </entryLink>
         <entryLink id="35b6-c0b4-2129-0b40" name="Heavy Flamer" hidden="false" collective="false" import="true" targetId="5507-b432-3b4c-df12" type="selectionEntry"/>
-      </entryLinks>
-    </selectionEntryGroup>
-    <selectionEntryGroup id="ffa3-1a57-1eb4-1818" name="Surgical Augment" hidden="true" collective="false" import="true">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditionGroups>
-            <conditionGroup type="and">
-              <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3edc-a1b9-6dc6-b1ea" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-        <modifier type="set" field="1937-af39-00f8-763d" value="1.0">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e221-0a54-9f94-988f" type="equalTo"/>
-          </conditions>
-        </modifier>
-      </modifiers>
-      <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1bf0-36d7-09fb-6daa" type="max"/>
-        <constraint field="selections" scope="parent" value="-1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1937-af39-00f8-763d" type="min"/>
-      </constraints>
-      <entryLinks>
-        <entryLink id="1c8d-f727-0e32-5e34" name="Sonic Lance" hidden="false" collective="false" import="true" targetId="5007-1732-6ad5-ce36" type="selectionEntry">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ec41-14ac-7eb0-73ce" type="max"/>
-          </constraints>
-          <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0"/>
-          </costs>
-        </entryLink>
-        <entryLink id="8a66-e544-763e-a6d7" name="Sub-sonic Pulser" hidden="false" collective="false" import="true" targetId="ddd0-22b3-ea96-680d" type="selectionEntry">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bdfd-6264-5007-cc3a" type="max"/>
-          </constraints>
-          <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0"/>
-          </costs>
-        </entryLink>
-        <entryLink id="87f8-c18d-35d7-179d" name="Sonic Shriekers" hidden="false" collective="false" import="true" targetId="3f61-86fe-eecf-aed7" type="selectionEntry">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ea88-35ec-c1f5-3207" type="max"/>
-          </constraints>
-          <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0"/>
-          </costs>
-        </entryLink>
       </entryLinks>
     </selectionEntryGroup>
   </sharedSelectionEntryGroups>

--- a/2022 - Legiones Astartes.cat
+++ b/2022 - Legiones Astartes.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="6393-649c-7213-a327" name="(HH V2) Legions Astartes" revision="88" battleScribeVersion="2.03" authorName="Various" authorUrl="https://github.com/BSData/horus-heresy" library="true" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="38" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="6393-649c-7213-a327" name="(HH V2) Legions Astartes" revision="89" battleScribeVersion="2.03" authorName="Various" authorUrl="https://github.com/BSData/horus-heresy" library="true" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="38" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <profileTypes>
     <profileType id="7002-2f9a-59c4-2742" name="Prosperine Arcana">
       <characteristicTypes>
@@ -47,28 +47,57 @@
         <constraint field="selections" scope="force" value="-1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f1eb-cf2a-8611-faad" type="max"/>
       </constraints>
     </categoryEntry>
-    <categoryEntry id="350d-03ac-0da9-0c8b" name="The Guard Of The Crimson King (TS) Compulsory HQ" hidden="false">
+    <categoryEntry id="db6f-0311-834c-e6ff" name="Infantry Only" hidden="false">
       <modifiers>
-        <modifier type="set" field="a0c7-dc64-dc1b-07d3" value="1.0">
+        <modifier type="set" field="80e6-cb32-4c9f-9518" value="1.0">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c83-69fb-8066-a773" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="force" value="-1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="80e6-cb32-4c9f-9518" type="min"/>
+      </constraints>
+    </categoryEntry>
+    <categoryEntry id="2bcf-6bbe-58a1-e082" name="Non-Infantry Only" hidden="false">
+      <modifiers>
+        <modifier type="set" field="8292-97e1-be59-de75" value="-1.0">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c83-69fb-8066-a773" type="lessThan"/>
+          </conditions>
+        </modifier>
+        <modifier type="increment" field="8292-97e1-be59-de75" value="1.0">
+          <repeats>
+            <repeat field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="db6f-0311-834c-e6ff" repeats="1" roundUp="false"/>
+          </repeats>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8292-97e1-be59-de75" type="max"/>
+      </constraints>
+    </categoryEntry>
+    <categoryEntry id="5472-b476-dcbd-c215" name="The Guard Of The Crimson King (TS) Compulsory HQ" hidden="false">
+      <modifiers>
+        <modifier type="set" field="a3ed-76b4-9d86-4b73" value="1.0">
           <conditions>
             <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0fa2-d71c-9cdb-86cb" type="equalTo"/>
           </conditions>
         </modifier>
       </modifiers>
       <constraints>
-        <constraint field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a0c7-dc64-dc1b-07d3" type="min"/>
+        <constraint field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a3ed-76b4-9d86-4b73" type="min"/>
       </constraints>
     </categoryEntry>
-    <categoryEntry id="14bd-5f53-021b-a0f3" name="Praevian Consul (The Achaean Configuration Requirment)" hidden="false">
+    <categoryEntry id="30e2-956f-1bf5-1110" name="Praevian Consul (The Achaean Configuration Requirment)" hidden="false">
       <modifiers>
-        <modifier type="set" field="8e06-18ee-9523-a43d" value="1.0">
+        <modifier type="set" field="b0af-1478-1380-c01b" value="1.0">
           <conditions>
             <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="373b-ce5a-ddc5-cf8f" type="equalTo"/>
           </conditions>
         </modifier>
       </modifiers>
       <constraints>
-        <constraint field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8e06-18ee-9523-a43d" type="min"/>
+        <constraint field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b0af-1478-1380-c01b" type="min"/>
       </constraints>
     </categoryEntry>
   </categoryEntries>
@@ -3751,6 +3780,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
         <categoryLink id="240b-61e9-f6cc-56fa" name="New CategoryLink" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="1571-4b68-f416-00ea" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="4138-d106-960e-94e0" name="Line Sub-type:" hidden="false" targetId="6399-5c65-7833-1025" primary="false"/>
+        <categoryLink id="9b4e-df25-fe2b-90be" name="Infantry Only" hidden="false" targetId="db6f-0311-834c-e6ff" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="638c-a192-24e6-1604" name=" Legion Tactical Sergeant" hidden="false" collective="false" import="true" type="model">
@@ -4215,11 +4245,21 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
               <modifiers>
                 <modifier type="set" field="hidden" value="false">
                   <conditionGroups>
-                    <conditionGroup type="and">
-                      <conditions>
-                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1977-49f2-7910-f177" type="equalTo"/>
-                        <condition field="selections" scope="aa72-63e4-bc60-4611" value="10.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f115-cfc4-4199-f8be" type="lessThan"/>
-                      </conditions>
+                    <conditionGroup type="or">
+                      <conditionGroups>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1977-49f2-7910-f177" type="equalTo"/>
+                            <condition field="selections" scope="aa72-63e4-bc60-4611" value="10.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f115-cfc4-4199-f8be" type="lessThan"/>
+                          </conditions>
+                        </conditionGroup>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="aa72-63e4-bc60-4611" value="10.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f115-cfc4-4199-f8be" type="lessThan"/>
+                            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e864-ddc1-da3a-138e" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
                     </conditionGroup>
                   </conditionGroups>
                 </modifier>
@@ -4890,6 +4930,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
         <categoryLink id="e07d-b552-90ef-c096" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="4048-d50e-f863-8094" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
         <categoryLink id="02a0-025a-fc68-8e2a" name="Transport" hidden="false" targetId="7b0a-a743-a8da-3a39" primary="false"/>
+        <categoryLink id="4e96-d77d-532c-741e" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="fffa-369b-8a93-c728" name="2) May take:" hidden="false" collective="false" import="true">
@@ -5101,6 +5142,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
       <categoryLinks>
         <categoryLink id="09bf-3b6b-fba1-8fae" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="566e-8e1f-ea26-51e1" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="305f-f9b4-05bd-c9a9" name="Infantry Only" hidden="false" targetId="db6f-0311-834c-e6ff" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="846e-c9da-5b90-861d" name=" Legion Tactical Support Sergeant" hidden="false" collective="false" import="true" type="model">
@@ -5577,6 +5619,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                     <conditionGroup type="or">
                       <conditions>
                         <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1977-49f2-7910-f177" type="equalTo"/>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e864-ddc1-da3a-138e" type="equalTo"/>
                       </conditions>
                     </conditionGroup>
                   </conditionGroups>
@@ -5988,6 +6031,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
         <categoryLink id="2a0a-16f7-36a7-f414" name="Skirmish:" hidden="false" targetId="59a4-7b61-600a-c457" primary="false"/>
         <categoryLink id="ca35-8e83-c135-9eaf" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="ed2e-e758-859f-2c45" name="Cavalry Sub-type:" hidden="false" targetId="6d79-a3e4-381f-7b0f" primary="false"/>
+        <categoryLink id="8019-98fe-157c-594d" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="97b6-65f8-df73-9551" name="Legion Outriders" hidden="false" collective="false" import="true" type="model">
@@ -6504,6 +6548,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
       <categoryLinks>
         <categoryLink id="08b4-0dc4-d272-47f7" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="7ee1-e5c8-570a-223d" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
+        <categoryLink id="36f7-406d-40f1-3472" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="e11b-4170-0afd-b025" name="Sicaran Omega" hidden="false" collective="false" import="true" type="model">
@@ -6783,6 +6828,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
           </profiles>
           <categoryLinks>
             <categoryLink id="e659-8bae-056e-7bf3" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+            <categoryLink id="9f9e-aaa0-df6a-0535" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="9fba-1911-69f1-4077" name="4) May Take:" hidden="false" collective="false" import="true">
@@ -7131,6 +7177,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
         <categoryLink id="cec9-0cba-c60c-7a82" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="002c-703f-e5f8-7705" name="Flyer" hidden="false" targetId="4e84-2d57-4986-2b23" primary="false"/>
         <categoryLink id="c857-29a3-277a-f9bb" name="Hover Sub-type" hidden="false" targetId="3a7a-8bb7-b0d3-e2e7" primary="false"/>
+        <categoryLink id="3769-fd6f-8878-eaf4" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="52b1-1b7c-90bf-eed2" name="Legion Fire Raptor Gunship" hidden="false" collective="false" import="true" type="model">
@@ -7299,6 +7346,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
           </infoLinks>
           <categoryLinks>
             <categoryLink id="6a3f-598c-9862-c796" name="Dreadnought:" hidden="false" targetId="4280-4963-02b5-e31d" primary="false"/>
+            <categoryLink id="0151-0251-1f64-1500" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="331d-145d-cd22-0f4e" name="1) Arm Weapon Choice:" hidden="false" collective="false" import="true" defaultSelectionEntryId="bf48-29c5-e0d0-56d0">
@@ -7535,6 +7583,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
         <categoryLink id="243d-5b6e-2794-2a35" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="2a7a-c446-f5fa-4eed" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="6165-b9b2-438c-a1a8" name="Transport" hidden="false" targetId="7b0a-a743-a8da-3a39" primary="false"/>
+        <categoryLink id="4ef6-6fa5-0abb-db97" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="dcd4-4e45-52d9-09b3" name="1) Pintle-mounted weapons:" hidden="false" collective="false" import="true">
@@ -7731,6 +7780,16 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
       </costs>
     </selectionEntry>
     <selectionEntry id="83ac-f9cf-cc29-00a3" name="Drop Pod" hidden="false" collective="false" import="true" type="upgrade">
+      <modifiers>
+        <modifier type="set" field="9a6e-8133-d94a-1f5c" value="0.0">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7a43-6793-013b-1af6" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="force" value="-1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9a6e-8133-d94a-1f5c" type="max"/>
+      </constraints>
       <infoLinks>
         <infoLink id="febd-7328-3ea8-fc2f" name="Inertial Guidance System" hidden="false" targetId="d222-fde9-51b8-8739" type="rule"/>
         <infoLink id="7278-a30b-5237-7829" name="Impact-reactive Doors" hidden="false" targetId="6c21-dd77-4c93-eeed" type="rule"/>
@@ -7743,6 +7802,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
         <categoryLink id="5dfa-b331-6bee-1fc7" name="Transport" hidden="false" targetId="7b0a-a743-a8da-3a39" primary="false"/>
         <categoryLink id="a8b7-3e8a-2180-6644" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="100e-fe74-c5a5-3a07" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+        <categoryLink id="19f3-25a9-c5b5-1ac4" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="216c-1984-d1a7-f3b1" name="Drop Pod" hidden="false" collective="false" import="true" type="model">
@@ -7827,6 +7887,16 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
       </costs>
     </selectionEntry>
     <selectionEntry id="1ffe-82e4-12db-538d" name="Dreadnought Drop Pod" hidden="false" collective="false" import="true" type="unit">
+      <modifiers>
+        <modifier type="set" field="ad98-c5b7-344a-b2d2" value="0.0">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7a43-6793-013b-1af6" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="force" value="-1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ad98-c5b7-344a-b2d2" type="max"/>
+      </constraints>
       <infoLinks>
         <infoLink id="440d-1b43-e5d0-4e98" name="Inertial Guidance System" hidden="false" targetId="d222-fde9-51b8-8739" type="rule"/>
         <infoLink id="4ab2-0edb-0296-12eb" name="Impact-reactive Doors" hidden="false" targetId="6c21-dd77-4c93-eeed" type="rule"/>
@@ -7839,6 +7909,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
         <categoryLink id="9430-425d-f0a1-3055" name="Transport" hidden="false" targetId="7b0a-a743-a8da-3a39" primary="false"/>
         <categoryLink id="ca1f-0918-3532-f963" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="1966-a329-a6b5-94e9" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+        <categoryLink id="7299-7f9e-9882-8f97" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="2a23-d677-62c5-ed1d" name="Dreadnought Drop Pod" hidden="false" collective="false" import="true" type="model">
@@ -7945,6 +8016,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
         <categoryLink id="3856-c687-8257-b20c" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
         <categoryLink id="905b-c1d8-b585-daaf" name="Transport" hidden="false" targetId="7b0a-a743-a8da-3a39" primary="false"/>
         <categoryLink id="2cbe-41c5-7149-b2a6" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
+        <categoryLink id="6b8c-c94a-b2ea-fa02" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="ede9-4deb-570d-70c0" name="Termite Assault Drill" hidden="false" collective="false" import="true" type="model">
@@ -8163,6 +8235,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
           </infoLinks>
           <categoryLinks>
             <categoryLink id="9df9-9e61-2785-d561" name="Dreadnought Unit-type:" hidden="false" targetId="4280-4963-02b5-e31d" primary="false"/>
+            <categoryLink id="bb4b-677f-5c22-6db5" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="9c64-0cf1-b27c-e84e" name="1) Weapon Option 1" hidden="false" collective="false" import="true" defaultSelectionEntryId="e636-ec3d-89ce-8cf5">
@@ -8596,6 +8669,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
         <categoryLink id="9c02-a9fe-a9c9-039f" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="8631-1aaf-e375-221c" name="Transport" hidden="false" targetId="7b0a-a743-a8da-3a39" primary="false"/>
         <categoryLink id="9ed7-53ba-9190-1c22" name="Reinforced Sub-type:" hidden="false" targetId="9b0d-738c-10e4-4ec1" primary="false"/>
+        <categoryLink id="34ac-1d95-e869-3f51" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="305c-37ae-3cda-349b" name="Land Raider Spartan" hidden="false" collective="false" import="true" type="upgrade">
@@ -8846,18 +8920,6 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
       </costs>
     </selectionEntry>
     <selectionEntry id="03be-5d55-d05a-771d" name="Praetor" hidden="false" collective="false" import="true" type="unit">
-      <modifiers>
-        <modifier type="add" field="category" value="350d-03ac-0da9-0c8b">
-          <conditionGroups>
-            <conditionGroup type="and">
-              <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0fa2-d71c-9cdb-86cb" type="equalTo"/>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2aa6-ed38-ddc9-60fa" type="equalTo"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-      </modifiers>
       <modifierGroups>
         <modifierGroup>
           <comment>Add Category (X)</comment>
@@ -8872,7 +8934,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                 </conditionGroup>
               </conditionGroups>
             </modifier>
-            <modifier type="add" field="category" value="8b4f-bfe2-ce7b-f1b1">
+            <modifier type="add" field="category" value="db6f-0311-834c-e6ff">
               <conditionGroups>
                 <conditionGroup type="and">
                   <conditions>
@@ -8908,6 +8970,38 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
               <conditions>
                 <condition field="selections" scope="03be-5d55-d05a-771d" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="cb35-21a5-c296-ddd9" type="equalTo"/>
               </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="8b4f-bfe2-ce7b-f1b1">
+              <conditionGroups>
+                <conditionGroup type="and">
+                  <conditions>
+                    <condition field="selections" scope="03be-5d55-d05a-771d" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e254-77a1-6dae-14a0" type="equalTo"/>
+                    <condition field="selections" scope="03be-5d55-d05a-771d" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3952-66ed-93ea-27ee" type="equalTo"/>
+                    <condition field="selections" scope="03be-5d55-d05a-771d" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4108-5f37-0b50-b419" type="equalTo"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+            <modifier type="add" field="category" value="2bcf-6bbe-58a1-e082">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="03be-5d55-d05a-771d" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3952-66ed-93ea-27ee" type="atLeast"/>
+                    <condition field="selections" scope="03be-5d55-d05a-771d" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4108-5f37-0b50-b419" type="atLeast"/>
+                    <condition field="selections" scope="03be-5d55-d05a-771d" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e254-77a1-6dae-14a0" type="atLeast"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+            <modifier type="add" field="category" value="5472-b476-dcbd-c215">
+              <conditionGroups>
+                <conditionGroup type="and">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0fa2-d71c-9cdb-86cb" type="equalTo"/>
+                    <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2aa6-ed38-ddc9-60fa" type="equalTo"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
             </modifier>
           </modifiers>
         </modifierGroup>
@@ -8952,6 +9046,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
       </infoLinks>
       <categoryLinks>
         <categoryLink id="555c-4c0c-29a0-082a" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="7a63-714c-8d20-c004" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="d862-5767-da41-cff0" name="Legion Praetor" hidden="false" collective="false" import="true" type="model">
@@ -9510,6 +9605,10 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
               </entryLinks>
             </selectionEntryGroup>
             <selectionEntryGroup id="f662-22a4-b0b4-3f15" name="0) Legion-specific upgrades" hidden="false" collective="false" import="true">
+              <categoryLinks>
+                <categoryLink id="ebe8-05b8-8ce2-ad96" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
+                <categoryLink id="eaa1-a718-303d-3a67" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
+              </categoryLinks>
               <entryLinks>
                 <entryLink id="ab3a-707f-7f67-8804" name="Dragonscale Shield" hidden="true" collective="false" import="true" targetId="489d-88d0-a0d8-b3e6" type="selectionEntry">
                   <modifiers>
@@ -9535,7 +9634,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="35.0"/>
                   </costs>
                 </entryLink>
-                <entryLink id="63e4-7f4f-70e7-64fd" name="Surgical Augment" hidden="true" collective="false" import="true" targetId="aeb3-6a73-da1d-2b90" type="selectionEntryGroup">
+                <entryLink id="63e4-7f4f-70e7-64fd" name="Surgical Augment" hidden="true" collective="false" import="true" targetId="ffa3-1a57-1eb4-1818" type="selectionEntryGroup">
                   <modifiers>
                     <modifier type="set" field="hidden" value="false">
                       <conditionGroups>
@@ -9850,7 +9949,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
             <condition field="selections" scope="1b79-1951-5a63-4b9e" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fd55-9459-b3b3-5d20" type="equalTo"/>
           </conditions>
         </modifier>
-        <modifier type="add" field="category" value="350d-03ac-0da9-0c8b">
+        <modifier type="add" field="category" value="5472-b476-dcbd-c215">
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
@@ -9895,6 +9994,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
         <categoryLink id="e1e8-360b-92f0-10e3" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
         <categoryLink id="e6ff-3685-f0a8-be34" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="a60b-1cf4-5ab4-bbff" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="e1f4-5100-9250-f86a" name="Infantry Only" hidden="false" targetId="db6f-0311-834c-e6ff" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="de73-2d79-156f-6f64" name="Legion Cataphractii Praetor" hidden="false" collective="false" import="true" type="model">
@@ -9996,7 +10096,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="35.0"/>
                   </costs>
                 </entryLink>
-                <entryLink id="b8e0-dc95-36b4-0a3f" name="Surgical Augment" hidden="true" collective="false" import="true" targetId="aeb3-6a73-da1d-2b90" type="selectionEntryGroup">
+                <entryLink id="b8e0-dc95-36b4-0a3f" name="Surgical Augment" hidden="true" collective="false" import="true" targetId="ffa3-1a57-1eb4-1818" type="selectionEntryGroup">
                   <modifiers>
                     <modifier type="set" field="hidden" value="false">
                       <conditionGroups>
@@ -10264,7 +10364,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
             <condition field="selections" scope="3760-204e-444c-1044" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fd55-9459-b3b3-5d20" type="equalTo"/>
           </conditions>
         </modifier>
-        <modifier type="add" field="category" value="350d-03ac-0da9-0c8b">
+        <modifier type="add" field="category" value="5472-b476-dcbd-c215">
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
@@ -10308,6 +10408,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
       <categoryLinks>
         <categoryLink id="9d49-2d09-dd7c-30c3" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="5225-7937-685c-e9db" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="94f4-55bb-a038-7394" name="Infantry Only" hidden="false" targetId="db6f-0311-834c-e6ff" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="a2f0-15d9-2b7a-2204" name="Legion Tartaros Praetor" hidden="false" collective="false" import="true" type="model">
@@ -10409,7 +10510,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="35.0"/>
                   </costs>
                 </entryLink>
-                <entryLink id="3a9d-a0b7-4e30-3f78" name="Surgical Augment" hidden="false" collective="false" import="true" targetId="aeb3-6a73-da1d-2b90" type="selectionEntryGroup">
+                <entryLink id="3a9d-a0b7-4e30-3f78" name="Surgical Augment" hidden="false" collective="false" import="true" targetId="ffa3-1a57-1eb4-1818" type="selectionEntryGroup">
                   <modifiers>
                     <modifier type="set" field="hidden" value="false">
                       <conditionGroups>
@@ -10699,6 +10800,28 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                     <condition field="selections" scope="25a2-7a52-632a-6b2c" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f152-51f5-b509-2d9c" type="equalTo"/>
                     <condition field="selections" scope="25a2-7a52-632a-6b2c" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9924-004c-e683-877b" type="equalTo"/>
                     <condition field="selections" scope="25a2-7a52-632a-6b2c" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a8ac-7465-70fb-70fb" type="equalTo"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+            <modifier type="add" field="category" value="db6f-0311-834c-e6ff">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="25a2-7a52-632a-6b2c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a8ac-7465-70fb-70fb" type="lessThan"/>
+                    <condition field="selections" scope="25a2-7a52-632a-6b2c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f152-51f5-b509-2d9c" type="lessThan"/>
+                    <condition field="selections" scope="25a2-7a52-632a-6b2c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9924-004c-e683-877b" type="lessThan"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+            <modifier type="add" field="category" value="2bcf-6bbe-58a1-e082">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="25a2-7a52-632a-6b2c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a8ac-7465-70fb-70fb" type="atLeast"/>
+                    <condition field="selections" scope="25a2-7a52-632a-6b2c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f152-51f5-b509-2d9c" type="atLeast"/>
+                    <condition field="selections" scope="25a2-7a52-632a-6b2c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9924-004c-e683-877b" type="atLeast"/>
                   </conditions>
                 </conditionGroup>
               </conditionGroups>
@@ -11887,7 +12010,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                     </modifier>
                   </modifiers>
                 </entryLink>
-                <entryLink id="a0ce-7130-54f7-edc5" name="Surgical Augment" hidden="true" collective="false" import="true" targetId="aeb3-6a73-da1d-2b90" type="selectionEntryGroup">
+                <entryLink id="a0ce-7130-54f7-edc5" name="Surgical Augment" hidden="true" collective="false" import="true" targetId="ffa3-1a57-1eb4-1818" type="selectionEntryGroup">
                   <modifiers>
                     <modifier type="set" field="hidden" value="false">
                       <conditionGroups>
@@ -12160,6 +12283,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
         <categoryLink id="9c7a-acc7-9230-fcc4" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="6901-e4b0-c5cc-a02b" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="a872-59ee-deae-90b7" name="Terminators:" hidden="false" targetId="bab3-f50d-3e5f-2f78" primary="false"/>
+        <categoryLink id="74d5-6f1c-2d5e-23df" name="Infantry Only" hidden="false" targetId="db6f-0311-834c-e6ff" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="87b7-091d-4bc3-9164" name="One Legion Tartaros may take:" hidden="false" collective="false" import="true">
@@ -12890,6 +13014,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
         <categoryLink id="d924-8839-45ef-d725" name="Terminators:" hidden="false" targetId="bab3-f50d-3e5f-2f78" primary="false"/>
         <categoryLink id="30ff-487a-51ee-62ce" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="8cc9-9b8f-dc8b-183f" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+        <categoryLink id="3353-4c41-7567-bc88" name="Infantry Only" hidden="false" targetId="db6f-0311-834c-e6ff" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="b908-ada3-76ab-8d4d" name="2) One Legion Cataphractii may take:" hidden="false" collective="false" import="true">
@@ -13486,6 +13611,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
         <categoryLink id="176f-2693-896f-9748" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="3a70-5ba0-7914-683a" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="3cfb-f16e-35b6-c89d" name="Line Sub-type:" hidden="false" targetId="6399-5c65-7833-1025" primary="false"/>
+        <categoryLink id="7bab-24c0-89e7-7898" name="Infantry Only" hidden="false" targetId="db6f-0311-834c-e6ff" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="ef23-ca32-6fe5-b736" name="  Legion Despoiler Sergeant" hidden="false" collective="false" import="true" type="model">
@@ -13972,6 +14098,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                     <conditionGroup type="or">
                       <conditions>
                         <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1977-49f2-7910-f177" type="equalTo"/>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e864-ddc1-da3a-138e" type="equalTo"/>
                       </conditions>
                     </conditionGroup>
                   </conditionGroups>
@@ -14421,6 +14548,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
         <categoryLink id="d5a1-47f5-0e3c-716d" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="ad69-ee1e-ec47-c17e" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
         <categoryLink id="39df-bd14-1a10-1f88" name="Line Sub-type:" hidden="false" targetId="6399-5c65-7833-1025" primary="false"/>
+        <categoryLink id="e462-1349-3629-f34d" name="Infantry Only" hidden="false" targetId="db6f-0311-834c-e6ff" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="8725-b9d1-1e86-0364" name="  Legion Breacher Sergeant" hidden="false" collective="false" import="true" type="model">
@@ -14851,6 +14979,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                     <conditionGroup type="or">
                       <conditions>
                         <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1977-49f2-7910-f177" type="equalTo"/>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e864-ddc1-da3a-138e" type="equalTo"/>
                       </conditions>
                     </conditionGroup>
                   </conditionGroups>
@@ -15308,6 +15437,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
         <categoryLink id="78f2-3b93-045e-9fff" name="Infantry" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="da59-0c31-03f1-ae38" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="95f4-7bc2-449f-5dd3" name="Line Sub-type:" hidden="false" targetId="6399-5c65-7833-1025" primary="false"/>
+        <categoryLink id="0802-5786-4bf3-c07b" name="Infantry Only" hidden="false" targetId="db6f-0311-834c-e6ff" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="4d0d-06f9-4989-439e" name=" Legion Recon Sergeant" hidden="false" collective="false" import="true" type="model">
@@ -15912,6 +16042,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                     <conditionGroup type="or">
                       <conditions>
                         <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1977-49f2-7910-f177" type="equalTo"/>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e864-ddc1-da3a-138e" type="equalTo"/>
                       </conditions>
                     </conditionGroup>
                   </conditionGroups>
@@ -16020,6 +16151,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
       <categoryLinks>
         <categoryLink id="1b9e-4e93-3914-a6e1" name="New CategoryLink" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="f887-300a-daae-7e57" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="49b4-8dc9-6457-dc3a" name="Infantry Only" hidden="false" targetId="db6f-0311-834c-e6ff" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="8867-1af4-01f7-da72" name="Legion Scout" hidden="false" collective="false" import="true" type="model">
@@ -16597,6 +16729,26 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
               <conditions>
                 <condition field="selections" scope="0aca-632d-1642-8af9" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6fb4-adf6-dbe8-86af" type="equalTo"/>
                 <condition field="selections" scope="0aca-632d-1642-8af9" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e8a8-b526-beab-bb82" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+        <modifier type="add" field="category" value="2bcf-6bbe-58a1-e082">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="0aca-632d-1642-8af9" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6fb4-adf6-dbe8-86af" type="equalTo"/>
+                <condition field="selections" scope="0aca-632d-1642-8af9" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e8a8-b526-beab-bb82" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+        <modifier type="add" field="category" value="db6f-0311-834c-e6ff">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="0aca-632d-1642-8af9" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6fb4-adf6-dbe8-86af" type="lessThan"/>
+                <condition field="selections" scope="0aca-632d-1642-8af9" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e8a8-b526-beab-bb82" type="lessThan"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
@@ -17349,6 +17501,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                     <conditionGroup type="or">
                       <conditions>
                         <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1977-49f2-7910-f177" type="equalTo"/>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e864-ddc1-da3a-138e" type="equalTo"/>
                       </conditions>
                     </conditionGroup>
                   </conditionGroups>
@@ -17460,6 +17613,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
         <categoryLink id="b8e8-4253-0c09-b2ef" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
         <categoryLink id="4448-0829-a17f-5502" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="b7b3-57a1-d3d8-2be0" name="Terminators:" hidden="false" targetId="bab3-f50d-3e5f-2f78" primary="false"/>
+        <categoryLink id="4971-18c0-7a6f-b3e6" name="Infantry Only" hidden="false" targetId="db6f-0311-834c-e6ff" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="da79-9588-cc7f-e02f" name="Legion Cataphractii Centurion" hidden="false" collective="false" import="true" type="model">
@@ -17867,7 +18021,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                     </modifier>
                   </modifiers>
                 </entryLink>
-                <entryLink id="0fc9-8d7b-c87d-ef5f" name="Surgical Augment" hidden="true" collective="false" import="true" targetId="aeb3-6a73-da1d-2b90" type="selectionEntryGroup">
+                <entryLink id="0fc9-8d7b-c87d-ef5f" name="Surgical Augment" hidden="true" collective="false" import="true" targetId="ffa3-1a57-1eb4-1818" type="selectionEntryGroup">
                   <modifiers>
                     <modifier type="set" field="hidden" value="false">
                       <conditionGroups>
@@ -18035,7 +18189,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
-        <entryLink id="00f3-a40a-f289-9fc1" name=" Legiones Consularis" hidden="false" collective="false" import="true" targetId="3cbf-9466-2558-2c22" type="selectionEntryGroup"/>
+        <entryLink id="00f3-a40a-f289-9fc1" name="0) Legiones Consularis" hidden="false" collective="false" import="true" targetId="3cbf-9466-2558-2c22" type="selectionEntryGroup"/>
         <entryLink id="8a18-8470-ccc2-0a97" name="0) Consul Additional Wargear and Options" hidden="false" collective="false" import="true" targetId="244a-2a7c-1349-94e7" type="selectionEntryGroup"/>
         <entryLink id="36be-ca67-c929-4725" name="Warlord" hidden="false" collective="false" import="true" targetId="0176-56a3-d590-b103" type="selectionEntry">
           <constraints>
@@ -18076,6 +18230,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
       <categoryLinks>
         <categoryLink id="6815-a77d-f59b-632f" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="480a-471d-9c29-a920" name="Terminators:" hidden="false" targetId="bab3-f50d-3e5f-2f78" primary="false"/>
+        <categoryLink id="79ca-0d38-d631-8f29" name="Infantry Only" hidden="false" targetId="db6f-0311-834c-e6ff" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="f059-2405-bfa0-11cf" name="Dedicated Transport" hidden="false" collective="false" import="true">
@@ -18411,6 +18566,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
       <categoryLinks>
         <categoryLink id="028b-dfb1-e521-2745" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="cea8-a6fe-2e41-d8ff" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="b9ec-1b6f-0509-0e5e" name="Infantry Only" hidden="false" targetId="db6f-0311-834c-e6ff" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="2dde-c679-4d2d-e928" name="0) Legiones Unit Upgrades:" hidden="false" collective="false" import="true">
@@ -19888,6 +20044,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
       </infoLinks>
       <categoryLinks>
         <categoryLink id="bb97-be52-aa75-a4d0" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="a1e2-f519-dbbb-da61" name="Infantry Only" hidden="false" targetId="db6f-0311-834c-e6ff" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="415c-6834-f4d2-d967" name="Apothecary" publicationId="a716-c1c4-7b26-8424" hidden="false" collective="false" import="true" type="model">
@@ -20306,6 +20463,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
       <categoryLinks>
         <categoryLink id="13fc-715d-8968-5d54" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="129e-3d72-2602-afcd" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="defe-34ad-aa73-cce7" name="Infantry Only" hidden="false" targetId="db6f-0311-834c-e6ff" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="53c3-7eec-4676-996e" name="Legion Seeker" hidden="false" collective="false" import="true" type="model">
@@ -20972,6 +21130,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                     <conditionGroup type="or">
                       <conditions>
                         <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1977-49f2-7910-f177" type="equalTo"/>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e864-ddc1-da3a-138e" type="equalTo"/>
                       </conditions>
                     </conditionGroup>
                   </conditionGroups>
@@ -21020,8 +21179,8 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
         </modifier>
       </modifiers>
       <constraints>
-        <constraint field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ff7e-29e9-15ce-eb81" type="min"/>
         <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8d60-d1f0-a95c-8b26" type="max"/>
+        <constraint field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ff7e-29e9-15ce-eb81" type="min"/>
       </constraints>
       <infoLinks>
         <infoLink id="ad67-cade-eb63-f8c5" name="Techmarine Covenant" hidden="false" targetId="93e9-2806-e822-bfaf" type="rule"/>
@@ -21034,6 +21193,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
       </infoLinks>
       <categoryLinks>
         <categoryLink id="bba9-768a-89c6-84ba" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="b902-b743-ba1b-0ec7" name="Infantry Only" hidden="false" targetId="db6f-0311-834c-e6ff" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="fc32-089e-1c59-70bd" name="Techmarine" publicationId="a716-c1c4-7b26-8424" hidden="false" collective="false" import="true" type="model">
@@ -21745,6 +21905,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
         <categoryLink id="cccf-e162-2ea4-885a" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="1237-8d7a-91b2-1565" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="9db9-a73f-ccf4-06a3" name="Terminators:" hidden="false" targetId="bab3-f50d-3e5f-2f78" primary="false"/>
+        <categoryLink id="8eb4-6b99-d451-bbae" name="Infantry Only" hidden="false" targetId="db6f-0311-834c-e6ff" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="69fc-a6ab-d7a8-0e83" name="Legion Tartaros Centurion" hidden="false" collective="false" import="true" type="model">
@@ -22139,7 +22300,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                     </modifier>
                   </modifiers>
                 </entryLink>
-                <entryLink id="2973-fa28-948b-8797" name="Surgical Augment" hidden="true" collective="false" import="true" targetId="aeb3-6a73-da1d-2b90" type="selectionEntryGroup">
+                <entryLink id="2973-fa28-948b-8797" name="Surgical Augment" hidden="true" collective="false" import="true" targetId="ffa3-1a57-1eb4-1818" type="selectionEntryGroup">
                   <modifiers>
                     <modifier type="set" field="hidden" value="false">
                       <conditionGroups>
@@ -22366,6 +22527,9 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
               </modifiers>
             </infoLink>
           </infoLinks>
+          <categoryLinks>
+            <categoryLink id="bf8f-6c7c-ed20-00bd" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
+          </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="5f5a-bc15-c9d5-e890" name="4) May take:" hidden="false" collective="false" import="true">
               <constraints>
@@ -22632,6 +22796,11 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
             <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
           </conditions>
         </modifier>
+        <modifier type="add" field="category" value="20ef-cd01-a8da-376e">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="50cf-edf5-d39a-8943" type="equalTo"/>
+          </conditions>
+        </modifier>
       </modifiers>
       <categoryLinks>
         <categoryLink id="0ea3-c6cc-f348-2226" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
@@ -22660,6 +22829,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
           </profiles>
           <categoryLinks>
             <categoryLink id="8b77-ae5c-8bac-f9e0" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+            <categoryLink id="1254-e8a0-4ef4-a552" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="5b1e-5fa8-bf4c-9339" name="4) May take:" hidden="false" collective="false" import="true">
@@ -23046,6 +23216,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
           </profiles>
           <categoryLinks>
             <categoryLink id="86f7-68a5-edfa-df3a" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+            <categoryLink id="f07f-3132-ba77-6566" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="030d-69f8-d9af-d6f6" name="1) Arcus Launcher" hidden="false" collective="false" import="true">
@@ -23318,6 +23489,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
           </profiles>
           <categoryLinks>
             <categoryLink id="532a-184b-6633-a933" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+            <categoryLink id="5cf1-62e8-6511-3de0" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="ea31-6d06-3a9a-8bf8" name="2) Sponson Mounted Weapons:" hidden="false" collective="false" import="true" defaultSelectionEntryId="50f8-01b2-554c-f3c8">
@@ -23688,6 +23860,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
           </infoLinks>
           <categoryLinks>
             <categoryLink id="4161-d5a7-0d9e-6234" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+            <categoryLink id="67b4-d4b8-eed0-a0e4" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="0d3c-a988-5a78-4077" name="3) May take:" hidden="false" collective="false" import="true">
@@ -23915,6 +24088,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
         <categoryLink id="8cda-e93d-10a1-8cbc" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
         <categoryLink id="b1af-aba1-ebba-987b" name="Transport" hidden="false" targetId="7b0a-a743-a8da-3a39" primary="false"/>
         <categoryLink id="d8cd-3887-6695-d480" name="Reinforced Sub-type:" hidden="false" targetId="9b0d-738c-10e4-4ec1" primary="false"/>
+        <categoryLink id="5da8-4d96-2cdf-5328" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="94f8-f071-903e-a4f9" name="2) Pintle mounted Weapon:" hidden="false" collective="false" import="true">
@@ -24186,6 +24360,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
           <categoryLinks>
             <categoryLink id="a3a3-24e2-ecd4-38fa" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
             <categoryLink id="328a-a860-4be3-e6c8" name="Reinforced Sub-type:" hidden="false" targetId="9b0d-738c-10e4-4ec1" primary="false"/>
+            <categoryLink id="9809-ace4-bae3-3375" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="c99e-c96d-5c57-7215" name="1) Centreline Mounted Weapon:" hidden="false" collective="false" import="true" defaultSelectionEntryId="646f-5064-f0b0-3a83">
@@ -24481,6 +24656,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
           </profiles>
           <categoryLinks>
             <categoryLink id="c2f1-cd11-ca0c-0d3b" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+            <categoryLink id="4cad-f81a-fda5-1703" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="ad38-0891-7db4-3528" name="1) Sponson Mounted Weapons:" hidden="false" collective="false" import="true" defaultSelectionEntryId="2f89-a5d7-94b6-6868">
@@ -24807,6 +24983,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
         <categoryLink id="2b45-00e1-5c3d-c2e5" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="c33e-fa91-93da-9bc9" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
         <categoryLink id="d4ab-bc77-4c9d-1887" name="Terminators:" hidden="false" targetId="bab3-f50d-3e5f-2f78" primary="false"/>
+        <categoryLink id="b5b0-a064-0704-2107" name="Infantry Only" hidden="false" targetId="db6f-0311-834c-e6ff" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="9fa9-d220-698d-8220" name="Dedicated Transport" hidden="false" collective="false" import="true">
@@ -25151,6 +25328,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
         <categoryLink id="ae9b-5609-d742-a57c" name="Flyer" hidden="false" targetId="4e84-2d57-4986-2b23" primary="false"/>
         <categoryLink id="9f22-19aa-22ca-5dbf" name="Hover Sub-type" hidden="false" targetId="3a7a-8bb7-b0d3-e2e7" primary="false"/>
         <categoryLink id="c289-9171-f7d9-d94a" name="Transport" hidden="false" targetId="7b0a-a743-a8da-3a39" primary="false"/>
+        <categoryLink id="d758-b63f-aa59-86e8" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="1b10-460e-e75a-3ffd" name="Dreadclaw Drop Pod" hidden="false" collective="false" import="true" type="upgrade">
@@ -25250,6 +25428,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
       <categoryLinks>
         <categoryLink id="156c-ae25-48d5-1e9d" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="1ef8-f347-84e3-b054" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="8cda-288b-945f-9e62" name="Infantry Only" hidden="false" targetId="db6f-0311-834c-e6ff" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="8aea-b995-e957-0c42" name=" Legion Support Sergeant" hidden="false" collective="false" import="true" type="model">
@@ -25665,6 +25844,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                     <conditionGroup type="or">
                       <conditions>
                         <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1977-49f2-7910-f177" type="equalTo"/>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e864-ddc1-da3a-138e" type="equalTo"/>
                       </conditions>
                     </conditionGroup>
                   </conditionGroups>
@@ -25956,6 +26136,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
           </profiles>
           <categoryLinks>
             <categoryLink id="5101-eca4-4a32-4c77" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+            <categoryLink id="472b-1cc7-49b5-86f3" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="6261-4456-2d7b-82b0" name="1) Centreline Mounted Weapon" hidden="false" collective="false" import="true">
@@ -26201,6 +26382,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
         <categoryLink id="6b9a-cce1-8d40-60e4" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="c641-0dd3-091e-e12d" name="Cavalry Sub-type:" hidden="false" targetId="6d79-a3e4-381f-7b0f" primary="false"/>
         <categoryLink id="d231-48d4-4a7e-88c4" name="Antigrav Sub-type" hidden="false" targetId="4303-1348-cce4-9501" primary="false"/>
+        <categoryLink id="a611-26f8-993e-8b71" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="d0b2-a77a-a4f4-0ae1" name="Legion Sky-Hunter" hidden="false" collective="false" import="true" type="model">
@@ -26689,6 +26871,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
         <categoryLink id="8179-34af-db8c-7a20" name="Flyer" hidden="false" targetId="4e84-2d57-4986-2b23" primary="false"/>
         <categoryLink id="ef8f-3fb2-f2d5-3e57" name="Hover Sub-type" hidden="false" targetId="3a7a-8bb7-b0d3-e2e7" primary="false"/>
         <categoryLink id="075f-3971-715b-a9a2" name="Transport" hidden="false" targetId="7b0a-a743-a8da-3a39" primary="false"/>
+        <categoryLink id="8d10-f5b1-a3bb-6206" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="1d23-3f85-0a01-95b9" name="Hull (Front) Mounted Vengeance launcher" hidden="false" collective="false" import="true" type="upgrade">
@@ -26845,6 +27028,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
         <categoryLink id="faad-a55f-fe5f-79ba" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="c58b-a48e-6286-c40d" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
         <categoryLink id="7123-b060-2ff0-00d4" name="Flyer" hidden="false" targetId="4e84-2d57-4986-2b23" primary="false"/>
+        <categoryLink id="1930-fffd-00e1-3db8" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="68ac-5612-184b-904d" name="Hull (Front) Mounted Rotary Missile Launcher" hidden="false" collective="false" import="true" type="upgrade">
@@ -26986,6 +27170,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
           </profiles>
           <categoryLinks>
             <categoryLink id="04bb-9232-6cae-47f2" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+            <categoryLink id="fab9-12fe-9e83-6faa" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="f24c-7b68-d78c-11e2" name="1) Heavy Bolter Options" hidden="false" collective="false" import="true" defaultSelectionEntryId="e8ee-9957-bb72-3155">
@@ -27257,6 +27442,9 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
               </characteristics>
             </profile>
           </profiles>
+          <categoryLinks>
+            <categoryLink id="bba5-15e2-0342-6847" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
+          </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="8e58-3e53-6466-d844" name="1) Cyclone Missile Launcher Options" hidden="false" collective="false" import="true" defaultSelectionEntryId="eae6-b0e3-f61d-7ed0">
               <constraints>
@@ -27476,6 +27664,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
           </profiles>
           <categoryLinks>
             <categoryLink id="3c86-f984-9801-c6ad" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+            <categoryLink id="f5d8-3a3b-d955-9664" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="6c2c-6557-be98-903a" name="3) May take:" hidden="false" collective="false" import="true">
@@ -27819,6 +28008,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
           </profiles>
           <categoryLinks>
             <categoryLink id="c3fb-b663-3e8c-fac8" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+            <categoryLink id="6eb8-767e-2988-9f20" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="8ebc-e1b7-eee0-81bc" name="3) May take:" hidden="false" collective="false" import="true">
@@ -28107,6 +28297,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
         <categoryLink id="ae99-700e-db56-fc27" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="7852-636a-6edc-9978" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
         <categoryLink id="5a6b-0473-e1ba-1a6e" name="Super-heavy" hidden="false" targetId="7381-1130-ca6e-1806" primary="false"/>
+        <categoryLink id="b5cd-403c-68c2-de62" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="43d4-8f65-a666-b6e3" name="May take:" hidden="false" collective="false" import="true">
@@ -28395,6 +28586,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
         <categoryLink id="ea22-733c-649a-1077" name="Hover Sub-type" hidden="false" targetId="3a7a-8bb7-b0d3-e2e7" primary="false"/>
         <categoryLink id="d4f2-aa4f-0399-dcfe" name="Lumbering" hidden="false" targetId="7f9b-c5ed-7edb-02dc" primary="false"/>
         <categoryLink id="0b61-29b5-1887-5b88" name="Transport" hidden="false" targetId="7b0a-a743-a8da-3a39" primary="false"/>
+        <categoryLink id="d918-0e6b-6844-4953" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="fb46-e14c-0a38-320b" name="1) Main Gun Options" hidden="false" collective="false" import="true" defaultSelectionEntryId="8df2-f6fb-f564-4c74">
@@ -28566,6 +28758,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
       </profiles>
       <categoryLinks>
         <categoryLink id="9bac-bc2a-2c38-ab28" name="Super-heavy" hidden="false" targetId="7381-1130-ca6e-1806" primary="false"/>
+        <categoryLink id="abd4-40bc-eb55-33b5" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="2dbd-13c2-ed9e-c395" name="1) Hull Weapon Options" hidden="false" collective="false" import="true" defaultSelectionEntryId="f831-4ab5-a7ea-f1d5">
@@ -28878,6 +29071,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
         <categoryLink id="231c-19d1-0097-c872" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
         <categoryLink id="35a4-7e73-f5a8-c7a8" name="Super-heavy" hidden="false" targetId="7381-1130-ca6e-1806" primary="false"/>
         <categoryLink id="9168-20ed-1639-2373" name="Transport" hidden="false" targetId="7b0a-a743-a8da-3a39" primary="false"/>
+        <categoryLink id="121d-8ef3-ef67-d18d" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="c830-8055-5fad-7768" name="1) Turret Mounted Equipment" hidden="false" collective="false" import="true" defaultSelectionEntryId="17eb-0577-023d-3735">
@@ -29336,6 +29530,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
         <categoryLink id="b8c4-671b-9a5f-eb6b" name="Hover Sub-type" hidden="false" targetId="3a7a-8bb7-b0d3-e2e7" primary="false"/>
         <categoryLink id="853a-8e69-b900-48c9" name="Lumbering" hidden="false" targetId="7f9b-c5ed-7edb-02dc" primary="false"/>
         <categoryLink id="4d3e-f11e-f213-f158" name="Transport" hidden="false" targetId="7b0a-a743-a8da-3a39" primary="false"/>
+        <categoryLink id="c5be-01dc-c977-d4f3" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="110f-5a27-f7d4-0302" name="1) Left Side Weapon Options" hidden="false" collective="false" import="true" defaultSelectionEntryId="a0f9-7e15-88f2-eef0">
@@ -29518,6 +29713,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
         <categoryLink id="4346-61f7-6ddb-7db4" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="0163-3f12-80b9-2221" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="eb3d-4f92-8ccb-b662" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+        <categoryLink id="3fa2-6d9b-66ca-29f3" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="985f-caea-1e37-8ac2" name="May take:" hidden="false" collective="false" import="true">
@@ -29766,6 +29962,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
         <categoryLink id="8775-c7f6-d071-55c9" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="1bb7-7735-8c97-b799" name="Transport" hidden="false" targetId="7b0a-a743-a8da-3a39" primary="false"/>
         <categoryLink id="d320-d9a9-315c-2b0c" name="Reinforced Sub-type:" hidden="false" targetId="9b0d-738c-10e4-4ec1" primary="false"/>
+        <categoryLink id="4fd1-ce55-689e-1af2" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="e097-5c31-84dd-dc26" name="1) Hull Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="9d6b-4a72-62ea-1317">
@@ -29987,6 +30184,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
         <categoryLink id="6beb-8854-14dd-3db9" name="Artillery Sub-type:" hidden="false" targetId="6f99-c178-6f9d-fb63" primary="false"/>
         <categoryLink id="fbe0-eca3-2aa2-eecc" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="5a2f-2252-bba0-e052" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+        <categoryLink id="a165-29f0-1617-b437" name="Infantry Only" hidden="false" targetId="db6f-0311-834c-e6ff" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="975a-c83c-1f06-b4c8" name="1) Battery Weapon Options" hidden="false" collective="false" import="true" defaultSelectionEntryId="beaa-2d73-874a-0897">
@@ -30086,6 +30284,56 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
           </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="b59d-e5b8-7f73-c6f8" name="Legiones Unit Upgrades:" hidden="false" collective="false" import="true">
+          <selectionEntryGroups>
+            <selectionEntryGroup id="c99d-7474-b00c-17f6" name="Surgical Augment (unit)" hidden="true" collective="false" import="true">
+              <modifiers>
+                <modifier type="set" field="hidden" value="false">
+                  <conditionGroups>
+                    <conditionGroup type="and">
+                      <conditions>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3edc-a1b9-6dc6-b1ea" type="equalTo"/>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo"/>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e221-0a54-9f94-988f" type="equalTo"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4b3f-7eff-88df-678c" type="max"/>
+                <constraint field="selections" scope="parent" value="-1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c0bf-00ad-da84-fa3c" type="min"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="e96d-7d0a-05fe-a833" name="Sonic Shriekers (Unit)" hidden="false" collective="false" import="true" targetId="7200-efa6-c232-eb74" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d3e5-14d5-869b-411b" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="30.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="93e6-e918-f10d-639f" name="Sonic Lance (Unit)" hidden="false" collective="false" import="true" targetId="b8b5-3d56-8f42-4b4d" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9f0c-f848-b052-6668" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="30.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="5f12-c462-0cff-417d" name="Sub-sonic Pulser Unit)" hidden="false" collective="false" import="true" targetId="a3c0-860a-2b71-c53e" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="name" value="Sub-sonic Pulser (Unit)"/>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7f68-ac49-f51a-7cd0" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="30.0"/>
+                  </costs>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
           <entryLinks>
             <entryLink id="b7ac-fadc-079e-b45e" name="Preysight" hidden="false" collective="false" import="true" targetId="b905-4d78-c141-4e63" type="selectionEntry">
               <constraints>
@@ -30423,6 +30671,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
         <categoryLink id="f0cb-e19d-2d73-aa3f" name="Terminators:" hidden="false" targetId="bab3-f50d-3e5f-2f78" primary="false"/>
         <categoryLink id="a888-0301-9c87-ae58" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
         <categoryLink id="94de-62fb-73ee-229d" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="9ae2-1bcd-de39-c704" name="Infantry Only" hidden="false" targetId="db6f-0311-834c-e6ff" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="0740-a851-4e97-fced" name="Nullificator" hidden="false" collective="false" import="true" type="model">
@@ -30833,6 +31082,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
           </profiles>
           <categoryLinks>
             <categoryLink id="f292-0604-29fa-a71e" name="Dreadnought Unit-type:" hidden="false" targetId="4280-4963-02b5-e31d" primary="false"/>
+            <categoryLink id="ad69-8717-dba6-9001" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="cdb1-bf93-df94-2bf9" name="4) May take:" hidden="false" collective="false" import="true">
@@ -31223,6 +31473,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
         <categoryLink id="ba6c-bb79-909d-33f1" name="Terminators:" hidden="false" targetId="bab3-f50d-3e5f-2f78" primary="false"/>
         <categoryLink id="0a43-ec27-0c1e-4c5b" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="5ff7-87f5-f921-d1c4" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+        <categoryLink id="c416-8484-3d86-bc26" name="Infantry Only" hidden="false" targetId="db6f-0311-834c-e6ff" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="23e2-4e21-6229-2444" name="3) One Legion Indomitus may take:" hidden="false" collective="false" import="true">
@@ -32098,6 +32349,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
           </profiles>
           <categoryLinks>
             <categoryLink id="5e23-61e4-47a0-0e3e" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+            <categoryLink id="383c-a4a3-8fc6-af0e" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="ae74-5d4e-7532-84ac" name="2) May Take:" hidden="false" collective="false" import="true">
@@ -32386,6 +32638,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
           </profiles>
           <categoryLinks>
             <categoryLink id="a0e0-36ae-f8cc-a99d" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+            <categoryLink id="8185-3d0d-5b63-df53" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="0c4f-3ecb-4134-314d" name="1) Turret Mounted Weapon:" hidden="false" collective="false" import="true" defaultSelectionEntryId="270d-03a1-1122-8540">
@@ -32907,6 +33160,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
         <categoryLink id="f9a5-3777-fc4c-4dba" name="Flyer" hidden="false" targetId="4e84-2d57-4986-2b23" primary="false"/>
         <categoryLink id="cec9-319f-7118-7cf8" name="Hover Sub-type" hidden="false" targetId="3a7a-8bb7-b0d3-e2e7" primary="false"/>
         <categoryLink id="9111-2535-4dc3-ad8e" name="Transport" hidden="false" targetId="7b0a-a743-a8da-3a39" primary="false"/>
+        <categoryLink id="23fd-cf06-d154-63db" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="50f2-4e31-2b38-674a" name="Turret Mounted Deathstorm Missile Launcher" hidden="false" collective="false" import="true" type="upgrade">
@@ -32962,6 +33216,16 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
       </costs>
     </selectionEntry>
     <selectionEntry id="af13-fb4e-b792-61a3" name="Deathstorm Drop Pod Squadron" hidden="false" collective="false" import="true" type="unit">
+      <modifiers>
+        <modifier type="set" field="7050-1866-b0b5-030e" value="0.0">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7a43-6793-013b-1af6" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="force" value="-1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7050-1866-b0b5-030e" type="max"/>
+      </constraints>
       <categoryLinks>
         <categoryLink id="7f67-e0ca-2b9d-4b1c" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="false"/>
         <categoryLink id="5d80-eb88-5146-595d" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
@@ -32996,6 +33260,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
           </infoLinks>
           <categoryLinks>
             <categoryLink id="38b0-7f4d-7fa6-5d5a" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+            <categoryLink id="88f4-2c3d-4f9c-3842" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="7865-513b-43f6-7ba3" name="May take:" hidden="false" collective="false" import="true">
@@ -33169,6 +33434,9 @@ Additionally, at the end of any Phase in which a model with Gorgon Terminator ar
         </infoLink>
         <infoLink id="cc20-196a-4ebc-7e1e" name="Master of Automata" hidden="false" targetId="8eef-f84b-37cb-554b" type="rule"/>
       </infoLinks>
+      <categoryLinks>
+        <categoryLink id="cbc7-7866-ccfb-b2df" name="Infantry Only" hidden="false" targetId="db6f-0311-834c-e6ff" primary="false"/>
+      </categoryLinks>
       <entryLinks>
         <entryLink id="7d01-2d81-485f-25aa" name="Servo-Arm" hidden="false" collective="false" import="true" targetId="4168-fc85-8912-7188" type="selectionEntry">
           <constraints>
@@ -33245,6 +33513,7 @@ Additionally, at the end of any Phase in which a model with Gorgon Terminator ar
         <categoryLink id="995e-aa85-478b-de47" name="Skirmish:" hidden="false" targetId="59a4-7b61-600a-c457" primary="false"/>
         <categoryLink id="1b08-e6e5-3d06-e1a1" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="1256-af1a-9a11-bd3b" name="Cavalry Sub-type:" hidden="false" targetId="6d79-a3e4-381f-7b0f" primary="false"/>
+        <categoryLink id="0f11-e290-4c84-1c95" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="a0ea-afcb-5c88-a699" name="Legion Spatha Attack Bike" hidden="false" collective="false" import="true" type="model">
@@ -33470,6 +33739,7 @@ Additionally, at the end of any Phase in which a model with Gorgon Terminator ar
       <categoryLinks>
         <categoryLink id="04e3-a81a-89b2-5f49" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
         <categoryLink id="793a-67fe-8731-7c9f" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="a266-5b5f-670e-df4c" name="Infantry Only" hidden="false" targetId="db6f-0311-834c-e6ff" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="e353-952c-5733-c446" name="Libertas" hidden="false" collective="false" import="true" type="upgrade">
@@ -33595,6 +33865,7 @@ Garro is fighting in a Challenge</characteristic>
         <categoryLink id="b8cf-ff1a-662e-6f72" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
         <categoryLink id="e2a6-00ad-2796-c89b" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="0528-07cf-ec83-bdab" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="93b2-1197-7163-cc43" name="Infantry Only" hidden="false" targetId="db6f-0311-834c-e6ff" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="7a6e-ff13-9c39-ff1d" name="The Aegis Argentum" publicationId="d0df-7166-5cd3-89fd" page="7" hidden="false" collective="false" import="true" type="upgrade">
@@ -33714,6 +33985,7 @@ containing the model that failed its Check. If the Psyker survives Perils of the
         <categoryLink id="12f4-8864-ab57-f9f9" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="c519-b6ff-7f40-4d69" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="7f7a-19de-90a2-4c95" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+        <categoryLink id="9c9b-f85a-e481-2931" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="0bf0-559f-72b9-cfa9" name="4) May take:" hidden="false" collective="false" import="true">
@@ -33957,6 +34229,7 @@ containing the model that failed its Check. If the Psyker survives Perils of the
         <categoryLink id="46f1-e90b-bf1d-882c" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="5f4a-4ffd-a8a7-2c3e" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="9823-f559-b33c-66e6" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+        <categoryLink id="5efe-4091-635b-6181" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="123c-539a-dca4-5fb2" name="May take:" hidden="false" collective="false" import="true">
@@ -34218,6 +34491,7 @@ containing the model that failed its Check. If the Psyker survives Perils of the
         <categoryLink id="6730-3426-65c4-b313" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="2c58-a573-56d4-ec73" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="d6e3-8a15-0d26-6d93" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+        <categoryLink id="876b-182e-5279-0ad9" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="6534-8d4a-6593-2806" name="May take:" hidden="false" collective="false" import="true">
@@ -34417,6 +34691,7 @@ containing the model that failed its Check. If the Psyker survives Perils of the
         <categoryLink id="3218-f8aa-2242-3c25" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="40ad-88a5-9830-de8c" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
         <categoryLink id="b90d-8751-2096-6845" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="c115-dbdb-1896-1db4" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="baa5-fc7e-f925-4a5d" name="May take:" hidden="false" collective="false" import="true">
@@ -34631,6 +34906,7 @@ containing the model that failed its Check. If the Psyker survives Perils of the
         <categoryLink id="0051-5fd8-4005-30c2" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="cb74-1081-9d7d-ec9c" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="c703-dfd8-1371-b64a" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+        <categoryLink id="7460-4132-50f4-e879" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="00c0-3a7c-15d7-3788" name="May take:" hidden="false" collective="false" import="true">
@@ -34865,6 +35141,7 @@ containing the model that failed its Check. If the Psyker survives Perils of the
         <categoryLink id="5907-22d5-cb57-2222" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="1bfc-4442-f18b-c57b" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="f3aa-c912-cb85-0629" name="Bombard Sub-type:" hidden="false" targetId="d5df-57ac-8f3c-097b" primary="false"/>
+        <categoryLink id="55d8-5a2b-cdf8-ab98" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="b4f4-a12a-e7da-3341" name="Pintle mounted Weapon Options" hidden="false" collective="false" import="true">
@@ -35059,6 +35336,7 @@ containing the model that failed its Check. If the Psyker survives Perils of the
           </profiles>
           <categoryLinks>
             <categoryLink id="9e86-a1f3-a85e-737c" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+            <categoryLink id="b0ea-e29a-2db5-7417" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="f661-cf57-5135-4146" name="May take:" hidden="false" collective="false" import="true">
@@ -35351,6 +35629,7 @@ containing the model that failed its Check. If the Psyker survives Perils of the
           </profiles>
           <categoryLinks>
             <categoryLink id="359b-fa5f-391b-96ba" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+            <categoryLink id="d8dd-7b4f-0879-f745" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="3640-9400-1ca4-403e" name="May take:" hidden="false" collective="false" import="true">
@@ -35626,6 +35905,7 @@ containing the model that failed its Check. If the Psyker survives Perils of the
         <categoryLink id="992a-101e-f1c0-2b6f" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="53cc-a648-20ea-e349" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="32f2-4ab0-d1cd-7cf0" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+        <categoryLink id="e09b-159a-e9a4-8697" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="ee7e-a739-4575-9ad9" name="2) May take:" hidden="false" collective="false" import="true">
@@ -35740,6 +36020,7 @@ containing the model that failed its Check. If the Psyker survives Perils of the
         <categoryLink id="b39e-518d-9b15-bc14" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="56be-a381-5681-4467" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="2a64-c9fa-2381-f3f9" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+        <categoryLink id="5292-b6e9-f677-dc5e" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="b870-bb30-dc67-fce8" name="Hull (Front) Mounted Avenger bolt cannon" hidden="false" collective="false" import="true" type="upgrade">
@@ -35900,6 +36181,7 @@ containing the model that failed its Check. If the Psyker survives Perils of the
         <categoryLink id="8d00-8a0b-d3d5-58a7" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="5822-e87b-5749-5a7d" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="ad65-dae6-bb16-edb5" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+        <categoryLink id="fd66-e86c-83e4-8aba" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="aa79-1382-6a4d-d728" name="2) May take:" hidden="false" collective="false" import="true">
@@ -36339,6 +36621,7 @@ containing the model that failed its Check. If the Psyker survives Perils of the
       <categoryLinks>
         <categoryLink id="b053-4b8e-8514-cb3f" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="c478-ab4e-1a65-2daa" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
+        <categoryLink id="493f-a6eb-f171-2ab4" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="8bf3-9b8d-578a-38f1" name="Land Raider Phobos " hidden="false" collective="false" import="true" type="model">
@@ -36648,6 +36931,7 @@ containing the model that failed its Check. If the Psyker survives Perils of the
           <categoryLinks>
             <categoryLink id="c3af-f5d6-2210-9218" name="Reinforced Sub-type:" hidden="false" targetId="9b0d-738c-10e4-4ec1" primary="false"/>
             <categoryLink id="8d73-a0a0-a804-6122" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+            <categoryLink id="7173-ee4b-f48d-a125" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
           </categoryLinks>
           <selectionEntries>
             <selectionEntry id="b44b-a321-7724-b2b6" name="1) Hull (Front) Mounted Achillus Quad Launcher" hidden="false" collective="false" import="true" type="upgrade">
@@ -36915,6 +37199,7 @@ containing the model that failed its Check. If the Psyker survives Perils of the
         <categoryLink id="7230-f0b9-a9e3-1a41" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="f4b6-841c-0647-e523" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="54c6-4521-16ef-9033" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+        <categoryLink id="9f7f-312c-0e0a-042a" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="9efc-950b-d435-50ce" name="Havoc Launcher Options" hidden="false" collective="false" import="true" defaultSelectionEntryId="e050-2037-d90c-6db3">
@@ -37013,6 +37298,7 @@ containing the model that failed its Check. If the Psyker survives Perils of the
           </profiles>
           <categoryLinks>
             <categoryLink id="b72e-0f0e-30be-2ae8" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+            <categoryLink id="9d49-4562-bee0-395a" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="06bc-e5bc-15a2-0ac3" name="1) Main Cannon" hidden="false" collective="false" import="true" defaultSelectionEntryId="9d4c-0f3b-54f2-5940">
@@ -37337,6 +37623,7 @@ containing the model that failed its Check. If the Psyker survives Perils of the
           <categoryLinks>
             <categoryLink id="3d15-4b03-3990-a801" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
             <categoryLink id="27f0-cd3d-9fbe-c047" name="Reinforced Sub-type:" hidden="false" targetId="9b0d-738c-10e4-4ec1" primary="false"/>
+            <categoryLink id="38e5-55aa-ecbf-f51d" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="2b42-c375-8d00-e27f" name="May take:" hidden="false" collective="false" import="true">
@@ -37482,6 +37769,7 @@ containing the model that failed its Check. If the Psyker survives Perils of the
           <categoryLinks>
             <categoryLink id="e8e4-d91a-160f-5f98" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
             <categoryLink id="0148-0faf-a575-11eb" name="Reinforced Sub-type:" hidden="false" targetId="9b0d-738c-10e4-4ec1" primary="false"/>
+            <categoryLink id="d79e-c4fc-7093-37e4" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="a082-432f-a77f-6c34" name="5) May take:" hidden="false" collective="false" import="true">
@@ -37802,6 +38090,7 @@ containing the model that failed its Check. If the Psyker survives Perils of the
       </infoLinks>
       <categoryLinks>
         <categoryLink id="96a4-abb8-aa87-c97a" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="97df-92e2-b5be-c45c" name="Infantry Only" hidden="false" targetId="db6f-0311-834c-e6ff" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="a58b-3293-d55c-ebc2" name="  Destroyer Sergeant" hidden="false" collective="false" import="true" type="model">
@@ -39401,6 +39690,7 @@ During a Reaction made in any Phase, a player may not choose to activate a model
         <categoryLink id="b857-6717-ae82-50fc" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="45c3-04df-2fcc-c0e5" name="Jump Infantry:" hidden="false" targetId="eee8-3c7c-2762-e33e" primary="false"/>
         <categoryLink id="c531-9282-85ea-930a" name="Line Sub-type:" hidden="false" targetId="6399-5c65-7833-1025" primary="false"/>
+        <categoryLink id="099f-44b6-75c1-ac5b" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="e6b7-06f3-c392-64c0" name=" Legion Assault Sergeant" hidden="false" collective="false" import="true" type="model">
@@ -40274,6 +40564,7 @@ During a Reaction made in any Phase, a player may not choose to activate a model
       <categoryLinks>
         <categoryLink id="ce73-ce2e-305f-269d" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="7aae-5c6b-5782-4d71" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="a643-ac25-74fa-48c7" name="Infantry Only" hidden="false" targetId="db6f-0311-834c-e6ff" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="2515-c6a7-16d6-ac9e" name="  Destroyer Sergeant" hidden="false" collective="false" import="true" type="model">
@@ -41634,6 +41925,7 @@ During a Reaction made in any Phase, a player may not choose to activate a model
                     <conditionGroup type="or">
                       <conditions>
                         <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1977-49f2-7910-f177" type="equalTo"/>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e864-ddc1-da3a-138e" type="equalTo"/>
                       </conditions>
                     </conditionGroup>
                   </conditionGroups>
@@ -41922,6 +42214,7 @@ During a Reaction made in any Phase, a player may not choose to activate a model
       </profiles>
       <categoryLinks>
         <categoryLink id="7516-dfe2-fcc7-c51f" name="Dreadnought Unit-type:" hidden="false" targetId="4280-4963-02b5-e31d" primary="false"/>
+        <categoryLink id="f4be-c2b4-e26e-9b8c" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="ac7d-4ee1-1a5f-ab7e" name="1) Weapon Option 1" hidden="false" collective="false" import="true" defaultSelectionEntryId="b892-eb06-ab29-e738">
@@ -42266,6 +42559,9 @@ During a Reaction made in any Phase, a player may not choose to activate a model
           </modifiers>
         </infoLink>
       </infoLinks>
+      <categoryLinks>
+        <categoryLink id="9f39-8e7d-5922-80a5" name="Infantry Only" hidden="false" targetId="db6f-0311-834c-e6ff" primary="false"/>
+      </categoryLinks>
       <entryLinks>
         <entryLink id="a9ca-16b0-72a2-74da" name="Cyber-Familiar" hidden="false" collective="false" import="true" targetId="6c85-4601-cf58-7b35" type="selectionEntry">
           <constraints>
@@ -42351,6 +42647,9 @@ During a Reaction made in any Phase, a player may not choose to activate a model
         <infoLink id="5916-3eef-ebd6-8340" name="Auxiliary Vehicle Bay" hidden="false" targetId="8837-14e8-344a-1f39" type="rule"/>
         <infoLink id="2cbf-6343-0385-6fd7" name="Transport Bay" hidden="false" targetId="0662-8b8d-38e8-60f8" type="rule"/>
       </infoLinks>
+      <categoryLinks>
+        <categoryLink id="3745-6766-beef-1ac5" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
+      </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="888e-2e77-4caf-9925" name="1) Wing Weapon Options" hidden="false" collective="false" import="true" defaultSelectionEntryId="4d67-aa4e-a987-f780">
           <constraints>
@@ -42462,6 +42761,9 @@ During a Reaction made in any Phase, a player may not choose to activate a model
       <infoLinks>
         <infoLink id="6535-5aa6-6722-753a" name="Deep Strike" hidden="false" targetId="f1e1-986f-c783-ca9e" type="rule"/>
       </infoLinks>
+      <categoryLinks>
+        <categoryLink id="a465-dde8-7b28-f028" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
+      </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="29cc-8d9e-f6dc-66f2" name="3) May take:" hidden="false" collective="false" import="true">
           <entryLinks>
@@ -42596,6 +42898,9 @@ During a Reaction made in any Phase, a player may not choose to activate a model
       <infoLinks>
         <infoLink id="afde-172b-93dd-3f84" name="Volatile Plasma Containment" hidden="false" targetId="564b-25f0-6bae-949e" type="rule"/>
       </infoLinks>
+      <categoryLinks>
+        <categoryLink id="04d1-2509-3ca2-8294" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
+      </categoryLinks>
       <selectionEntries>
         <selectionEntry id="ba7f-1983-eb26-3761" name="Omega-pattern Plasma Blastgun" hidden="false" collective="false" import="true" type="upgrade">
           <modifiers>
@@ -42730,6 +43035,9 @@ During a Reaction made in any Phase, a player may not choose to activate a model
           </characteristics>
         </profile>
       </profiles>
+      <categoryLinks>
+        <categoryLink id="ec79-ca96-6e14-adc3" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
+      </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="584c-1391-dc26-2454" name="3) May take:" hidden="false" collective="false" import="true">
           <entryLinks>
@@ -42955,6 +43263,9 @@ During a Reaction made in any Phase, a player may not choose to activate a model
           </characteristics>
         </profile>
       </profiles>
+      <categoryLinks>
+        <categoryLink id="7f60-9530-6ca1-4d05" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
+      </categoryLinks>
       <selectionEntries>
         <selectionEntry id="597b-12c7-3a14-cf77" name="Praetor Launcher" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
@@ -43132,6 +43443,9 @@ During a Reaction made in any Phase, a player may not choose to activate a model
       <infoLinks>
         <infoLink id="6a90-76f9-404a-d5f0" name="Deep Strike" hidden="false" targetId="f1e1-986f-c783-ca9e" type="rule"/>
       </infoLinks>
+      <categoryLinks>
+        <categoryLink id="a052-258f-f41d-79b7" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
+      </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="1089-f39e-058e-636c" name="3) May take:" hidden="false" collective="false" import="true">
           <entryLinks>
@@ -44261,6 +44575,7 @@ Invulnerable saves granted by a combat shield or boarding shield do not stack wi
       </infoLinks>
       <categoryLinks>
         <categoryLink id="b7a0-67ed-9fdb-1187" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="9706-3749-5fae-0300" name="Non-Infantry Only" hidden="false" targetId="2bcf-6bbe-58a1-e082" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="b2f2-ebdf-0ced-fe23" name="Legiones Unit Upgrades:" hidden="false" collective="false" import="true">
@@ -44720,6 +45035,80 @@ Invulnerable saves granted by a combat shield or boarding shield do not stack wi
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
       </costs>
     </selectionEntry>
+    <selectionEntry id="b8b5-3d56-8f42-4b4d" name="Sonic Lance (Unit)" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="9e08-c99e-cdb5-250d" name="Sonic Lance " hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="95ba-cda7-b831-6066">Template </characteristic>
+            <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">2</characteristic>
+            <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">-</characteristic>
+            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Assault 1, Breaching (6+), Pinning</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="da94-fac3-4d7a-ba15" name="Breaching (X)" hidden="false" targetId="a760-f736-1bf3-fa3c" type="rule">
+          <modifiers>
+            <modifier type="set" field="name" value="Breaching (6+)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="cae9-14ab-72a5-ba54" name="Pinning" hidden="false" targetId="1c96-205c-59a0-3cf2" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="7200-efa6-c232-eb74" name="Sonic Shriekers (Unit)" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="0247-367b-9758-715f" name="Sonic Shriekers " page="154" hidden="false" typeId="2a1f-7837-f0ef-be44" typeName="Wargear Item">
+          <characteristics>
+            <characteristic name="Description" typeId="347e-ee4a-764f-6be3">During a turn in which a unit with at least one model equipped with sonic shriekers Successfully Charges, or themselves successfully Charged, all models in any enemy unit(s) locked in combat with them suffer a -1 penalty to all To Hit rolls, Models which are immunte to the effect of the Fear (X) special rule are not affected by this modifier.</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="a3c0-860a-2b71-c53e" name="Sub-sonic Pulser Unit)" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="d8f9-5f16-cb56-5d54" name="Sub-sonic Pulser " hidden="false" typeId="2a1f-7837-f0ef-be44" typeName="Wargear Item">
+          <characteristics>
+            <characteristic name="Description" typeId="347e-ee4a-764f-6be3">A model equipped with this upgrade, and any unit it joins, ignores the penalties to Leadership and Ballistic Skill imposed by the Night Fighting special rules.</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="fdb9-b132-5012-2f30" name="Maru Skara HQ (Champion or Phoenix Warden)" hidden="true" collective="false" import="true" type="upgrade">
+      <modifiers>
+        <modifier type="set" field="b5c8-3596-2cbb-1761" value="1.0">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7a43-6793-013b-1af6" type="equalTo"/>
+          </conditions>
+        </modifier>
+        <modifier type="set" field="hidden" value="false">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7a43-6793-013b-1af6" type="equalTo"/>
+          </conditions>
+        </modifier>
+        <modifier type="set" field="8f77-0642-c5b9-9df0" value="1.0">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7a43-6793-013b-1af6" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="force" value="-1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b5c8-3596-2cbb-1761" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ab6b-6529-2ced-5244" type="max"/>
+        <constraint field="selections" scope="parent" value="-1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8f77-0642-c5b9-9df0" type="min"/>
+      </constraints>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
   </sharedSelectionEntries>
   <sharedSelectionEntryGroups>
     <selectionEntryGroup id="61a2-7005-1e6c-c08e" name="Hexagrammaton Choice:" hidden="true" collective="false" import="true">
@@ -44926,7 +45315,7 @@ Invulnerable saves granted by a combat shield or boarding shield do not stack wi
         <entryLink id="78be-935f-1458-e8fd" name="Pavoni" hidden="false" collective="false" import="true" targetId="5532-04aa-8302-2038" type="selectionEntry"/>
       </entryLinks>
     </selectionEntryGroup>
-    <selectionEntryGroup id="aeb3-6a73-da1d-2b90" name="Surgical Augment" hidden="true" collective="false" import="true">
+    <selectionEntryGroup id="aeb3-6a73-da1d-2b90" name="Surgical Augment (unit)" hidden="true" collective="false" import="true">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditionGroups>
@@ -44938,12 +45327,25 @@ Invulnerable saves granted by a combat shield or boarding shield do not stack wi
             </conditionGroup>
           </conditionGroups>
         </modifier>
+        <modifier type="set" field="9eb6-371d-de44-c12b" value="1.0">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e221-0a54-9f94-988f" type="equalTo"/>
+          </conditions>
+        </modifier>
       </modifiers>
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="25f0-6d13-3ccb-ec05" type="max"/>
+        <constraint field="selections" scope="parent" value="-1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9eb6-371d-de44-c12b" type="min"/>
       </constraints>
       <entryLinks>
         <entryLink id="4852-ee62-1f85-3dc2" name="Sonic Lance" hidden="false" collective="false" import="true" targetId="5007-1732-6ad5-ce36" type="selectionEntry">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="6f99-c178-6f9d-fb63" type="greaterThan"/>
+              </conditions>
+            </modifier>
+          </modifiers>
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="93a5-1699-4b06-c31a" type="max"/>
           </constraints>
@@ -44951,12 +45353,12 @@ Invulnerable saves granted by a combat shield or boarding shield do not stack wi
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0"/>
           </costs>
         </entryLink>
-        <entryLink id="e855-5157-0264-17c1" name="Sonic Shriekers" hidden="false" collective="false" import="true" targetId="3f61-86fe-eecf-aed7" type="selectionEntry">
+        <entryLink id="e855-5157-0264-17c1" name="Sonic Shriekers (Unit)" hidden="false" collective="false" import="true" targetId="7200-efa6-c232-eb74" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fe5e-6f5c-cf7b-4148" type="max"/>
           </constraints>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="30.0"/>
           </costs>
         </entryLink>
         <entryLink id="bb4c-2ee2-3b1d-c799" name="Sub-sonic Pulser" hidden="false" collective="false" import="true" targetId="ddd0-22b3-ea96-680d" type="selectionEntry">
@@ -44965,6 +45367,33 @@ Invulnerable saves granted by a combat shield or boarding shield do not stack wi
           </constraints>
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0"/>
+          </costs>
+        </entryLink>
+        <entryLink id="cec6-a6f4-378f-07a4" name="Sonic Lance (Unit)" hidden="false" collective="false" import="true" targetId="b8b5-3d56-8f42-4b4d" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5e5b-072a-3b18-6788" type="max"/>
+          </constraints>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="30.0"/>
+          </costs>
+        </entryLink>
+        <entryLink id="ed2b-8971-e7e8-809d" name="Sonic Shriekers" hidden="false" collective="false" import="true" targetId="3f61-86fe-eecf-aed7" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dbb0-4253-1dbe-599c" type="max"/>
+          </constraints>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0"/>
+          </costs>
+        </entryLink>
+        <entryLink id="b22b-99c8-2c03-62da" name="Sub-sonic Pulser Unit)" hidden="false" collective="false" import="true" targetId="a3c0-860a-2b71-c53e" type="selectionEntry">
+          <modifiers>
+            <modifier type="set" field="name" value="Sub-sonic Pulser (Unit)"/>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2e5c-c9e3-9e0a-cd41" type="max"/>
+          </constraints>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="30.0"/>
           </costs>
         </entryLink>
       </entryLinks>
@@ -45093,17 +45522,24 @@ Legion Only: Paladin of Hekatonystika (Dark Angels), Phoenix Warden (Emperor&apo
         </selectionEntry>
         <selectionEntry id="35ac-992e-97a7-1612" name="Master of Signals" publicationId="a716-c1c4-7b26-8424" page="105" hidden="false" collective="false" import="true" type="upgrade">
           <modifiers>
+            <modifier type="set" field="8f5a-e3ec-734d-23ab" value="1.0">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fbe5-123b-cb17-6049" type="equalTo"/>
+              </conditions>
+            </modifier>
             <modifier type="set" field="hidden" value="true">
               <conditionGroups>
                 <conditionGroup type="or">
                   <conditions>
-                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="25a2-7a52-632a-6b2c" type="notInstanceOf"/>
                     <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
                   </conditions>
                 </conditionGroup>
               </conditionGroups>
             </modifier>
           </modifiers>
+          <constraints>
+            <constraint field="selections" scope="force" value="-1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8f5a-e3ec-734d-23ab" type="min"/>
+          </constraints>
           <rules>
             <rule id="5fb1-c000-121c-b16e" name="Strategic Comms" publicationId="a716-c1c4-7b26-8424" page="105" hidden="false">
               <description>At the start of each Game Turn you can declare whether each vox disruptor array in your army is turned on or turned off. While there is at least one model on the battlefield with a vox disruptor array turned on, regardless of whether that model is enemy or friendly, any attempt to perform a Deep Strike Assault, Drop Pod Assault, Area Denial Drop or Subterranean Assault during that turn is Disordered on the roll of a &apos;1&apos;, &apos;2&apos; or &apos;3&apos; instead of iust on a 1&apos;</description>
@@ -45516,6 +45952,7 @@ Legion Only: Paladin of Hekatonystika (Dark Angels), Phoenix Warden (Emperor&apo
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4a57-7b36-258e-096c" type="min"/>
               </constraints>
             </entryLink>
+            <entryLink id="58b4-dc5e-e68d-35d3" name="Maru Skara HQ (Champion or Phoenix Warden)" hidden="false" collective="false" import="true" targetId="fdb9-b132-5012-2f30" type="selectionEntry"/>
           </entryLinks>
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="30.0"/>
@@ -45741,14 +46178,16 @@ A Legion Primus Nullificator Consul gains the Psyker Sub-type and has only the P
                 </conditionGroup>
               </conditionGroups>
             </modifier>
+            <modifier type="add" field="category" value="30e2-956f-1bf5-1110">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="373b-ce5a-ddc5-cf8f" type="equalTo"/>
+              </conditions>
+            </modifier>
           </modifiers>
           <infoLinks>
             <infoLink id="328e-31c9-9aa5-89ed" name="Legiones Cybernetica" hidden="false" targetId="a2ef-63a4-3531-db91" type="rule"/>
             <infoLink id="6c18-66c0-7c82-ed9b" name="Master of Automata" hidden="false" targetId="8eef-f84b-37cb-554b" type="rule"/>
           </infoLinks>
-          <categoryLinks>
-            <categoryLink id="5954-d075-a735-1999" name="Praevian Consul (The Achaean Configuration Requirment)" hidden="false" targetId="14bd-5f53-021b-a0f3" primary="false"/>
-          </categoryLinks>
           <entryLinks>
             <entryLink id="3322-e7ba-5d2e-6bf4" name="Cortex Controller" hidden="false" collective="false" import="true" targetId="2fda-455f-d34d-97e0" type="selectionEntry">
               <constraints>
@@ -45836,7 +46275,7 @@ Hit rolls for each attack, for a total of 24 To Hit rolls over the full 6 attack
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e93a-c6a3-e263-8791" type="min"/>
               </constraints>
               <infoLinks>
-                <infoLink id="7b97-24be-0e39-3c50" name="Master-crafted" hidden="false" targetId="6de0-55b0-bf21-48b9" type="rule"/>
+                <infoLink id="9c1a-016a-1532-ee50" name="Master-crafted" hidden="false" targetId="6de0-55b0-bf21-48b9" type="rule"/>
               </infoLinks>
             </entryLink>
             <entryLink id="2f93-d2e2-553f-670b" name="Scout Armour" hidden="false" collective="false" import="true" targetId="b282-55aa-d1e2-ebe7" type="selectionEntry">
@@ -45897,23 +46336,23 @@ Hit rolls for each attack, for a total of 24 To Hit rolls over the full 6 attack
             <infoLink id="598d-8c9f-e5a4-f2a4" name="Marked For Death" hidden="false" targetId="4f41-4c04-9cd8-c5a1" type="rule"/>
           </infoLinks>
           <selectionEntryGroups>
-            <selectionEntryGroup id="1830-db0c-3c9f-788a" name="Special Rules" hidden="false" collective="false" import="true">
+            <selectionEntryGroup id="5e1c-fd8a-849a-d161" name="Special Rules" hidden="false" collective="false" import="true">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="86c0-37d4-1381-be9d" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="75cb-3194-4ae6-d8b0" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2fb9-6bd0-2d71-b75e" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="71fa-6c9f-d020-a162" type="max"/>
               </constraints>
               <selectionEntries>
-                <selectionEntry id="ee9b-5275-8627-1861" name="Scout" hidden="false" collective="false" import="true" type="upgrade">
+                <selectionEntry id="73f3-dc7d-f12b-1b8d" name="Scout" hidden="false" collective="false" import="true" type="upgrade">
                   <infoLinks>
-                    <infoLink id="b014-b991-5932-714d" name="Scout" hidden="false" targetId="aacf-9a7e-982d-b793" type="rule"/>
+                    <infoLink id="b608-76b1-fd84-e666" name="Scout" hidden="false" targetId="aacf-9a7e-982d-b793" type="rule"/>
                   </infoLinks>
                   <costs>
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
                   </costs>
                 </selectionEntry>
-                <selectionEntry id="d2fb-7bb1-d577-9b98" name="Infilitrate" hidden="false" collective="false" import="true" type="upgrade">
+                <selectionEntry id="43e6-9190-ee71-178d" name="Infilitrate" hidden="false" collective="false" import="true" type="upgrade">
                   <infoLinks>
-                    <infoLink id="f5d1-8ea8-9c4b-2e98" name="Infiltrate" hidden="false" targetId="0e32-5b92-a95a-8464" type="rule"/>
+                    <infoLink id="771f-dffe-bf8c-24e2" name="Infiltrate" hidden="false" targetId="0e32-5b92-a95a-8464" type="rule"/>
                   </infoLinks>
                   <costs>
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
@@ -46088,6 +46527,7 @@ Hit rolls for each attack, for a total of 24 To Hit rolls over the full 6 attack
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="971f-26aa-10df-fbb4" type="max"/>
               </constraints>
             </entryLink>
+            <entryLink id="f1c3-7e93-64f1-a1b5" name="Maru Skara HQ (Champion or Phoenix Warden)" hidden="false" collective="false" import="true" targetId="fdb9-b132-5012-2f30" type="selectionEntry"/>
           </entryLinks>
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="35.0"/>
@@ -47568,6 +48008,55 @@ Hit rolls for each attack, for a total of 24 To Hit rolls over the full 6 attack
           </costs>
         </entryLink>
         <entryLink id="35b6-c0b4-2129-0b40" name="Heavy Flamer" hidden="false" collective="false" import="true" targetId="5507-b432-3b4c-df12" type="selectionEntry"/>
+      </entryLinks>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="ffa3-1a57-1eb4-1818" name="Surgical Augment" hidden="true" collective="false" import="true">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3edc-a1b9-6dc6-b1ea" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+        <modifier type="set" field="1937-af39-00f8-763d" value="1.0">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e221-0a54-9f94-988f" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1bf0-36d7-09fb-6daa" type="max"/>
+        <constraint field="selections" scope="parent" value="-1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1937-af39-00f8-763d" type="min"/>
+      </constraints>
+      <entryLinks>
+        <entryLink id="1c8d-f727-0e32-5e34" name="Sonic Lance" hidden="false" collective="false" import="true" targetId="5007-1732-6ad5-ce36" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ec41-14ac-7eb0-73ce" type="max"/>
+          </constraints>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0"/>
+          </costs>
+        </entryLink>
+        <entryLink id="8a66-e544-763e-a6d7" name="Sub-sonic Pulser" hidden="false" collective="false" import="true" targetId="ddd0-22b3-ea96-680d" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bdfd-6264-5007-cc3a" type="max"/>
+          </constraints>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0"/>
+          </costs>
+        </entryLink>
+        <entryLink id="87f8-c18d-35d7-179d" name="Sonic Shriekers" hidden="false" collective="false" import="true" targetId="3f61-86fe-eecf-aed7" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ea88-35ec-c1f5-3207" type="max"/>
+          </constraints>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0"/>
+          </costs>
+        </entryLink>
       </entryLinks>
     </selectionEntryGroup>
   </sharedSelectionEntryGroups>


### PR DESCRIPTION
Added the TS changes to your pull request in this one. I don't think i've messed any of your work up. It all looked good my end.

Haven't been able to test the full pull yet.

World Eaters Crimson Path
There were some issues with the infantry / non infantry settings.

It was applying the restrictions to every army 
It also also keeping units tagged as Infantry even if they had dedicated transports.
It was also counting in some instances multiple of something in a unit as multiple instances in a unit of being non-infantry in some dreadnoughts and vehicles.

I have also tagged Assassins, Knights & Titans as Non-Infantry in their root, and Thallax that a Forgelord can take as Infantry in root.
There might be an issue with Fortifications currently that they can't be tagged either way. But either the category can be moved to GST. Or maybe this is the point in which a "Fortifications Library" could be made, then linked to LA and the other libraries. Then the roots added to each rather than imported.