### PR TITLE
LoW and RoW 25% Restriction (Mainly)

### DIFF
--- a/2022 - Horus Heresy.gst
+++ b/2022 - Horus Heresy.gst
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<gameSystem id="28d4-bd2e-4858-ece6" name="(HH V2) Horus Heresy (2022)" revision="40" battleScribeVersion="2.03" xmlns="http://www.battlescribe.net/schema/gameSystemSchema">
+<gameSystem id="28d4-bd2e-4858-ece6" name="(HH V2) Horus Heresy (2022)" revision="41" battleScribeVersion="2.03" xmlns="http://www.battlescribe.net/schema/gameSystemSchema">
   <publications>
     <publication id="e77a-823a-da94-16b9" name="Warhammer: The Horus Heresy - Age of Darkness Rulebook" shortName="Main Rules" publicationDate="June 2022"/>
     <publication id="817a-6288-e016-7469" name="Liber Astartes – Loyalist Legiones Astartes Army Book" shortName="LA - Loyalist" publicationDate="June 2022"/>
@@ -915,6 +915,7 @@ In addition, when a Fast Vehicle moves, it may choose to move at Flat-out:</desc
       </constraints>
     </categoryEntry>
     <categoryEntry id="1bb5-d88b-e1fe-2984" name="Ironfire Restriction (Arquitors, Basilisks, Medusa)" hidden="false"/>
+    <categoryEntry id="2eaf-32d6-9d1d-d906" name="LoW &amp; Primarchs (25% Limit)" hidden="false"/>
   </categoryEntries>
   <forceEntries>
     <forceEntry id="d926-652f-8436-30ce" name="Crusade Force Organisation Chart" hidden="false">
@@ -1138,6 +1139,18 @@ In addition, when a Fast Vehicle moves, it may choose to move at Flat-out:</desc
           </constraints>
         </categoryLink>
         <categoryLink id="2545-86dd-f928-73f3" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="dc87-6668-f349-2a8c" name="LoW &amp; Primarchs" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false">
+          <modifiers>
+            <modifier type="increment" field="d9f7-954e-b8d3-7a39" value="1.0">
+              <repeats>
+                <repeat field="d2ee-04cb-5f8a-2642" scope="roster" value="4.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2eaf-32d6-9d1d-d906" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="d2ee-04cb-5f8a-2642" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="d9f7-954e-b8d3-7a39" type="max"/>
+          </constraints>
+        </categoryLink>
       </categoryLinks>
     </forceEntry>
     <forceEntry id="d4f2-6da5-b6de-06ec" name="Allied Detachment" hidden="false">

--- a/2022 - LA - Alpha Legion.cat
+++ b/2022 - LA - Alpha Legion.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="9c06-1c61-d01d-8445" name="LA - XX: Alpha Legion" revision="32" battleScribeVersion="2.03" authorName="Alphalas" authorContact="BSData Developers Discord" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="32" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="9c06-1c61-d01d-8445" name="LA - XX: Alpha Legion" revision="33" battleScribeVersion="2.03" authorName="Alphalas" authorContact="BSData Developers Discord" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="41" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <categoryEntries>
     <categoryEntry id="2275-5253-2421-7383" name="Rewards of Trechery" hidden="false">
       <constraints>
@@ -63,6 +63,11 @@
         <categoryLink id="3a48-ebd5-979a-ab0e" name="New CategoryLink" hidden="false" targetId="ad5f-31db-8bc7-5c46" primary="true"/>
         <categoryLink id="b56c-b87b-07a2-6437" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
+      <entryLinks>
+        <entryLink id="4c84-ff78-6653-f033" name="Retinue" hidden="false" collective="false" import="true" targetId="09f9-933c-a88e-6e38" type="selectionEntryGroup">
+          <comment>    template_id_fe8f-c701-4ebd-ae76    template_targetId_be38-a066-4f8e-ae54</comment>
+        </entryLink>
+      </entryLinks>
     </entryLink>
     <entryLink id="d7e9-6d99-675b-0a20" name="Armillus Dynat" hidden="false" collective="false" import="false" targetId="42af-ab98-e733-dc01" type="selectionEntry">
       <categoryLinks>
@@ -735,7 +740,7 @@
         <categoryLink id="d328-4b4c-55b5-63bf" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="38cc-adf2-fed4-85be" name="Reaver Agressor Squad" hidden="true" collective="false" import="false" targetId="af3a-334f-152f-d55f" type="selectionEntry">
+    <entryLink id="38cc-adf2-fed4-85be" name="Reaver Aggressor Squad" hidden="true" collective="false" import="false" targetId="af3a-334f-152f-d55f" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
@@ -1463,49 +1468,6 @@
         </categoryLink>
         <categoryLink id="056a-4c0d-47ef-a90a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>    template_id_2b20-1a8b-4753-b657</comment>
-        </categoryLink>
-      </categoryLinks>
-    </entryLink>
-    <entryLink id="0879-5810-e96b-da21" name="Command Squad" hidden="false" collective="false" import="false" targetId="0aca-632d-1642-8af9" type="selectionEntry">
-      <comment>    template_id_23b2-54e0-4f09-95e5</comment>
-      <categoryLinks>
-        <categoryLink id="10ad-5649-4d41-a7b6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
-          <comment>    template_id_4207-8d8f-4b1a-836b</comment>
-        </categoryLink>
-        <categoryLink id="2aba-b6bf-4981-8577" name="Primarch&apos;s Retinue:" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true">
-          <comment>    template_id_2b34-077f-4279-86fb</comment>
-        </categoryLink>
-      </categoryLinks>
-    </entryLink>
-    <entryLink id="b51f-90bc-e5ba-2a3c" name="Command Squad, Cataphractii" hidden="false" collective="false" import="false" targetId="1b17-dcd6-0153-3efe" type="selectionEntry">
-      <comment>    template_id_9e78-3e8a-477d-9920</comment>
-      <modifiers>
-        <modifier type="append" field="name" value="(Reserve Only)">
-          <comment>    node_id_421a-b0ab-45e5-b4a7</comment>
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
-              <comment>    node_id_26f8-b35f-4d47-bcf3</comment>
-            </condition>
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="e8ee-b856-4e5c-83f0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
-          <comment>    template_id_6577-e0fb-4fda-834e</comment>
-        </categoryLink>
-        <categoryLink id="52ac-2db5-4d9f-9f7f" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true">
-          <comment>    template_id_5d59-09bf-4566-b7e1</comment>
-        </categoryLink>
-      </categoryLinks>
-    </entryLink>
-    <entryLink id="c07f-7c57-bdbe-2daa" name="Command Squad, Tartaros " hidden="false" collective="false" import="false" targetId="58d0-a0fd-d20b-cb1b" type="selectionEntry">
-      <comment>    template_id_2029-1f36-432f-a6a1</comment>
-      <categoryLinks>
-        <categoryLink id="ca47-d0a1-41d1-b02d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
-          <comment>    template_id_aa93-057d-42f6-82d7</comment>
-        </categoryLink>
-        <categoryLink id="148e-4b11-4409-97c5" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true">
-          <comment>    template_id_403c-4e9c-4af5-84ec</comment>
         </categoryLink>
       </categoryLinks>
     </entryLink>
@@ -5704,6 +5666,7 @@
       <categoryLinks>
         <categoryLink id="f996-05bf-ded5-1995" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
         <categoryLink id="3719-acf7-a932-2783" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="4eec-94db-1f92-b595" name="LoW &amp; Primarchs (25% Limit)" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="c60e-92ed-d696-b0b9" name="The Hydra&apos;s Spite" publicationId="09c5-eeae-f398-b653" page="337" hidden="false" collective="false" import="true" type="upgrade">

--- a/2022 - LA - Blood Angels.cat
+++ b/2022 - LA - Blood Angels.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="cd4d-8765-5387-8409" name="LA -  IX: Blood Angels" revision="30" battleScribeVersion="2.03" authorName="Jon K &quot;Alphalas&quot;" authorContact="Twitter: Alphalas_ Discord: Alphalas#8789" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="32" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="cd4d-8765-5387-8409" name="LA -  IX: Blood Angels" revision="31" battleScribeVersion="2.03" authorName="Jon K &quot;Alphalas&quot;" authorContact="Twitter: Alphalas_ Discord: Alphalas#8789" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="41" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entryLinks>
     <entryLink id="1900-3f09-f47b-bed2" name="Praetor" hidden="false" collective="false" import="false" targetId="03be-5d55-d05a-771d" type="selectionEntry">
       <comment>    template_id_5798-3fc7-4d4c-ad41</comment>
@@ -132,6 +132,11 @@
         <categoryLink id="9dac-939c-1711-76ba" name="New CategoryLink" hidden="false" targetId="ad5f-31db-8bc7-5c46" primary="true"/>
         <categoryLink id="b565-cac7-63e5-fb44" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
+      <entryLinks>
+        <entryLink id="aae5-4d24-fbd7-9939" name="Retinue" hidden="false" collective="false" import="true" targetId="6307-ed53-0ac4-0212" type="selectionEntryGroup">
+          <comment>    template_id_fe8f-c701-4ebd-ae76    template_targetId_be38-a066-4f8e-ae54</comment>
+        </entryLink>
+      </entryLinks>
     </entryLink>
     <entryLink id="d781-5311-119f-a8e2" name="The Angel&apos;s Tears" hidden="false" collective="false" import="false" targetId="dda1-0fcf-0245-6c10" type="selectionEntry">
       <modifiers>
@@ -1652,17 +1657,6 @@
         </categoryLink>
       </categoryLinks>
     </entryLink>
-    <entryLink id="ec42-0835-db7c-c5f1" name="Command Squad" hidden="false" collective="false" import="false" targetId="0aca-632d-1642-8af9" type="selectionEntry">
-      <comment>    template_id_23b2-54e0-4f09-95e5</comment>
-      <categoryLinks>
-        <categoryLink id="1551-ed40-4cf0-81dc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
-          <comment>    template_id_4207-8d8f-4b1a-836b</comment>
-        </categoryLink>
-        <categoryLink id="e7ff-aeaf-46c3-97ea" name="Primarch&apos;s Retinue:" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true">
-          <comment>    template_id_2b34-077f-4279-86fb</comment>
-        </categoryLink>
-      </categoryLinks>
-    </entryLink>
     <entryLink id="8dd6-67d7-980c-1196" name="Avenger Strike Fighter" hidden="true" collective="false" import="false" targetId="b25c-e85c-1c29-9e05" type="selectionEntry">
       <comment>    template_id_1064-175d-4616-9c71</comment>
       <modifiers>
@@ -2427,38 +2421,6 @@
         </categoryLink>
       </categoryLinks>
     </entryLink>
-    <entryLink id="a8f5-7ff9-9e96-10d8" name="Command Squad, Cataphractii" hidden="false" collective="false" import="false" targetId="1b17-dcd6-0153-3efe" type="selectionEntry">
-      <comment>    template_id_9e78-3e8a-477d-9920</comment>
-      <modifiers>
-        <modifier type="append" field="name" value="(Reserve Only)">
-          <comment>    node_id_421a-b0ab-45e5-b4a7</comment>
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
-              <comment>    node_id_26f8-b35f-4d47-bcf3</comment>
-            </condition>
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="a38a-dfe9-445e-9222" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
-          <comment>    template_id_6577-e0fb-4fda-834e</comment>
-        </categoryLink>
-        <categoryLink id="55df-2300-4a01-8e0a" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true">
-          <comment>    template_id_5d59-09bf-4566-b7e1</comment>
-        </categoryLink>
-      </categoryLinks>
-    </entryLink>
-    <entryLink id="7c64-df4d-4b4f-2624" name="Command Squad, Tartaros " hidden="false" collective="false" import="false" targetId="58d0-a0fd-d20b-cb1b" type="selectionEntry">
-      <comment>    template_id_2029-1f36-432f-a6a1</comment>
-      <categoryLinks>
-        <categoryLink id="34e9-adb8-47de-a028" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
-          <comment>    template_id_aa93-057d-42f6-82d7</comment>
-        </categoryLink>
-        <categoryLink id="5cb9-15c5-4a29-b6d6" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true">
-          <comment>    template_id_403c-4e9c-4af5-84ec</comment>
-        </categoryLink>
-      </categoryLinks>
-    </entryLink>
     <entryLink id="f983-a88b-b170-fe04" name="Master of Armour" hidden="true" collective="false" import="false" targetId="0e4e-1b9a-6b38-e575" type="selectionEntry">
       <comment>    template_id_ed2f-2214-418e-8562</comment>
       <modifiers>
@@ -2985,6 +2947,11 @@ Sanguinius may still Run on a turn when his wings have been activated. When maki
         </infoLink>
         <infoLink id="aebf-6de7-429f-727c" name="Deep Strike" hidden="false" targetId="f1e1-986f-c783-ca9e" type="rule"/>
       </infoLinks>
+      <categoryLinks>
+        <categoryLink id="38e2-0f6e-7779-5ec3" name="LoW &amp; Primarchs (25% Limit)" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false"/>
+        <categoryLink id="4705-df50-16b6-2e57" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="3aee-2b27-81b1-a1e1" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
+      </categoryLinks>
       <selectionEntries>
         <selectionEntry id="eb7d-aff3-ce83-30e5" name="The Regalia Resplendant" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>

--- a/2022 - LA - Dark Angels.cat
+++ b/2022 - LA - Dark Angels.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="ee5e-198e-1b19-4b9f" name="LA -   I: Dark Angels" revision="21" battleScribeVersion="2.03" authorName="revivedtitan" authorContact="BSData Developers Discord" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="32" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="ee5e-198e-1b19-4b9f" name="LA -   I: Dark Angels" revision="23" battleScribeVersion="2.03" authorName="revivedtitan" authorContact="BSData Developers Discord" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="41" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entryLinks>
     <entryLink id="7653-8041-8d1c-c872" name="Dreadwing Interemptor Squad" hidden="false" collective="false" import="false" targetId="3008-e8ed-9e97-71c9" type="selectionEntry">
       <categoryLinks>
@@ -91,6 +91,9 @@
         <categoryLink id="9d97-2b3e-e904-a1c9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="ab33-7225-f48a-340c" name="New CategoryLink" hidden="false" targetId="ad5f-31db-8bc7-5c46" primary="true"/>
       </categoryLinks>
+      <entryLinks>
+        <entryLink id="f6a1-76fb-9dff-b12b" name="Retinue" hidden="false" collective="false" import="true" targetId="66e9-e8f8-5eb6-1cf6" type="selectionEntryGroup"/>
+      </entryLinks>
     </entryLink>
     <entryLink id="5233-1cc8-f2d5-9023" name="Marduk Sedras" hidden="true" collective="false" import="false" targetId="9136-b5e8-13f9-0c0f" type="selectionEntry">
       <modifiers>
@@ -429,34 +432,6 @@
       <categoryLinks>
         <categoryLink id="098d-b390-5331-2b62" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
         <categoryLink id="8899-78cc-8e41-0087" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-      </categoryLinks>
-    </entryLink>
-    <entryLink id="66a3-50a1-18b4-6a49" name="Command Squad" hidden="false" collective="false" import="false" targetId="0aca-632d-1642-8af9" type="selectionEntry">
-      <comment>    template_id_23b2-54e0-4f09-95e5</comment>
-      <categoryLinks>
-        <categoryLink id="409c-667a-cd3b-787d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="bd8c-ad60-028c-44e6" name="Primarch&apos;s Retinue:" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true"/>
-      </categoryLinks>
-    </entryLink>
-    <entryLink id="944b-431e-0266-806a" name="Command Squad, Cataphractii" hidden="false" collective="false" import="false" targetId="1b17-dcd6-0153-3efe" type="selectionEntry">
-      <comment>    template_id_9e78-3e8a-477d-9920</comment>
-      <modifiers>
-        <modifier type="append" field="name" value="(Reserve Only)">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="bd83-88ad-c226-08c4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="2503-db14-ebf9-3f8b" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true"/>
-      </categoryLinks>
-    </entryLink>
-    <entryLink id="4fa8-8b77-1e3c-4654" name="Command Squad, Tartaros " hidden="false" collective="false" import="false" targetId="58d0-a0fd-d20b-cb1b" type="selectionEntry">
-      <comment>    template_id_2029-1f36-432f-a6a1</comment>
-      <categoryLinks>
-        <categoryLink id="f5e4-c880-6e68-4e28" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="c8ca-2cb0-7997-1a00" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="339f-af2f-d50a-0be6" name="Contemptor Dreadnought Talon" hidden="false" collective="false" import="false" targetId="d664-5692-cd41-f9be" type="selectionEntry">
@@ -2786,15 +2761,6 @@
         <categoryLink id="8411-1862-5232-cf37" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="5e8c-d93d-15f1-15c4" name="Deathwing Companion Detachment" hidden="false" collective="false" import="false" targetId="a9b5-ef4c-31db-4104" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false"/>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="13f8-ee40-a8db-e8b0" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true"/>
-        <categoryLink id="a8ef-1c9a-9008-a576" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-      </categoryLinks>
-    </entryLink>
   </entryLinks>
   <sharedSelectionEntries>
     <selectionEntry id="4097-b2b4-d9da-da99" name="Corswain" hidden="false" collective="false" import="true" type="unit">
@@ -4715,6 +4681,7 @@ special rule.</description>
       <categoryLinks>
         <categoryLink id="1159-e4ba-1ed9-3218" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="f149-e20a-bc3b-9a43" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
+        <categoryLink id="53e8-ece2-7f01-3d85" name="LoW &amp; Primarchs (25% Limit)" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="ea6d-8560-75cc-fbca" name="Lion El&apos;Jonson" hidden="false" collective="false" import="true" type="model">
@@ -6177,6 +6144,7 @@ Legion and Legiones Astartes (Dark Angels) special rules is referred to as the r
                     <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3766-ea98-0aa7-62d0" type="instanceOf"/>
                     <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1b79-1951-5a63-4b9e" type="instanceOf"/>
                     <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9136-b5e8-13f9-0c0f" type="instanceOf"/>
+                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0689-b550-0b0e-63d6" type="instanceOf"/>
                   </conditions>
                 </conditionGroup>
               </conditionGroups>
@@ -6194,8 +6162,9 @@ Legion and Legiones Astartes (Dark Angels) special rules is referred to as the r
               <conditionGroups>
                 <conditionGroup type="or">
                   <conditions>
-                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3760-204e-444c-1044" type="instanceOf"/>
+                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0689-b550-0b0e-63d6" type="instanceOf"/>
                     <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f806-8a4e-d0d6-beaa" type="instanceOf"/>
+                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3760-204e-444c-1044" type="instanceOf"/>
                   </conditions>
                 </conditionGroup>
               </conditionGroups>

--- a/2022 - LA - Death Guard.cat
+++ b/2022 - LA - Death Guard.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="d228-55e8-b58c-1b77" name="LA -  XIV: Death Guard" revision="19" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="39" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="d228-55e8-b58c-1b77" name="LA -  XIV: Death Guard" revision="20" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="41" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entryLinks>
     <entryLink id="fb89-32c1-bdc5-2e3d" name="Mortarion" hidden="false" collective="false" import="false" targetId="7427-bdfa-c359-ebb8" type="selectionEntry">
       <modifiers>
@@ -13,6 +13,11 @@
         <categoryLink id="44be-4e1f-6984-02f2" name="New CategoryLink" hidden="false" targetId="ad5f-31db-8bc7-5c46" primary="true"/>
         <categoryLink id="edd2-1a56-37a4-4b58" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
+      <entryLinks>
+        <entryLink id="66ca-39a9-1b99-9840" name="Retinue" hidden="false" collective="false" import="true" targetId="2bcb-6e52-0eb9-9ffe" type="selectionEntryGroup">
+          <comment>    template_id_831f-3373-456a-8fbc    template_targetId_be38-a066-4f8e-ae54</comment>
+        </entryLink>
+      </entryLinks>
     </entryLink>
     <entryLink id="72f2-159d-02fd-662b" name="Calas Typhon" hidden="false" collective="false" import="false" targetId="e830-3788-1a0d-0c02" type="selectionEntry">
       <modifiers>
@@ -494,49 +499,6 @@
         </categoryLink>
         <categoryLink id="a612-c826-40aa-aeea" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>    template_id_2b20-1a8b-4753-b657</comment>
-        </categoryLink>
-      </categoryLinks>
-    </entryLink>
-    <entryLink id="6542-9165-2e72-f5e6" name="Command Squad" hidden="false" collective="false" import="false" targetId="0aca-632d-1642-8af9" type="selectionEntry">
-      <comment>    template_id_23b2-54e0-4f09-95e5</comment>
-      <categoryLinks>
-        <categoryLink id="3c2e-2fcb-4960-8822" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
-          <comment>    template_id_4207-8d8f-4b1a-836b</comment>
-        </categoryLink>
-        <categoryLink id="8e62-a341-4670-be46" name="Primarch&apos;s Retinue:" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true">
-          <comment>    template_id_2b34-077f-4279-86fb</comment>
-        </categoryLink>
-      </categoryLinks>
-    </entryLink>
-    <entryLink id="6124-e860-1360-d4a4" name="Command Squad, Cataphractii" hidden="false" collective="false" import="false" targetId="1b17-dcd6-0153-3efe" type="selectionEntry">
-      <comment>    template_id_9e78-3e8a-477d-9920</comment>
-      <modifiers>
-        <modifier type="append" field="name" value="(Reserve Only)">
-          <comment>    node_id_421a-b0ab-45e5-b4a7</comment>
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
-              <comment>    node_id_26f8-b35f-4d47-bcf3</comment>
-            </condition>
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="43a8-467a-4822-a9ab" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
-          <comment>    template_id_6577-e0fb-4fda-834e</comment>
-        </categoryLink>
-        <categoryLink id="ae85-c823-4a29-bf11" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true">
-          <comment>    template_id_5d59-09bf-4566-b7e1</comment>
-        </categoryLink>
-      </categoryLinks>
-    </entryLink>
-    <entryLink id="a7e8-35f5-42bf-eb25" name="Command Squad, Tartaros " hidden="false" collective="false" import="false" targetId="58d0-a0fd-d20b-cb1b" type="selectionEntry">
-      <comment>    template_id_2029-1f36-432f-a6a1</comment>
-      <categoryLinks>
-        <categoryLink id="795c-30c1-42a6-9768" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
-          <comment>    template_id_aa93-057d-42f6-82d7</comment>
-        </categoryLink>
-        <categoryLink id="8415-7326-49f2-8b63" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true">
-          <comment>    template_id_403c-4e9c-4af5-84ec</comment>
         </categoryLink>
       </categoryLinks>
     </entryLink>
@@ -2475,12 +2437,6 @@
         <categoryLink id="c965-8eea-54a5-dbbe" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="bf98-3ce4-bbae-27f4" name="Deathshroud Terminator Squad" hidden="false" collective="false" import="false" targetId="7669-a6c0-7f86-e641" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="b426-11a9-a374-dc73" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true"/>
-        <categoryLink id="9101-b7e1-a69a-8690" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-      </categoryLinks>
-    </entryLink>
     <entryLink id="1f21-083f-ed75-5d38" name="Seeker Squad" hidden="true" collective="false" import="false" targetId="58e6-f9cc-4c46-e258" type="selectionEntry">
       <comment>    template_id_dd8c-cf5d-4edb-a314</comment>
       <modifiers>
@@ -3151,6 +3107,7 @@
       <categoryLinks>
         <categoryLink id="b149-05d4-2f7b-a3bd" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="4055-f3db-da41-c441" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
+        <categoryLink id="713f-55c6-1fc9-4fca" name="LoW &amp; Primarchs" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="4106-fc7b-3756-ae9a" name="Mortarion" hidden="false" collective="false" import="true" type="model">

--- a/2022 - LA - Emperor's Children.cat
+++ b/2022 - LA - Emperor's Children.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="72ba-61c2-37ad-c785" name="LA -   III: Emperor&apos;s Children" revision="16" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="38" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="72ba-61c2-37ad-c785" name="LA -   III: Emperor&apos;s Children" revision="17" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="40" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entryLinks>
     <entryLink id="b36e-8c73-fe83-f087" name="   III: Emperor&apos;s Children" hidden="false" collective="false" import="false" targetId="3edc-a1b9-6dc6-b1ea" type="selectionEntry">
       <constraints>
@@ -50,6 +50,11 @@
         <categoryLink id="d1b1-8747-b31c-93ba" name="New CategoryLink" hidden="false" targetId="ad5f-31db-8bc7-5c46" primary="true"/>
         <categoryLink id="d25a-accf-b6de-facb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
+      <entryLinks>
+        <entryLink id="39cf-7589-ae76-3a78" name="Retinue" hidden="false" collective="false" import="true" targetId="30af-29e4-7637-73ea" type="selectionEntryGroup">
+          <comment>    template_id_831f-3373-456a-8fbc    template_targetId_be38-a066-4f8e-ae54</comment>
+        </entryLink>
+      </entryLinks>
     </entryLink>
     <entryLink id="3e78-22f5-fc51-3a6e" name="Kakophoni Squad" hidden="true" collective="false" import="false" targetId="8359-c463-9cde-4f21" type="selectionEntry">
       <modifiers>
@@ -509,49 +514,6 @@
         </categoryLink>
         <categoryLink id="e148-4310-47b0-b49b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>    template_id_2b20-1a8b-4753-b657</comment>
-        </categoryLink>
-      </categoryLinks>
-    </entryLink>
-    <entryLink id="c8dc-8233-18d7-0b6e" name="Command Squad" hidden="false" collective="false" import="false" targetId="0aca-632d-1642-8af9" type="selectionEntry">
-      <comment>    template_id_23b2-54e0-4f09-95e5</comment>
-      <categoryLinks>
-        <categoryLink id="6267-635f-497a-b7e4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
-          <comment>    template_id_4207-8d8f-4b1a-836b</comment>
-        </categoryLink>
-        <categoryLink id="d770-d464-4b60-96c8" name="Primarch&apos;s Retinue:" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true">
-          <comment>    template_id_2b34-077f-4279-86fb</comment>
-        </categoryLink>
-      </categoryLinks>
-    </entryLink>
-    <entryLink id="8d5d-ed86-9d48-de73" name="Command Squad, Cataphractii" hidden="false" collective="false" import="false" targetId="1b17-dcd6-0153-3efe" type="selectionEntry">
-      <comment>    template_id_9e78-3e8a-477d-9920</comment>
-      <modifiers>
-        <modifier type="append" field="name" value="(Reserve Only)">
-          <comment>    node_id_421a-b0ab-45e5-b4a7</comment>
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
-              <comment>    node_id_26f8-b35f-4d47-bcf3</comment>
-            </condition>
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="7c0c-dd2a-4f86-a073" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
-          <comment>    template_id_6577-e0fb-4fda-834e</comment>
-        </categoryLink>
-        <categoryLink id="faab-941e-4727-8896" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true">
-          <comment>    template_id_5d59-09bf-4566-b7e1</comment>
-        </categoryLink>
-      </categoryLinks>
-    </entryLink>
-    <entryLink id="0b7d-e2ff-4475-489c" name="Command Squad, Tartaros " hidden="false" collective="false" import="false" targetId="58d0-a0fd-d20b-cb1b" type="selectionEntry">
-      <comment>    template_id_2029-1f36-432f-a6a1</comment>
-      <categoryLinks>
-        <categoryLink id="afe1-a3ac-4f1e-a6de" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
-          <comment>    template_id_aa93-057d-42f6-82d7</comment>
-        </categoryLink>
-        <categoryLink id="d677-2de9-460a-8c81" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true">
-          <comment>    template_id_403c-4e9c-4af5-84ec</comment>
         </categoryLink>
       </categoryLinks>
     </entryLink>
@@ -2945,6 +2907,7 @@
       <categoryLinks>
         <categoryLink id="f617-3901-e330-116d" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="63e2-604e-8ad8-2949" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
+        <categoryLink id="0144-fa04-5a73-9890" name="LoW &amp; Primarchs" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="7350-db6b-c492-06cf" name="Firebrand" hidden="false" collective="false" import="true" type="upgrade">

--- a/2022 - LA - Imperial Fists.cat
+++ b/2022 - LA - Imperial Fists.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="8866-00ec-715f-f21a" name="LA -   VII: Imperial Fists" revision="19" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="32" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="8866-00ec-715f-f21a" name="LA -   VII: Imperial Fists" revision="20" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="41" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entryLinks>
     <entryLink id="b3e4-1487-4ab7-7515" name="Alexis Polux " hidden="false" collective="false" import="false" targetId="9229-b4f9-2213-9672" type="selectionEntry">
       <modifiers>
@@ -101,6 +101,11 @@
         <categoryLink id="47a6-fca8-5f4d-405a" name="New CategoryLink" hidden="false" targetId="ad5f-31db-8bc7-5c46" primary="true"/>
         <categoryLink id="e638-6d16-32ac-73f5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
+      <entryLinks>
+        <entryLink id="6b40-1eaa-cd91-0399" name="Retinue" hidden="false" collective="false" import="true" targetId="446f-102e-289b-bdc5" type="selectionEntryGroup">
+          <comment>    template_id_fe8f-c701-4ebd-ae76    template_targetId_be38-a066-4f8e-ae54</comment>
+        </entryLink>
+      </entryLinks>
     </entryLink>
     <entryLink id="bf53-51f2-5ab5-fecc" name="Huscarl Squad" hidden="true" collective="false" import="false" targetId="4420-5ce0-beb7-cb5e" type="selectionEntry">
       <modifiers>
@@ -525,49 +530,6 @@
         </categoryLink>
         <categoryLink id="ac8f-1e05-4ff4-8738" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>    template_id_2b20-1a8b-4753-b657</comment>
-        </categoryLink>
-      </categoryLinks>
-    </entryLink>
-    <entryLink id="c6a4-c488-a354-644d" name="Command Squad" hidden="false" collective="false" import="false" targetId="0aca-632d-1642-8af9" type="selectionEntry">
-      <comment>    template_id_23b2-54e0-4f09-95e5</comment>
-      <categoryLinks>
-        <categoryLink id="93ff-519d-4b8a-b0f3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
-          <comment>    template_id_4207-8d8f-4b1a-836b</comment>
-        </categoryLink>
-        <categoryLink id="9d10-3bdc-44e1-a20b" name="Primarch&apos;s Retinue:" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true">
-          <comment>    template_id_2b34-077f-4279-86fb</comment>
-        </categoryLink>
-      </categoryLinks>
-    </entryLink>
-    <entryLink id="c0b1-dd05-761b-b6bc" name="Command Squad, Cataphractii" hidden="false" collective="false" import="false" targetId="1b17-dcd6-0153-3efe" type="selectionEntry">
-      <comment>    template_id_9e78-3e8a-477d-9920</comment>
-      <modifiers>
-        <modifier type="append" field="name" value="(Reserve Only)">
-          <comment>    node_id_421a-b0ab-45e5-b4a7</comment>
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
-              <comment>    node_id_26f8-b35f-4d47-bcf3</comment>
-            </condition>
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="a16b-c834-45bd-ad7e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
-          <comment>    template_id_6577-e0fb-4fda-834e</comment>
-        </categoryLink>
-        <categoryLink id="fd15-a95a-4c48-b7f9" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true">
-          <comment>    template_id_5d59-09bf-4566-b7e1</comment>
-        </categoryLink>
-      </categoryLinks>
-    </entryLink>
-    <entryLink id="be42-e556-3b98-ac06" name="Command Squad, Tartaros " hidden="false" collective="false" import="false" targetId="58d0-a0fd-d20b-cb1b" type="selectionEntry">
-      <comment>    template_id_2029-1f36-432f-a6a1</comment>
-      <categoryLinks>
-        <categoryLink id="8367-cdd9-43a6-894e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
-          <comment>    template_id_aa93-057d-42f6-82d7</comment>
-        </categoryLink>
-        <categoryLink id="b8c6-34da-4eb1-845f" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true">
-          <comment>    template_id_403c-4e9c-4af5-84ec</comment>
         </categoryLink>
       </categoryLinks>
     </entryLink>
@@ -3141,7 +3103,9 @@
                     <conditionGroup type="or">
                       <conditions>
                         <condition field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="greaterThan"/>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e5ae-fd1c-729d-d855" type="equalTo"/>
                         <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo"/>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="95a4-07ae-c2e4-fe33" type="equalTo"/>
                       </conditions>
                     </conditionGroup>
                   </conditionGroups>
@@ -4175,6 +4139,7 @@ Both weapons are counted as ‘Power’ weapons for those rules that affect such
       <categoryLinks>
         <categoryLink id="c043-4561-4769-2322" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
         <categoryLink id="0895-b881-212f-b491" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="1b7e-1f5c-21dc-59f1" name="LoW &amp; Primarchs (25% Limit)" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="ddda-cf8e-7722-1e7f" name="Storm&apos;s Teeth" hidden="false" collective="false" import="true" type="upgrade">
@@ -4629,6 +4594,7 @@ Both weapons are counted as ‘Power’ weapons for those rules that affect such
         <categoryLink id="0926-4bcb-7263-d6a1" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
         <categoryLink id="9de5-657e-8970-390d" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="4ee5-2ad3-9806-aa1c" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="e00a-c6ab-98ea-c6f8" name="LoW &amp; Primarchs (25% Limit)" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="d982-313d-0d97-d831" name="Wing Weapon Options" hidden="false" collective="false" import="true" defaultSelectionEntryId="0127-b935-d076-9419">

--- a/2022 - LA - Iron Hands.cat
+++ b/2022 - LA - Iron Hands.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="b73e-125f-db29-17f2" name="LA -  X: Iron Hands" revision="22" battleScribeVersion="2.03" authorName="Figjam Bohica" authorContact="BSData Developers Discord" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="39" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="b73e-125f-db29-17f2" name="LA -  X: Iron Hands" revision="24" battleScribeVersion="2.03" authorName="Figjam Bohica" authorContact="BSData Developers Discord" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="41" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entryLinks>
     <entryLink id="6107-168e-198e-2e94" name="  X: Iron Hands" hidden="false" collective="false" import="false" targetId="bfc9-c99c-bf8a-3917" type="selectionEntry">
       <constraints>
@@ -101,6 +101,11 @@
         <categoryLink id="84ec-691d-8d75-7998" name="New CategoryLink" hidden="false" targetId="ad5f-31db-8bc7-5c46" primary="true"/>
         <categoryLink id="4198-15b1-372c-89c8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
+      <entryLinks>
+        <entryLink id="2ad9-8ddd-07ac-2cd0" name="Retinue" hidden="false" collective="false" import="true" targetId="8a62-e4e2-d57f-5c33" type="selectionEntryGroup">
+          <comment>    template_id_fe8f-c701-4ebd-ae76    template_targetId_be38-a066-4f8e-ae54</comment>
+        </entryLink>
+      </entryLinks>
     </entryLink>
     <entryLink id="2dbc-c2bc-600f-0c06" name="Apothecarion Detachment" hidden="false" collective="false" import="false" targetId="81df-ffd4-a32b-b4a1" type="selectionEntry">
       <comment>    template_id_c2bc-2985-468b-b512</comment>
@@ -476,49 +481,6 @@
         </categoryLink>
         <categoryLink id="2ced-12a5-4348-b66f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>    template_id_2b20-1a8b-4753-b657</comment>
-        </categoryLink>
-      </categoryLinks>
-    </entryLink>
-    <entryLink id="7fbd-8c69-0c5d-8ae0" name="Command Squad" hidden="false" collective="false" import="false" targetId="0aca-632d-1642-8af9" type="selectionEntry">
-      <comment>    template_id_23b2-54e0-4f09-95e5</comment>
-      <categoryLinks>
-        <categoryLink id="127c-2d74-47bb-8f5f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
-          <comment>    template_id_4207-8d8f-4b1a-836b</comment>
-        </categoryLink>
-        <categoryLink id="1f70-c692-4919-8175" name="Primarch&apos;s Retinue:" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true">
-          <comment>    template_id_2b34-077f-4279-86fb</comment>
-        </categoryLink>
-      </categoryLinks>
-    </entryLink>
-    <entryLink id="02b9-6b6a-ac24-1614" name="Command Squad, Cataphractii" hidden="false" collective="false" import="false" targetId="1b17-dcd6-0153-3efe" type="selectionEntry">
-      <comment>    template_id_9e78-3e8a-477d-9920</comment>
-      <modifiers>
-        <modifier type="append" field="name" value="(Reserve Only)">
-          <comment>    node_id_421a-b0ab-45e5-b4a7</comment>
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
-              <comment>    node_id_26f8-b35f-4d47-bcf3</comment>
-            </condition>
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="1f60-a02b-458d-915b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
-          <comment>    template_id_6577-e0fb-4fda-834e</comment>
-        </categoryLink>
-        <categoryLink id="1186-f153-49c1-a39b" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true">
-          <comment>    template_id_5d59-09bf-4566-b7e1</comment>
-        </categoryLink>
-      </categoryLinks>
-    </entryLink>
-    <entryLink id="993e-8cdb-d3b7-9f4c" name="Command Squad, Tartaros " hidden="false" collective="false" import="false" targetId="58d0-a0fd-d20b-cb1b" type="selectionEntry">
-      <comment>    template_id_2029-1f36-432f-a6a1</comment>
-      <categoryLinks>
-        <categoryLink id="70c4-0a82-45d4-a57f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
-          <comment>    template_id_aa93-057d-42f6-82d7</comment>
-        </categoryLink>
-        <categoryLink id="5bbd-9c26-43d2-8da7" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true">
-          <comment>    template_id_403c-4e9c-4af5-84ec</comment>
         </categoryLink>
       </categoryLinks>
     </entryLink>
@@ -3800,6 +3762,7 @@
         <categoryLink id="ea33-c875-88be-d428" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
         <categoryLink id="9014-262a-9067-0e59" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="d7ac-8652-d9dd-8de6" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+        <categoryLink id="4ea5-44d6-046c-15da" name="LoW &amp; Primarchs (25% Limit)" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="6b2c-960f-6914-2c01" name="Ferrus Manus" hidden="false" collective="false" import="true" type="upgrade">

--- a/2022 - LA - Iron Warriors.cat
+++ b/2022 - LA - Iron Warriors.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="2ee4-57ed-db44-8a63" name="LA -   IV: Iron Warriors" revision="22" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="40" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="2ee4-57ed-db44-8a63" name="LA -   IV: Iron Warriors" revision="23" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="40" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entryLinks>
     <entryLink id="fe10-3104-0252-96de" name="Nârik Dreygur" hidden="true" collective="false" import="false" targetId="ac97-c8ce-16ba-9c49" type="selectionEntry">
       <modifiers>
@@ -27,6 +27,11 @@
         <categoryLink id="4fe3-7aed-a86d-e3a9" name="New CategoryLink" hidden="false" targetId="ad5f-31db-8bc7-5c46" primary="true"/>
         <categoryLink id="23ea-8f2f-28bd-c663" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
+      <entryLinks>
+        <entryLink id="8c24-60da-1f2e-692f" name="Retinue" hidden="false" collective="false" import="true" targetId="6590-c91a-fceb-8048" type="selectionEntryGroup">
+          <comment>    template_id_fe8f-c701-4ebd-ae76    template_targetId_be38-a066-4f8e-ae54</comment>
+        </entryLink>
+      </entryLinks>
     </entryLink>
     <entryLink id="ede1-9c07-8401-67f9" name="Iron Havocs" hidden="true" collective="false" import="false" targetId="d355-5488-1277-fabf" type="selectionEntry">
       <modifiers>
@@ -2439,49 +2444,6 @@
         </categoryLink>
       </categoryLinks>
     </entryLink>
-    <entryLink id="8a1e-fea5-c86e-d00b" name="Command Squad" hidden="false" collective="false" import="false" targetId="0aca-632d-1642-8af9" type="selectionEntry">
-      <comment>    template_id_23b2-54e0-4f09-95e5</comment>
-      <categoryLinks>
-        <categoryLink id="f2b2-4cfb-4fb8-9f31" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
-          <comment>    template_id_4207-8d8f-4b1a-836b</comment>
-        </categoryLink>
-        <categoryLink id="94f5-6e09-4b09-9b4f" name="Primarch&apos;s Retinue:" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true">
-          <comment>    template_id_2b34-077f-4279-86fb</comment>
-        </categoryLink>
-      </categoryLinks>
-    </entryLink>
-    <entryLink id="ebfc-98ae-c842-10a6" name="Command Squad, Cataphractii" hidden="false" collective="false" import="false" targetId="1b17-dcd6-0153-3efe" type="selectionEntry">
-      <comment>    template_id_9e78-3e8a-477d-9920</comment>
-      <modifiers>
-        <modifier type="append" field="name" value="(Reserve Only)">
-          <comment>    node_id_421a-b0ab-45e5-b4a7</comment>
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
-              <comment>    node_id_26f8-b35f-4d47-bcf3</comment>
-            </condition>
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="87e4-4720-4830-b87d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
-          <comment>    template_id_6577-e0fb-4fda-834e</comment>
-        </categoryLink>
-        <categoryLink id="ff8c-ece8-4dff-b44a" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true">
-          <comment>    template_id_5d59-09bf-4566-b7e1</comment>
-        </categoryLink>
-      </categoryLinks>
-    </entryLink>
-    <entryLink id="c136-3a99-b744-4fff" name="Command Squad, Tartaros " hidden="false" collective="false" import="false" targetId="58d0-a0fd-d20b-cb1b" type="selectionEntry">
-      <comment>    template_id_2029-1f36-432f-a6a1</comment>
-      <categoryLinks>
-        <categoryLink id="4641-6be8-42e3-a291" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
-          <comment>    template_id_aa93-057d-42f6-82d7</comment>
-        </categoryLink>
-        <categoryLink id="3f38-6c2f-4b2d-badc" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true">
-          <comment>    template_id_403c-4e9c-4af5-84ec</comment>
-        </categoryLink>
-      </categoryLinks>
-    </entryLink>
     <entryLink id="6be4-dbc0-31f4-7957" name="Seeker Squad" hidden="true" collective="false" import="false" targetId="58e6-f9cc-4c46-e258" type="selectionEntry">
       <comment>    template_id_dd8c-cf5d-4edb-a314</comment>
       <modifiers>
@@ -2874,32 +2836,6 @@
         <categoryLink id="14b8-379a-2d2f-2054" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="b5ef-d719-5ed6-46b7" name="Iron Circle Maniple" hidden="false" collective="false" import="false" targetId="a6e3-baab-45b9-7fea" type="selectionEntry">
-      <modifiers>
-        <modifier type="append" field="name" value="(Reserve Only)">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="f517-b886-d9e5-2bf5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="9967-8b55-7789-04ce" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true"/>
-      </categoryLinks>
-    </entryLink>
-    <entryLink id="20c7-daad-ae5a-c04f" name="Dominator Cohort" hidden="true" collective="false" import="false" targetId="1bfa-2413-beb9-5f32" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8d56-d960-0687-7fee" type="equalTo"/>
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="0d0a-54b0-b916-906e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="1eba-8ed0-5b2b-1af5" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true"/>
-      </categoryLinks>
-    </entryLink>
     <entryLink id="a4a3-4242-de71-c82b" name="Thallax Cohort" hidden="true" collective="false" import="false" targetId="25c8-3e0f-e22d-a7eb" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
@@ -3072,6 +3008,7 @@
       <categoryLinks>
         <categoryLink id="652f-8767-983f-8259" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
         <categoryLink id="2cb8-f4af-7359-ee4e" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="9de2-18e7-2489-6f6a" name="LoW &amp; Primarchs" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="877c-1463-cab0-6661" name="Forgebreaker Desecrated" hidden="false" collective="false" import="true" type="upgrade">
@@ -4796,7 +4733,7 @@
           </modifiers>
         </entryLink>
         <entryLink id="fc39-8924-a69f-10b5" name="Tartaros Command Squad" hidden="false" collective="false" import="true" targetId="58d0-a0fd-d20b-cb1b" type="selectionEntry"/>
-        <entryLink id="cd97-51bf-2a68-1186" name="Command Squad (Placeholder Points)" hidden="false" collective="false" import="true" targetId="0aca-632d-1642-8af9" type="selectionEntry"/>
+        <entryLink id="cd97-51bf-2a68-1186" name="Command Squad" hidden="false" collective="false" import="true" targetId="0aca-632d-1642-8af9" type="selectionEntry"/>
         <entryLink id="9b82-c43c-3987-cea4" name="Iron Circle Maniple" hidden="true" collective="false" import="true" targetId="a6e3-baab-45b9-7fea" type="selectionEntry">
           <modifiers>
             <modifier type="set" field="hidden" value="false">

--- a/2022 - LA - Night Lords.cat
+++ b/2022 - LA - Night Lords.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="36dc-14fc-8872-476b" name="LA -   VIII: Night Lords" revision="21" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="38" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="36dc-14fc-8872-476b" name="LA -   VIII: Night Lords" revision="22" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="41" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entryLinks>
     <entryLink id="f491-c7fa-f6d3-917d" name="Contekar Terminator Squad" hidden="false" collective="false" import="false" targetId="837e-c3ca-437e-dfbf" type="selectionEntry">
       <modifiers>
@@ -24,20 +24,25 @@
     <entryLink id="77a5-7cca-d050-de27" name="Konrad Curze" hidden="false" collective="false" import="false" targetId="1636-d8d9-2428-f166" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
-          <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo"/>
-          </conditions>
-        </modifier>
-        <modifier type="set" field="hidden" value="true">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="64a2-0d7a-e716-e67f" type="equalTo"/>
-          </conditions>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="64a2-0d7a-e716-e67f" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
         <categoryLink id="c700-6253-d5c4-b462" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="dead-a3bc-6447-64ea" name="New CategoryLink" hidden="false" targetId="ad5f-31db-8bc7-5c46" primary="true"/>
       </categoryLinks>
+      <entryLinks>
+        <entryLink id="6585-f156-4a2a-d71c" name="Retinue" hidden="false" collective="false" import="true" targetId="f728-26bf-3c99-1529" type="selectionEntryGroup">
+          <comment>    template_id_831f-3373-456a-8fbc    template_targetId_be38-a066-4f8e-ae54</comment>
+        </entryLink>
+      </entryLinks>
     </entryLink>
     <entryLink id="44dc-815a-7895-cfa0" name="Night Raptor Squad" hidden="true" collective="false" import="false" targetId="9bb8-8fe4-11c1-9e50" type="selectionEntry">
       <modifiers>
@@ -607,54 +612,6 @@
         </categoryLink>
         <categoryLink id="2580-f2ab-4d8a-909e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>    template_id_2b20-1a8b-4753-b657</comment>
-        </categoryLink>
-      </categoryLinks>
-    </entryLink>
-    <entryLink id="b2a8-ede4-2774-1e57" name="Command Squad" hidden="false" collective="false" import="false" targetId="0aca-632d-1642-8af9" type="selectionEntry">
-      <comment>    template_id_23b2-54e0-4f09-95e5</comment>
-      <categoryLinks>
-        <categoryLink id="20eb-6929-4b51-adad" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
-          <comment>    template_id_4207-8d8f-4b1a-836b</comment>
-        </categoryLink>
-        <categoryLink id="835c-c0f7-423c-bb94" name="Primarch&apos;s Retinue:" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true">
-          <comment>    template_id_2b34-077f-4279-86fb</comment>
-        </categoryLink>
-      </categoryLinks>
-    </entryLink>
-    <entryLink id="c262-7af0-6986-95ac" name="Command Squad, Cataphractii" hidden="false" collective="false" import="false" targetId="1b17-dcd6-0153-3efe" type="selectionEntry">
-      <comment>    template_id_9e78-3e8a-477d-9920</comment>
-      <modifiers>
-        <modifier type="append" field="name" value="(Reserve Only)">
-          <comment>    node_id_421a-b0ab-45e5-b4a7</comment>
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
-              <comment>    node_id_26f8-b35f-4d47-bcf3</comment>
-            </condition>
-          </conditions>
-        </modifier>
-        <modifier type="set" field="hidden" value="true">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="64a2-0d7a-e716-e67f" type="equalTo"/>
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="08ec-97df-4e60-8628" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
-          <comment>    template_id_6577-e0fb-4fda-834e</comment>
-        </categoryLink>
-        <categoryLink id="c26d-3fa1-4501-bae6" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true">
-          <comment>    template_id_5d59-09bf-4566-b7e1</comment>
-        </categoryLink>
-      </categoryLinks>
-    </entryLink>
-    <entryLink id="2000-179d-70cc-8970" name="Command Squad, Tartaros " hidden="false" collective="false" import="false" targetId="58d0-a0fd-d20b-cb1b" type="selectionEntry">
-      <comment>    template_id_2029-1f36-432f-a6a1</comment>
-      <categoryLinks>
-        <categoryLink id="efd9-3653-4499-9015" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
-          <comment>    template_id_aa93-057d-42f6-82d7</comment>
-        </categoryLink>
-        <categoryLink id="3719-de4b-4e4a-b83b" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true">
-          <comment>    template_id_403c-4e9c-4af5-84ec</comment>
         </categoryLink>
       </categoryLinks>
     </entryLink>
@@ -4352,6 +4309,7 @@
         <categoryLink id="3ecd-9823-e8e4-14f8" name="Psyker:" hidden="false" targetId="6e0c-29ba-a445-8321" primary="false"/>
         <categoryLink id="9bd6-18bb-2ebc-e958" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="9920-bfc8-5c9b-5ffc" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
+        <categoryLink id="1549-4a7a-03ae-30e6" name="LoW &amp; Primarchs (25% Limit)" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="7cea-1a9a-cee1-7d17" name="Konrad Curze" hidden="false" collective="false" import="true" type="model">

--- a/2022 - LA - Raven Guard.cat
+++ b/2022 - LA - Raven Guard.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="d21e-9c80-a7f8-728c" name="LA - XIX: Raven Guard" revision="18" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="38" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="d21e-9c80-a7f8-728c" name="LA - XIX: Raven Guard" revision="18" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="41" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entryLinks>
     <entryLink id="84cc-e59c-174e-fb25" name="Mor Deythan Squad" hidden="false" collective="false" import="false" targetId="c268-08ac-5b90-d034" type="selectionEntry">
       <categoryLinks>
@@ -52,6 +52,11 @@
         <categoryLink id="f2cb-5a4e-7c3e-733a" name="New CategoryLink" hidden="false" targetId="ad5f-31db-8bc7-5c46" primary="true"/>
         <categoryLink id="393b-c443-85dd-4f06" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
+      <entryLinks>
+        <entryLink id="4a8f-58bb-3473-6a14" name="Retinue" hidden="false" collective="false" import="true" targetId="5a61-7572-048d-9bb4" type="selectionEntryGroup">
+          <comment>    template_id_a6a6-9bc7-4d4e-86a7    template_targetId_be38-a066-4f8e-ae54</comment>
+        </entryLink>
+      </entryLinks>
     </entryLink>
     <entryLink id="1efd-f4c5-634b-d9f2" name=" XIX: Raven Guard" hidden="false" collective="false" import="false" targetId="dc34-fe08-dd44-fb99" type="selectionEntry">
       <constraints>
@@ -467,54 +472,6 @@
         </categoryLink>
         <categoryLink id="8fed-b877-4cf0-9433" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>    template_id_2b20-1a8b-4753-b657</comment>
-        </categoryLink>
-      </categoryLinks>
-    </entryLink>
-    <entryLink id="b00c-2263-1932-f88b" name="Command Squad" hidden="false" collective="false" import="false" targetId="0aca-632d-1642-8af9" type="selectionEntry">
-      <comment>    template_id_23b2-54e0-4f09-95e5</comment>
-      <categoryLinks>
-        <categoryLink id="28cd-8de6-46fc-829a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
-          <comment>    template_id_4207-8d8f-4b1a-836b</comment>
-        </categoryLink>
-        <categoryLink id="13a7-2a4c-4080-90da" name="Primarch&apos;s Retinue:" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true">
-          <comment>    template_id_2b34-077f-4279-86fb</comment>
-        </categoryLink>
-      </categoryLinks>
-    </entryLink>
-    <entryLink id="ff73-39dc-6d96-14e6" name="Command Squad, Cataphractii" hidden="false" collective="false" import="false" targetId="1b17-dcd6-0153-3efe" type="selectionEntry">
-      <comment>    template_id_9e78-3e8a-477d-9920</comment>
-      <modifiers>
-        <modifier type="append" field="name" value="(Reserve Only)">
-          <comment>    node_id_421a-b0ab-45e5-b4a7</comment>
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
-              <comment>    node_id_26f8-b35f-4d47-bcf3</comment>
-            </condition>
-          </conditions>
-        </modifier>
-        <modifier type="set" field="hidden" value="true">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="12f2-df1a-525f-7957" type="equalTo"/>
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="2516-ca21-44f8-bf47" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
-          <comment>    template_id_6577-e0fb-4fda-834e</comment>
-        </categoryLink>
-        <categoryLink id="d225-bd9e-4b85-bc36" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true">
-          <comment>    template_id_5d59-09bf-4566-b7e1</comment>
-        </categoryLink>
-      </categoryLinks>
-    </entryLink>
-    <entryLink id="cdf8-ca69-9f1f-edc7" name="Command Squad, Tartaros " hidden="false" collective="false" import="false" targetId="58d0-a0fd-d20b-cb1b" type="selectionEntry">
-      <comment>    template_id_2029-1f36-432f-a6a1</comment>
-      <categoryLinks>
-        <categoryLink id="fc5a-eda0-4b4f-8052" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
-          <comment>    template_id_aa93-057d-42f6-82d7</comment>
-        </categoryLink>
-        <categoryLink id="f587-6c66-4b64-a8dc" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true">
-          <comment>    template_id_403c-4e9c-4af5-84ec</comment>
         </categoryLink>
       </categoryLinks>
     </entryLink>
@@ -3046,6 +3003,7 @@
         <categoryLink id="d718-986e-82a3-6418" name="Jump Infantry:" hidden="false" targetId="eee8-3c7c-2762-e33e" primary="false"/>
         <categoryLink id="077f-e8dd-5f24-86e9" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="26ee-c51c-b946-63f4" name="Skirmish Sub-type:" hidden="false" targetId="59a4-7b61-600a-c457" primary="false"/>
+        <categoryLink id="1aa4-254b-db10-45c3" name="LoW &amp; Primarchs (25% Limit)" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="9115-3297-32da-6ac4" name="Corvus Corax" publicationId="817a-6288-e016-7469" page="333" hidden="false" collective="false" import="true" type="model">
@@ -4776,7 +4734,7 @@ When in base to base contact with an enemy Infantry or Cavalry model whose Weapo
             </modifier>
           </modifiers>
         </entryLink>
-        <entryLink id="ddf1-3ff4-ef67-c4f1" name="Tartaros Command Squad (Placeholder Points)" hidden="false" collective="false" import="true" targetId="58d0-a0fd-d20b-cb1b" type="selectionEntry"/>
+        <entryLink id="ddf1-3ff4-ef67-c4f1" name="Command Squad, Tartaros " hidden="false" collective="false" import="true" targetId="58d0-a0fd-d20b-cb1b" type="selectionEntry"/>
         <entryLink id="b94f-e962-0b23-adff" name="Command Squad" hidden="false" collective="false" import="true" targetId="0aca-632d-1642-8af9" type="selectionEntry"/>
       </entryLinks>
     </selectionEntryGroup>

--- a/2022 - LA - Salamanders.cat
+++ b/2022 - LA - Salamanders.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="3547-84d8-d789-bab7" name="LA -  XVIII: Salamanders" revision="18" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="38" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="3547-84d8-d789-bab7" name="LA -  XVIII: Salamanders" revision="19" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="41" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entryLinks>
     <entryLink id="93d2-b1cb-b684-a9b3" name="  XVIII: Salamanders" hidden="false" collective="false" import="false" targetId="c805-ca3a-ff93-5e2f" type="selectionEntry">
       <constraints>
@@ -85,6 +85,11 @@
         <categoryLink id="64a8-ba7d-4c9b-3f3e" name="New CategoryLink" hidden="false" targetId="ad5f-31db-8bc7-5c46" primary="true"/>
         <categoryLink id="6d75-8f0a-3caa-689d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
+      <entryLinks>
+        <entryLink id="bc7a-ac29-6730-32df" name="Retinue" hidden="false" collective="false" import="true" targetId="ec53-0911-52b7-dafa" type="selectionEntryGroup">
+          <comment>    template_id_5c5d-d6ce-4ee4-9846    template_targetId_be38-a066-4f8e-ae54</comment>
+        </entryLink>
+      </entryLinks>
     </entryLink>
     <entryLink id="2607-05cd-6852-2f52" name="Xiaphas Jurr" hidden="true" collective="false" import="false" targetId="30b8-05a5-fef7-fe66" type="selectionEntry">
       <modifiers>
@@ -478,49 +483,6 @@
         </categoryLink>
         <categoryLink id="cb13-6872-45b5-86e8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>    template_id_2b20-1a8b-4753-b657</comment>
-        </categoryLink>
-      </categoryLinks>
-    </entryLink>
-    <entryLink id="5458-163e-22de-4a00" name="Command Squad" hidden="false" collective="false" import="false" targetId="0aca-632d-1642-8af9" type="selectionEntry">
-      <comment>    template_id_23b2-54e0-4f09-95e5</comment>
-      <categoryLinks>
-        <categoryLink id="8a63-c4d9-4139-9cf4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
-          <comment>    template_id_4207-8d8f-4b1a-836b</comment>
-        </categoryLink>
-        <categoryLink id="793c-b0a0-4e5d-b164" name="Primarch&apos;s Retinue:" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true">
-          <comment>    template_id_2b34-077f-4279-86fb</comment>
-        </categoryLink>
-      </categoryLinks>
-    </entryLink>
-    <entryLink id="dba9-1176-0331-fc7e" name="Command Squad, Cataphractii" hidden="false" collective="false" import="false" targetId="1b17-dcd6-0153-3efe" type="selectionEntry">
-      <comment>    template_id_9e78-3e8a-477d-9920</comment>
-      <modifiers>
-        <modifier type="append" field="name" value="(Reserve Only)">
-          <comment>    node_id_421a-b0ab-45e5-b4a7</comment>
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
-              <comment>    node_id_26f8-b35f-4d47-bcf3</comment>
-            </condition>
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="a892-a7ba-4d11-9a36" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
-          <comment>    template_id_6577-e0fb-4fda-834e</comment>
-        </categoryLink>
-        <categoryLink id="b0d0-d3e5-4358-b231" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true">
-          <comment>    template_id_5d59-09bf-4566-b7e1</comment>
-        </categoryLink>
-      </categoryLinks>
-    </entryLink>
-    <entryLink id="c4ec-a665-f42a-0af3" name="Command Squad, Tartaros " hidden="false" collective="false" import="false" targetId="58d0-a0fd-d20b-cb1b" type="selectionEntry">
-      <comment>    template_id_2029-1f36-432f-a6a1</comment>
-      <categoryLinks>
-        <categoryLink id="5ff9-d6a7-450a-af4e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
-          <comment>    template_id_aa93-057d-42f6-82d7</comment>
-        </categoryLink>
-        <categoryLink id="fbc0-c28c-4add-9ec4" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true">
-          <comment>    template_id_403c-4e9c-4af5-84ec</comment>
         </categoryLink>
       </categoryLinks>
     </entryLink>
@@ -2894,6 +2856,7 @@
       <categoryLinks>
         <categoryLink id="97f1-63ad-b403-6ae7" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="ff2f-d33d-2e7c-9895" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
+        <categoryLink id="ac1c-f729-b363-44d6" name="LoW &amp; Primarchs (25% Limit)" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="b52a-be67-5e91-6268" name="Dawnbringer" hidden="false" collective="false" import="true" type="upgrade">
@@ -4132,19 +4095,24 @@
       <entryLinks>
         <entryLink id="420e-70d3-d9fe-a868" name="Command Squad, Cataphractii" hidden="false" collective="false" import="true" targetId="1b17-dcd6-0153-3efe" type="selectionEntry">
           <modifiers>
-            <modifier type="set" field="hidden" value="true">
-              <conditionGroups>
-                <conditionGroup type="or">
-                  <conditions>
-                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
-                  </conditions>
-                </conditionGroup>
-              </conditionGroups>
+            <modifier type="append" field="name" value="(Reserve Only)">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+              </conditions>
             </modifier>
           </modifiers>
         </entryLink>
-        <entryLink id="f7b0-e209-7d07-e62c" name="Tartaros Command Squad (Placeholder Points)" hidden="false" collective="false" import="true" targetId="58d0-a0fd-d20b-cb1b" type="selectionEntry"/>
+        <entryLink id="f7b0-e209-7d07-e62c" name="Command Squad, Tartaros " hidden="false" collective="false" import="true" targetId="58d0-a0fd-d20b-cb1b" type="selectionEntry"/>
         <entryLink id="9d06-d7bf-1138-373a" name="Command Squad" hidden="false" collective="false" import="true" targetId="0aca-632d-1642-8af9" type="selectionEntry"/>
+        <entryLink id="bc1c-d3d2-235f-fbe0" name="Firedrake Terminator Squad" hidden="false" collective="false" import="true" targetId="6775-8379-8d6b-9614" type="selectionEntry">
+          <modifiers>
+            <modifier type="append" field="name" value="(Reserve Only)">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </entryLink>
       </entryLinks>
     </selectionEntryGroup>
   </sharedSelectionEntryGroups>

--- a/2022 - LA - Sons of Horus.cat
+++ b/2022 - LA - Sons of Horus.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="62c7-42f4-5523-af1b" name="LA -  XVI: Sons of Horus" revision="22" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="38" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="62c7-42f4-5523-af1b" name="LA -  XVI: Sons of Horus" revision="23" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="41" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entryLinks>
     <entryLink id="c2a2-9b6d-b384-3f43" name="  XVI: Sons of Horus" hidden="false" collective="false" import="false" targetId="01b4-57c7-bf61-2abf" type="selectionEntry">
       <constraints>
@@ -130,6 +130,11 @@
         <categoryLink id="2fe4-5c5c-bead-f06e" name="New CategoryLink" hidden="false" targetId="ad5f-31db-8bc7-5c46" primary="true"/>
         <categoryLink id="734c-b12a-678e-ad6a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
+      <entryLinks>
+        <entryLink id="9105-b87b-8f32-dee6" name="Retinue" hidden="false" collective="false" import="true" targetId="b574-7838-ac21-b8f6" type="selectionEntryGroup">
+          <comment>    template_id_5c5d-d6ce-4ee4-9846    template_targetId_be38-a066-4f8e-ae54</comment>
+        </entryLink>
+      </entryLinks>
     </entryLink>
     <entryLink id="f092-385d-cb95-de74" name="Garviel Loken" hidden="false" collective="false" import="false" targetId="44bf-8a69-f21a-dfba" type="selectionEntry">
       <modifiers>
@@ -532,49 +537,6 @@
         </categoryLink>
         <categoryLink id="0ce3-a809-4add-8a1d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>    template_id_2b20-1a8b-4753-b657</comment>
-        </categoryLink>
-      </categoryLinks>
-    </entryLink>
-    <entryLink id="298a-7e54-6282-d112" name="Command Squad" hidden="false" collective="false" import="false" targetId="0aca-632d-1642-8af9" type="selectionEntry">
-      <comment>    template_id_23b2-54e0-4f09-95e5</comment>
-      <categoryLinks>
-        <categoryLink id="8a51-62aa-44c4-92a7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
-          <comment>    template_id_4207-8d8f-4b1a-836b</comment>
-        </categoryLink>
-        <categoryLink id="cf72-ca21-4571-bba2" name="Primarch&apos;s Retinue:" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true">
-          <comment>    template_id_2b34-077f-4279-86fb</comment>
-        </categoryLink>
-      </categoryLinks>
-    </entryLink>
-    <entryLink id="9230-f176-32b2-7d8d" name="Command Squad, Cataphractii" hidden="false" collective="false" import="false" targetId="1b17-dcd6-0153-3efe" type="selectionEntry">
-      <comment>    template_id_9e78-3e8a-477d-9920</comment>
-      <modifiers>
-        <modifier type="append" field="name" value="(Reserve Only)">
-          <comment>    node_id_421a-b0ab-45e5-b4a7</comment>
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
-              <comment>    node_id_26f8-b35f-4d47-bcf3</comment>
-            </condition>
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="9ec8-2731-4ca4-bc1d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
-          <comment>    template_id_6577-e0fb-4fda-834e</comment>
-        </categoryLink>
-        <categoryLink id="c437-5a23-42ae-905f" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true">
-          <comment>    template_id_5d59-09bf-4566-b7e1</comment>
-        </categoryLink>
-      </categoryLinks>
-    </entryLink>
-    <entryLink id="391b-a79f-876c-4c33" name="Command Squad, Tartaros " hidden="false" collective="false" import="false" targetId="58d0-a0fd-d20b-cb1b" type="selectionEntry">
-      <comment>    template_id_2029-1f36-432f-a6a1</comment>
-      <categoryLinks>
-        <categoryLink id="82c8-4dd0-46d7-b491" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
-          <comment>    template_id_aa93-057d-42f6-82d7</comment>
-        </categoryLink>
-        <categoryLink id="c9c6-3fe8-4e33-85d3" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true">
-          <comment>    template_id_403c-4e9c-4af5-84ec</comment>
         </categoryLink>
       </categoryLinks>
     </entryLink>
@@ -3260,6 +3222,7 @@
       <categoryLinks>
         <categoryLink id="6438-a713-c788-02e4" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
         <categoryLink id="be89-a0c6-b0cb-b46e" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="6be2-fe80-9f03-8beb" name="LoW &amp; Primarchs (25% Limit)" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="28c5-de31-09e9-9a57" name="The Serpent&apos;s Scales" hidden="false" collective="false" import="true" type="upgrade">

--- a/2022 - LA - Space Wolves.cat
+++ b/2022 - LA - Space Wolves.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="ca15-13de-89cb-bbb2" name="LA -   VI: Space Wolves" revision="21" battleScribeVersion="2.03" authorName="Mr_Dark, UrsinePatriarch" authorContact="BSData Developers Discord" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="38" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="ca15-13de-89cb-bbb2" name="LA -   VI: Space Wolves" revision="23" battleScribeVersion="2.03" authorName="Mr_Dark, UrsinePatriarch" authorContact="BSData Developers Discord" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="40" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entryLinks>
     <entryLink id="ff53-69d9-ec0b-9caa" name="   VI: Space Wolves" hidden="false" collective="false" import="false" targetId="4916-965e-8339-44f6" type="selectionEntry">
       <constraints>
@@ -21,19 +21,6 @@
       <categoryLinks>
         <categoryLink id="afb7-b32a-da09-ad2f" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="90f3-333e-c096-a39d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-      </categoryLinks>
-    </entryLink>
-    <entryLink id="8eb8-d620-5aae-d5ff" name="Fenrisian Wolf Pack" hidden="true" collective="false" import="false" targetId="f47e-c270-b62a-4205" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8d56-d960-0687-7fee" type="greaterThan"/>
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="ecf9-012f-8171-c36a" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true"/>
-        <categoryLink id="026f-5075-581f-d0fb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="145a-e620-0394-c8e6" name="Geigor Fell-Hand" hidden="false" collective="false" import="false" targetId="b4c7-4f96-122b-7ade" type="selectionEntry">
@@ -127,19 +114,11 @@
         <categoryLink id="02d9-6d81-e872-d7b7" name="New CategoryLink" hidden="false" targetId="ad5f-31db-8bc7-5c46" primary="true"/>
         <categoryLink id="1b8f-f807-3d22-80df" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
-    </entryLink>
-    <entryLink id="89e7-9749-8180-3d09" name="The Wolf-kin of Russ" hidden="false" collective="false" import="false" targetId="3bb9-4637-e963-b36f" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="1194-4568-72cb-9521" name="New CategoryLink" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="true"/>
-        <categoryLink id="a879-10d5-44fa-e515" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-      </categoryLinks>
+      <entryLinks>
+        <entryLink id="66de-17b9-a9bf-bdd7" name="Retinue" hidden="false" collective="false" import="true" targetId="5408-6204-0336-0ce2" type="selectionEntryGroup">
+          <comment>    template_id_831f-3373-456a-8fbc    template_targetId_be38-a066-4f8e-ae54</comment>
+        </entryLink>
+      </entryLinks>
     </entryLink>
     <entryLink id="1928-6d13-b015-a13f" name="Varagyr Wolf Guard Terminator Squad" hidden="false" collective="false" import="false" targetId="9359-61a5-fcdb-c28e" type="selectionEntry">
       <modifiers>
@@ -528,49 +507,6 @@
         </categoryLink>
         <categoryLink id="ce34-de82-4a0d-b5a0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>    template_id_2b20-1a8b-4753-b657</comment>
-        </categoryLink>
-      </categoryLinks>
-    </entryLink>
-    <entryLink id="00cf-817e-bd67-0e6d" name="Command Squad" hidden="false" collective="false" import="false" targetId="0aca-632d-1642-8af9" type="selectionEntry">
-      <comment>    template_id_23b2-54e0-4f09-95e5</comment>
-      <categoryLinks>
-        <categoryLink id="d876-4430-43a4-aa60" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
-          <comment>    template_id_4207-8d8f-4b1a-836b</comment>
-        </categoryLink>
-        <categoryLink id="e0b7-6cd4-437c-86ea" name="Primarch&apos;s Retinue:" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true">
-          <comment>    template_id_2b34-077f-4279-86fb</comment>
-        </categoryLink>
-      </categoryLinks>
-    </entryLink>
-    <entryLink id="d269-cb1c-f9a7-05a9" name="Command Squad, Cataphractii" hidden="false" collective="false" import="false" targetId="1b17-dcd6-0153-3efe" type="selectionEntry">
-      <comment>    template_id_9e78-3e8a-477d-9920</comment>
-      <modifiers>
-        <modifier type="append" field="name" value="(Reserve Only)">
-          <comment>    node_id_421a-b0ab-45e5-b4a7</comment>
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
-              <comment>    node_id_26f8-b35f-4d47-bcf3</comment>
-            </condition>
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="e112-f7bb-40a2-a18b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
-          <comment>    template_id_6577-e0fb-4fda-834e</comment>
-        </categoryLink>
-        <categoryLink id="8788-9654-4d90-aaac" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true">
-          <comment>    template_id_5d59-09bf-4566-b7e1</comment>
-        </categoryLink>
-      </categoryLinks>
-    </entryLink>
-    <entryLink id="1b2e-e05b-a2b3-5362" name="Command Squad, Tartaros " hidden="false" collective="false" import="false" targetId="58d0-a0fd-d20b-cb1b" type="selectionEntry">
-      <comment>    template_id_2029-1f36-432f-a6a1</comment>
-      <categoryLinks>
-        <categoryLink id="516b-14e8-4960-99fe" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
-          <comment>    template_id_aa93-057d-42f6-82d7</comment>
-        </categoryLink>
-        <categoryLink id="d382-ba8f-4059-a25e" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true">
-          <comment>    template_id_403c-4e9c-4af5-84ec</comment>
         </categoryLink>
       </categoryLinks>
     </entryLink>
@@ -2925,6 +2861,7 @@
         <categoryLink id="0c18-6f90-811e-6f2d" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
         <categoryLink id="935c-5280-2665-ebbe" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="94c4-d1c1-31a4-0cce" name="Skirmish Sub-type:" hidden="false" targetId="59a4-7b61-600a-c457" primary="false"/>
+        <categoryLink id="0a97-1c28-655b-6262" name="LoW &amp; Primarchs" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="1c95-89ac-6ffc-46f3" name="Leman Russ" hidden="false" collective="false" import="true" type="model">
@@ -3904,7 +3841,12 @@
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="db05-98c2-3719-2118" name="Cataphractii Terminator Armour" hidden="false" collective="false" import="true" targetId="7c9b-b9ab-9a40-8eb5" type="selectionEntry"/>
+        <entryLink id="db05-98c2-3719-2118" name="Cataphractii Terminator Armour" hidden="false" collective="false" import="true" targetId="7c9b-b9ab-9a40-8eb5" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0406-ea5f-4b03-38a4" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d751-3849-7cec-ea34" type="max"/>
+          </constraints>
+        </entryLink>
       </entryLinks>
       <costs>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
@@ -6548,6 +6490,30 @@
         </entryLink>
         <entryLink id="98fa-f5c5-68da-a472" name="Tartaros Command Squad (Placeholder Points)" hidden="false" collective="false" import="true" targetId="58d0-a0fd-d20b-cb1b" type="selectionEntry"/>
         <entryLink id="3df3-f24f-ade5-13a5" name="Command Squad" hidden="false" collective="false" import="true" targetId="0aca-632d-1642-8af9" type="selectionEntry"/>
+        <entryLink id="7954-2299-eaa4-0299" name="Fenrisian Wolf Pack" hidden="true" collective="false" import="true" targetId="f47e-c270-b62a-4205" type="selectionEntry">
+          <modifiers>
+            <modifier type="set" field="hidden" value="false">
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8d56-d960-0687-7fee" type="greaterThan"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <categoryLinks>
+            <categoryLink id="ca0e-7a88-0585-5f44" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+          </categoryLinks>
+        </entryLink>
+        <entryLink id="8e3b-c79c-8412-5d8e" name="The Wolf-kin of Russ" hidden="true" collective="false" import="true" targetId="3bb9-4637-e963-b36f" type="selectionEntry">
+          <modifiers>
+            <modifier type="set" field="hidden" value="false">
+              <conditions>
+                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c028-dc90-e4b6-8b43" type="instanceOf"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <categoryLinks>
+            <categoryLink id="5fd0-3b08-a584-5ec8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+          </categoryLinks>
+        </entryLink>
       </entryLinks>
     </selectionEntryGroup>
     <selectionEntryGroup id="e6b4-bd3b-1d71-963c" name="Retinue (Caster/Speaker)" hidden="false" collective="false" import="true">

--- a/2022 - LA - Thousand Sons.cat
+++ b/2022 - LA - Thousand Sons.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="abac-8dd1-df65-e253" name="LA -  XV: Thousand Sons" revision="20" battleScribeVersion="2.03" authorName="Arkangelmark5" authorContact="BSData Developers Discord" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="38" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="abac-8dd1-df65-e253" name="LA -  XV: Thousand Sons" revision="21" battleScribeVersion="2.03" authorName="Arkangelmark5" authorContact="BSData Developers Discord" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="41" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="f743-7ff9-a2f3-01c7" name="Exemplary Battles of the Age of Darkness: The Axandria IV Incident" shortName="Axandria IV" publisher="Exemplary Battles of the Age of Darkness: The Axandria IV Incident" publicationDate="9/16/2022" publisherUrl="https://www.warhammer-community.com/wp-content/uploads/2022/09/3mVvZrTG9XOWeVxv.pdf"/>
   </publications>
@@ -79,6 +79,11 @@
         <categoryLink id="9eae-bf6a-4193-af6b" name="New CategoryLink" hidden="false" targetId="ad5f-31db-8bc7-5c46" primary="true"/>
         <categoryLink id="922a-8088-b111-6bad" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
+      <entryLinks>
+        <entryLink id="6ee1-9e29-92e1-7c95" name="Retinue" hidden="false" collective="false" import="true" targetId="39e7-5296-42e0-fe94" type="selectionEntryGroup">
+          <comment>    template_id_fe8f-c701-4ebd-ae76    template_targetId_be38-a066-4f8e-ae54</comment>
+        </entryLink>
+      </entryLinks>
     </entryLink>
     <entryLink id="cefc-c45c-128a-fbce" name="Sekhmet Terminator Cabal" hidden="false" collective="false" import="false" targetId="dda2-bdd0-3ced-b427" type="selectionEntry">
       <modifiers>
@@ -479,49 +484,6 @@
         </categoryLink>
         <categoryLink id="4fd2-aca5-4de8-8946" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>    template_id_2b20-1a8b-4753-b657</comment>
-        </categoryLink>
-      </categoryLinks>
-    </entryLink>
-    <entryLink id="4e9d-586d-9da8-2dba" name="Command Squad" hidden="false" collective="false" import="false" targetId="0aca-632d-1642-8af9" type="selectionEntry">
-      <comment>    template_id_23b2-54e0-4f09-95e5</comment>
-      <categoryLinks>
-        <categoryLink id="a76d-22e2-47bf-b4fb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
-          <comment>    template_id_4207-8d8f-4b1a-836b</comment>
-        </categoryLink>
-        <categoryLink id="c3b1-ab38-4a5a-a952" name="Primarch&apos;s Retinue:" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true">
-          <comment>    template_id_2b34-077f-4279-86fb</comment>
-        </categoryLink>
-      </categoryLinks>
-    </entryLink>
-    <entryLink id="aa8e-3301-ff58-8790" name="Command Squad, Cataphractii" hidden="false" collective="false" import="false" targetId="1b17-dcd6-0153-3efe" type="selectionEntry">
-      <comment>    template_id_9e78-3e8a-477d-9920</comment>
-      <modifiers>
-        <modifier type="append" field="name" value="(Reserve Only)">
-          <comment>    node_id_421a-b0ab-45e5-b4a7</comment>
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
-              <comment>    node_id_26f8-b35f-4d47-bcf3</comment>
-            </condition>
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="0c6d-3fc1-4ce7-8f74" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
-          <comment>    template_id_6577-e0fb-4fda-834e</comment>
-        </categoryLink>
-        <categoryLink id="c292-5e0f-4fba-a530" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true">
-          <comment>    template_id_5d59-09bf-4566-b7e1</comment>
-        </categoryLink>
-      </categoryLinks>
-    </entryLink>
-    <entryLink id="8aa3-f18d-3323-3f4a" name="Command Squad, Tartaros " hidden="false" collective="false" import="false" targetId="58d0-a0fd-d20b-cb1b" type="selectionEntry">
-      <comment>    template_id_2029-1f36-432f-a6a1</comment>
-      <categoryLinks>
-        <categoryLink id="5ba5-a120-4608-8b86" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
-          <comment>    template_id_aa93-057d-42f6-82d7</comment>
-        </categoryLink>
-        <categoryLink id="d277-f37c-4d81-a221" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true">
-          <comment>    template_id_403c-4e9c-4af5-84ec</comment>
         </categoryLink>
       </categoryLinks>
     </entryLink>
@@ -4654,6 +4616,7 @@
         <categoryLink id="45af-d7ac-39f4-2234" name="Primarch:" hidden="false" targetId="ad5f-31db-8bc7-5c46" primary="false"/>
         <categoryLink id="2f4f-2382-f656-0475" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
         <categoryLink id="9f33-3de6-2245-536e" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="930a-fad8-ff6f-4b38" name="LoW &amp; Primarchs (25% Limit)" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="b643-0093-699a-1d81" name="Arch-Sorcerer" page="" hidden="false" collective="false" import="true" type="upgrade">

--- a/2022 - LA - Ultramarines.cat
+++ b/2022 - LA - Ultramarines.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="68ae-9855-b56a-95e6" name="LA -  XIII: Ultramarines" revision="22" battleScribeVersion="2.03" authorName="Mr_Dark, Alphalas, UrsinePatriarch" authorContact="BSData Developers Discord" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="38" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="68ae-9855-b56a-95e6" name="LA -  XIII: Ultramarines" revision="23" battleScribeVersion="2.03" authorName="Mr_Dark, Alphalas, UrsinePatriarch" authorContact="BSData Developers Discord" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="41" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entryLinks>
     <entryLink id="76b3-52d9-a195-2b31" name="  XIII: Ultramarines" hidden="false" collective="false" import="false" targetId="8e0f-3552-8842-f281" type="selectionEntry">
       <constraints>
@@ -119,6 +119,11 @@
         <categoryLink id="4e41-472d-ebca-f3ce" name="New CategoryLink" hidden="false" targetId="ad5f-31db-8bc7-5c46" primary="true"/>
         <categoryLink id="9f58-9b7f-011e-d79c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
+      <entryLinks>
+        <entryLink id="a2d5-2927-b429-ded7" name="Retinue" hidden="false" collective="false" import="true" targetId="f822-e866-658f-a875" type="selectionEntryGroup">
+          <comment>    template_id_fe8f-c701-4ebd-ae76    template_targetId_be38-a066-4f8e-ae54</comment>
+        </entryLink>
+      </entryLinks>
     </entryLink>
     <entryLink id="ea1b-3176-6e4b-8a4d" name="Nemesis Destroyer Squad" hidden="false" collective="false" import="false" targetId="32d1-29a6-9023-142c" type="selectionEntry">
       <modifiers>
@@ -507,49 +512,6 @@
         </categoryLink>
         <categoryLink id="1d4f-58bf-468a-bcbb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>    template_id_2b20-1a8b-4753-b657</comment>
-        </categoryLink>
-      </categoryLinks>
-    </entryLink>
-    <entryLink id="a7bd-0ec8-cefa-e114" name="Command Squad" hidden="false" collective="false" import="false" targetId="0aca-632d-1642-8af9" type="selectionEntry">
-      <comment>    template_id_23b2-54e0-4f09-95e5</comment>
-      <categoryLinks>
-        <categoryLink id="b011-a7f8-4eb3-bf73" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
-          <comment>    template_id_4207-8d8f-4b1a-836b</comment>
-        </categoryLink>
-        <categoryLink id="22bc-0d14-457c-8de1" name="Primarch&apos;s Retinue:" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true">
-          <comment>    template_id_2b34-077f-4279-86fb</comment>
-        </categoryLink>
-      </categoryLinks>
-    </entryLink>
-    <entryLink id="ed53-e716-d08b-ce4b" name="Command Squad, Cataphractii" hidden="false" collective="false" import="false" targetId="1b17-dcd6-0153-3efe" type="selectionEntry">
-      <comment>    template_id_9e78-3e8a-477d-9920</comment>
-      <modifiers>
-        <modifier type="append" field="name" value="(Reserve Only)">
-          <comment>    node_id_421a-b0ab-45e5-b4a7</comment>
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
-              <comment>    node_id_26f8-b35f-4d47-bcf3</comment>
-            </condition>
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="cdb8-c979-4255-94f2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
-          <comment>    template_id_6577-e0fb-4fda-834e</comment>
-        </categoryLink>
-        <categoryLink id="9fad-ddcf-4d45-ba0c" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true">
-          <comment>    template_id_5d59-09bf-4566-b7e1</comment>
-        </categoryLink>
-      </categoryLinks>
-    </entryLink>
-    <entryLink id="9771-30e2-246e-d113" name="Command Squad, Tartaros " hidden="false" collective="false" import="false" targetId="58d0-a0fd-d20b-cb1b" type="selectionEntry">
-      <comment>    template_id_2029-1f36-432f-a6a1</comment>
-      <categoryLinks>
-        <categoryLink id="a65c-f47c-443c-86a9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
-          <comment>    template_id_aa93-057d-42f6-82d7</comment>
-        </categoryLink>
-        <categoryLink id="f281-29b7-4055-8a5f" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true">
-          <comment>    template_id_403c-4e9c-4af5-84ec</comment>
         </categoryLink>
       </categoryLinks>
     </entryLink>
@@ -2890,6 +2852,7 @@
       <categoryLinks>
         <categoryLink id="7543-c1ba-1564-20a8" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
         <categoryLink id="ceea-9434-a82b-934b" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="6121-320d-a6b5-fff5" name="LoW &amp; Primarchs (25% Limit)" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="c91f-d9e6-97eb-9233" name="Roboute Guilliman" hidden="false" collective="false" import="true" type="model">

--- a/2022 - LA - White Scars.cat
+++ b/2022 - LA - White Scars.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="caa9-c50e-8eed-2259" name="LA -   V: White Scars" revision="21" battleScribeVersion="2.03" authorName="Mr_Dark, UrsinePatriarch" authorContact="BSData Developers Discord" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="34" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="caa9-c50e-8eed-2259" name="LA -   V: White Scars" revision="22" battleScribeVersion="2.03" authorName="Mr_Dark, UrsinePatriarch" authorContact="BSData Developers Discord" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="41" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entryLinks>
     <entryLink id="a738-6a11-dfe7-286c" name="   V: White Scars" hidden="false" collective="false" import="false" targetId="e01e-5cdd-e512-8353" type="selectionEntry">
       <constraints>
@@ -94,6 +94,11 @@
         <categoryLink id="cb05-ddea-48b7-7034" name="New CategoryLink" hidden="false" targetId="ad5f-31db-8bc7-5c46" primary="true"/>
         <categoryLink id="f969-cbdf-b170-b089" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
+      <entryLinks>
+        <entryLink id="437c-d5c6-3914-de22" name="Retinue" hidden="false" collective="false" import="true" targetId="f874-317d-d582-11d5" type="selectionEntryGroup">
+          <comment>    template_id_fe8f-c701-4ebd-ae76    template_targetId_be38-a066-4f8e-ae54</comment>
+        </entryLink>
+      </entryLinks>
     </entryLink>
     <entryLink id="2b7a-a60d-fbc4-7000" name="Tsolmon Khan" hidden="false" collective="false" import="false" targetId="54fb-d060-193b-675d" type="selectionEntry">
       <modifiers>
@@ -497,49 +502,6 @@
         </categoryLink>
         <categoryLink id="728d-68de-44ef-b45c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>    template_id_2b20-1a8b-4753-b657</comment>
-        </categoryLink>
-      </categoryLinks>
-    </entryLink>
-    <entryLink id="081e-dd7c-d5a8-972a" name="Command Squad" hidden="false" collective="false" import="false" targetId="0aca-632d-1642-8af9" type="selectionEntry">
-      <comment>    template_id_23b2-54e0-4f09-95e5</comment>
-      <categoryLinks>
-        <categoryLink id="f1f0-3f92-424c-9ec5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
-          <comment>    template_id_4207-8d8f-4b1a-836b</comment>
-        </categoryLink>
-        <categoryLink id="dd80-d15b-4502-ab2e" name="Primarch&apos;s Retinue:" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true">
-          <comment>    template_id_2b34-077f-4279-86fb</comment>
-        </categoryLink>
-      </categoryLinks>
-    </entryLink>
-    <entryLink id="d877-17ec-54b9-3ede" name="Command Squad, Cataphractii" hidden="false" collective="false" import="false" targetId="1b17-dcd6-0153-3efe" type="selectionEntry">
-      <comment>    template_id_9e78-3e8a-477d-9920</comment>
-      <modifiers>
-        <modifier type="append" field="name" value="(Reserve Only)">
-          <comment>    node_id_421a-b0ab-45e5-b4a7</comment>
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
-              <comment>    node_id_26f8-b35f-4d47-bcf3</comment>
-            </condition>
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="baf9-a8e8-49d8-888e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
-          <comment>    template_id_6577-e0fb-4fda-834e</comment>
-        </categoryLink>
-        <categoryLink id="b4de-198c-4985-8b94" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true">
-          <comment>    template_id_5d59-09bf-4566-b7e1</comment>
-        </categoryLink>
-      </categoryLinks>
-    </entryLink>
-    <entryLink id="099b-30ad-6545-a3a1" name="Command Squad, Tartaros " hidden="false" collective="false" import="false" targetId="58d0-a0fd-d20b-cb1b" type="selectionEntry">
-      <comment>    template_id_2029-1f36-432f-a6a1</comment>
-      <categoryLinks>
-        <categoryLink id="36f1-9eb0-4446-bb32" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
-          <comment>    template_id_aa93-057d-42f6-82d7</comment>
-        </categoryLink>
-        <categoryLink id="9517-26ca-451f-b7e7" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true">
-          <comment>    template_id_403c-4e9c-4af5-84ec</comment>
         </categoryLink>
       </categoryLinks>
     </entryLink>
@@ -4757,6 +4719,7 @@
       <categoryLinks>
         <categoryLink id="f5c8-2bd1-122d-be0e" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="afc4-8a34-2caa-f28a" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
+        <categoryLink id="021b-732f-02c0-bcec" name="LoW &amp; Primarchs (25% Limit)" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="7afd-2248-2e02-e05f" name="Sojutsu Pattern Voidbike" publicationId="817a-6288-e016-7469" page="183" hidden="false" collective="false" import="true" type="upgrade">

--- a/2022 - LA - Word Bearers.cat
+++ b/2022 - LA - Word Bearers.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="1df7-bbbc-b70e-6a3f" name="LA -  XVII: Word Bearers" revision="18" battleScribeVersion="2.03" authorName="UrsinePatriarch" authorContact="BSData Developers Discord" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="38" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="1df7-bbbc-b70e-6a3f" name="LA -  XVII: Word Bearers" revision="19" battleScribeVersion="2.03" authorName="UrsinePatriarch" authorContact="BSData Developers Discord" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="41" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entryLinks>
     <entryLink id="70a7-c1ee-bf88-94ab" name="  XVII: Word Bearers" hidden="false" collective="false" import="false" targetId="9dbf-0760-d7ae-f125" type="selectionEntry">
       <constraints>
@@ -49,6 +49,11 @@
         <categoryLink id="bd80-e5c5-9f6b-9c59" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="bc01-7a4b-4350-fc46" name="New CategoryLink" hidden="false" targetId="ad5f-31db-8bc7-5c46" primary="true"/>
       </categoryLinks>
+      <entryLinks>
+        <entryLink id="c07d-7c24-a0ba-e25e" name="Retinue" hidden="false" collective="false" import="true" targetId="bda8-b52d-c914-4ac2" type="selectionEntryGroup">
+          <comment>    template_id_5c5d-d6ce-4ee4-9846    template_targetId_be38-a066-4f8e-ae54</comment>
+        </entryLink>
+      </entryLinks>
     </entryLink>
     <entryLink id="b296-2ad3-1158-0110" name="High Chaplain Erebus" hidden="false" collective="false" import="false" targetId="18c4-d715-caba-b450" type="selectionEntry">
       <modifiers>
@@ -501,49 +506,6 @@
         </categoryLink>
         <categoryLink id="0a43-5492-46ca-8d97" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>    template_id_2b20-1a8b-4753-b657</comment>
-        </categoryLink>
-      </categoryLinks>
-    </entryLink>
-    <entryLink id="749b-143d-7a74-ec6f" name="Command Squad" hidden="false" collective="false" import="false" targetId="0aca-632d-1642-8af9" type="selectionEntry">
-      <comment>    template_id_23b2-54e0-4f09-95e5</comment>
-      <categoryLinks>
-        <categoryLink id="f260-84c4-4970-b80f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
-          <comment>    template_id_4207-8d8f-4b1a-836b</comment>
-        </categoryLink>
-        <categoryLink id="524a-36cb-4e32-8ace" name="Primarch&apos;s Retinue:" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true">
-          <comment>    template_id_2b34-077f-4279-86fb</comment>
-        </categoryLink>
-      </categoryLinks>
-    </entryLink>
-    <entryLink id="a41b-9b79-b4e5-7065" name="Command Squad, Cataphractii" hidden="false" collective="false" import="false" targetId="1b17-dcd6-0153-3efe" type="selectionEntry">
-      <comment>    template_id_9e78-3e8a-477d-9920</comment>
-      <modifiers>
-        <modifier type="append" field="name" value="(Reserve Only)">
-          <comment>    node_id_421a-b0ab-45e5-b4a7</comment>
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
-              <comment>    node_id_26f8-b35f-4d47-bcf3</comment>
-            </condition>
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="a538-6661-45cf-aaa5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
-          <comment>    template_id_6577-e0fb-4fda-834e</comment>
-        </categoryLink>
-        <categoryLink id="b3d2-ffd7-408b-abe7" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true">
-          <comment>    template_id_5d59-09bf-4566-b7e1</comment>
-        </categoryLink>
-      </categoryLinks>
-    </entryLink>
-    <entryLink id="7305-0ef6-b303-8748" name="Command Squad, Tartaros " hidden="false" collective="false" import="false" targetId="58d0-a0fd-d20b-cb1b" type="selectionEntry">
-      <comment>    template_id_2029-1f36-432f-a6a1</comment>
-      <categoryLinks>
-        <categoryLink id="277c-aaa1-4b01-aee4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
-          <comment>    template_id_aa93-057d-42f6-82d7</comment>
-        </categoryLink>
-        <categoryLink id="e196-0c0f-4866-b47b" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true">
-          <comment>    template_id_403c-4e9c-4af5-84ec</comment>
         </categoryLink>
       </categoryLinks>
     </entryLink>
@@ -3215,6 +3177,7 @@ In addition, once per battle, one friendly unit composed entirely of models with
         <categoryLink id="26e2-2438-3fe6-0af3" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="69cd-1ac9-f49d-16e1" name="Psyker:" hidden="false" targetId="6e0c-29ba-a445-8321" primary="false"/>
         <categoryLink id="5a9e-fc41-ec12-1b8f" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
+        <categoryLink id="898e-20ef-648b-3ffc" name="LoW &amp; Primarchs (25% Limit)" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="42b4-8e18-3d94-a2c1" name="Lorgar Choice:" hidden="false" collective="false" import="true" defaultSelectionEntryId="b851-3073-1d88-4c68">

--- a/2022 - LA - World Eaters.cat
+++ b/2022 - LA - World Eaters.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="d901-0eca-48b5-304a" name="LA -  XII: World Eaters" revision="20" battleScribeVersion="2.03" authorName="UrsinePatriarch" authorContact="BSData Developers Discord" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="38" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="d901-0eca-48b5-304a" name="LA -  XII: World Eaters" revision="21" battleScribeVersion="2.03" authorName="UrsinePatriarch" authorContact="BSData Developers Discord" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="41" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entryLinks>
     <entryLink id="d647-fd99-73e0-bd57" name="Angron" hidden="false" collective="false" import="false" targetId="6352-8efa-0cc4-cfa7" type="selectionEntry">
       <modifiers>
@@ -13,6 +13,11 @@
         <categoryLink id="e3d0-6c05-8d56-6e01" name="New CategoryLink" hidden="false" targetId="ad5f-31db-8bc7-5c46" primary="true"/>
         <categoryLink id="b212-8e0c-46ce-f3b9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
+      <entryLinks>
+        <entryLink id="9db7-975d-ce99-6f47" name="Retinue" hidden="false" collective="false" import="true" targetId="a01f-cd9e-bd21-853e" type="selectionEntryGroup">
+          <comment>    template_id_5c5d-d6ce-4ee4-9846    template_targetId_be38-a066-4f8e-ae54</comment>
+        </entryLink>
+      </entryLinks>
     </entryLink>
     <entryLink id="eae7-92b5-7fb5-0667" name="Khârn the Bloody" hidden="false" collective="false" import="false" targetId="e726-7208-d919-a4a1" type="selectionEntry">
       <modifiers>
@@ -2035,17 +2040,6 @@
         </categoryLink>
       </categoryLinks>
     </entryLink>
-    <entryLink id="66b8-529a-be23-5a19" name="Command Squad, Tartaros " hidden="false" collective="false" import="false" targetId="58d0-a0fd-d20b-cb1b" type="selectionEntry">
-      <comment>    template_id_2029-1f36-432f-a6a1</comment>
-      <categoryLinks>
-        <categoryLink id="2ff6-8c3b-4b32-909f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
-          <comment>    template_id_aa93-057d-42f6-82d7</comment>
-        </categoryLink>
-        <categoryLink id="c8bd-7caf-41da-abc5" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true">
-          <comment>    template_id_403c-4e9c-4af5-84ec</comment>
-        </categoryLink>
-      </categoryLinks>
-    </entryLink>
     <entryLink id="2fa4-73e6-82b1-5754" name="Contemptor Dreadnought Talon" hidden="false" collective="false" import="false" targetId="d664-5692-cd41-f9be" type="selectionEntry">
       <comment>    template_id_3aed-0370-44b8-9b06</comment>
       <modifiers>
@@ -2069,38 +2063,6 @@
         </categoryLink>
         <categoryLink id="f92e-2ba6-4038-b567" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
           <comment>    template_id_c5b0-f9ae-468d-924a</comment>
-        </categoryLink>
-      </categoryLinks>
-    </entryLink>
-    <entryLink id="319b-3912-a5ce-cece" name="Command Squad, Cataphractii" hidden="false" collective="false" import="false" targetId="1b17-dcd6-0153-3efe" type="selectionEntry">
-      <comment>    template_id_9e78-3e8a-477d-9920</comment>
-      <modifiers>
-        <modifier type="append" field="name" value="(Reserve Only)">
-          <comment>    node_id_421a-b0ab-45e5-b4a7</comment>
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
-              <comment>    node_id_26f8-b35f-4d47-bcf3</comment>
-            </condition>
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="6f14-114c-45d9-ab62" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
-          <comment>    template_id_6577-e0fb-4fda-834e</comment>
-        </categoryLink>
-        <categoryLink id="2c10-c3f5-43bf-9cbc" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true">
-          <comment>    template_id_5d59-09bf-4566-b7e1</comment>
-        </categoryLink>
-      </categoryLinks>
-    </entryLink>
-    <entryLink id="b2e6-42ba-afdd-367d" name="Command Squad" hidden="false" collective="false" import="false" targetId="0aca-632d-1642-8af9" type="selectionEntry">
-      <comment>    template_id_23b2-54e0-4f09-95e5</comment>
-      <categoryLinks>
-        <categoryLink id="efa5-dc24-419e-a745" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
-          <comment>    template_id_4207-8d8f-4b1a-836b</comment>
-        </categoryLink>
-        <categoryLink id="14a8-d8bb-4070-998b" name="Primarch&apos;s Retinue:" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true">
-          <comment>    template_id_2b34-077f-4279-86fb</comment>
         </categoryLink>
       </categoryLinks>
     </entryLink>
@@ -4461,6 +4423,7 @@
         <categoryLink id="8d69-ffc8-873e-2e42" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
         <categoryLink id="b990-1902-a070-c6d2" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="a500-e244-4c25-e4aa" name="Primarch:" hidden="false" targetId="ad5f-31db-8bc7-5c46" primary="true"/>
+        <categoryLink id="c7ff-aaf0-0516-ca7b" name="LoW &amp; Primarchs (25% Limit)" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="646c-85f5-7755-cc45" name="Gorefather &amp; Gorechild" hidden="false" collective="false" import="true" type="upgrade">

--- a/2022 - LI - Custodes.cat
+++ b/2022 - LI - Custodes.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="2f2b-1f31-c455-1701" name="2022 - LI - Custodes" revision="1" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="34" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="2f2b-1f31-c455-1701" name="2022 - LI - Custodes" revision="2" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="41" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <categoryEntries>
     <categoryEntry id="ccca-a9de-0cd9-f8be" name="Legio Custodes" hidden="false">
       <rules>
@@ -140,6 +140,7 @@ A &quot;Nemesis&apos; unit is defined as any enemy unit that fulfils at least on
         <categoryLink id="177a-2178-fbc5-5e7a" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
         <categoryLink id="1908-8353-a742-a305" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="a334-041e-df7e-a5f5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="f332-e132-2b69-fa50" name="LoW &amp; Primarchs (25% Limit)" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="66f2-559e-5d03-f1dc" name="Knight Acheron" hidden="false" collective="false" import="false" targetId="f971-ef52-5344-0b26" type="selectionEntry">
@@ -147,6 +148,7 @@ A &quot;Nemesis&apos; unit is defined as any enemy unit that fulfils at least on
         <categoryLink id="df5d-1d89-0f5d-043a" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
         <categoryLink id="070d-8796-5859-bf8a" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="24e0-37ee-2fe8-7df9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="ffac-4c05-3088-61c5" name="LoW &amp; Primarchs (25% Limit)" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="2d3b-e347-e9c0-b318" name="Knight Castigator" hidden="false" collective="false" import="false" targetId="0a65-543c-19b2-fd34" type="selectionEntry">
@@ -154,6 +156,7 @@ A &quot;Nemesis&apos; unit is defined as any enemy unit that fulfils at least on
         <categoryLink id="aa6a-c631-a945-1dc6" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
         <categoryLink id="a12a-e57c-bb93-96d0" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="d11e-c7f3-0055-10dd" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="d0a8-cfb2-907e-1b62" name="LoW &amp; Primarchs (25% Limit)" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="d30d-f48e-c154-eb4d" name="Knight Lancer" hidden="false" collective="false" import="false" targetId="8312-7457-e7b6-fd9f" type="selectionEntry">
@@ -161,6 +164,7 @@ A &quot;Nemesis&apos; unit is defined as any enemy unit that fulfils at least on
         <categoryLink id="7392-519a-2bdd-182b" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
         <categoryLink id="b7bc-cfb6-774d-14fc" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="e50a-0102-5ea9-6c14" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="1ccb-d285-c41e-7db8" name="LoW &amp; Primarchs (25% Limit)" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="cead-27b0-4133-77a4" name="Knight Questoris" hidden="false" collective="false" import="false" targetId="3706-a84c-678d-b1c6" type="selectionEntry">
@@ -168,6 +172,7 @@ A &quot;Nemesis&apos; unit is defined as any enemy unit that fulfils at least on
         <categoryLink id="620d-59b2-2500-cd93" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
         <categoryLink id="bbaa-e7aa-2f92-f3cd" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="eecf-bdb7-80bb-63bf" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="fbed-1f04-2d33-57ab" name="LoW &amp; Primarchs (25% Limit)" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="8d2f-d3c7-d533-220a" name="Questoris Acastus Knight Asterius" hidden="false" collective="false" import="false" targetId="7b6b-49ab-d71d-e359" type="selectionEntry">
@@ -175,6 +180,7 @@ A &quot;Nemesis&apos; unit is defined as any enemy unit that fulfils at least on
         <categoryLink id="030a-7a8b-e4e0-30de" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
         <categoryLink id="1fdd-c8b2-1ec0-5887" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="ee38-2ba6-8e9c-5e68" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="21d6-96b9-3bf4-5da5" name="LoW &amp; Primarchs (25% Limit)" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="0e67-1603-5047-ff60" name="Questoris Knight Atrapos" hidden="false" collective="false" import="false" targetId="012b-109f-74d2-2c82" type="selectionEntry">
@@ -182,6 +188,7 @@ A &quot;Nemesis&apos; unit is defined as any enemy unit that fulfils at least on
         <categoryLink id="9258-869d-beef-5bca" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
         <categoryLink id="44e8-2381-6586-f89d" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="eea9-7ef0-c56e-cfc3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="0593-7e5a-0758-f187" name="LoW &amp; Primarchs (25% Limit)" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="9d8c-cf78-12fb-e8e1" name="Questoris Knight Magaera" hidden="false" collective="false" import="false" targetId="6d0e-0d72-d9e2-01d1" type="selectionEntry">
@@ -189,6 +196,7 @@ A &quot;Nemesis&apos; unit is defined as any enemy unit that fulfils at least on
         <categoryLink id="f6fc-91ec-a1e7-a895" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
         <categoryLink id="e3ea-baaa-8f32-fe1d" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="5f97-f53d-3fd2-2b7d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="ca8f-0c45-9494-0e26" name="LoW &amp; Primarchs (25% Limit)" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="3b92-049f-1cd2-69d8" name="Questoris Knight Styrix" hidden="false" collective="false" import="false" targetId="1944-033c-5b7e-a378" type="selectionEntry">
@@ -196,30 +204,35 @@ A &quot;Nemesis&apos; unit is defined as any enemy unit that fulfils at least on
         <categoryLink id="58c1-5517-f3da-c026" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
         <categoryLink id="2d9c-d14f-0753-24e4" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="b06e-c918-f0e5-5900" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="8248-afd6-80da-17cc" name="LoW &amp; Primarchs (25% Limit)" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="9038-4f71-656f-ba8e" name="Reaver Battle Titan" hidden="false" collective="false" import="false" targetId="2dbc-7655-bb05-ab89" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="73b6-a942-df62-c5bc" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
         <categoryLink id="129b-dcec-7dae-c996" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="85c8-338b-b2cb-ccaa" name="LoW &amp; Primarchs (25% Limit)" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="f4ed-f6b1-9ed5-f14a" name="Warbringer Nemesis Titan" hidden="false" collective="false" import="false" targetId="3dd1-77d8-4289-b745" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="76c3-552a-1a9c-a18b" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
         <categoryLink id="0ea7-1dee-7ed7-0921" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="e705-f470-475a-416b" name="LoW &amp; Primarchs (25% Limit)" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="69e0-8b51-758f-e356" name="Warhound Scout Titan" hidden="false" collective="false" import="false" targetId="841c-c2f5-9817-3061" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="96f2-f301-ea09-cfb7" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
         <categoryLink id="7b76-70ab-a016-540a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="1389-49e3-7250-acff" name="LoW &amp; Primarchs (25% Limit)" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="3985-e9aa-92a9-e85b" name="Warlord Battle Titan" hidden="false" collective="false" import="false" targetId="d737-baca-32e7-8da6" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="ea6f-6db3-7d60-2146" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
         <categoryLink id="5ac2-b654-addc-bee3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="37cd-b0fe-4353-43e2" name="LoW &amp; Primarchs (25% Limit)" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="23b7-2bb1-90a6-51b1" name="Clade Assassins (Loyalist)" hidden="false" collective="false" import="false" targetId="7363-5a05-4102-24fa" type="selectionEntry">
@@ -249,6 +262,7 @@ A &quot;Nemesis&apos; unit is defined as any enemy unit that fulfils at least on
       <categoryLinks>
         <categoryLink id="be43-c176-c4d7-d2c2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="4be9-11e6-026c-7213" name="Legio Custodes" hidden="false" targetId="ccca-a9de-0cd9-f8be" primary="false"/>
+        <categoryLink id="7e32-799c-415f-dc07" name="LoW &amp; Primarchs (25% Limit)" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="2e47-1bab-310c-dcc3" name="Constantin Valdor" hidden="false" collective="false" import="true" type="model">
@@ -2037,6 +2051,7 @@ A &quot;Nemesis&apos; unit is defined as any enemy unit that fulfils at least on
         <categoryLink id="eaf9-bfd2-d41b-80a0" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
         <categoryLink id="b453-06ee-ef58-1a22" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="99f6-3c92-eb7b-f901" name="Hover Sub-type" hidden="false" targetId="3a7a-8bb7-b0d3-e2e7" primary="false"/>
+        <categoryLink id="ec81-3363-31bc-e5a0" name="LoW &amp; Primarchs (25% Limit)" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="5d53-f751-9175-f224" name="Orion Assault Dropship" hidden="false" collective="false" import="true" type="model">
@@ -2059,6 +2074,7 @@ A &quot;Nemesis&apos; unit is defined as any enemy unit that fulfils at least on
         <categoryLink id="bbf4-a690-6e1c-3121" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
         <categoryLink id="135a-02cf-2615-e6be" name="Hover Sub-type" hidden="false" targetId="3a7a-8bb7-b0d3-e2e7" primary="false"/>
         <categoryLink id="ca13-8262-92d9-b19f" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
+        <categoryLink id="72bc-cc45-252a-dc99" name="LoW &amp; Primarchs (25% Limit)" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="d071-e0b4-112f-ecc1" name="Ares Gunship" hidden="false" collective="false" import="true" type="model">

--- a/2022 - LI - Sisters Of Silence.cat
+++ b/2022 - LI - Sisters Of Silence.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="585a-5ac2-a233-a6a6" name="2022 - LI - Sisters of Silence" revision="3" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="37" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="585a-5ac2-a233-a6a6" name="2022 - LI - Sisters of Silence" revision="4" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="41" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <categoryEntries>
     <categoryEntry id="b760-8313-847f-1afa" name="Obivion HQ" hidden="false"/>
     <categoryEntry id="a9b6-f66f-e8ee-553e" name="Judgement HQ" hidden="false"/>
@@ -72,6 +72,7 @@
         <categoryLink id="2d3a-d9f0-cba2-a4ca" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
         <categoryLink id="3abd-bb36-47ee-4a7e" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="f2fe-17c4-2c95-5fde" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="4c3d-e5fe-6814-9e20" name="LoW &amp; Primarchs (25% Limit)" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="42a1-0c7b-12f9-5883" name="Knight Acheron" hidden="false" collective="false" import="false" targetId="f971-ef52-5344-0b26" type="selectionEntry">
@@ -79,6 +80,7 @@
         <categoryLink id="2c35-d2e9-3e30-118d" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
         <categoryLink id="df8b-d2c3-9308-ff2f" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="ea3c-57fb-a503-db58" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="26cc-cda0-d5f4-3207" name="LoW &amp; Primarchs (25% Limit)" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="7382-56f0-86b1-6954" name="Knight Castigator" hidden="false" collective="false" import="false" targetId="0a65-543c-19b2-fd34" type="selectionEntry">
@@ -86,6 +88,7 @@
         <categoryLink id="f3a5-0909-f8dc-ec4d" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
         <categoryLink id="b9b9-ef5d-a292-a176" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="6849-6c84-6d08-3275" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="e4c7-fdb4-0148-0f4d" name="LoW &amp; Primarchs (25% Limit)" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="9e14-cce5-0769-35c6" name="Knight Lancer" hidden="false" collective="false" import="false" targetId="8312-7457-e7b6-fd9f" type="selectionEntry">
@@ -93,6 +96,7 @@
         <categoryLink id="7a99-43ec-205d-8169" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
         <categoryLink id="01d1-46c5-8b9e-2495" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="6ec9-50f3-61b0-279d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="826e-5405-1ced-739b" name="LoW &amp; Primarchs (25% Limit)" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="dc86-b629-147c-d1cb" name="Knight Questoris" hidden="false" collective="false" import="false" targetId="3706-a84c-678d-b1c6" type="selectionEntry">
@@ -105,8 +109,9 @@
     <entryLink id="07a7-d29a-d9e8-07a6" name="Questoris Acastus Knight Asterius" hidden="false" collective="false" import="false" targetId="7b6b-49ab-d71d-e359" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="46a8-7c4a-9d13-1809" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="5b5f-4632-0441-15b3" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="d477-223e-7e6e-9017" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="4dc5-c1e5-399f-38e5" name="LoW &amp; Primarchs (25% Limit)" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false"/>
+        <categoryLink id="64a3-5fe7-02ff-5c59" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="78fd-e31c-a02b-0242" name="Questoris Knight Atrapos" hidden="false" collective="false" import="false" targetId="012b-109f-74d2-2c82" type="selectionEntry">
@@ -114,6 +119,7 @@
         <categoryLink id="b52a-07d6-e32d-542c" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
         <categoryLink id="84ce-f8ec-59dc-f658" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="a38a-d1f4-adad-aff0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="6427-b357-fda2-838f" name="LoW &amp; Primarchs (25% Limit)" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="bccb-9569-2f37-6f05" name="Questoris Knight Magaera" hidden="false" collective="false" import="false" targetId="6d0e-0d72-d9e2-01d1" type="selectionEntry">
@@ -121,6 +127,7 @@
         <categoryLink id="c962-f78d-040d-5360" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
         <categoryLink id="696a-33cf-5628-db0c" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="f6b4-6bf5-239e-a45d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="17ca-dfb9-a709-42fe" name="LoW &amp; Primarchs (25% Limit)" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="1912-53d4-1174-0029" name="Questoris Knight Styrix" hidden="false" collective="false" import="false" targetId="1944-033c-5b7e-a378" type="selectionEntry">
@@ -128,30 +135,35 @@
         <categoryLink id="99e2-bdc7-aa5c-7050" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
         <categoryLink id="0a9b-7599-4783-cef6" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="f9ce-9795-a797-e1f6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="455e-3769-a542-30d8" name="LoW &amp; Primarchs (25% Limit)" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="0e81-b9e2-e3df-789b" name="Reaver Battle Titan" hidden="false" collective="false" import="false" targetId="2dbc-7655-bb05-ab89" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="8a3f-35f0-0e26-4fb3" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
         <categoryLink id="b1bb-3035-a95f-0dbe" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="01d3-ba77-90c7-9fe1" name="LoW &amp; Primarchs (25% Limit)" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="3211-947f-53b4-eee8" name="Warbringer Nemesis Titan" hidden="false" collective="false" import="false" targetId="3dd1-77d8-4289-b745" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="3858-aed0-2035-aa5d" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
         <categoryLink id="01ff-ca30-2214-b936" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="f4b5-a664-e971-83ee" name="LoW &amp; Primarchs (25% Limit)" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="c955-ea88-b85e-3692" name="Warhound Scout Titan" hidden="false" collective="false" import="false" targetId="841c-c2f5-9817-3061" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="2a04-4ac3-009a-d8a9" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
         <categoryLink id="3047-66fa-0e32-1067" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="3f85-6f32-9b23-6210" name="LoW &amp; Primarchs (25% Limit)" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="f2b7-8a2e-c4f9-c02e" name="Warlord Battle Titan" hidden="false" collective="false" import="false" targetId="d737-baca-32e7-8da6" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="c4d8-c1b2-7bfc-872f" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
         <categoryLink id="1f0d-cc98-6c11-ade2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="8b9f-cd04-9128-eace" name="LoW &amp; Primarchs (25% Limit)" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="e415-f03a-c52c-c52a" name="Jenetia Krole" hidden="false" collective="false" import="false" targetId="c400-14ac-853c-161f" type="selectionEntry">
@@ -201,7 +213,7 @@
         <categoryLink id="5932-acd1-3f37-9a41" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="6864-9f7f-2c42-f856" name="09) Oblivion Knights" hidden="false" collective="false" import="false" targetId="a104-d140-eb76-5777" type="selectionEntry">
+    <entryLink id="6864-9f7f-2c42-f856" name="Oblivion Knights" hidden="false" collective="false" import="false" targetId="a104-d140-eb76-5777" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="7a69-6a9c-50cc-badd" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="4c2a-14f2-87c7-89f7" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
@@ -213,7 +225,7 @@
         <categoryLink id="e9e5-99f1-02ce-cf35" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="b4c2-8102-8847-b9fc" name="11) Prosecutor Cadre" hidden="false" collective="false" import="false" targetId="a2df-539a-6cc6-92a3" type="selectionEntry">
+    <entryLink id="b4c2-8102-8847-b9fc" name="Prosecutor Cadre" hidden="false" collective="false" import="false" targetId="a2df-539a-6cc6-92a3" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="8dbb-879e-0444-08cd" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="e009-530c-88db-53dc" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
@@ -227,7 +239,7 @@
         <categoryLink id="cb3e-e13b-b028-5fb3" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="708c-1eb1-6145-2023" name="14) Pursuer Cadre" hidden="false" collective="false" import="false" targetId="db4a-57f3-f451-da91" type="selectionEntry">
+    <entryLink id="708c-1eb1-6145-2023" name="Pursuer Cadre" hidden="false" collective="false" import="false" targetId="db4a-57f3-f451-da91" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="a59b-a741-2a64-c857" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="a378-3781-8012-2c8d" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
@@ -251,7 +263,7 @@
         <categoryLink id="55c9-fe02-8204-e098" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="19d2-53d8-3f64-0c48" name="18) Sanctioner Cadre" hidden="false" collective="false" import="false" targetId="11ee-6fbc-3206-1f33" type="selectionEntry">
+    <entryLink id="19d2-53d8-3f64-0c48" name="Sanctioner Cadre" hidden="false" collective="false" import="false" targetId="11ee-6fbc-3206-1f33" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="d6c2-127c-63bf-4bfc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="596b-39de-8064-788d" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>

--- a/2022 - LI - Solar Auxilia.cat
+++ b/2022 - LI - Solar Auxilia.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="6af7-3fee-5bc1-7533" name="2022 - LI - Solar Auxilia" revision="5" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="38" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="6af7-3fee-5bc1-7533" name="2022 - LI - Solar Auxilia" revision="6" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="41" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <categoryEntries>
     <categoryEntry id="19f3-8727-02db-3ce5" name="Static Artillery" hidden="false">
       <rules>
@@ -300,6 +300,7 @@
         <categoryLink id="a00e-e43d-8775-5741" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
         <categoryLink id="3d31-c17e-cc6b-cff0" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="d89c-7b14-de0e-edc2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="a06f-66b7-d26d-8de6" name="LoW &amp; Primarchs (25% Limit)" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="f2fc-2d62-06b1-0bd9" name="Knight Acheron" hidden="false" collective="false" import="false" targetId="f971-ef52-5344-0b26" type="selectionEntry">
@@ -307,6 +308,7 @@
         <categoryLink id="bf1b-17f4-0dcd-85eb" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
         <categoryLink id="3752-b300-8e50-b617" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="1341-ba40-eabb-7f67" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="34b7-947e-f65f-fd9f" name="LoW &amp; Primarchs (25% Limit)" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="95c6-62c9-c97c-50c1" name="Knight Castigator" hidden="false" collective="false" import="false" targetId="0a65-543c-19b2-fd34" type="selectionEntry">
@@ -314,6 +316,7 @@
         <categoryLink id="38c8-b6f2-d4b1-f3dd" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
         <categoryLink id="0a5d-36a9-b471-a7cd" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="03d2-e4ee-d242-c1c2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="1833-b2b5-ef7f-07fd" name="LoW &amp; Primarchs (25% Limit)" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="c942-b9c6-1bad-982f" name="Knight Lancer" hidden="false" collective="false" import="false" targetId="8312-7457-e7b6-fd9f" type="selectionEntry">
@@ -321,6 +324,7 @@
         <categoryLink id="85c9-7460-690f-c7d9" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
         <categoryLink id="0fad-480a-617b-d66d" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="1eb1-31ee-2c61-eec2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="3fb3-3f29-2a0d-bb72" name="LoW &amp; Primarchs (25% Limit)" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="4014-99e7-42bb-7eb9" name="Knight Questoris" hidden="false" collective="false" import="false" targetId="3706-a84c-678d-b1c6" type="selectionEntry">
@@ -328,6 +332,7 @@
         <categoryLink id="d536-77e1-8313-214b" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
         <categoryLink id="ee13-a61d-db24-afd2" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="3df0-789e-7624-ff65" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="4d83-540a-c76b-7875" name="LoW &amp; Primarchs (25% Limit)" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="e8a1-a06b-3d6b-913a" name="Questoris Acastus Knight Asterius" hidden="false" collective="false" import="false" targetId="7b6b-49ab-d71d-e359" type="selectionEntry">
@@ -335,6 +340,7 @@
         <categoryLink id="08a9-df08-717a-eaf1" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
         <categoryLink id="c381-0179-4ffb-ec8c" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="a09d-faa7-c0b7-08c0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="2987-b01d-d5c4-803d" name="LoW &amp; Primarchs (25% Limit)" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="db05-1162-433f-f0fc" name="Questoris Knight Atrapos" hidden="false" collective="false" import="false" targetId="012b-109f-74d2-2c82" type="selectionEntry">
@@ -342,6 +348,7 @@
         <categoryLink id="2afc-cea9-3a22-f382" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
         <categoryLink id="4f93-63a2-e2ab-cf46" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="9531-6419-fa00-297b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="697a-d869-feba-26ac" name="LoW &amp; Primarchs (25% Limit)" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="0078-1063-35e3-9b9d" name="Questoris Knight Magaera" hidden="false" collective="false" import="false" targetId="6d0e-0d72-d9e2-01d1" type="selectionEntry">
@@ -349,6 +356,7 @@
         <categoryLink id="52a8-b0f4-48eb-b13e" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
         <categoryLink id="2008-3c5f-63d7-4a60" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="e023-3ed2-c7f9-0cc0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="5eed-5c8b-b4fe-5927" name="LoW &amp; Primarchs (25% Limit)" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="9512-add2-8da1-aba1" name="Questoris Knight Styrix" hidden="false" collective="false" import="false" targetId="1944-033c-5b7e-a378" type="selectionEntry">
@@ -356,30 +364,35 @@
         <categoryLink id="20ce-7d70-c5ca-557e" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
         <categoryLink id="0018-c234-636b-00c0" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="2fa4-563f-2fca-479d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="1509-7fa9-19b1-0e71" name="LoW &amp; Primarchs (25% Limit)" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="e4f2-15bb-89d6-26b8" name="Reaver Battle Titan" hidden="false" collective="false" import="false" targetId="2dbc-7655-bb05-ab89" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="4de0-27c1-eb32-152a" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
         <categoryLink id="2bac-92de-8275-56ce" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="17fa-ab60-0e93-c7ae" name="LoW &amp; Primarchs (25% Limit)" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="2d77-c86d-81b1-15df" name="Warbringer Nemesis Titan" hidden="false" collective="false" import="false" targetId="3dd1-77d8-4289-b745" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="e5d2-6d45-ae74-2ebf" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
         <categoryLink id="f4ee-9245-f5b1-cb2e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="4eb6-f302-bee4-2f10" name="LoW &amp; Primarchs (25% Limit)" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="0782-c0f7-2e82-08b0" name="Warhound Scout Titan" hidden="false" collective="false" import="false" targetId="841c-c2f5-9817-3061" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="fff3-c172-42a5-3b5a" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
         <categoryLink id="8dee-2bb1-d77b-aa6c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="c0c7-0069-70fa-0138" name="LoW &amp; Primarchs (25% Limit)" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="8e9a-a183-85df-59e2" name="Warlord Battle Titan" hidden="false" collective="false" import="false" targetId="d737-baca-32e7-8da6" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="5f2a-bb9e-2f82-fab4" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
         <categoryLink id="4b26-1e26-0cc5-0ea6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="b233-2e02-4165-b295" name="LoW &amp; Primarchs (25% Limit)" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="c6aa-1923-1ee3-1647" name="Clade Assassins (Loyalist)" hidden="false" collective="false" import="false" targetId="7363-5a05-4102-24fa" type="selectionEntry">
@@ -505,7 +518,7 @@
         <categoryLink id="66cb-a717-bf71-5bb8" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="cf45-ae22-f4b8-2d90" name="Solar Auxilia Baneblade" hidden="true" collective="false" import="false" targetId="1c10-5772-2e27-1e51" type="selectionEntry">
+    <entryLink id="cf45-ae22-f4b8-2d90" name="Baneblade" hidden="true" collective="false" import="false" targetId="1c10-5772-2e27-1e51" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
@@ -565,7 +578,7 @@
         <categoryLink id="cef8-739c-ccfe-3326" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="c908-965a-0e07-8eda" name="Solar Auxilia Shadowsword" hidden="true" collective="false" import="false" targetId="4713-c9ee-2c57-9457" type="selectionEntry">
+    <entryLink id="c908-965a-0e07-8eda" name="Shadowsword" hidden="true" collective="false" import="false" targetId="4713-c9ee-2c57-9457" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
@@ -595,7 +608,7 @@
         <categoryLink id="8684-456f-2370-86ef" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="0faa-98f3-251b-367c" name="Solar Auxilia Praetor Armoured Assault Launcher" hidden="true" collective="false" import="false" targetId="2d13-ea6e-e48d-f352" type="selectionEntry">
+    <entryLink id="0faa-98f3-251b-367c" name="Praetor Armoured Assault Launcher" hidden="true" collective="false" import="false" targetId="2d13-ea6e-e48d-f352" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
@@ -640,7 +653,7 @@
         <categoryLink id="02e0-513b-8a00-470c" name="New CategoryLink" hidden="false" targetId="a24f-12d8-36c1-f477" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="0741-744f-034a-1221" name="Solar Auxilia Macharius Heavy Tank Squadron" hidden="true" collective="false" import="false" targetId="e59c-1b65-8de1-4490" type="selectionEntry">
+    <entryLink id="0741-744f-034a-1221" name="Macharius Heavy Tank Squadron" hidden="true" collective="false" import="false" targetId="e59c-1b65-8de1-4490" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
@@ -8393,6 +8406,9 @@ Once assigned to a unit, the Auxilia Medicae is considered part of that unit and
       </profiles>
       <categoryLinks>
         <categoryLink id="8103-298f-c2e8-b5b3" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+        <categoryLink id="9141-41d3-5ce3-3abc" name="LoW &amp; Primarchs (25% Limit)" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false"/>
+        <categoryLink id="4e8f-271c-2fd5-7f27" name="Super-heavy Sub-type:" hidden="false" targetId="7381-1130-ca6e-1806" primary="false"/>
+        <categoryLink id="151f-d2f4-bd4f-ee41" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="66d9-d28d-067b-177e" name="May exchange all of its Hull (Right) Mounted and Hull (Left)Mounted multi-lasers for the following:" hidden="false" collective="false" import="true" defaultSelectionEntryId="2aeb-24b1-5925-0d54">
@@ -9744,6 +9760,7 @@ If a Weapon Destroyed result is repaired, that weapon may not be used to attack 
       <categoryLinks>
         <categoryLink id="3cf6-cfb2-9cec-19aa" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="0894-5a2a-e649-9e11" name="Super-heavy" hidden="false" targetId="7381-1130-ca6e-1806" primary="false"/>
+        <categoryLink id="ef5d-7e4a-3f44-2c74" name="LoW &amp; Primarchs (25% Limit)" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="83fd-3959-0a1c-1815" name="Macharius Heavy Tank" hidden="false" collective="false" import="true" type="model">
@@ -9962,6 +9979,7 @@ If a Weapon Destroyed result is repaired, that weapon may not be used to attack 
         <categoryLink id="de09-1df4-8669-471a" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="ad54-ca78-7edc-a179" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
         <categoryLink id="69ce-1545-0115-6b4c" name="Super-heavy" hidden="false" targetId="7381-1130-ca6e-1806" primary="false"/>
+        <categoryLink id="d531-f3df-e669-2625" name="LoW &amp; Primarchs (25% Limit)" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="1b61-1ce9-fe0e-4085" name="1) Pintle mounted Weapon:" hidden="false" collective="false" import="true">
@@ -10105,6 +10123,7 @@ If a Weapon Destroyed result is repaired, that weapon may not be used to attack 
         <categoryLink id="19d7-d7c4-347e-ab03" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="f144-30f4-a71a-1ae2" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
         <categoryLink id="6efd-84a8-f464-cf15" name="Super-heavy" hidden="false" targetId="7381-1130-ca6e-1806" primary="false"/>
+        <categoryLink id="f0e7-a326-6e7e-379a" name="LoW &amp; Primarchs (25% Limit)" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="3b42-2548-b05e-4265" name="May take:" hidden="false" collective="false" import="true">
@@ -10278,6 +10297,7 @@ If a Weapon Destroyed result is repaired, that weapon may not be used to attack 
         <categoryLink id="f58f-1579-7361-c081" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="e4ad-1c54-0ec3-d2e9" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
         <categoryLink id="037c-b14a-bd4d-4165" name="Super-heavy" hidden="false" targetId="7381-1130-ca6e-1806" primary="false"/>
+        <categoryLink id="ab12-4d4c-d43a-85ae" name="LoW &amp; Primarchs (25% Limit)" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="7c5d-6384-b8e0-8613" name="1) Pintle mounted Weapon:" hidden="false" collective="false" import="true">
@@ -10431,6 +10451,7 @@ If a Weapon Destroyed result is repaired, that weapon may not be used to attack 
         <categoryLink id="aed3-b3e9-451c-a98a" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
         <categoryLink id="ec0b-0bbd-f8e9-c06a" name="Super-heavy" hidden="false" targetId="7381-1130-ca6e-1806" primary="false"/>
         <categoryLink id="26c6-dd68-7098-6b24" name="Transport" hidden="false" targetId="7b0a-a743-a8da-3a39" primary="false"/>
+        <categoryLink id="a37a-866c-74a7-ff6e" name="LoW &amp; Primarchs (25% Limit)" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="473c-bcf8-e0b8-7ece" name="1) Pintle mounted Weapon:" hidden="false" collective="false" import="true">
@@ -10574,6 +10595,7 @@ If a Weapon Destroyed result is repaired, that weapon may not be used to attack 
         <categoryLink id="68fc-594f-9744-6ddc" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="4084-88dc-f96d-60c9" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
         <categoryLink id="2f9c-4226-7b42-7315" name="Super-heavy" hidden="false" targetId="7381-1130-ca6e-1806" primary="false"/>
+        <categoryLink id="73f8-ec6c-d95f-2590" name="LoW &amp; Primarchs (25% Limit)" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="192f-66b3-4c66-c21b" name="1) Pintle mounted Weapon:" hidden="false" collective="false" import="true">
@@ -10725,6 +10747,7 @@ If a Weapon Destroyed result is repaired, that weapon may not be used to attack 
         <categoryLink id="bc40-3790-05be-92af" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="8b0f-4a5b-5b79-4889" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
         <categoryLink id="64f9-5968-2846-c2dd" name="Super-heavy" hidden="false" targetId="7381-1130-ca6e-1806" primary="false"/>
+        <categoryLink id="430e-9dcd-57a4-c158" name="LoW &amp; Primarchs (25% Limit)" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="1d42-5751-b802-b0a0" name="3) Pintle mounted Weapon:" hidden="false" collective="false" import="true">
@@ -10888,6 +10911,7 @@ If a Weapon Destroyed result is repaired, that weapon may not be used to attack 
         <categoryLink id="b18b-0269-2997-701b" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
         <categoryLink id="292c-2ba6-1ffe-edf3" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="68b3-c9fb-8111-8174" name="Super-heavy" hidden="false" targetId="7381-1130-ca6e-1806" primary="false"/>
+        <categoryLink id="ee2c-9ed9-6d30-f2f7" name="LoW &amp; Primarchs (25% Limit)" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="aae7-cba1-91ac-8636" name="Praetor Launcher" hidden="false" collective="false" import="true" type="model">
@@ -10989,6 +11013,7 @@ If a Weapon Destroyed result is repaired, that weapon may not be used to attack 
         <categoryLink id="97e6-b9cf-c1f9-798c" name="Super-heavy" hidden="false" targetId="7381-1130-ca6e-1806" primary="false"/>
         <categoryLink id="bd8e-77b3-327b-2d75" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="5d63-23f1-06ba-ecf7" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+        <categoryLink id="3963-6e6a-dbb0-a0f5" name="LoW &amp; Primarchs (25% Limit)" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="6040-4644-dccc-0233" name="Crassus Armoured Assault Transport" hidden="false" collective="false" import="true" type="model">

--- a/2022 - Legiones Astartes.cat
+++ b/2022 - Legiones Astartes.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="6393-649c-7213-a327" name="(HH V2) Legions Astartes" revision="92" battleScribeVersion="2.03" authorName="Various" authorUrl="https://github.com/BSData/horus-heresy" library="true" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="40" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="6393-649c-7213-a327" name="(HH V2) Legions Astartes" revision="92" battleScribeVersion="2.03" authorName="Various" authorUrl="https://github.com/BSData/horus-heresy" library="true" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="41" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <profileTypes>
     <profileType id="7002-2f9a-59c4-2742" name="Prosperine Arcana">
       <characteristicTypes>
@@ -198,7 +198,6 @@
       <categoryLinks>
         <categoryLink id="c61f-81cf-227b-ebbc" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
         <categoryLink id="a772-d554-3ea0-899d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="95f7-ea61-6038-2b24" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="0ec9-1be3-366c-c5cd" name="Legion Marauder Destroyer" hidden="true" collective="false" import="true" targetId="cf51-6d23-8764-af94" type="selectionEntry">
@@ -219,7 +218,6 @@
       <categoryLinks>
         <categoryLink id="80c8-b49a-77fe-bf48" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
         <categoryLink id="02b6-8a03-5503-88b0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="d3f4-3596-d149-f9b3" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="296b-c0ab-14dc-ab15" name="Thunderhawk Transporter" hidden="true" collective="false" import="true" targetId="5b94-a916-9864-8d15" type="selectionEntry">
@@ -240,7 +238,6 @@
       <categoryLinks>
         <categoryLink id="a85c-37b5-4e04-a592" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
         <categoryLink id="5c22-fb95-78b3-0683" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="4889-3943-d0cf-7221" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="5a76-4f7c-531e-5722" name="Legion Crassus Armoured Assault Transport" hidden="true" collective="false" import="true" targetId="5b2b-3e3f-3b2c-0a8b" type="selectionEntry">
@@ -263,7 +260,6 @@
       <categoryLinks>
         <categoryLink id="727e-3e4f-91cb-2703" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
         <categoryLink id="7037-b93a-127c-3a9d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="e88e-44e5-cd10-648b" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="9867-ffe3-186c-8334" name="Legion Macharius Omega Heavy Tank" hidden="true" collective="false" import="true" targetId="6865-9d88-95dc-2d3f" type="selectionEntry">
@@ -286,7 +282,6 @@
       <categoryLinks>
         <categoryLink id="8bb4-a24c-9326-02c9" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
         <categoryLink id="a44e-6843-7671-8f79" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="f26f-3df8-de63-a343" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="5baf-6610-812e-1d2b" name="Legion Praetor Armoured Assault Launcher" hidden="true" collective="false" import="true" targetId="4a3e-181e-993d-948f" type="selectionEntry">
@@ -309,7 +304,6 @@
       <categoryLinks>
         <categoryLink id="7eae-6825-eb9b-8303" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
         <categoryLink id="2754-2933-dacc-17e2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="9382-3d87-b98d-b2a8" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="9202-e7d5-0b22-dfd6" name="Acastus Knight Porphyrion" hidden="false" collective="false" import="true" targetId="8cb2-7235-fc34-9983" type="selectionEntry">
@@ -336,6 +330,7 @@
         <categoryLink id="2f91-acc5-328b-d376" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
         <categoryLink id="85b9-32a5-cdc7-2254" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="75cf-91f2-6b49-68e8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="68b6-af15-4aad-71ae" name="LoW &amp; Primarchs (25% Limit)" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="0576-0899-65d2-c137" name="Knight Castigator" hidden="false" collective="false" import="true" targetId="0a65-543c-19b2-fd34" type="selectionEntry">
@@ -362,6 +357,7 @@
         <categoryLink id="4845-9c77-b4c8-0b5b" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
         <categoryLink id="c42b-c753-f3c5-28b3" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="957b-1134-2f60-f914" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="d8d7-3dff-45b1-1a7e" name="LoW &amp; Primarchs (25% Limit)" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="2045-e4c8-18cb-fec5" name="Knight Acheron" hidden="false" collective="false" import="true" targetId="f971-ef52-5344-0b26" type="selectionEntry">
@@ -388,6 +384,7 @@
         <categoryLink id="73f6-f624-9bb9-4b8e" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
         <categoryLink id="4097-4a32-f677-282b" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="9cbc-0c5e-6bfb-6345" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="d56d-4e05-2864-02e7" name="LoW &amp; Primarchs (25% Limit)" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="5b5d-80cd-a104-0fc5" name="Knight Lancer" hidden="false" collective="false" import="true" targetId="8312-7457-e7b6-fd9f" type="selectionEntry">
@@ -414,6 +411,7 @@
         <categoryLink id="a6f6-5a43-3e72-d5b6" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
         <categoryLink id="dfb3-d250-61d6-8e7a" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="b573-9439-b450-c205" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="01d1-13cc-d97a-7aa6" name="LoW &amp; Primarchs (25% Limit)" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="4802-c63f-0d36-6024" name="Knight Questoris" hidden="false" collective="false" import="true" targetId="3706-a84c-678d-b1c6" type="selectionEntry">
@@ -440,6 +438,7 @@
         <categoryLink id="e8b5-e501-541a-3432" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
         <categoryLink id="549d-505b-cab5-9bed" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="d5d5-248c-0d5a-d8d5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="dce0-ea4b-e0bd-6281" name="LoW &amp; Primarchs (25% Limit)" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="61f9-83c1-5e0c-57a3" name="Questoris Acastus Knight Asterius" hidden="false" collective="false" import="true" targetId="7b6b-49ab-d71d-e359" type="selectionEntry">
@@ -466,6 +465,7 @@
         <categoryLink id="3ada-bf78-4587-c8ab" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
         <categoryLink id="ca39-c583-346f-36ef" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="e956-ec9f-b036-205a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="4707-7e01-53da-382b" name="LoW &amp; Primarchs (25% Limit)" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="c5f4-48be-3898-287c" name="Questoris Knight Atrapos" hidden="false" collective="false" import="true" targetId="012b-109f-74d2-2c82" type="selectionEntry">
@@ -492,6 +492,7 @@
         <categoryLink id="6849-516b-9701-6e33" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
         <categoryLink id="0c77-157c-b60f-fc74" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="1eba-e0c8-9fbf-bcea" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="983b-3f87-a1ec-c84e" name="LoW &amp; Primarchs (25% Limit)" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="87ef-faea-626b-d0db" name="Questoris Knight Magaera" hidden="false" collective="false" import="true" targetId="6d0e-0d72-d9e2-01d1" type="selectionEntry">
@@ -518,6 +519,7 @@
         <categoryLink id="f076-93f0-91f1-277a" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
         <categoryLink id="ce1c-94ae-f999-89bd" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="16e7-9772-168a-6fb0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="1fb0-6b41-bdd5-7085" name="LoW &amp; Primarchs (25% Limit)" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="b2a3-fa68-b857-ac2a" name="Questoris Knight Styrix" hidden="false" collective="false" import="true" targetId="1944-033c-5b7e-a378" type="selectionEntry">
@@ -544,6 +546,7 @@
         <categoryLink id="a7f9-aa17-ef6d-061b" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
         <categoryLink id="340d-c79e-667f-fc72" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="ad7a-b69f-ae47-4f59" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="3c60-8f10-cdd5-fd21" name="LoW &amp; Primarchs (25% Limit)" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="38f5-e9ae-90cc-3133" name="Reaver Battle Titan" hidden="false" collective="false" import="true" targetId="2dbc-7655-bb05-ab89" type="selectionEntry">
@@ -569,6 +572,7 @@
       <categoryLinks>
         <categoryLink id="e768-2478-84ab-b7f7" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
         <categoryLink id="0f23-0882-0830-e60a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="8a65-f092-96a1-63a7" name="LoW &amp; Primarchs (25% Limit)" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="5423-f6d0-6185-5562" name="Warbringer Nemesis Titan" hidden="false" collective="false" import="true" targetId="3dd1-77d8-4289-b745" type="selectionEntry">
@@ -594,6 +598,7 @@
       <categoryLinks>
         <categoryLink id="6267-6e16-bae5-ba15" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
         <categoryLink id="6172-94c2-325a-67a6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="16a9-90f4-8651-0f7a" name="LoW &amp; Primarchs (25% Limit)" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="6d83-0817-81d5-2f89" name="Warhound Scout Titan" hidden="false" collective="false" import="true" targetId="841c-c2f5-9817-3061" type="selectionEntry">
@@ -619,6 +624,7 @@
       <categoryLinks>
         <categoryLink id="39c6-006d-c8de-0cee" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
         <categoryLink id="7b8e-7e2a-8b09-730b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="d363-61e7-09c5-c0f7" name="LoW &amp; Primarchs (25% Limit)" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="f940-5637-97dc-dd01" name="Warlord Battle Titan" hidden="false" collective="false" import="true" targetId="d737-baca-32e7-8da6" type="selectionEntry">
@@ -644,6 +650,7 @@
       <categoryLinks>
         <categoryLink id="6c72-5e9f-a028-aa94" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
         <categoryLink id="b656-a898-3480-f03b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="053e-817d-d495-181d" name="LoW &amp; Primarchs (25% Limit)" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="bc6c-85f6-1b67-4b4e" name="Clade Assassins (Loyalist)" hidden="false" collective="false" import="true" targetId="7363-5a05-4102-24fa" type="selectionEntry">
@@ -29113,6 +29120,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
         <categoryLink id="1dad-6367-e309-77a9" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="47a9-ca6e-de96-6c52" name="Bombard Sub-type:" hidden="false" targetId="d5df-57ac-8f3c-097b" primary="false"/>
         <categoryLink id="a5dd-5af9-477e-951a" name="Reinforced Sub-type:" hidden="false" targetId="9b0d-738c-10e4-4ec1" primary="false"/>
+        <categoryLink id="f45f-5b3d-6bf2-22d8" name="LoW &amp; Primarchs (25% Limit)" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="8547-be6e-bfb0-60b3" name="Cerberus" hidden="false" collective="false" import="true" type="model">
@@ -29461,6 +29469,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
         <categoryLink id="85a4-3c3e-2fc2-7234" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="1179-4754-4028-55a0" name="Bombard Sub-type:" hidden="false" targetId="d5df-57ac-8f3c-097b" primary="false"/>
         <categoryLink id="1263-9e7a-f3d5-ce52" name="Reinforced Sub-type:" hidden="false" targetId="9b0d-738c-10e4-4ec1" primary="false"/>
+        <categoryLink id="16d7-a9d4-745d-5494" name="LoW &amp; Primarchs (25% Limit)" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="f16c-c9da-4006-35ae" name="Typhon" hidden="false" collective="false" import="true" type="model">
@@ -29778,6 +29787,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
         <categoryLink id="ae99-700e-db56-fc27" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="7852-636a-6edc-9978" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
         <categoryLink id="5a6b-0473-e1ba-1a6e" name="Super-heavy" hidden="false" targetId="7381-1130-ca6e-1806" primary="false"/>
+        <categoryLink id="6f6c-c6ed-c35a-5b88" name="LoW &amp; Primarchs (25% Limit)" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="43d4-8f65-a666-b6e3" name="May take:" hidden="false" collective="false" import="true">
@@ -30073,6 +30083,8 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
         <categoryLink id="ea22-733c-649a-1077" name="Hover Sub-type" hidden="false" targetId="3a7a-8bb7-b0d3-e2e7" primary="false"/>
         <categoryLink id="d4f2-aa4f-0399-dcfe" name="Lumbering" hidden="false" targetId="7f9b-c5ed-7edb-02dc" primary="false"/>
         <categoryLink id="0b61-29b5-1887-5b88" name="Transport" hidden="false" targetId="7b0a-a743-a8da-3a39" primary="false"/>
+        <categoryLink id="f41b-c167-7b99-f714" name="LoW &amp; Primarchs (25% Limit)" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false"/>
+        <categoryLink id="24c1-11a5-435a-868e" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="fb46-e14c-0a38-320b" name="1) Main Gun Options" hidden="false" collective="false" import="true" defaultSelectionEntryId="8df2-f6fb-f564-4c74">
@@ -30252,6 +30264,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
         <categoryLink id="336d-7ecd-0887-bf93" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="ffc6-c6ff-9abc-d9bc" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="a55f-5ffd-bc2c-6409" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+        <categoryLink id="4ccf-c173-3edf-35b5" name="LoW &amp; Primarchs (25% Limit)" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="2dbd-13c2-ed9e-c395" name="1) Hull Weapon Options" hidden="false" collective="false" import="true" defaultSelectionEntryId="f831-4ab5-a7ea-f1d5">
@@ -30569,6 +30582,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
         <categoryLink id="231c-19d1-0097-c872" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
         <categoryLink id="35a4-7e73-f5a8-c7a8" name="Super-heavy" hidden="false" targetId="7381-1130-ca6e-1806" primary="false"/>
         <categoryLink id="9168-20ed-1639-2373" name="Transport" hidden="false" targetId="7b0a-a743-a8da-3a39" primary="false"/>
+        <categoryLink id="b8ed-38b8-dd5c-1bab" name="LoW &amp; Primarchs (25% Limit)" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="c830-8055-5fad-7768" name="1) Turret Mounted Equipment" hidden="false" collective="false" import="true" defaultSelectionEntryId="17eb-0577-023d-3735">
@@ -30751,6 +30765,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
         <categoryLink id="f2ce-ce8c-5b2a-e655" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="494f-55cb-75d9-3608" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
         <categoryLink id="4ab6-5b75-adb5-7c72" name="Super-heavy" hidden="false" targetId="7381-1130-ca6e-1806" primary="false"/>
+        <categoryLink id="f5e0-234e-55ab-14ed" name="LoW &amp; Primarchs (25% Limit)" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="3f48-e7eb-114c-a774" name="4) May take:" hidden="false" collective="false" import="true">
@@ -31039,6 +31054,8 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
         <categoryLink id="b8c4-671b-9a5f-eb6b" name="Hover Sub-type" hidden="false" targetId="3a7a-8bb7-b0d3-e2e7" primary="false"/>
         <categoryLink id="853a-8e69-b900-48c9" name="Lumbering" hidden="false" targetId="7f9b-c5ed-7edb-02dc" primary="false"/>
         <categoryLink id="4d3e-f11e-f213-f158" name="Transport" hidden="false" targetId="7b0a-a743-a8da-3a39" primary="false"/>
+        <categoryLink id="0df5-43ad-fab1-198c" name="LoW &amp; Primarchs (25% Limit)" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false"/>
+        <categoryLink id="8108-a51b-2d5e-9506" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="110f-5a27-f7d4-0302" name="1) Left Side Weapon Options" hidden="false" collective="false" import="true" defaultSelectionEntryId="a0f9-7e15-88f2-eef0">
@@ -31227,6 +31244,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
         <categoryLink id="0163-3f12-80b9-2221" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="eb3d-4f92-8ccb-b662" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
         <categoryLink id="8bbc-a8f4-a077-ea2b" name="Super-heavy Sub-type:" hidden="false" targetId="7381-1130-ca6e-1806" primary="false"/>
+        <categoryLink id="0a7c-9ab5-e4e7-1571" name="LoW &amp; Primarchs (25% Limit)" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="985f-caea-1e37-8ac2" name="May take:" hidden="false" collective="false" import="true">
@@ -35671,6 +35689,7 @@ containing the model that failed its Check. If the Psyker survives Perils of the
         <categoryLink id="c519-b6ff-7f40-4d69" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="7f7a-19de-90a2-4c95" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
         <categoryLink id="f34e-8d5e-83b1-5099" name="Super-heavy Sub-type:" hidden="false" targetId="7381-1130-ca6e-1806" primary="false"/>
+        <categoryLink id="9623-ae88-7095-08d9" name="LoW &amp; Primarchs (25% Limit)" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="0bf0-559f-72b9-cfa9" name="4) May take:" hidden="false" collective="false" import="true">
@@ -35920,6 +35939,7 @@ containing the model that failed its Check. If the Psyker survives Perils of the
         <categoryLink id="5f4a-4ffd-a8a7-2c3e" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="9823-f559-b33c-66e6" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
         <categoryLink id="b8d4-910c-af0a-2176" name="Super-heavy Sub-type:" hidden="false" targetId="7381-1130-ca6e-1806" primary="false"/>
+        <categoryLink id="79a3-ee95-59b6-5776" name="LoW &amp; Primarchs (25% Limit)" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="123c-539a-dca4-5fb2" name="May take:" hidden="false" collective="false" import="true">
@@ -36187,6 +36207,7 @@ containing the model that failed its Check. If the Psyker survives Perils of the
         <categoryLink id="2c58-a573-56d4-ec73" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="d6e3-8a15-0d26-6d93" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
         <categoryLink id="d7ff-cbea-16ee-7503" name="Super-heavy Sub-type:" hidden="false" targetId="7381-1130-ca6e-1806" primary="false"/>
+        <categoryLink id="2fb4-30b7-f4cc-2e9e" name="LoW &amp; Primarchs (25% Limit)" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="6534-8d4a-6593-2806" name="May take:" hidden="false" collective="false" import="true">
@@ -36392,6 +36413,7 @@ containing the model that failed its Check. If the Psyker survives Perils of the
         <categoryLink id="40ad-88a5-9830-de8c" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
         <categoryLink id="b90d-8751-2096-6845" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="bfb6-7063-ccfd-5417" name="Super-heavy Sub-type:" hidden="false" targetId="7381-1130-ca6e-1806" primary="false"/>
+        <categoryLink id="c091-695c-02c6-3006" name="LoW &amp; Primarchs (25% Limit)" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="baa5-fc7e-f925-4a5d" name="May take:" hidden="false" collective="false" import="true">
@@ -36612,6 +36634,7 @@ containing the model that failed its Check. If the Psyker survives Perils of the
         <categoryLink id="cb74-1081-9d7d-ec9c" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="c703-dfd8-1371-b64a" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
         <categoryLink id="f267-c3a6-0b71-60f5" name="Super-heavy Sub-type:" hidden="false" targetId="7381-1130-ca6e-1806" primary="false"/>
+        <categoryLink id="0f24-11ce-a5ed-87df" name="LoW &amp; Primarchs (25% Limit)" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="00c0-3a7c-15d7-3788" name="May take:" hidden="false" collective="false" import="true">
@@ -39047,6 +39070,7 @@ containing the model that failed its Check. If the Psyker survives Perils of the
         <categoryLink id="4740-ca67-2937-0722" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="901e-f757-8434-fc68" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="1375-f0fe-bf93-3d8a" name="Super-heavy Sub-type:" hidden="false" targetId="7381-1130-ca6e-1806" primary="false"/>
+        <categoryLink id="e60e-88e3-4204-f7b3" name="LoW &amp; Primarchs (25% Limit)" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="e41f-865b-9859-5eea" name="Macharius Heavy Tank" hidden="false" collective="false" import="true" type="model">
@@ -39523,6 +39547,7 @@ containing the model that failed its Check. If the Psyker survives Perils of the
       <categoryLinks>
         <categoryLink id="bd2a-3b6a-6bc2-faf2" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="0fbb-025e-4fde-5df9" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="1d22-179e-b939-31de" name="LoW &amp; Primarchs (25% Limit)" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="5477-cc2b-ef70-878d" name="Malcador Assault Tank" hidden="false" collective="false" import="true" type="model">
@@ -44558,6 +44583,15 @@ During a Reaction made in any Phase, a player may not choose to activate a model
         <infoLink id="5916-3eef-ebd6-8340" name="Auxiliary Vehicle Bay" hidden="false" targetId="8837-14e8-344a-1f39" type="rule"/>
         <infoLink id="2cbf-6343-0385-6fd7" name="Transport Bay" hidden="false" targetId="0662-8b8d-38e8-60f8" type="rule"/>
       </infoLinks>
+      <categoryLinks>
+        <categoryLink id="06f2-1929-bbc9-dc38" name="LoW &amp; Primarchs (25% Limit)" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false"/>
+        <categoryLink id="76c0-7181-3be3-3061" name="Flyer Sub-type:" hidden="false" targetId="4e84-2d57-4986-2b23" primary="false"/>
+        <categoryLink id="5d32-5438-459b-ba9a" name="Hover Sub-type" hidden="false" targetId="3a7a-8bb7-b0d3-e2e7" primary="false"/>
+        <categoryLink id="62f8-f360-4247-073a" name="Lumbering Sub-type:" hidden="false" targetId="7f9b-c5ed-7edb-02dc" primary="false"/>
+        <categoryLink id="c8b6-992f-b320-c525" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
+        <categoryLink id="4217-70bc-8b77-f8a6" name="Transport Sub-type:" hidden="false" targetId="7b0a-a743-a8da-3a39" primary="false"/>
+        <categoryLink id="648c-f634-aaa4-78b3" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+      </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="888e-2e77-4caf-9925" name="1) Wing Weapon Options" hidden="false" collective="false" import="true" defaultSelectionEntryId="4d67-aa4e-a987-f780">
           <constraints>
@@ -44682,6 +44716,7 @@ During a Reaction made in any Phase, a player may not choose to activate a model
         <categoryLink id="114c-ce7e-54c5-1bfe" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="78ec-39bd-42d5-625c" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="ea60-f563-7312-2430" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+        <categoryLink id="5071-3a19-7ef9-2905" name="LoW &amp; Primarchs (25% Limit)" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="29cc-8d9e-f6dc-66f2" name="3) May take:" hidden="false" collective="false" import="true">
@@ -44827,6 +44862,7 @@ During a Reaction made in any Phase, a player may not choose to activate a model
         <categoryLink id="1ab1-822c-bec8-16ea" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
         <categoryLink id="5b31-4f2e-b6cf-2d2c" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="8403-715d-947c-00da" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="a146-4468-7b37-c95e" name="LoW &amp; Primarchs (25% Limit)" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="ba7f-1983-eb26-3761" name="Omega-pattern Plasma Blastgun" hidden="false" collective="false" import="true" type="upgrade">
@@ -44969,6 +45005,10 @@ During a Reaction made in any Phase, a player may not choose to activate a model
       </profiles>
       <categoryLinks>
         <categoryLink id="0836-4db3-83f3-3528" name="Super-heavy Sub-type:" hidden="false" targetId="7381-1130-ca6e-1806" primary="false"/>
+        <categoryLink id="452d-61a7-e177-aa4d" name="LoW &amp; Primarchs (25% Limit)" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false"/>
+        <categoryLink id="5a1b-9e00-c67f-23ba" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+        <categoryLink id="2882-d977-7e17-16d5" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
+        <categoryLink id="e62c-3cc1-bac3-f7cb" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="584c-1391-dc26-2454" name="3) May take:" hidden="false" collective="false" import="true">
@@ -45205,6 +45245,7 @@ During a Reaction made in any Phase, a player may not choose to activate a model
         <categoryLink id="93d9-aa7d-2cf3-cabe" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
         <categoryLink id="8c94-c4b6-d34e-3e4c" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="732e-9ec9-9f51-9d10" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="0901-9931-9d9b-ce5b" name="LoW &amp; Primarchs (25% Limit)" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="597b-12c7-3a14-cf77" name="Praetor Launcher" hidden="false" collective="false" import="true" type="upgrade">
@@ -45396,6 +45437,7 @@ During a Reaction made in any Phase, a player may not choose to activate a model
         <categoryLink id="d2f1-0b76-b3d4-1b6a" name="Flyer Sub-type:" hidden="false" targetId="4e84-2d57-4986-2b23" primary="false"/>
         <categoryLink id="4525-80fd-6b1f-d411" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="b1d6-8653-cf4c-a1da" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+        <categoryLink id="844e-ce8c-882b-dd05" name="LoW &amp; Primarchs (25% Limit)" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="1089-f39e-058e-636c" name="3) May take:" hidden="false" collective="false" import="true">

--- a/2022 - Mechanicum.cat
+++ b/2022 - Mechanicum.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="c247-da79-1654-d39e" name="2022 - Mechanicum" revision="16" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="34" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="c247-da79-1654-d39e" name="2022 - Mechanicum" revision="18" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="41" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entryLinks>
     <entryLink id="29c6-0ec7-0162-e817" name="Mechanicum" hidden="false" collective="false" import="false" targetId="ddf5-d792-3146-6e9a" type="selectionEntry">
       <constraints>
@@ -9,48 +9,48 @@
         <categoryLink id="e8be-9a28-67c2-ab93" name="New CategoryLink" hidden="false" targetId="e90d-e5a8-f42d-da84" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="12ef-d6e7-3e43-41f7" name="Archmagos Prime" hidden="false" collective="false" import="true" targetId="d0f2-ee39-450c-39db" type="selectionEntry">
+    <entryLink id="12ef-d6e7-3e43-41f7" name="Archmagos Prime" hidden="false" collective="false" import="false" targetId="d0f2-ee39-450c-39db" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="b654-9601-210e-2023" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="ed2f-e502-9c88-ef9e" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="943e-3900-7eb5-e5ab" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="c24f-27c9-1759-4427" name="Archmagos Prime on Abeyant" hidden="false" collective="false" import="true" targetId="3821-7503-6139-3054" type="selectionEntry">
+    <entryLink id="c24f-27c9-1759-4427" name="Archmagos Prime on Abeyant" hidden="false" collective="false" import="false" targetId="3821-7503-6139-3054" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="7fc8-bff9-1ce8-4ab5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="fec0-6e63-9264-bfd2" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="4592-5ca2-9c47-09ba" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="850d-b62e-8f76-b1be" name="Magos Dominus" hidden="false" collective="false" import="true" targetId="2dcd-d6c5-9f57-0084" type="selectionEntry">
+    <entryLink id="850d-b62e-8f76-b1be" name="Magos Dominus" hidden="false" collective="false" import="false" targetId="2dcd-d6c5-9f57-0084" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="5b02-7a0e-57ce-4c30" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="3984-61d8-2f84-c437" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="ce21-60e8-7612-3909" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="2f3b-dd15-7f5e-9cf7" name="Magos Dominus on Abeyant" hidden="false" collective="false" import="true" targetId="ed8b-48de-1e04-fa9d" type="selectionEntry">
+    <entryLink id="2f3b-dd15-7f5e-9cf7" name="Magos Dominus on Abeyant" hidden="false" collective="false" import="false" targetId="ed8b-48de-1e04-fa9d" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="071e-1aff-6f80-5a67" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="44e7-ba3a-da35-d5fc" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="ae9b-7528-7813-39d2" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="140c-306c-d09d-265f" name="Calleb Decima Invictus" hidden="true" collective="false" import="true" targetId="a204-6b74-3aeb-0231" type="selectionEntry">
+    <entryLink id="140c-306c-d09d-265f" name="Calleb Decima Invictus" hidden="true" collective="false" import="false" targetId="a204-6b74-3aeb-0231" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="58b5-6803-6799-0aa9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="3d6b-6612-cc33-5f72" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="ae5d-99ed-bca3-5c51" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="eb03-59c6-97aa-8f6b" name="Tech-Priest Auxilia" hidden="false" collective="false" import="true" targetId="0eae-0c52-1087-a3b0" type="selectionEntry">
+    <entryLink id="eb03-59c6-97aa-8f6b" name="Tech-Priest Auxilia" hidden="false" collective="false" import="false" targetId="0eae-0c52-1087-a3b0" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="0e6d-0458-4a4d-ca4d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="5ba2-c0ac-fb56-e190" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="d629-dd69-e689-c38a" name="Arcuitor Magisterium" hidden="false" collective="false" import="true" targetId="6f33-657c-a1b4-710e" type="selectionEntry">
+    <entryLink id="d629-dd69-e689-c38a" name="Arcuitor Magisterium" hidden="false" collective="false" import="false" targetId="6f33-657c-a1b4-710e" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
@@ -63,124 +63,124 @@
         <categoryLink id="0c0f-9a1e-4050-56d4" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="4f46-e279-a2c2-df18" name="Myrmidon Secutor Host" hidden="false" collective="false" import="true" targetId="1869-2d16-d825-04c3" type="selectionEntry">
+    <entryLink id="4f46-e279-a2c2-df18" name="Myrmidon Secutor Host" hidden="false" collective="false" import="false" targetId="1869-2d16-d825-04c3" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="8567-d030-d756-4c6a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="e0af-3ec1-6313-926e" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="c06a-da74-71b7-fee1" name="Adsecularis Tech-thralls Covenant" hidden="false" collective="false" import="true" targetId="bc2c-076a-209b-f121" type="selectionEntry">
+    <entryLink id="c06a-da74-71b7-fee1" name="Adsecularis Tech-thralls Covenant" hidden="false" collective="false" import="false" targetId="bc2c-076a-209b-f121" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="b03f-214f-f4e8-8de8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="e761-63e9-40c4-57ff" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="9bef-dc92-297a-da86" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="123c-8d49-5eb2-8e19" name="Thallax Cohort" hidden="false" collective="false" import="true" targetId="25c8-3e0f-e22d-a7eb" type="selectionEntry">
+    <entryLink id="123c-8d49-5eb2-8e19" name="Thallax Cohort" hidden="false" collective="false" import="false" targetId="25c8-3e0f-e22d-a7eb" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="670f-cf2a-d36d-be6e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="eb58-ed23-c958-3d96" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="02de-e1ca-567c-d897" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="88d1-a0a6-3637-5bf8" name="Scyllax Guardian-Automata Maniple" hidden="false" collective="false" import="true" targetId="57ab-2409-6707-b967" type="selectionEntry">
+    <entryLink id="88d1-a0a6-3637-5bf8" name="Scyllax Guardian-Automata Maniple" hidden="false" collective="false" import="false" targetId="57ab-2409-6707-b967" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="6658-9df3-d4ac-70d7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="f1b8-f9a4-e1fb-c21f" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="de1b-2a5f-b271-fd61" name="Arlatax Battle-Automata Maniple" hidden="false" collective="false" import="true" targetId="b178-7d35-136f-d305" type="selectionEntry">
+    <entryLink id="de1b-2a5f-b271-fd61" name="Arlatax Battle-Automata Maniple" hidden="false" collective="false" import="false" targetId="b178-7d35-136f-d305" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="b0c1-fb4e-652e-7630" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="fa0b-cfcd-a68a-1c73" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="a722-3efe-7ccb-6242" name="Ursarax Cohort" hidden="false" collective="false" import="true" targetId="0750-2aed-2d36-8a82" type="selectionEntry">
+    <entryLink id="a722-3efe-7ccb-6242" name="Ursarax Cohort" hidden="false" collective="false" import="false" targetId="0750-2aed-2d36-8a82" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="d453-d437-1236-00c0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="9ca5-73ce-baf3-ecf1" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="b790-b6dc-b904-118c" name="Vultarax Stratos-Automata Squadron" hidden="false" collective="false" import="true" targetId="0e08-6b7e-8fff-1f02" type="selectionEntry">
+    <entryLink id="b790-b6dc-b904-118c" name="Vultarax Stratos-Automata Squadron" hidden="false" collective="false" import="false" targetId="0e08-6b7e-8fff-1f02" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="76a8-0091-e9f9-e5e2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="ef35-36e0-2fc3-f8c7" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="6558-9557-4654-31fc" name="Myrmidon Destructor Host" hidden="false" collective="false" import="true" targetId="356f-a88b-1d13-3700" type="selectionEntry">
+    <entryLink id="6558-9557-4654-31fc" name="Myrmidon Destructor Host" hidden="false" collective="false" import="false" targetId="356f-a88b-1d13-3700" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="23e1-8fa1-49c1-1d77" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="66c0-0a59-046b-249b" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="4467-970e-236e-6118" name="Karacnos Assault Tank" hidden="false" collective="false" import="true" targetId="8920-3184-2455-1834" type="selectionEntry">
+    <entryLink id="4467-970e-236e-6118" name="Karacnos Assault Tank" hidden="false" collective="false" import="false" targetId="8920-3184-2455-1834" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="3691-ade8-41f9-ecf2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="1e5d-4224-528c-7cba" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="30bc-6d27-6a7b-5d02" name="Krios Squadron" hidden="false" collective="false" import="true" targetId="ce87-68e2-0134-3c84" type="selectionEntry">
+    <entryLink id="30bc-6d27-6a7b-5d02" name="Krios Squadron" hidden="false" collective="false" import="false" targetId="ce87-68e2-0134-3c84" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="90f5-b210-0447-2356" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="4b9e-daec-dd50-1582" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="4351-1507-2a58-b11d" name="Knight Moirax Talon" hidden="false" collective="false" import="true" targetId="c21c-3c14-2d2e-4bc0" type="selectionEntry">
+    <entryLink id="4351-1507-2a58-b11d" name="Knight Moirax Talon" hidden="false" collective="false" import="false" targetId="c21c-3c14-2d2e-4bc0" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="ca25-1bf8-642c-6aa4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="ff46-2a7c-d938-8c35" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="9ca0-8d1b-faa7-e89d" name="Mechanicum Knight Magaera" hidden="false" collective="false" import="true" targetId="b582-e53e-5e13-286c" type="selectionEntry">
+    <entryLink id="9ca0-8d1b-faa7-e89d" name="Mechanicum Knight Magaera" hidden="false" collective="false" import="false" targetId="b582-e53e-5e13-286c" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="6411-f60a-4ee6-fa8a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="76b5-a3b8-07c7-eb28" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="c5d0-e078-888c-4574" name="Mechanicum Knight Styrix" hidden="false" collective="false" import="true" targetId="aae3-4a95-fbce-6d01" type="selectionEntry">
+    <entryLink id="c5d0-e078-888c-4574" name="Mechanicum Knight Styrix" hidden="false" collective="false" import="false" targetId="aae3-4a95-fbce-6d01" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="9984-1655-436c-e75c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="d445-8c66-903b-de69" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="c7b8-2484-8229-9d47" name="Mechanicum Knight Atrapos" hidden="false" collective="false" import="true" targetId="6405-d682-11c9-35b6" type="selectionEntry">
+    <entryLink id="c7b8-2484-8229-9d47" name="Mechanicum Knight Atrapos" hidden="false" collective="false" import="false" targetId="6405-d682-11c9-35b6" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="5572-322f-3fd4-df9c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="d947-9ad4-b373-47f7" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="fd4a-8cec-3721-c94f" name="Mechanicum Acastus Knight Asterius" hidden="false" collective="false" import="true" targetId="ccc2-5689-4796-61b4" type="selectionEntry">
+    <entryLink id="fd4a-8cec-3721-c94f" name="Mechanicum Acastus Knight Asterius" hidden="false" collective="false" import="false" targetId="ccc2-5689-4796-61b4" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="ef49-9452-4d80-69a3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="58ac-b3ec-8a9d-0f89" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="1521-2b96-fcbd-095b" name="Ordinatus Ulator" hidden="false" collective="false" import="true" targetId="1277-aefb-66c5-bd35" type="selectionEntry">
+    <entryLink id="1521-2b96-fcbd-095b" name="Ordinatus Ulator" hidden="false" collective="false" import="false" targetId="1277-aefb-66c5-bd35" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="5a23-8aaf-d1cc-9a2c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="8f5e-22b8-50e7-1004" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="ac39-4b53-e47f-d54c" name="Ordinatus Aktaeus" hidden="false" collective="false" import="true" targetId="89a5-fa4d-0e01-3a55" type="selectionEntry">
+    <entryLink id="ac39-4b53-e47f-d54c" name="Ordinatus Aktaeus" hidden="false" collective="false" import="false" targetId="89a5-fa4d-0e01-3a55" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="8eee-4e6f-0d30-cbd6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="3331-9a71-e131-6128" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="6a07-9580-9c41-dbc6" name="Archmagos Anacharis Scoria" hidden="true" collective="false" import="true" targetId="2185-5fd1-2e59-b467" type="selectionEntry">
+    <entryLink id="6a07-9580-9c41-dbc6" name="Archmagos Anacharis Scoria" hidden="true" collective="false" import="false" targetId="2185-5fd1-2e59-b467" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="1bfa-3de2-bf04-16db" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="d3aa-2699-4210-25dd" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="2583-0dcb-f271-6960" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="60ea-7150-b6b9-7b9b" name="Thanatar Siege-automata Maniple" hidden="false" collective="false" import="true" targetId="2903-fef6-e839-368b" type="selectionEntry">
+    <entryLink id="60ea-7150-b6b9-7b9b" name="Thanatar Siege-automata Maniple" hidden="false" collective="false" import="false" targetId="2903-fef6-e839-368b" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="9d6b-f8e9-44a9-9974" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="b283-74d2-92e1-5d80" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="3c04-f537-6cf1-65bc" name="Castellax Battle-Automata Maniple " hidden="false" collective="false" import="true" targetId="537f-846d-90e3-2526" type="selectionEntry">
+    <entryLink id="3c04-f537-6cf1-65bc" name="Castellax Battle-Automata Maniple " hidden="false" collective="false" import="false" targetId="537f-846d-90e3-2526" type="selectionEntry">
       <modifiers>
         <modifier type="add" field="category" value="6399-5c65-7833-1025">
           <conditions>
@@ -194,26 +194,26 @@
         <categoryLink id="63cb-4eca-61e7-11af" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="2394-56b3-7592-01ae" name="Domitar Battle-Automata Maniple" hidden="false" collective="false" import="true" targetId="1a1b-fa35-a6a2-ca78" type="selectionEntry">
+    <entryLink id="2394-56b3-7592-01ae" name="Domitar Battle-Automata Maniple" hidden="false" collective="false" import="false" targetId="1a1b-fa35-a6a2-ca78" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="ca4b-e16a-f7d8-fc3d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="ed71-00ef-b55e-2e50" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="8010-9dfe-c8dc-3561" name="Vorax Battle-automata Maniple" hidden="false" collective="false" import="true" targetId="f144-1079-11ff-019d" type="selectionEntry">
+    <entryLink id="8010-9dfe-c8dc-3561" name="Vorax Battle-automata Maniple" hidden="false" collective="false" import="false" targetId="f144-1079-11ff-019d" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="5e13-e19b-50c8-72ad" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="099a-66ab-81aa-4ac7" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="cb9d-dcbd-a336-3687" name="Archmagos Draykavac" hidden="false" collective="false" import="true" targetId="8b4c-01f4-f39f-7c55" type="selectionEntry">
+    <entryLink id="cb9d-dcbd-a336-3687" name="Archmagos Draykavac" hidden="false" collective="false" import="false" targetId="8b4c-01f4-f39f-7c55" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="e5b1-a8f4-deff-e3fc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="f7a4-e7ef-9bc9-80b2" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="22c6-2c40-c433-b524" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="0d52-bf5d-15d6-0470" name="Tech-Priest Auxilia" hidden="true" collective="false" import="true" targetId="0eae-0c52-1087-a3b0" type="selectionEntry">
+    <entryLink id="0d52-bf5d-15d6-0470" name="Tech-Priest Auxilia" hidden="true" collective="false" import="false" targetId="0eae-0c52-1087-a3b0" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
@@ -227,7 +227,7 @@
         <categoryLink id="2e88-4d17-543b-453e" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="a311-28b2-65d1-193d" name="Arcuitor Magisterium" hidden="true" collective="false" import="true" targetId="6f33-657c-a1b4-710e" type="selectionEntry">
+    <entryLink id="a311-28b2-65d1-193d" name="Arcuitor Magisterium" hidden="true" collective="false" import="false" targetId="6f33-657c-a1b4-710e" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditionGroups>
@@ -246,7 +246,7 @@
         <categoryLink id="cd51-74f1-04ca-2248" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="d1c5-ff4b-1a9e-2a92" name="Thanatar Siege-automata Maniple" hidden="true" collective="false" import="true" targetId="2903-fef6-e839-368b" type="selectionEntry">
+    <entryLink id="d1c5-ff4b-1a9e-2a92" name="Thanatar Siege-automata Maniple" hidden="true" collective="false" import="false" targetId="2903-fef6-e839-368b" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
@@ -259,7 +259,7 @@
         <categoryLink id="db76-cda6-0690-9f5c" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="3ca2-40e2-1b7e-b0b3" name="Myrmidon Secutor Host" hidden="true" collective="false" import="true" targetId="1869-2d16-d825-04c3" type="selectionEntry">
+    <entryLink id="3ca2-40e2-1b7e-b0b3" name="Myrmidon Secutor Host" hidden="true" collective="false" import="false" targetId="1869-2d16-d825-04c3" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
@@ -273,7 +273,7 @@
         <categoryLink id="44d3-3b8a-f672-7fb4" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="001b-6e55-0b99-c015" name="Myrmidon Destructor Host" hidden="true" collective="false" import="true" targetId="356f-a88b-1d13-3700" type="selectionEntry">
+    <entryLink id="001b-6e55-0b99-c015" name="Myrmidon Destructor Host" hidden="true" collective="false" import="false" targetId="356f-a88b-1d13-3700" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
@@ -286,7 +286,7 @@
         <categoryLink id="7c96-b532-93cb-02c2" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="46b7-2b32-94fe-5552" name="Adsecularis Tech-thralls Certus Covenant" hidden="true" collective="false" import="true" targetId="4436-7062-9be3-b233" type="selectionEntry">
+    <entryLink id="46b7-2b32-94fe-5552" name="Adsecularis Tech-thralls Certus Covenant" hidden="true" collective="false" import="false" targetId="4436-7062-9be3-b233" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
@@ -300,7 +300,7 @@
         <categoryLink id="c03f-8360-930b-f691" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="8f88-8be3-05ff-8f5e" name="Mechanicum Termite Assault Drill" hidden="true" collective="false" import="true" targetId="9991-c84b-dc5d-2125" type="selectionEntry">
+    <entryLink id="8f88-8be3-05ff-8f5e" name="Mechanicum Termite Assault Drill" hidden="true" collective="false" import="false" targetId="9991-c84b-dc5d-2125" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
@@ -313,7 +313,7 @@
         <categoryLink id="cfdb-cade-a93c-d5ac" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="1113-81b2-107c-5c57" name="Mechanicum Tarantula Sentry Gun Battery" hidden="true" collective="false" import="true" targetId="1905-926d-628c-a411" type="selectionEntry">
+    <entryLink id="1113-81b2-107c-5c57" name="Mechanicum Tarantula Sentry Gun Battery" hidden="true" collective="false" import="false" targetId="1905-926d-628c-a411" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
@@ -326,7 +326,7 @@
         <categoryLink id="8578-ba1d-17f6-7c6e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="71b9-6a72-a0cb-b43b" name="Inar Satarael" hidden="true" collective="false" import="true" targetId="e26f-a72f-8ea2-1641" type="selectionEntry">
+    <entryLink id="71b9-6a72-a0cb-b43b" name="Inar Satarael" hidden="true" collective="false" import="false" targetId="e26f-a72f-8ea2-1641" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditionGroups>
@@ -345,7 +345,7 @@
         <categoryLink id="ff26-0ed6-3de9-4c30" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="db9e-a946-5ad7-a81f" name="Mechanicum Land Raider Phobos " hidden="true" collective="false" import="true" targetId="ad56-a7fc-a815-aebf" type="selectionEntry">
+    <entryLink id="db9e-a946-5ad7-a81f" name="Mechanicum Land Raider Phobos " hidden="true" collective="false" import="false" targetId="ad56-a7fc-a815-aebf" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
@@ -358,7 +358,7 @@
         <categoryLink id="5e30-0ad2-6f7f-6943" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="134c-75ba-ebdb-d54c" name="Ordo Reductor Minotaur Battery (incomplete)" hidden="true" collective="false" import="true" targetId="ebf8-fbe4-1473-7903" type="selectionEntry">
+    <entryLink id="134c-75ba-ebdb-d54c" name="Ordo Reductor Minotaur Battery" hidden="true" collective="false" import="false" targetId="ebf8-fbe4-1473-7903" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
@@ -371,7 +371,7 @@
         <categoryLink id="e795-e3e7-17d4-cfc3" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="f092-9b7c-0ece-5f1a" name="Ordo Reductor Artillery Tank Battery (incomplete)" hidden="true" collective="false" import="true" targetId="6353-c4c3-d099-002e" type="selectionEntry">
+    <entryLink id="f092-9b7c-0ece-5f1a" name="Ordo Reductor Artillery Tank Battery" hidden="true" collective="false" import="false" targetId="6353-c4c3-d099-002e" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
@@ -384,7 +384,7 @@
         <categoryLink id="2363-773b-54f6-4940" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="75ab-47e9-3e7d-1fcb" name="Macrocarid Explorator (incomplete)" hidden="true" collective="false" import="true" targetId="bd83-b47d-1f37-1159" type="selectionEntry">
+    <entryLink id="75ab-47e9-3e7d-1fcb" name="Macrocarid Explorator" hidden="true" collective="false" import="false" targetId="bd83-b47d-1f37-1159" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
@@ -408,6 +408,73 @@
       <categoryLinks>
         <categoryLink id="c131-9ece-247d-39d7" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="c8d6-cac0-a82b-e544" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="673a-5285-5eb5-8075" name="Acastus Knight Porphyrion" hidden="false" collective="false" import="false" targetId="8cb2-7235-fc34-9983" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="1701-a7cf-a915-225c" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="d8eb-be83-5365-ed73" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
+        <categoryLink id="7777-bc24-ee0f-3a0e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="78b3-902d-566a-7377" name="LoW &amp; Primarchs (25% Limit)" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="7455-101c-6eca-211a" name="Knight Acheron" hidden="false" collective="false" import="false" targetId="f971-ef52-5344-0b26" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="c109-9e03-6ade-4ce6" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="897a-06f7-2e4e-5642" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
+        <categoryLink id="9df9-1050-8c8f-91af" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="24ed-e278-e49a-5572" name="LoW &amp; Primarchs (25% Limit)" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="aed4-de51-1fca-ed42" name="Knight Castigator" hidden="false" collective="false" import="false" targetId="0a65-543c-19b2-fd34" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="bad4-594d-32d5-5e9a" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="ba9f-9c0b-f107-7ecc" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
+        <categoryLink id="7871-62b4-fe92-0022" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="0403-0ca9-8d74-4597" name="LoW &amp; Primarchs (25% Limit)" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="1c19-dda6-0b4d-ca60" name="Knight Lancer" hidden="false" collective="false" import="false" targetId="8312-7457-e7b6-fd9f" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="4da5-dc59-1b97-1ca7" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="a018-5d60-eb84-06d3" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
+        <categoryLink id="cc12-7c02-c1a2-d1f1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="56ef-3009-6d03-2b18" name="LoW &amp; Primarchs (25% Limit)" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="f6c8-5853-151f-56c0" name="Knight Questoris" hidden="false" collective="false" import="false" targetId="3706-a84c-678d-b1c6" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="cf64-a7bd-b65b-04d6" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="25f2-8d01-060a-6027" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
+        <categoryLink id="574c-c956-658a-4920" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="72c8-446e-cf56-cb4a" name="Reaver Battle Titan" hidden="false" collective="false" import="false" targetId="2dbc-7655-bb05-ab89" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="0bad-5ea4-01de-2032" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="3620-ec9f-5397-a568" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="68ea-b6ae-664a-7c1d" name="LoW &amp; Primarchs (25% Limit)" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="9862-a6be-4f49-0aef" name="Warbringer Nemesis Titan" hidden="false" collective="false" import="false" targetId="3dd1-77d8-4289-b745" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="b45b-dba8-3350-a95f" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="043f-135d-79f0-35f1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="dc28-89ec-4a04-13cf" name="LoW &amp; Primarchs (25% Limit)" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="eb37-5616-2e3a-744b" name="Warhound Scout Titan" hidden="false" collective="false" import="false" targetId="841c-c2f5-9817-3061" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="9509-ccd5-6448-a6d6" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="a1eb-b281-a894-08a1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="d3ae-5612-a584-009e" name="LoW &amp; Primarchs (25% Limit)" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="1c42-effa-4780-bf17" name="Warlord Battle Titan" hidden="false" collective="false" import="false" targetId="d737-baca-32e7-8da6" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="d70a-460c-771d-8e14" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="4b90-1f7f-6839-cb2a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="36d2-2b46-3158-e0a3" name="LoW &amp; Primarchs (25% Limit)" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false"/>
       </categoryLinks>
     </entryLink>
   </entryLinks>
@@ -3890,6 +3957,7 @@ This unit may be upgraded freely as described in their profile, though they may 
       <categoryLinks>
         <categoryLink id="bada-ebff-8f90-0b2c" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="4cd2-af0c-e2d2-1c91" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+        <categoryLink id="2ed6-c200-27d0-fcd6" name="LoW &amp; Primarchs (25% Limit)" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="808a-6ab8-6d40-6006" name="Ordinatus Dispersion Shield" publicationId="bde1-6db1-163b-3b76" page="126" hidden="false" collective="false" import="true" type="upgrade">
@@ -4017,6 +4085,7 @@ The area under the Apocalyptic Blast marker (10&quot;) is treated as Difficult T
       <categoryLinks>
         <categoryLink id="bd10-1dfe-07bf-f938" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
         <categoryLink id="4445-4267-604e-58a8" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
+        <categoryLink id="3b5f-6e86-9b3f-9b61" name="LoW &amp; Primarchs (25% Limit)" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="9e55-edca-5116-d240" name="Centreline Mounted Terrebrax Rocket Battery" publicationId="bde1-6db1-163b-3b76" page="118" hidden="false" collective="false" import="true" type="upgrade">
@@ -4289,6 +4358,9 @@ removed as a casualty.�</characteristic>
         <infoLink id="2e6d-ab1c-59a1-f48d" name="Night Vision" hidden="false" targetId="683e-b4f2-f032-d31b" type="rule"/>
         <infoLink id="9eb4-352b-08a2-716f" name="Macro-extinction Targeting Protocols" hidden="false" targetId="359e-2a2e-3a01-42e7" type="rule"/>
       </infoLinks>
+      <categoryLinks>
+        <categoryLink id="ce34-1823-ef4a-f38e" name="LoW &amp; Primarchs (25% Limit)" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false"/>
+      </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="2f78-69c3-fd78-43f2" name="Arm Mounted Twin-Linked Heavy Conversion Beam Cannon" hidden="false" collective="false" import="true" defaultSelectionEntryId="8183-c411-6b59-3742">
           <constraints>
@@ -4356,6 +4428,9 @@ removed as a casualty.�</characteristic>
         <infoLink id="e934-d22c-a028-5551" name="Flank Speed" hidden="false" targetId="41ab-227d-9d91-8001" type="rule"/>
         <infoLink id="c900-fa1d-551d-0ccc" name="Catastrophic Destruction" hidden="false" targetId="c41f-6ac9-6909-44c4" type="rule"/>
       </infoLinks>
+      <categoryLinks>
+        <categoryLink id="078c-3ffe-27ce-ab16" name="LoW &amp; Primarchs (25% Limit)" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false"/>
+      </categoryLinks>
       <selectionEntries>
         <selectionEntry id="dad2-d4d4-fca4-2b1b" name="Arm Mounted Atrapos Phasecutter" publicationId="bde1-6db1-163b-3b76" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
@@ -4440,6 +4515,9 @@ removed as a casualty.�</characteristic>
         <infoLink id="0ef0-90de-31a7-e777" name="Night Vision" hidden="false" targetId="683e-b4f2-f032-d31b" type="rule"/>
         <infoLink id="356d-2f9f-7a07-7b62" name="Overtaxed Reactor" hidden="false" targetId="5f22-e7a4-4141-ee2e" type="rule"/>
       </infoLinks>
+      <categoryLinks>
+        <categoryLink id="4464-f177-32c5-eaba" name="LoW &amp; Primarchs (25% Limit)" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false"/>
+      </categoryLinks>
       <selectionEntries>
         <selectionEntry id="fea6-d32c-554d-b5a3" name="Arm Mounted Volkite Chieorovile" publicationId="bde1-6db1-163b-3b76" page="119" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
@@ -4514,6 +4592,9 @@ removed as a casualty.�</characteristic>
         <infoLink id="0b76-f798-f8c1-0d47" name="Night Vision" hidden="false" targetId="683e-b4f2-f032-d31b" type="rule"/>
         <infoLink id="b7be-0884-f011-c7a5" name="Overtaxed Reactor" hidden="false" targetId="5f22-e7a4-4141-ee2e" type="rule"/>
       </infoLinks>
+      <categoryLinks>
+        <categoryLink id="461e-6b90-77cd-cc74" name="LoW &amp; Primarchs (25% Limit)" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false"/>
+      </categoryLinks>
       <selectionEntries>
         <selectionEntry id="2862-f27b-74c7-3c4a" name="Arm Mounted Lightning Cannon" publicationId="bde1-6db1-163b-3b76" page="113" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>

--- a/2022 - Questoris Household.cat
+++ b/2022 - Questoris Household.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="92b4-d476-8b4c-e7ef" name="2022 - Questoris Household" revision="4" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="15" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="92b4-d476-8b4c-e7ef" name="2022 - Questoris Household" revision="5" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="41" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <forceEntries>
     <forceEntry id="28d3-4be2-608d-bf8a" name="Questoris Household Force Organisation Chart" hidden="false">
       <categoryLinks>
@@ -49,6 +49,13 @@
       </categoryLinks>
     </entryLink>
     <entryLink id="d584-89d3-0ba5-7faa" name="Knight Questoris" hidden="false" collective="false" import="true" targetId="3706-a84c-678d-b1c6" type="selectionEntry">
+      <modifiers>
+        <modifier type="add" field="category" value="2eaf-32d6-9d1d-d906">
+          <conditions>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="d926-652f-8436-30ce" type="greaterThan"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="365e-b0a4-87b6-2f2a" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
         <categoryLink id="e579-64c8-62ad-2e6f" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
@@ -63,6 +70,13 @@
       </categoryLinks>
     </entryLink>
     <entryLink id="09eb-0791-7539-e3fe" name="Knight Lancer" hidden="false" collective="false" import="true" targetId="8312-7457-e7b6-fd9f" type="selectionEntry">
+      <modifiers>
+        <modifier type="add" field="category" value="2eaf-32d6-9d1d-d906">
+          <conditions>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="d926-652f-8436-30ce" type="greaterThan"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="3e12-5f5e-ac9c-4354" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
         <categoryLink id="79bf-3d91-67d1-33fb" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
@@ -70,6 +84,13 @@
       </categoryLinks>
     </entryLink>
     <entryLink id="4432-80ac-042a-591c" name="Knight Castigator" hidden="false" collective="false" import="true" targetId="0a65-543c-19b2-fd34" type="selectionEntry">
+      <modifiers>
+        <modifier type="add" field="category" value="2eaf-32d6-9d1d-d906">
+          <conditions>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="d926-652f-8436-30ce" type="greaterThan"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="b47e-a501-6a7c-4580" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
         <categoryLink id="83cc-eb2d-633f-e999" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
@@ -77,6 +98,13 @@
       </categoryLinks>
     </entryLink>
     <entryLink id="16f1-41d4-e11d-7eea" name="Knight Acheron" hidden="false" collective="false" import="true" targetId="f971-ef52-5344-0b26" type="selectionEntry">
+      <modifiers>
+        <modifier type="add" field="category" value="2eaf-32d6-9d1d-d906">
+          <conditions>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="d926-652f-8436-30ce" type="greaterThan"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="3d5a-ce72-e96a-7b84" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
         <categoryLink id="7bef-0998-45bf-ea1c" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
@@ -84,6 +112,13 @@
       </categoryLinks>
     </entryLink>
     <entryLink id="ea1b-ebb0-a727-f6a1" name="Acastus Knight Porphyrion" hidden="false" collective="false" import="true" targetId="8cb2-7235-fc34-9983" type="selectionEntry">
+      <modifiers>
+        <modifier type="add" field="category" value="2eaf-32d6-9d1d-d906">
+          <conditions>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="d926-652f-8436-30ce" type="greaterThan"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="2e28-e276-031d-c76e" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
         <categoryLink id="9ada-aa9b-2414-57c2" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
@@ -91,6 +126,13 @@
       </categoryLinks>
     </entryLink>
     <entryLink id="f6ab-b360-5a0c-ff16" name="Questoris Knight Styrix" hidden="false" collective="false" import="true" targetId="1944-033c-5b7e-a378" type="selectionEntry">
+      <modifiers>
+        <modifier type="add" field="category" value="2eaf-32d6-9d1d-d906">
+          <conditions>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="d926-652f-8436-30ce" type="greaterThan"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="d0e2-884a-8ff6-1276" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
         <categoryLink id="039b-e62e-649e-c494" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
@@ -98,6 +140,13 @@
       </categoryLinks>
     </entryLink>
     <entryLink id="03a7-8a19-46fc-fb34" name="Questoris Knight Magaera" hidden="false" collective="false" import="true" targetId="6d0e-0d72-d9e2-01d1" type="selectionEntry">
+      <modifiers>
+        <modifier type="add" field="category" value="2eaf-32d6-9d1d-d906">
+          <conditions>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="d926-652f-8436-30ce" type="greaterThan"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="f6c1-febb-5445-a61e" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
         <categoryLink id="aaf6-7f9a-dc73-4735" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
@@ -105,6 +154,13 @@
       </categoryLinks>
     </entryLink>
     <entryLink id="b701-ae0d-cf44-cd62" name="Questoris Knight Atrapos" hidden="false" collective="false" import="true" targetId="012b-109f-74d2-2c82" type="selectionEntry">
+      <modifiers>
+        <modifier type="add" field="category" value="2eaf-32d6-9d1d-d906">
+          <conditions>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="d926-652f-8436-30ce" type="greaterThan"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="081a-4cc1-02c0-4470" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
         <categoryLink id="f903-585f-a0ec-9d17" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
@@ -112,6 +168,13 @@
       </categoryLinks>
     </entryLink>
     <entryLink id="1748-7d92-81f0-08be" name="Questoris Acastus Knight Asterius" hidden="false" collective="false" import="true" targetId="7b6b-49ab-d71d-e359" type="selectionEntry">
+      <modifiers>
+        <modifier type="add" field="category" value="2eaf-32d6-9d1d-d906">
+          <conditions>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="d926-652f-8436-30ce" type="greaterThan"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="fe46-14a5-092c-1063" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
         <categoryLink id="6233-a9df-929f-7b0c" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>

--- a/2022 - Titan Legions.cat
+++ b/2022 - Titan Legions.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="c01b-0224-f806-0d23" name="2022 - Titan Legions" revision="6" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="34" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="c01b-0224-f806-0d23" name="2022 - Titan Legions" revision="6" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="41" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <forceEntries>
     <forceEntry id="aebe-bed9-b32f-a8ea" name="Titan Maniple" hidden="false">
       <categoryLinks>
@@ -48,24 +48,28 @@
       <categoryLinks>
         <categoryLink id="53aa-f28d-38ab-c2fc" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
         <categoryLink id="5e25-d5c2-8f6e-1e86" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="bdf3-6ff5-236a-cdba" name="LoW &amp; Primarchs (25% Limit)" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="d6ad-baec-87f6-e839" name="Warbringer Nemesis Titan" hidden="false" collective="false" import="true" targetId="3dd1-77d8-4289-b745" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="fcdb-3e8d-a4f7-7665" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
         <categoryLink id="203a-2c3d-872b-9cc1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="7460-3671-ebc8-97ff" name="LoW &amp; Primarchs (25% Limit)" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="61a7-4c8e-1ef8-84cc" name="Warhound Scout Titan" hidden="false" collective="false" import="true" targetId="841c-c2f5-9817-3061" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="eef0-bad3-f27a-6a02" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
         <categoryLink id="acf1-ae9e-a4c0-91af" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="179a-b78e-4846-e731" name="LoW &amp; Primarchs (25% Limit)" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="c8ee-7d52-39c1-17d4" name="Reaver Battle Titan" hidden="false" collective="false" import="true" targetId="2dbc-7655-bb05-ab89" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="e182-a612-dbd0-e0be" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
         <categoryLink id="49e9-613a-ed0b-5efb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="c1c8-11dd-c376-f3f7" name="LoW &amp; Primarchs (25% Limit)" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="fc74-4887-4a56-b156" name="Secutarii Axiarch" hidden="false" collective="false" import="false" targetId="b08e-55fe-3e1d-913b" type="selectionEntry">


### PR DESCRIPTION
LoW and RoW 25% Restriction implemented in GST.
Added category to all that need it at SE level in most cases, but at Root for Knights and Titans due to interaction with their own maniple lists. Also did the Drop Pod / Termite restrictions to BA, IF units from RoW. Left AL & DA alone for them, as I think DA is working, and AL is a big job for Jon.

Stlll to do:
Add new Salamander unit from Exemplarly Battles doc. Complete Salamanders RoWs
Custodes needs to go from Placeholders to full stats.

Then Blood Angels, Imperial Fists and Alpha Legion RoWs need completing