### PR TITLE
Fix for Wolf-kin

### DIFF
--- a/2022 - LA - Space Wolves.cat
+++ b/2022 - LA - Space Wolves.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="ca15-13de-89cb-bbb2" name="LA -   VI: Space Wolves" revision="23" battleScribeVersion="2.03" authorName="Mr_Dark, UrsinePatriarch" authorContact="BSData Developers Discord" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="40" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="ca15-13de-89cb-bbb2" name="LA -   VI: Space Wolves" revision="24" battleScribeVersion="2.03" authorName="Mr_Dark, UrsinePatriarch" authorContact="BSData Developers Discord" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="41" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entryLinks>
     <entryLink id="ff53-69d9-ec0b-9caa" name="   VI: Space Wolves" hidden="false" collective="false" import="false" targetId="4916-965e-8339-44f6" type="selectionEntry">
       <constraints>
@@ -3025,6 +3025,14 @@
               </characteristics>
             </profile>
           </profiles>
+        </entryLink>
+        <entryLink id="f319-9376-ad7f-aa47" name="The Wolf-kin of Russ" hidden="false" collective="false" import="true" targetId="3bb9-4637-e963-b36f" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fd80-016a-c3d0-72c0" type="max"/>
+          </constraints>
+          <categoryLinks>
+            <categoryLink id="dede-c0cd-a849-d910" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+          </categoryLinks>
         </entryLink>
       </entryLinks>
       <costs>
@@ -6500,18 +6508,6 @@
           </modifiers>
           <categoryLinks>
             <categoryLink id="ca0e-7a88-0585-5f44" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-          </categoryLinks>
-        </entryLink>
-        <entryLink id="8e3b-c79c-8412-5d8e" name="The Wolf-kin of Russ" hidden="true" collective="false" import="true" targetId="3bb9-4637-e963-b36f" type="selectionEntry">
-          <modifiers>
-            <modifier type="set" field="hidden" value="false">
-              <conditions>
-                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c028-dc90-e4b6-8b43" type="instanceOf"/>
-              </conditions>
-            </modifier>
-          </modifiers>
-          <categoryLinks>
-            <categoryLink id="5fd0-3b08-a584-5ec8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
           </categoryLinks>
         </entryLink>
       </entryLinks>


### PR DESCRIPTION
Fix for Wolf-kin as they don't count as retinue, but don't take up force org slot. Required due to removal of Primarchs Chosen.