### PR TITLE
Custard Lances, WS movement and Allies in RoW

### DIFF
--- a/2022 - Horus Heresy.gst
+++ b/2022 - Horus Heresy.gst
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<gameSystem id="28d4-bd2e-4858-ece6" name="(HH V2) Horus Heresy (2022)" revision="50" battleScribeVersion="2.03" xmlns="http://www.battlescribe.net/schema/gameSystemSchema">
+<gameSystem id="28d4-bd2e-4858-ece6" name="(HH V2) Horus Heresy (2022)" revision="51" battleScribeVersion="2.03" xmlns="http://www.battlescribe.net/schema/gameSystemSchema">
   <publications>
     <publication id="e77a-823a-da94-16b9" name="Warhammer: The Horus Heresy - Age of Darkness Rulebook" shortName="Main Rules" publicationDate="June 2022"/>
     <publication id="817a-6288-e016-7469" name="Liber Astartes – Loyalist Legiones Astartes Army Book" shortName="LA - Loyalist" publicationDate="June 2022"/>
@@ -1253,6 +1253,27 @@ In addition, when a Fast Vehicle moves, it may choose to move at Flat-out:</desc
           </constraints>
         </categoryLink>
         <categoryLink id="0b76-5263-40ac-0721" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="false">
+          <modifiers>
+            <modifier type="increment" field="a59f-bf8a-6c0a-c006" value="1.0">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b23c-e41d-1ffe-1a38" type="equalTo"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+            <modifier type="increment" field="e335-2401-dec4-2d28" value="1.0">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="41b5-73f0-cdc9-1f83" type="equalTo"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b23c-e41d-1ffe-1a38" type="equalTo"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
           <constraints>
             <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e335-2401-dec4-2d28" type="max"/>
             <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a59f-bf8a-6c0a-c006" type="min"/>
@@ -1270,8 +1291,34 @@ In addition, when a Fast Vehicle moves, it may choose to move at Flat-out:</desc
           </constraints>
         </categoryLink>
         <categoryLink id="52d9-e513-b7c1-59d3" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="false">
+          <modifiers>
+            <modifier type="increment" field="88d4-d4ce-998d-8024" value="1.0">
+              <repeats>
+                <repeat field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7031-469a-1aeb-eab0" repeats="1" roundUp="false"/>
+              </repeats>
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e6ec-f3e6-760c-f9bb" type="equalTo"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4342-923b-e0dd-9e87" type="equalTo"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+            <modifier type="increment" field="88d4-d4ce-998d-8024" value="1.0">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e6ec-f3e6-760c-f9bb" type="equalTo"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4342-923b-e0dd-9e87" type="equalTo"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
           <constraints>
             <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2ede-2dee-1530-5c26" type="max"/>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="88d4-d4ce-998d-8024" type="min"/>
           </constraints>
         </categoryLink>
         <categoryLink id="3dd4-cf96-9425-f583" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="false">
@@ -1280,11 +1327,25 @@ In addition, when a Fast Vehicle moves, it may choose to move at Flat-out:</desc
           </constraints>
         </categoryLink>
         <categoryLink id="4df4-9c0d-3f28-4dd3" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false">
+          <modifiers>
+            <modifier type="increment" field="efa5-391f-c0d5-86f2" value="1.0">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b23c-e41d-1ffe-1a38" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
           <constraints>
             <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="efa5-391f-c0d5-86f2" type="min"/>
           </constraints>
         </categoryLink>
         <categoryLink id="bec3-b01f-58f1-ef8a" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false">
+          <modifiers>
+            <modifier type="increment" field="3965-7b5b-1e0b-d284" value="1.0">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b23c-e41d-1ffe-1a38" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
           <constraints>
             <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3965-7b5b-1e0b-d284" type="min"/>
           </constraints>

--- a/2022 - LA - White Scars.cat
+++ b/2022 - LA - White Scars.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="caa9-c50e-8eed-2259" name="LA -   V: White Scars" revision="25" battleScribeVersion="2.03" authorName="Mr_Dark, UrsinePatriarch" authorContact="BSData Developers Discord" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="49" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="caa9-c50e-8eed-2259" name="LA -   V: White Scars" revision="26" battleScribeVersion="2.03" authorName="Mr_Dark, UrsinePatriarch" authorContact="BSData Developers Discord" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="50" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entryLinks>
     <entryLink id="a738-6a11-dfe7-286c" name="   V: White Scars" hidden="false" collective="false" import="false" targetId="e01e-5cdd-e512-8353" type="selectionEntry">
       <constraints>
@@ -3021,6 +3021,13 @@
           </constraints>
           <profiles>
             <profile id="1129-c6a8-eeb6-2cca" name="Golden Keshig Rider" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
+              <modifiers>
+                <modifier type="set" field="893e-2d76-8f04-44e5" value="14">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c0df-c1fa-5ddc-9ee5" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
               <characteristics>
                 <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Cavalry (Antigrav, Heavy)</characteristic>
                 <characteristic name="Move" typeId="893e-2d76-8f04-44e5">15&quot;</characteristic>
@@ -3047,6 +3054,13 @@
           </constraints>
           <profiles>
             <profile id="fad2-07ca-a41b-17d7" name="Golden Keshig Champion" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
+              <modifiers>
+                <modifier type="set" field="893e-2d76-8f04-44e5" value="14">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c0df-c1fa-5ddc-9ee5" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
               <characteristics>
                 <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Cavalry (Antigrav, Heavy, Character)</characteristic>
                 <characteristic name="Move" typeId="893e-2d76-8f04-44e5">15&quot;</characteristic>
@@ -3260,6 +3274,13 @@
           </constraints>
           <profiles>
             <profile id="a138-c23f-03db-90fc" name="Kharash" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
+              <modifiers>
+                <modifier type="set" field="893e-2d76-8f04-44e5" value="7">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c0df-c1fa-5ddc-9ee5" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
               <characteristics>
                 <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry</characteristic>
                 <characteristic name="Move" typeId="893e-2d76-8f04-44e5">8&quot;</characteristic>
@@ -3482,6 +3503,13 @@
           </constraints>
           <profiles>
             <profile id="a56d-7fe2-97b3-2b86" name="Kyzagan Assault Speeder" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
+              <modifiers>
+                <modifier type="set" field="893e-2d76-8f04-44e5" value="14">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c0df-c1fa-5ddc-9ee5" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
               <characteristics>
                 <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Cavalry (Antigrav, Heavy)</characteristic>
                 <characteristic name="Move" typeId="893e-2d76-8f04-44e5">15&quot;</characteristic>
@@ -3583,6 +3611,13 @@
           </constraints>
           <profiles>
             <profile id="3f9e-3df7-0bf7-af79" name="Falcon&apos;s Claws Champion" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
+              <modifiers>
+                <modifier type="set" field="893e-2d76-8f04-44e5" value="8">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c0df-c1fa-5ddc-9ee5" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
               <characteristics>
                 <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Light, Skirmish, Character)</characteristic>
                 <characteristic name="Move" typeId="893e-2d76-8f04-44e5">9*</characteristic>
@@ -3696,6 +3731,13 @@
           </constraints>
           <profiles>
             <profile id="e5d4-61f8-f665-9fa2" name="Falcon&apos;s Claw" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
+              <modifiers>
+                <modifier type="set" field="893e-2d76-8f04-44e5" value="8">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c0df-c1fa-5ddc-9ee5" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
               <characteristics>
                 <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Light, Skirmish)</characteristic>
                 <characteristic name="Move" typeId="893e-2d76-8f04-44e5">9*</characteristic>
@@ -3840,6 +3882,11 @@
                     <condition field="selections" scope="5102-02bb-c8d6-56d6" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="583e-62cb-53f1-f952" type="equalTo"/>
                   </conditions>
                 </modifier>
+                <modifier type="set" field="893e-2d76-8f04-44e5" value="7">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c0df-c1fa-5ddc-9ee5" type="equalTo"/>
+                  </conditions>
+                </modifier>
               </modifiers>
               <characteristics>
                 <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Character)</characteristic>
@@ -3978,6 +4025,13 @@
           </constraints>
           <profiles>
             <profile id="f3ac-831d-b87c-d568" name="Dark Son" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
+              <modifiers>
+                <modifier type="set" field="893e-2d76-8f04-44e5" value="7">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c0df-c1fa-5ddc-9ee5" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
               <characteristics>
                 <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry</characteristic>
                 <characteristic name="Move" typeId="893e-2d76-8f04-44e5">8*</characteristic>

--- a/2022 - LI - Custodes.cat
+++ b/2022 - LI - Custodes.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="2f2b-1f31-c455-1701" name="2022 - LI - Custodes" revision="5" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="49" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="2f2b-1f31-c455-1701" name="2022 - LI - Custodes" revision="6" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="50" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <categoryEntries>
     <categoryEntry id="ccca-a9de-0cd9-f8be" name="Legio Custodes" hidden="false">
       <rules>
@@ -2171,6 +2171,12 @@ A &quot;Nemesis&apos; unit is defined as any enemy unit that fulfils at least on
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0937-9904-0578-39d7" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7a1b-0ad2-07ee-d383" type="max"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="5e19-e8ea-d007-6775" name="Solarite Power Lance" hidden="false" collective="false" import="true" targetId="50a3-987d-8087-4708" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fd2a-91d4-e012-35cb" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fd5c-91e6-a6f1-84bd" type="max"/>
           </constraints>
         </entryLink>
       </entryLinks>
@@ -4404,6 +4410,47 @@ During a Reaction made in any Phase, a player may not choose to activate a model
       <costs>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="365.0"/>
       </costs>
+    </selectionEntry>
+    <selectionEntry id="50a3-987d-8087-4708" name="Solarite Power Lance" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="a054-3f56-0058-9b35" name="Solarite Power Lance" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="95ba-cda7-b831-6066">-</characteristic>
+            <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">10</characteristic>
+            <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">1</characteristic>
+            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Melee, Armourbane (Melee), Two-handed, Sudden Strike (3)</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="74e6-59df-78fa-966c" name="Armourbane (X)" hidden="false" targetId="cb59-f920-f071-7cd4" type="rule">
+          <modifiers>
+            <modifier type="set" field="name" value="Armourbane (Melee)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="92f2-180d-97a8-099e" name="Two-handed" hidden="false" targetId="4c23-e863-a569-7617" type="rule"/>
+        <infoLink id="91f6-7d63-b4bc-6e44" name="Sudden Strike (X)" hidden="false" targetId="58b3-7d84-b92d-1363" type="rule">
+          <modifiers>
+            <modifier type="set" field="name" value="Sudden Strike (3)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+    </selectionEntry>
+    <selectionEntry id="978d-b267-2025-dd15" name="Solarite Power Lance" hidden="false" collective="true" import="true" type="upgrade">
+      <infoLinks>
+        <infoLink id="fff0-8ac0-499c-9861" name="Armourbane (X)" hidden="false" targetId="cb59-f920-f071-7cd4" type="rule">
+          <modifiers>
+            <modifier type="set" field="name" value="Armourbane (Melee)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="f786-25ca-4d47-6f9b" name="Two-handed" hidden="false" targetId="4c23-e863-a569-7617" type="rule"/>
+        <infoLink id="c3b4-a8f8-1aaa-ccad" name="Sudden Strike (X)" hidden="false" targetId="58b3-7d84-b92d-1363" type="rule">
+          <modifiers>
+            <modifier type="set" field="name" value="Sudden Strike (3)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="5ca8-431e-79b2-2d93" name="Solarite Power Lance" hidden="false" targetId="a054-3f56-0058-9b35" type="profile"/>
+      </infoLinks>
     </selectionEntry>
   </sharedSelectionEntries>
   <sharedSelectionEntryGroups>

--- a/2022 - Legiones Astartes.cat
+++ b/2022 - Legiones Astartes.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="6393-649c-7213-a327" name="(HH V2) Legions Astartes" revision="108" battleScribeVersion="2.03" authorName="Various" authorUrl="https://github.com/BSData/horus-heresy" library="true" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="50" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="6393-649c-7213-a327" name="(HH V2) Legions Astartes" revision="109" battleScribeVersion="2.03" authorName="Various" authorUrl="https://github.com/BSData/horus-heresy" library="true" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="50" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <profileTypes>
     <profileType id="7002-2f9a-59c4-2742" name="Prosperine Arcana">
       <characteristicTypes>
@@ -4240,7 +4240,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
           <profiles>
             <profile id="cf03-e706-59c3-3ea6" name="Legion Tactical Sergeant" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
               <modifiers>
-                <modifier type="set" field="893e-2d76-8f04-44e5" value="8&quot;">
+                <modifier type="set" field="893e-2d76-8f04-44e5" value="8*">
                   <conditions>
                     <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
                   </conditions>
@@ -4263,7 +4263,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
               </modifiers>
               <characteristics>
                 <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Character, Line)</characteristic>
-                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
+                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7</characteristic>
                 <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
                 <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
                 <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -5001,7 +5001,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
               <profiles>
                 <profile id="5bf2-8597-cc05-f7c5" name="Legionary" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
                   <modifiers>
-                    <modifier type="set" field="893e-2d76-8f04-44e5" value="8&quot;">
+                    <modifier type="set" field="893e-2d76-8f04-44e5" value="8*">
                       <conditions>
                         <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
                       </conditions>
@@ -5019,7 +5019,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                   </modifiers>
                   <characteristics>
                     <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Line)</characteristic>
-                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
+                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7</characteristic>
                     <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
                     <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
                     <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -5412,9 +5412,16 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
       </modifiers>
       <profiles>
         <profile id="ab48-605d-a6cc-7ad6" name="Legion Rhino Transport" hidden="false" typeId="2fae-b053-3f78-e7b2" typeName=" Vehicle">
+          <modifiers>
+            <modifier type="set" field="3614-4a2d-bffb-90e4" value="15*">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
           <characteristics>
             <characteristic name="Unit Type" typeId="e555-4aed-dfcc-c0b4">Vehicle (Transport)</characteristic>
-            <characteristic name="Move" typeId="3614-4a2d-bffb-90e4">14&quot;</characteristic>
+            <characteristic name="Move" typeId="3614-4a2d-bffb-90e4">14</characteristic>
             <characteristic name="BS" typeId="51fb-b7d9-aa59-863d">4</characteristic>
             <characteristic name="Front" typeId="0ef8-a648-01d0-08ee">11</characteristic>
             <characteristic name="Side" typeId="f150-c0dc-c192-9cb3">11</characteristic>
@@ -5697,7 +5704,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                     <condition field="selections" scope="50ed-5869-643d-1ac5" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="555f-3998-a06e-f415" type="equalTo"/>
                   </conditions>
                 </modifier>
-                <modifier type="set" field="893e-2d76-8f04-44e5" value="8&quot;">
+                <modifier type="set" field="893e-2d76-8f04-44e5" value="8*">
                   <conditions>
                     <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
                   </conditions>
@@ -6279,7 +6286,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                         <condition field="selections" scope="50ed-5869-643d-1ac5" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="555f-3998-a06e-f415" type="equalTo"/>
                       </conditions>
                     </modifier>
-                    <modifier type="set" field="893e-2d76-8f04-44e5" value="8&quot;">
+                    <modifier type="set" field="893e-2d76-8f04-44e5" value="8*">
                       <conditions>
                         <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
                       </conditions>
@@ -6292,7 +6299,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                   </modifiers>
                   <characteristics>
                     <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Legionary (Infantry)</characteristic>
-                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
+                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7</characteristic>
                     <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
                     <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
                     <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -6632,7 +6639,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
           <profiles>
             <profile id="48dd-962d-c447-f7a9" name="Legion Outriders" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
               <modifiers>
-                <modifier type="set" field="893e-2d76-8f04-44e5" value="15&quot;">
+                <modifier type="set" field="893e-2d76-8f04-44e5" value="15*">
                   <conditions>
                     <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
                   </conditions>
@@ -6645,7 +6652,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
               </modifiers>
               <characteristics>
                 <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Cavalry (Skirmish)</characteristic>
-                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">14&quot;</characteristic>
+                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">14</characteristic>
                 <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
                 <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
                 <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -6790,7 +6797,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
           <profiles>
             <profile id="ac5e-9558-1319-2590" name="Legion Outrider Sergeant" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
               <modifiers>
-                <modifier type="set" field="893e-2d76-8f04-44e5" value="15&quot;">
+                <modifier type="set" field="893e-2d76-8f04-44e5" value="15*">
                   <conditions>
                     <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
                   </conditions>
@@ -6808,7 +6815,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
               </modifiers>
               <characteristics>
                 <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Cavalry (Skirmish, Character)</characteristic>
-                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">14&quot;</characteristic>
+                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">14</characteristic>
                 <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
                 <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
                 <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -7209,9 +7216,16 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
           </constraints>
           <profiles>
             <profile id="97b3-e5c1-4e3d-eec3" name="Sicaran Omega" hidden="false" typeId="2fae-b053-3f78-e7b2" typeName=" Vehicle">
+              <modifiers>
+                <modifier type="set" field="3614-4a2d-bffb-90e4" value="17*">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
               <characteristics>
                 <characteristic name="Unit Type" typeId="e555-4aed-dfcc-c0b4">Vehicle</characteristic>
-                <characteristic name="Move" typeId="3614-4a2d-bffb-90e4">16&quot;</characteristic>
+                <characteristic name="Move" typeId="3614-4a2d-bffb-90e4">16</characteristic>
                 <characteristic name="BS" typeId="51fb-b7d9-aa59-863d">4</characteristic>
                 <characteristic name="Front" typeId="0ef8-a648-01d0-08ee">13</characteristic>
                 <characteristic name="Side" typeId="f150-c0dc-c192-9cb3">12</characteristic>
@@ -7469,9 +7483,16 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
           </constraints>
           <profiles>
             <profile id="7cbb-66ee-3d5a-9f19" name="Legion Sicaran " hidden="false" typeId="2fae-b053-3f78-e7b2" typeName=" Vehicle">
+              <modifiers>
+                <modifier type="set" field="3614-4a2d-bffb-90e4" value="17*">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
               <characteristics>
                 <characteristic name="Unit Type" typeId="e555-4aed-dfcc-c0b4">Vehicle</characteristic>
-                <characteristic name="Move" typeId="3614-4a2d-bffb-90e4">16&quot;</characteristic>
+                <characteristic name="Move" typeId="3614-4a2d-bffb-90e4">16</characteristic>
                 <characteristic name="BS" typeId="51fb-b7d9-aa59-863d">4</characteristic>
                 <characteristic name="Front" typeId="0ef8-a648-01d0-08ee">13</characteristic>
                 <characteristic name="Side" typeId="f150-c0dc-c192-9cb3">12</characteristic>
@@ -7846,9 +7867,16 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
           </constraints>
           <profiles>
             <profile id="dd1e-d6e6-65dd-c544" name="Legion Fire Raptor Gunship" hidden="false" typeId="2fae-b053-3f78-e7b2" typeName=" Vehicle">
+              <modifiers>
+                <modifier type="set" field="3614-4a2d-bffb-90e4" value="19*">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
               <characteristics>
                 <characteristic name="Unit Type" typeId="e555-4aed-dfcc-c0b4">Vehicle (Flyer, Hover)</characteristic>
-                <characteristic name="Move" typeId="3614-4a2d-bffb-90e4">18&quot;</characteristic>
+                <characteristic name="Move" typeId="3614-4a2d-bffb-90e4">18</characteristic>
                 <characteristic name="BS" typeId="51fb-b7d9-aa59-863d">4</characteristic>
                 <characteristic name="Front" typeId="0ef8-a648-01d0-08ee">12</characteristic>
                 <characteristic name="Side" typeId="f150-c0dc-c192-9cb3">12</characteristic>
@@ -7992,9 +8020,16 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
           </constraints>
           <profiles>
             <profile id="641b-3e7e-b0c4-2fce" name="Legion Deredeo Dreadnought" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
+              <modifiers>
+                <modifier type="set" field="893e-2d76-8f04-44e5" value="8*">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
               <characteristics>
                 <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Dreadnought (Heavy)</characteristic>
-                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
+                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7</characteristic>
                 <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">5</characteristic>
                 <characteristic name="BS" typeId="74ae-c840-0036-d244">5</characteristic>
                 <characteristic name="S" typeId="e478-41d4-a092-48a8">7</characteristic>
@@ -8267,6 +8302,13 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
       </modifiers>
       <profiles>
         <profile id="a63c-190a-da0f-cb7f" name="Damocles Command Rhino" hidden="false" typeId="2fae-b053-3f78-e7b2" typeName=" Vehicle">
+          <modifiers>
+            <modifier type="set" field="3614-4a2d-bffb-90e4" value="15*">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
           <characteristics>
             <characteristic name="Unit Type" typeId="e555-4aed-dfcc-c0b4">Vehicle (Transport)</characteristic>
             <characteristic name="Move" typeId="3614-4a2d-bffb-90e4">14</characteristic>
@@ -8734,6 +8776,13 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
       </modifiers>
       <profiles>
         <profile id="502f-3ae3-b1ce-455a" name="Termite Assault Drill" hidden="false" typeId="2fae-b053-3f78-e7b2" typeName=" Vehicle">
+          <modifiers>
+            <modifier type="set" field="3614-4a2d-bffb-90e4" value="9*">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
           <characteristics>
             <characteristic name="Unit Type" typeId="e555-4aed-dfcc-c0b4">Vehicle (Transport)</characteristic>
             <characteristic name="Move" typeId="3614-4a2d-bffb-90e4">8</characteristic>
@@ -8955,6 +9004,11 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                 <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Dreadnought (Corrupted)">
                   <conditions>
                     <condition field="selections" scope="d664-5692-cd41-f9be" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="555f-3998-a06e-f415" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="set" field="893e-2d76-8f04-44e5" value="9*">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
                   </conditions>
                 </modifier>
               </modifiers>
@@ -9454,6 +9508,13 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
           </constraints>
           <profiles>
             <profile id="f707-403e-d4c3-0ed6" name="Land Raider Spartan" publicationId="a716-c1c4-7b26-8424" page="79" hidden="false" typeId="2fae-b053-3f78-e7b2" typeName=" Vehicle">
+              <modifiers>
+                <modifier type="set" field="3614-4a2d-bffb-90e4" value="13*">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
               <characteristics>
                 <characteristic name="Unit Type" typeId="e555-4aed-dfcc-c0b4">Vehicle (Transport, Reinforced)</characteristic>
                 <characteristic name="Move" typeId="3614-4a2d-bffb-90e4">12</characteristic>
@@ -9950,15 +10011,10 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                     <condition field="selections" scope="03be-5d55-d05a-771d" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="93af-e204-255b-b095" type="equalTo"/>
                   </conditions>
                 </modifier>
-                <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Cavalry (Character, Skirmish, Antigrav)">
-                  <conditionGroups>
-                    <conditionGroup type="and">
-                      <conditions>
-                        <condition field="selections" scope="d862-5767-da41-cff0" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6fb4-adf6-dbe8-86af" type="equalTo"/>
-                        <condition field="selections" scope="03be-5d55-d05a-771d" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0759-a4bb-a15b-7cef" type="equalTo"/>
-                      </conditions>
-                    </conditionGroup>
-                  </conditionGroups>
+                <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Cavalry (Character, Skirmish)">
+                  <conditions>
+                    <condition field="selections" scope="d862-5767-da41-cff0" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e8a8-b526-beab-bb82" type="equalTo"/>
+                  </conditions>
                 </modifier>
                 <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Infantry (Character, Psyker, Corrupted)">
                   <conditions>
@@ -9975,7 +10031,92 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                     </conditionGroup>
                   </conditionGroups>
                 </modifier>
+                <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Cavalry (Character, Skirmish, Antigrav)">
+                  <conditionGroups>
+                    <conditionGroup type="and">
+                      <conditions>
+                        <condition field="selections" scope="d862-5767-da41-cff0" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6fb4-adf6-dbe8-86af" type="equalTo"/>
+                        <condition field="selections" scope="03be-5d55-d05a-771d" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0759-a4bb-a15b-7cef" type="equalTo"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+                <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Cavalry (Character, Psyker)">
+                  <conditionGroups>
+                    <conditionGroup type="and">
+                      <conditions>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="21c3-2f28-7820-e51a" type="equalTo"/>
+                        <condition field="selections" scope="d862-5767-da41-cff0" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e8a8-b526-beab-bb82" type="equalTo"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
               </modifiers>
+              <modifierGroups>
+                <modifierGroup>
+                  <modifiers>
+                    <modifier type="set" field="893e-2d76-8f04-44e5" value="8*">
+                      <conditionGroups>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
+                            <condition field="selections" scope="d862-5767-da41-cff0" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6fb4-adf6-dbe8-86af" type="equalTo"/>
+                            <condition field="selections" scope="d862-5767-da41-cff0" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e8a8-b526-beab-bb82" type="equalTo"/>
+                            <condition field="selections" scope="d862-5767-da41-cff0" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="567d-4386-3196-ca89" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                    <modifier type="set" field="893e-2d76-8f04-44e5" value="14">
+                      <conditionGroups>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
+                            <condition field="selections" scope="d862-5767-da41-cff0" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e8a8-b526-beab-bb82" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                    <modifier type="set" field="893e-2d76-8f04-44e5" value="17*">
+                      <conditionGroups>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
+                            <condition field="selections" scope="d862-5767-da41-cff0" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6fb4-adf6-dbe8-86af" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                    <modifier type="set" field="893e-2d76-8f04-44e5" value="16">
+                      <conditionGroups>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
+                            <condition field="selections" scope="d862-5767-da41-cff0" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6fb4-adf6-dbe8-86af" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                    <modifier type="set" field="893e-2d76-8f04-44e5" value="15*">
+                      <conditionGroups>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
+                          </conditions>
+                          <conditionGroups>
+                            <conditionGroup type="and">
+                              <conditions>
+                                <condition field="selections" scope="d862-5767-da41-cff0" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e8a8-b526-beab-bb82" type="equalTo"/>
+                                <condition field="selections" scope="d862-5767-da41-cff0" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="567d-4386-3196-ca89" type="equalTo"/>
+                              </conditions>
+                            </conditionGroup>
+                          </conditionGroups>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                  </modifiers>
+                </modifierGroup>
+              </modifierGroups>
               <characteristics>
                 <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Character)</characteristic>
                 <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7</characteristic>
@@ -11047,6 +11188,11 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                     <condition field="selections" scope="1b79-1951-5a63-4b9e" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fd55-9459-b3b3-5d20" type="equalTo"/>
                   </conditions>
                 </modifier>
+                <modifier type="set" field="893e-2d76-8f04-44e5" value="7*">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
+                  </conditions>
+                </modifier>
               </modifiers>
               <characteristics>
                 <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Heavy, Character)</characteristic>
@@ -11527,6 +11673,11 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                 <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Infantry (Character, Psyker, Corrupted)">
                   <conditions>
                     <condition field="selections" scope="3760-204e-444c-1044" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fd55-9459-b3b3-5d20" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="set" field="893e-2d76-8f04-44e5" value="8*">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
                   </conditions>
                 </modifier>
               </modifiers>
@@ -12250,14 +12401,10 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                         <condition field="selections" scope="25a2-7a52-632a-6b2c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b1c4-f1e2-2f66-6d38" type="equalTo"/>
                         <condition field="selections" scope="25a2-7a52-632a-6b2c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a28d-408e-c833-9055" type="equalTo"/>
                         <condition field="selections" scope="25a2-7a52-632a-6b2c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c2a0-636c-9918-f851" type="equalTo"/>
+                        <condition field="selections" scope="c681-938e-6d11-cd43" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e8a8-b526-beab-bb82" type="equalTo"/>
                       </conditions>
                     </conditionGroup>
                   </conditionGroups>
-                </modifier>
-                <modifier type="set" field="893e-2d76-8f04-44e5" value="8&quot;">
-                  <conditions>
-                    <condition field="selections" scope="25a2-7a52-632a-6b2c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a28d-408e-c833-9055" type="equalTo"/>
-                  </conditions>
                 </modifier>
                 <modifier type="set" field="cc42-7ed5-7092-5c84" value="6">
                   <conditionGroups>
@@ -12309,6 +12456,91 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                   </conditions>
                 </modifier>
               </modifiers>
+              <modifierGroups>
+                <modifierGroup>
+                  <modifiers>
+                    <modifier type="set" field="893e-2d76-8f04-44e5" value="8*">
+                      <conditionGroups>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
+                            <condition field="selections" scope="c681-938e-6d11-cd43" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e8a8-b526-beab-bb82" type="equalTo"/>
+                            <condition field="selections" scope="c681-938e-6d11-cd43" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6fb4-adf6-dbe8-86af" type="equalTo"/>
+                            <condition field="selections" scope="c681-938e-6d11-cd43" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="567d-4386-3196-ca89" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                    <modifier type="set" field="893e-2d76-8f04-44e5" value="14">
+                      <conditionGroups>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
+                            <condition field="selections" scope="c681-938e-6d11-cd43" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e8a8-b526-beab-bb82" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                    <modifier type="set" field="893e-2d76-8f04-44e5" value="17*">
+                      <conditionGroups>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
+                            <condition field="selections" scope="c681-938e-6d11-cd43" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6fb4-adf6-dbe8-86af" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                    <modifier type="set" field="893e-2d76-8f04-44e5" value="16">
+                      <conditionGroups>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
+                            <condition field="selections" scope="c681-938e-6d11-cd43" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6fb4-adf6-dbe8-86af" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                    <modifier type="set" field="893e-2d76-8f04-44e5" value="15*">
+                      <conditionGroups>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
+                          </conditions>
+                          <conditionGroups>
+                            <conditionGroup type="or">
+                              <conditions>
+                                <condition field="selections" scope="c681-938e-6d11-cd43" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e8a8-b526-beab-bb82" type="equalTo"/>
+                                <condition field="selections" scope="c681-938e-6d11-cd43" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="567d-4386-3196-ca89" type="equalTo"/>
+                              </conditions>
+                            </conditionGroup>
+                          </conditionGroups>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                    <modifier type="set" field="893e-2d76-8f04-44e5" value="8">
+                      <conditionGroups>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
+                            <condition field="selections" scope="25a2-7a52-632a-6b2c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a28d-408e-c833-9055" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                    <modifier type="set" field="893e-2d76-8f04-44e5" value="9*">
+                      <conditionGroups>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
+                            <condition field="selections" scope="25a2-7a52-632a-6b2c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a28d-408e-c833-9055" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                  </modifiers>
+                </modifierGroup>
+              </modifierGroups>
               <characteristics>
                 <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Character)</characteristic>
                 <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7</characteristic>
@@ -13765,35 +13997,9 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
           </constraints>
           <selectionEntries>
             <selectionEntry id="671a-c0ee-d4a0-df80" name=" Tartaros Sergeant w/Lightning Claws" hidden="false" collective="false" import="true" type="model">
-              <profiles>
-                <profile id="93d6-c0b0-b2c5-b1ba" name="Tartaros Sergeant" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
-                  <modifiers>
-                    <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Infantry (Character, Psyker)">
-                      <conditions>
-                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="21c3-2f28-7820-e51a" type="equalTo"/>
-                      </conditions>
-                    </modifier>
-                    <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Infantry (Character, Corrupted)">
-                      <conditions>
-                        <condition field="selections" scope="1a8e-0ded-a4dc-2b4e" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="555f-3998-a06e-f415" type="equalTo"/>
-                      </conditions>
-                    </modifier>
-                  </modifiers>
-                  <characteristics>
-                    <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Character)</characteristic>
-                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7</characteristic>
-                    <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
-                    <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
-                    <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
-                    <characteristic name="T" typeId="c32b-5fdd-3fbe-9b1f">4</characteristic>
-                    <characteristic name="W" typeId="57ee-1126-32a9-5672">2</characteristic>
-                    <characteristic name="I" typeId="62d3-22d7-2d49-52dc">4</characteristic>
-                    <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">3</characteristic>
-                    <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">8</characteristic>
-                    <characteristic name="Save" typeId="e593-6b3c-f169-04f0">2+</characteristic>
-                  </characteristics>
-                </profile>
-              </profiles>
+              <infoLinks>
+                <infoLink id="005f-a31d-064a-fc82" name="Tartaros Sergeant" hidden="false" targetId="1bde-413a-7f98-a39e" type="profile"/>
+              </infoLinks>
               <categoryLinks>
                 <categoryLink id="0cc0-0c4e-c86c-64d0" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
               </categoryLinks>
@@ -13923,6 +14129,11 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                     <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Infantry (Character, Corrupted)">
                       <conditions>
                         <condition field="selections" scope="1a8e-0ded-a4dc-2b4e" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="555f-3998-a06e-f415" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="set" field="893e-2d76-8f04-44e5" value="8*">
+                      <conditions>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
                       </conditions>
                     </modifier>
                   </modifiers>
@@ -14080,35 +14291,9 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
           </constraints>
           <selectionEntries>
             <selectionEntry id="e39b-935f-7bc9-e945" name="Tartaros w/Lightning Claws" hidden="false" collective="false" import="true" type="model">
-              <profiles>
-                <profile id="2841-9449-a535-2f82" name="Tartaros" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
-                  <modifiers>
-                    <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Infantry (Psyker)">
-                      <conditions>
-                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="21c3-2f28-7820-e51a" type="equalTo"/>
-                      </conditions>
-                    </modifier>
-                    <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Infantry (Corrupted)">
-                      <conditions>
-                        <condition field="selections" scope="1a8e-0ded-a4dc-2b4e" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="555f-3998-a06e-f415" type="equalTo"/>
-                      </conditions>
-                    </modifier>
-                  </modifiers>
-                  <characteristics>
-                    <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry</characteristic>
-                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7</characteristic>
-                    <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
-                    <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
-                    <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
-                    <characteristic name="T" typeId="c32b-5fdd-3fbe-9b1f">4</characteristic>
-                    <characteristic name="W" typeId="57ee-1126-32a9-5672">2</characteristic>
-                    <characteristic name="I" typeId="62d3-22d7-2d49-52dc">4</characteristic>
-                    <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">2</characteristic>
-                    <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">7</characteristic>
-                    <characteristic name="Save" typeId="e593-6b3c-f169-04f0">2+</characteristic>
-                  </characteristics>
-                </profile>
-              </profiles>
+              <infoLinks>
+                <infoLink id="34a7-80f4-3af9-4031" name="Tartaros" hidden="false" targetId="7aea-92c5-6016-dfaf" type="profile"/>
+              </infoLinks>
               <entryLinks>
                 <entryLink id="3b20-2b8d-19d2-6fed" name="Pair of Lightning Claws" hidden="false" collective="false" import="true" targetId="405f-030d-0343-ade8" type="selectionEntry">
                   <constraints>
@@ -14129,23 +14314,9 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                   </conditions>
                 </modifier>
               </modifiers>
-              <profiles>
-                <profile id="9575-b67f-1bb6-8537" name="Tartaros" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
-                  <characteristics>
-                    <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry</characteristic>
-                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7</characteristic>
-                    <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
-                    <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
-                    <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
-                    <characteristic name="T" typeId="c32b-5fdd-3fbe-9b1f">4</characteristic>
-                    <characteristic name="W" typeId="57ee-1126-32a9-5672">2</characteristic>
-                    <characteristic name="I" typeId="62d3-22d7-2d49-52dc">4</characteristic>
-                    <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">2</characteristic>
-                    <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">7</characteristic>
-                    <characteristic name="Save" typeId="e593-6b3c-f169-04f0">2+</characteristic>
-                  </characteristics>
-                </profile>
-              </profiles>
+              <infoLinks>
+                <infoLink id="846e-e1ec-0083-33cc" name="Tartaros" hidden="false" targetId="7aea-92c5-6016-dfaf" type="profile"/>
+              </infoLinks>
               <entryLinks>
                 <entryLink id="118a-7eed-7c29-194a" name="Pair of Raven&apos;s Talons" hidden="false" collective="false" import="true" targetId="08e4-5e02-da82-f296" type="selectionEntry">
                   <constraints>
@@ -14170,6 +14341,11 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                     <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Infantry (Corrupted)">
                       <conditions>
                         <condition field="selections" scope="1a8e-0ded-a4dc-2b4e" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="555f-3998-a06e-f415" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="set" field="893e-2d76-8f04-44e5" value="8*">
+                      <conditions>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
                       </conditions>
                     </modifier>
                   </modifiers>
@@ -14208,35 +14384,9 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                 <constraint field="selections" scope="1a8e-0ded-a4dc-2b4e" value="0.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="c5b0-9e78-27b2-9a04" type="max"/>
                 <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c68d-0e06-30f0-0034" type="max"/>
               </constraints>
-              <profiles>
-                <profile id="b83e-aab3-6234-0962" name="Tartaros" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
-                  <modifiers>
-                    <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Infantry (Psyker)">
-                      <conditions>
-                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="21c3-2f28-7820-e51a" type="equalTo"/>
-                      </conditions>
-                    </modifier>
-                    <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Infantry (Corrupted)">
-                      <conditions>
-                        <condition field="selections" scope="1a8e-0ded-a4dc-2b4e" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="555f-3998-a06e-f415" type="equalTo"/>
-                      </conditions>
-                    </modifier>
-                  </modifiers>
-                  <characteristics>
-                    <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry</characteristic>
-                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7</characteristic>
-                    <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
-                    <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
-                    <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
-                    <characteristic name="T" typeId="c32b-5fdd-3fbe-9b1f">4</characteristic>
-                    <characteristic name="W" typeId="57ee-1126-32a9-5672">2</characteristic>
-                    <characteristic name="I" typeId="62d3-22d7-2d49-52dc">4</characteristic>
-                    <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">2</characteristic>
-                    <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">7</characteristic>
-                    <characteristic name="Save" typeId="e593-6b3c-f169-04f0">2+</characteristic>
-                  </characteristics>
-                </profile>
-              </profiles>
+              <infoLinks>
+                <infoLink id="e439-6200-c0a0-4104" name="Tartaros" hidden="false" targetId="7aea-92c5-6016-dfaf" type="profile"/>
+              </infoLinks>
               <entryLinks>
                 <entryLink id="f2df-40db-2c2c-cad2" name="Terminator Melee Weapon" hidden="false" collective="false" import="true" targetId="8b46-faad-df3a-6929" type="selectionEntryGroup"/>
                 <entryLink id="8df3-833a-75a4-656a" name="Terminator Heavy Weapons" hidden="false" collective="false" import="true" targetId="bdce-5793-7a7f-8d2a" type="selectionEntryGroup"/>
@@ -14518,7 +14668,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
         <categoryLink id="8cc9-9b8f-dc8b-183f" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="b908-ada3-76ab-8d4d" name="2) One Legion Cataphractii may take:" hidden="false" collective="false" import="true">
+        <selectionEntryGroup id="b908-ada3-76ab-8d4d" name="3) One Legion Cataphractii may take:" hidden="false" collective="false" import="true">
           <entryLinks>
             <entryLink id="fa31-6ba2-2032-289f" name="Nuncio-Vox" hidden="false" collective="false" import="true" targetId="005e-aae6-ddac-bb45" type="selectionEntry">
               <constraints>
@@ -14546,7 +14696,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="6766-d205-3ee9-7543" name="3) Dedicated Transport:" hidden="false" collective="false" import="true">
+        <selectionEntryGroup id="6766-d205-3ee9-7543" name="4) Dedicated Transport:" hidden="false" collective="false" import="true">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ef2f-0a06-3e0f-cf6e" type="max"/>
           </constraints>
@@ -14642,6 +14792,11 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                         <condition field="selections" scope="d91a-a3c7-d7be-4293" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="555f-3998-a06e-f415" type="equalTo"/>
                       </conditions>
                     </modifier>
+                    <modifier type="set" field="893e-2d76-8f04-44e5" value="7*">
+                      <conditions>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
+                      </conditions>
+                    </modifier>
                   </modifiers>
                   <characteristics>
                     <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Heavy)</characteristic>
@@ -14670,35 +14825,9 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
               <constraints>
                 <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="406f-43af-fd36-28e1" type="max"/>
               </constraints>
-              <profiles>
-                <profile id="39dc-153f-595e-8b13" name="Cataphractii" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
-                  <modifiers>
-                    <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Infantry (Heavy, Psyker)">
-                      <conditions>
-                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="21c3-2f28-7820-e51a" type="equalTo"/>
-                      </conditions>
-                    </modifier>
-                    <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Infantry (Heavy, Corrupted)">
-                      <conditions>
-                        <condition field="selections" scope="d91a-a3c7-d7be-4293" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="555f-3998-a06e-f415" type="equalTo"/>
-                      </conditions>
-                    </modifier>
-                  </modifiers>
-                  <characteristics>
-                    <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Heavy)</characteristic>
-                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">6</characteristic>
-                    <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
-                    <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
-                    <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
-                    <characteristic name="T" typeId="c32b-5fdd-3fbe-9b1f">4</characteristic>
-                    <characteristic name="W" typeId="57ee-1126-32a9-5672">2</characteristic>
-                    <characteristic name="I" typeId="62d3-22d7-2d49-52dc">4</characteristic>
-                    <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">2</characteristic>
-                    <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">7</characteristic>
-                    <characteristic name="Save" typeId="e593-6b3c-f169-04f0">2+</characteristic>
-                  </characteristics>
-                </profile>
-              </profiles>
+              <infoLinks>
+                <infoLink id="e0a3-f96d-3e2f-3567" name="Cataphractii" hidden="false" targetId="9767-9cdc-ef59-6d7f" type="profile"/>
+              </infoLinks>
               <entryLinks>
                 <entryLink id="8f24-c794-b5c4-8bf3" name="Pair of Lightning Claws" hidden="false" collective="false" import="true" targetId="405f-030d-0343-ade8" type="selectionEntry">
                   <constraints>
@@ -14723,35 +14852,9 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                 <constraint field="selections" scope="d91a-a3c7-d7be-4293" value="0.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="b861-10b1-2488-2158" type="max"/>
                 <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="72db-2b27-8008-7e76" type="max"/>
               </constraints>
-              <profiles>
-                <profile id="3eec-96a2-77c8-21cf" name="Cataphractii" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
-                  <modifiers>
-                    <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Infantry (Heavy, Psyker)">
-                      <conditions>
-                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="21c3-2f28-7820-e51a" type="equalTo"/>
-                      </conditions>
-                    </modifier>
-                    <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Infantry (Heavy, Corrupted)">
-                      <conditions>
-                        <condition field="selections" scope="d91a-a3c7-d7be-4293" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="555f-3998-a06e-f415" type="equalTo"/>
-                      </conditions>
-                    </modifier>
-                  </modifiers>
-                  <characteristics>
-                    <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Heavy)</characteristic>
-                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">6</characteristic>
-                    <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
-                    <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
-                    <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
-                    <characteristic name="T" typeId="c32b-5fdd-3fbe-9b1f">4</characteristic>
-                    <characteristic name="W" typeId="57ee-1126-32a9-5672">2</characteristic>
-                    <characteristic name="I" typeId="62d3-22d7-2d49-52dc">4</characteristic>
-                    <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">2</characteristic>
-                    <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">7</characteristic>
-                    <characteristic name="Save" typeId="e593-6b3c-f169-04f0">2+</characteristic>
-                  </characteristics>
-                </profile>
-              </profiles>
+              <infoLinks>
+                <infoLink id="20d3-de72-0ed6-b8f5" name="Cataphractii" hidden="false" targetId="9767-9cdc-ef59-6d7f" type="profile"/>
+              </infoLinks>
               <entryLinks>
                 <entryLink id="b695-6f4e-375b-8cc1" name="Terminator Melee Weapon" hidden="false" collective="false" import="true" targetId="8b46-faad-df3a-6929" type="selectionEntryGroup"/>
                 <entryLink id="827e-4e5b-cacb-1b7c" name="Terminator Heavy Weapons" hidden="false" collective="false" import="true" targetId="bdce-5793-7a7f-8d2a" type="selectionEntryGroup"/>
@@ -14771,23 +14874,9 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
               <constraints>
                 <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9d92-52a8-e6c3-d92f" type="max"/>
               </constraints>
-              <profiles>
-                <profile id="867a-0978-bde7-02dc" name="Cataphractii" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
-                  <characteristics>
-                    <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Heavy)</characteristic>
-                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">6</characteristic>
-                    <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
-                    <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
-                    <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
-                    <characteristic name="T" typeId="c32b-5fdd-3fbe-9b1f">4</characteristic>
-                    <characteristic name="W" typeId="57ee-1126-32a9-5672">2</characteristic>
-                    <characteristic name="I" typeId="62d3-22d7-2d49-52dc">4</characteristic>
-                    <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">2</characteristic>
-                    <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">7</characteristic>
-                    <characteristic name="Save" typeId="e593-6b3c-f169-04f0">2+</characteristic>
-                  </characteristics>
-                </profile>
-              </profiles>
+              <infoLinks>
+                <infoLink id="4b14-316d-f416-2b47" name="Cataphractii" hidden="false" targetId="9767-9cdc-ef59-6d7f" type="profile"/>
+              </infoLinks>
               <entryLinks>
                 <entryLink id="50ed-5374-b37c-ea65" name="Pair of Raven&apos;s Talons" hidden="false" collective="false" import="true" targetId="08e4-5e02-da82-f296" type="selectionEntry">
                   <constraints>
@@ -14821,35 +14910,9 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
           </infoLinks>
           <selectionEntries>
             <selectionEntry id="1dcd-65fa-34bb-f0e9" name=" Cataphractii Sergeant w/TLC" hidden="false" collective="false" import="true" type="model">
-              <profiles>
-                <profile id="6b6a-f375-7d75-ad20" name="Cataphractii Sergeant" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
-                  <modifiers>
-                    <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Infantry (Heavy, Character, Psyker)">
-                      <conditions>
-                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="21c3-2f28-7820-e51a" type="equalTo"/>
-                      </conditions>
-                    </modifier>
-                    <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Infantry (Heavy, Character, Corrupted)">
-                      <conditions>
-                        <condition field="selections" scope="d91a-a3c7-d7be-4293" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="555f-3998-a06e-f415" type="equalTo"/>
-                      </conditions>
-                    </modifier>
-                  </modifiers>
-                  <characteristics>
-                    <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Heavy, Character)</characteristic>
-                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">6</characteristic>
-                    <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
-                    <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
-                    <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
-                    <characteristic name="T" typeId="c32b-5fdd-3fbe-9b1f">4</characteristic>
-                    <characteristic name="W" typeId="57ee-1126-32a9-5672">2</characteristic>
-                    <characteristic name="I" typeId="62d3-22d7-2d49-52dc">4</characteristic>
-                    <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">3</characteristic>
-                    <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">8</characteristic>
-                    <characteristic name="Save" typeId="e593-6b3c-f169-04f0">2+</characteristic>
-                  </characteristics>
-                </profile>
-              </profiles>
+              <infoLinks>
+                <infoLink id="c901-b36a-f503-f2d4" name="Cataphractii Sergeant" hidden="false" targetId="768c-34e9-1ed4-3229" type="profile"/>
+              </infoLinks>
               <categoryLinks>
                 <categoryLink id="2b1e-b781-a807-6fe1" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
               </categoryLinks>
@@ -14979,6 +15042,11 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                     <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Infantry (Heavy, Character, Corrupted)">
                       <conditions>
                         <condition field="selections" scope="d91a-a3c7-d7be-4293" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="555f-3998-a06e-f415" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="set" field="893e-2d76-8f04-44e5" value="7*">
+                      <conditions>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
                       </conditions>
                     </modifier>
                   </modifiers>
@@ -15234,7 +15302,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
           <profiles>
             <profile id="749f-1625-aa4a-d4bc" name="Legion Despoiler Sergeant" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
               <modifiers>
-                <modifier type="set" field="893e-2d76-8f04-44e5" value="8&quot;">
+                <modifier type="set" field="893e-2d76-8f04-44e5" value="8*">
                   <conditions>
                     <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
                   </conditions>
@@ -15252,7 +15320,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
               </modifiers>
               <characteristics>
                 <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Character, Line)</characteristic>
-                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
+                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7</characteristic>
                 <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
                 <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
                 <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -15796,7 +15864,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
               <profiles>
                 <profile id="226a-e0f1-6ca4-8a9d" name="Despoiler" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
                   <modifiers>
-                    <modifier type="set" field="893e-2d76-8f04-44e5" value="8&quot;">
+                    <modifier type="set" field="893e-2d76-8f04-44e5" value="8*">
                       <conditions>
                         <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
                       </conditions>
@@ -15814,7 +15882,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                   </modifiers>
                   <characteristics>
                     <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Line)</characteristic>
-                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
+                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7</characteristic>
                     <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
                     <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
                     <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -16242,7 +16310,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
           <profiles>
             <profile id="dd49-1946-cd29-0609" name="Legion Breacher Sergeant" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
               <modifiers>
-                <modifier type="set" field="893e-2d76-8f04-44e5" value="8&quot;">
+                <modifier type="set" field="893e-2d76-8f04-44e5" value="8*">
                   <conditions>
                     <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
                   </conditions>
@@ -16265,7 +16333,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
               </modifiers>
               <characteristics>
                 <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Heavy, Character, Line)</characteristic>
-                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
+                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7</characteristic>
                 <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
                 <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
                 <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -16756,7 +16824,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
               <profiles>
                 <profile id="2ce5-1570-1c14-82e8" name="Breacher" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
                   <modifiers>
-                    <modifier type="set" field="893e-2d76-8f04-44e5" value="8&quot;">
+                    <modifier type="set" field="893e-2d76-8f04-44e5" value="8*">
                       <conditions>
                         <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
                       </conditions>
@@ -16774,7 +16842,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                   </modifiers>
                   <characteristics>
                     <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Heavy, Line)</characteristic>
-                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
+                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7</characteristic>
                     <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
                     <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
                     <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -17216,7 +17284,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
           <profiles>
             <profile id="4301-472d-08ee-c44b" name="Legion Recon Sergeant" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
               <modifiers>
-                <modifier type="set" field="893e-2d76-8f04-44e5" value="8&quot;">
+                <modifier type="set" field="893e-2d76-8f04-44e5" value="8*">
                   <conditions>
                     <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
                   </conditions>
@@ -17234,7 +17302,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
               </modifiers>
               <characteristics>
                 <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Character, Skirmish, Line)</characteristic>
-                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
+                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7</characteristic>
                 <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
                 <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
                 <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -17580,7 +17648,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
           <profiles>
             <profile id="b4e0-46e1-1ffb-edba" name="Recon Legionary" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
               <modifiers>
-                <modifier type="set" field="893e-2d76-8f04-44e5" value="8&quot;">
+                <modifier type="set" field="893e-2d76-8f04-44e5" value="8*">
                   <conditions>
                     <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
                   </conditions>
@@ -17598,7 +17666,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
               </modifiers>
               <characteristics>
                 <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Skirmish, Line)</characteristic>
-                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
+                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7</characteristic>
                 <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
                 <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
                 <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -17983,7 +18051,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
           <profiles>
             <profile id="4d1e-cd90-7734-8418" name="Scout" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
               <modifiers>
-                <modifier type="set" field="893e-2d76-8f04-44e5" value="9&quot;">
+                <modifier type="set" field="893e-2d76-8f04-44e5" value="9*">
                   <conditions>
                     <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
                   </conditions>
@@ -18001,7 +18069,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
               </modifiers>
               <characteristics>
                 <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Light, Skirmish)</characteristic>
-                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">8&quot;</characteristic>
+                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">8</characteristic>
                 <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
                 <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
                 <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -18152,7 +18220,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
           <profiles>
             <profile id="7522-2c5b-8724-70c1" name="Legion Scout Sergeant" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
               <modifiers>
-                <modifier type="set" field="893e-2d76-8f04-44e5" value="9&quot;">
+                <modifier type="set" field="893e-2d76-8f04-44e5" value="9*">
                   <conditions>
                     <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
                   </conditions>
@@ -18170,7 +18238,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
               </modifiers>
               <characteristics>
                 <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Character, Light, Skirmish)</characteristic>
-                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">8&quot;</characteristic>
+                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">8</characteristic>
                 <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
                 <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
                 <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -18661,10 +18729,15 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                     <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0c0f-f751-cc4e-4951" type="equalTo"/>
                   </conditions>
                 </modifier>
+                <modifier type="set" field="893e-2d76-8f04-44e5" value="8*">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
+                  </conditions>
+                </modifier>
               </modifiers>
               <characteristics>
                 <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry</characteristic>
-                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
+                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7</characteristic>
                 <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">5</characteristic>
                 <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
                 <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -19002,10 +19075,15 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                     <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0c0f-f751-cc4e-4951" type="equalTo"/>
                   </conditions>
                 </modifier>
+                <modifier type="set" field="893e-2d76-8f04-44e5" value="8*">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
+                  </conditions>
+                </modifier>
               </modifiers>
               <characteristics>
                 <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry</characteristic>
-                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
+                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7</characteristic>
                 <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">5</characteristic>
                 <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
                 <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -19745,10 +19823,15 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                     <condition field="selections" scope="3766-ea98-0aa7-62d0" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="93af-e204-255b-b095" type="equalTo"/>
                   </conditions>
                 </modifier>
+                <modifier type="set" field="893e-2d76-8f04-44e5" value="7*">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
+                  </conditions>
+                </modifier>
               </modifiers>
               <characteristics>
                 <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Heavy, Character)</characteristic>
-                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">6&quot;</characteristic>
+                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">6</characteristic>
                 <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">5</characteristic>
                 <characteristic name="BS" typeId="74ae-c840-0036-d244">5</characteristic>
                 <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -20365,6 +20448,11 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                         <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="21c3-2f28-7820-e51a" type="equalTo"/>
                       </conditions>
                     </modifier>
+                    <modifier type="set" field="893e-2d76-8f04-44e5" value="8*">
+                      <conditions>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
+                      </conditions>
+                    </modifier>
                   </modifiers>
                   <characteristics>
                     <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry</characteristic>
@@ -20403,30 +20491,9 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
               </costs>
             </selectionEntry>
             <selectionEntry id="bae2-f47b-d224-85fd" name="Tartaros Standard Bearer w/Ranged Weapon" hidden="false" collective="false" import="true" type="model">
-              <profiles>
-                <profile id="203f-00a4-651b-4512" name="Tartaros Standard Bearer" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
-                  <modifiers>
-                    <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Infantry (Psyker)">
-                      <conditions>
-                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="21c3-2f28-7820-e51a" type="equalTo"/>
-                      </conditions>
-                    </modifier>
-                  </modifiers>
-                  <characteristics>
-                    <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry</characteristic>
-                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7</characteristic>
-                    <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">5</characteristic>
-                    <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
-                    <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
-                    <characteristic name="T" typeId="c32b-5fdd-3fbe-9b1f">4</characteristic>
-                    <characteristic name="W" typeId="57ee-1126-32a9-5672">2</characteristic>
-                    <characteristic name="I" typeId="62d3-22d7-2d49-52dc">4</characteristic>
-                    <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">2</characteristic>
-                    <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">8</characteristic>
-                    <characteristic name="Save" typeId="e593-6b3c-f169-04f0">2+</characteristic>
-                  </characteristics>
-                </profile>
-              </profiles>
+              <infoLinks>
+                <infoLink id="7df6-80c3-86b9-590c" name="Tartaros Standard Bearer" hidden="false" targetId="e9b9-804b-185c-3dd7" type="profile"/>
+              </infoLinks>
               <entryLinks>
                 <entryLink id="fc60-5ff0-b038-0134" name="Terminator Ranged Weapon" hidden="false" collective="false" import="true" targetId="bb49-6a88-7ffa-6aa7" type="selectionEntryGroup"/>
                 <entryLink id="02be-953e-52c8-158e" name="Grenade Harness" hidden="false" collective="false" import="true" targetId="251a-860d-2c4d-62cc" type="selectionEntry">
@@ -20457,30 +20524,9 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
           </constraints>
           <selectionEntries>
             <selectionEntry id="bea7-fc9d-2800-1739" name="Tartaros w/Lightning Claws" hidden="false" collective="false" import="true" type="model">
-              <profiles>
-                <profile id="5b4f-e980-035f-aec9" name="Legion Tartaros Chosen" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
-                  <modifiers>
-                    <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Infantry (Psyker)">
-                      <conditions>
-                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="21c3-2f28-7820-e51a" type="equalTo"/>
-                      </conditions>
-                    </modifier>
-                  </modifiers>
-                  <characteristics>
-                    <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry</characteristic>
-                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7</characteristic>
-                    <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">5</characteristic>
-                    <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
-                    <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
-                    <characteristic name="T" typeId="c32b-5fdd-3fbe-9b1f">4</characteristic>
-                    <characteristic name="W" typeId="57ee-1126-32a9-5672">2</characteristic>
-                    <characteristic name="I" typeId="62d3-22d7-2d49-52dc">4</characteristic>
-                    <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">2</characteristic>
-                    <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">8</characteristic>
-                    <characteristic name="Save" typeId="e593-6b3c-f169-04f0">2+</characteristic>
-                  </characteristics>
-                </profile>
-              </profiles>
+              <infoLinks>
+                <infoLink id="96b8-a7b8-9551-c98d" name="Legion Tartaros Chosen" hidden="false" targetId="e3a2-6a24-fc63-8685" type="profile"/>
+              </infoLinks>
               <entryLinks>
                 <entryLink id="0f46-5178-bf60-1374" name="Pair of Lightning Claws" hidden="false" collective="false" import="true" targetId="405f-030d-0343-ade8" type="selectionEntry">
                   <constraints>
@@ -20496,6 +20542,13 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
             <selectionEntry id="29d8-226b-1c88-0d1b" name="Tartaros Chosen" hidden="false" collective="false" import="true" type="model">
               <profiles>
                 <profile id="e3a2-6a24-fc63-8685" name="Legion Tartaros Chosen" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
+                  <modifiers>
+                    <modifier type="set" field="893e-2d76-8f04-44e5" value="8*">
+                      <conditions>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
                   <characteristics>
                     <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry</characteristic>
                     <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7</characteristic>
@@ -20527,30 +20580,9 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                   </conditions>
                 </modifier>
               </modifiers>
-              <profiles>
-                <profile id="7657-948f-802e-74c4" name="Legion Tartaros Chosen" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
-                  <modifiers>
-                    <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Infantry (Psyker)">
-                      <conditions>
-                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="21c3-2f28-7820-e51a" type="equalTo"/>
-                      </conditions>
-                    </modifier>
-                  </modifiers>
-                  <characteristics>
-                    <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry</characteristic>
-                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7</characteristic>
-                    <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">5</characteristic>
-                    <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
-                    <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
-                    <characteristic name="T" typeId="c32b-5fdd-3fbe-9b1f">4</characteristic>
-                    <characteristic name="W" typeId="57ee-1126-32a9-5672">2</characteristic>
-                    <characteristic name="I" typeId="62d3-22d7-2d49-52dc">4</characteristic>
-                    <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">2</characteristic>
-                    <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">8</characteristic>
-                    <characteristic name="Save" typeId="e593-6b3c-f169-04f0">2+</characteristic>
-                  </characteristics>
-                </profile>
-              </profiles>
+              <infoLinks>
+                <infoLink id="672f-3bb2-581a-bbd8" name="Legion Tartaros Chosen" hidden="false" targetId="e3a2-6a24-fc63-8685" type="profile"/>
+              </infoLinks>
               <entryLinks>
                 <entryLink id="044c-9278-0322-d5d2" name="Pair of Raven&apos;s Talons" hidden="false" collective="false" import="true" targetId="08e4-5e02-da82-f296" type="selectionEntry">
                   <constraints>
@@ -20893,7 +20925,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
               <profiles>
                 <profile id="3dd0-d791-32fd-1e21" name="Veteran" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
                   <modifiers>
-                    <modifier type="set" field="893e-2d76-8f04-44e5" value="8&quot;">
+                    <modifier type="set" field="893e-2d76-8f04-44e5" value="8*">
                       <conditions>
                         <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
                       </conditions>
@@ -20911,7 +20943,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                   </modifiers>
                   <characteristics>
                     <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry</characteristic>
-                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
+                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7</characteristic>
                     <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">5</characteristic>
                     <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
                     <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -21133,40 +21165,9 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
               <constraints>
                 <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7d98-f4f1-828f-aa12" type="max"/>
               </constraints>
-              <profiles>
-                <profile id="98be-056b-8222-2ee3" name="Veteran" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
-                  <modifiers>
-                    <modifier type="set" field="893e-2d76-8f04-44e5" value="8&quot;">
-                      <conditions>
-                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
-                      </conditions>
-                    </modifier>
-                    <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Infantry (Psyker)">
-                      <conditions>
-                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="21c3-2f28-7820-e51a" type="equalTo"/>
-                      </conditions>
-                    </modifier>
-                    <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Infantry (Corrupted)">
-                      <conditions>
-                        <condition field="selections" scope="a423-7dd8-3f1b-3e28" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bc7e-1e83-8e1a-afab" type="equalTo"/>
-                      </conditions>
-                    </modifier>
-                  </modifiers>
-                  <characteristics>
-                    <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry</characteristic>
-                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
-                    <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">5</characteristic>
-                    <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
-                    <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
-                    <characteristic name="T" typeId="c32b-5fdd-3fbe-9b1f">4</characteristic>
-                    <characteristic name="W" typeId="57ee-1126-32a9-5672">2</characteristic>
-                    <characteristic name="I" typeId="62d3-22d7-2d49-52dc">4</characteristic>
-                    <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">2</characteristic>
-                    <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">8</characteristic>
-                    <characteristic name="Save" typeId="e593-6b3c-f169-04f0">3+</characteristic>
-                  </characteristics>
-                </profile>
-              </profiles>
+              <infoLinks>
+                <infoLink id="f7db-5760-eeed-bc31" name="Veteran" hidden="false" targetId="3dd0-d791-32fd-1e21" type="profile"/>
+              </infoLinks>
               <selectionEntryGroups>
                 <selectionEntryGroup id="6a4b-5547-21e5-f62a" name="1) Heavy/Special Weapon Options" hidden="false" collective="false" import="true" defaultSelectionEntryId="9907-9a12-9cdb-d4f7">
                   <constraints>
@@ -21411,40 +21412,9 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
               <constraints>
                 <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3e4b-df08-466d-28de" type="max"/>
               </constraints>
-              <profiles>
-                <profile id="6add-02ef-c9b3-77f0" name="Veteran" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
-                  <modifiers>
-                    <modifier type="set" field="893e-2d76-8f04-44e5" value="8&quot;">
-                      <conditions>
-                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
-                      </conditions>
-                    </modifier>
-                    <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Infantry (Psyker)">
-                      <conditions>
-                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="21c3-2f28-7820-e51a" type="equalTo"/>
-                      </conditions>
-                    </modifier>
-                    <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Infantry (Corrupted)">
-                      <conditions>
-                        <condition field="selections" scope="a423-7dd8-3f1b-3e28" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bc7e-1e83-8e1a-afab" type="equalTo"/>
-                      </conditions>
-                    </modifier>
-                  </modifiers>
-                  <characteristics>
-                    <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry</characteristic>
-                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
-                    <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">5</characteristic>
-                    <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
-                    <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
-                    <characteristic name="T" typeId="c32b-5fdd-3fbe-9b1f">4</characteristic>
-                    <characteristic name="W" typeId="57ee-1126-32a9-5672">2</characteristic>
-                    <characteristic name="I" typeId="62d3-22d7-2d49-52dc">4</characteristic>
-                    <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">2</characteristic>
-                    <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">8</characteristic>
-                    <characteristic name="Save" typeId="e593-6b3c-f169-04f0">3+</characteristic>
-                  </characteristics>
-                </profile>
-              </profiles>
+              <infoLinks>
+                <infoLink id="915b-2f01-6108-60dd" name="Veteran" hidden="false" targetId="3dd0-d791-32fd-1e21" type="profile"/>
+              </infoLinks>
               <selectionEntryGroups>
                 <selectionEntryGroup id="3706-8883-27ac-ef95" name="1) Paired Melee Options" hidden="false" collective="false" import="true" defaultSelectionEntryId="4a56-b520-18b4-c37c">
                   <constraints>
@@ -21535,45 +21505,9 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
           </constraints>
           <selectionEntries>
             <selectionEntry id="d537-390a-01de-3e2c" name="  Veteran Sergeant w/Paired Melee Weapons" publicationId="a716-c1c4-7b26-8424" hidden="false" collective="false" import="true" type="model">
-              <profiles>
-                <profile id="ecf4-e0c5-7239-61cb" name="Legion Tactical Sergeant" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
-                  <modifiers>
-                    <modifier type="set" field="893e-2d76-8f04-44e5" value="8&quot;">
-                      <conditions>
-                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
-                      </conditions>
-                    </modifier>
-                    <modifier type="set" field="e593-6b3c-f169-04f0" value="2+">
-                      <conditions>
-                        <condition field="selections" scope="a423-7dd8-3f1b-3e28" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="583e-62cb-53f1-f952" type="equalTo"/>
-                      </conditions>
-                    </modifier>
-                    <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Infantry (Character, Psyker)">
-                      <conditions>
-                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="21c3-2f28-7820-e51a" type="equalTo"/>
-                      </conditions>
-                    </modifier>
-                    <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Infantry (Character, Corrupted)">
-                      <conditions>
-                        <condition field="selections" scope="a423-7dd8-3f1b-3e28" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bc7e-1e83-8e1a-afab" type="equalTo"/>
-                      </conditions>
-                    </modifier>
-                  </modifiers>
-                  <characteristics>
-                    <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Character)</characteristic>
-                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
-                    <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">5</characteristic>
-                    <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
-                    <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
-                    <characteristic name="T" typeId="c32b-5fdd-3fbe-9b1f">4</characteristic>
-                    <characteristic name="W" typeId="57ee-1126-32a9-5672">2</characteristic>
-                    <characteristic name="I" typeId="62d3-22d7-2d49-52dc">4</characteristic>
-                    <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">3</characteristic>
-                    <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">8</characteristic>
-                    <characteristic name="Save" typeId="e593-6b3c-f169-04f0">3+</characteristic>
-                  </characteristics>
-                </profile>
-              </profiles>
+              <infoLinks>
+                <infoLink id="308e-910a-de93-f0e0" name="Legion Veteran Sergeant" hidden="false" targetId="4d27-c159-8345-2378" type="profile"/>
+              </infoLinks>
               <categoryLinks>
                 <categoryLink id="5639-da94-4fb8-6ee7" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
               </categoryLinks>
@@ -21800,9 +21734,9 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
             </selectionEntry>
             <selectionEntry id="3cbb-2495-eb12-f014" name="  Veteran Sergeant" publicationId="a716-c1c4-7b26-8424" hidden="false" collective="false" import="true" type="model">
               <profiles>
-                <profile id="4d27-c159-8345-2378" name="Legion Tactical Sergeant" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
+                <profile id="4d27-c159-8345-2378" name="Legion Veteran Sergeant" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
                   <modifiers>
-                    <modifier type="set" field="893e-2d76-8f04-44e5" value="8&quot;">
+                    <modifier type="set" field="893e-2d76-8f04-44e5" value="8*">
                       <conditions>
                         <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
                       </conditions>
@@ -21825,7 +21759,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                   </modifiers>
                   <characteristics>
                     <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Character)</characteristic>
-                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
+                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7</characteristic>
                     <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">5</characteristic>
                     <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
                     <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -22335,7 +22269,73 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                     <condition field="selections" scope="415c-6834-f4d2-d967" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6fb4-adf6-dbe8-86af" type="equalTo"/>
                   </conditions>
                 </modifier>
+                <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Skirmish)">
+                  <conditionGroups>
+                    <conditionGroup type="and">
+                      <conditions>
+                        <condition field="selections" scope="415c-6834-f4d2-d967" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e8a8-b526-beab-bb82" type="equalTo"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
               </modifiers>
+              <modifierGroups>
+                <modifierGroup>
+                  <modifiers>
+                    <modifier type="set" field="893e-2d76-8f04-44e5" value="8*">
+                      <conditionGroups>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
+                            <condition field="selections" scope="415c-6834-f4d2-d967" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6fb4-adf6-dbe8-86af" type="equalTo"/>
+                            <condition field="selections" scope="415c-6834-f4d2-d967" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e8a8-b526-beab-bb82" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                    <modifier type="set" field="893e-2d76-8f04-44e5" value="14">
+                      <conditionGroups>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
+                            <condition field="selections" scope="415c-6834-f4d2-d967" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e8a8-b526-beab-bb82" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                    <modifier type="set" field="893e-2d76-8f04-44e5" value="17*">
+                      <conditionGroups>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
+                            <condition field="selections" scope="415c-6834-f4d2-d967" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6fb4-adf6-dbe8-86af" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                    <modifier type="set" field="893e-2d76-8f04-44e5" value="16">
+                      <conditionGroups>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
+                            <condition field="selections" scope="415c-6834-f4d2-d967" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6fb4-adf6-dbe8-86af" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                    <modifier type="set" field="893e-2d76-8f04-44e5" value="15*">
+                      <conditionGroups>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
+                            <condition field="selections" scope="415c-6834-f4d2-d967" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e8a8-b526-beab-bb82" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                  </modifiers>
+                </modifierGroup>
+              </modifierGroups>
               <characteristics>
                 <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Character)</characteristic>
                 <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
@@ -22787,7 +22787,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
           <profiles>
             <profile id="61c8-2601-2f35-f8b6" name="Legion Seeker" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
               <modifiers>
-                <modifier type="set" field="893e-2d76-8f04-44e5" value="8&quot;">
+                <modifier type="set" field="893e-2d76-8f04-44e5" value="8*">
                   <conditions>
                     <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
                   </conditions>
@@ -22805,7 +22805,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
               </modifiers>
               <characteristics>
                 <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Skirmish)</characteristic>
-                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
+                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7</characteristic>
                 <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
                 <characteristic name="BS" typeId="74ae-c840-0036-d244">5</characteristic>
                 <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -22988,7 +22988,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
           <profiles>
             <profile id="c111-0098-1299-1262" name="Legion Seeker Sergeant" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
               <modifiers>
-                <modifier type="set" field="893e-2d76-8f04-44e5" value="8&quot;">
+                <modifier type="set" field="893e-2d76-8f04-44e5" value="8*">
                   <conditions>
                     <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
                   </conditions>
@@ -23011,7 +23011,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
               </modifiers>
               <characteristics>
                 <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Character, Skirmish)</characteristic>
-                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
+                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7</characteristic>
                 <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
                 <characteristic name="BS" typeId="74ae-c840-0036-d244">5</characteristic>
                 <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -23624,10 +23624,76 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                     <condition field="selections" scope="fc32-089e-1c59-70bd" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e8a8-b526-beab-bb82" type="equalTo"/>
                   </conditions>
                 </modifier>
+                <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Skirmish)">
+                  <conditionGroups>
+                    <conditionGroup type="and">
+                      <conditions>
+                        <condition field="selections" scope="fc32-089e-1c59-70bd" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e8a8-b526-beab-bb82" type="equalTo"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
               </modifiers>
+              <modifierGroups>
+                <modifierGroup>
+                  <modifiers>
+                    <modifier type="set" field="893e-2d76-8f04-44e5" value="8*">
+                      <conditionGroups>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
+                            <condition field="selections" scope="fc32-089e-1c59-70bd" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6fb4-adf6-dbe8-86af" type="equalTo"/>
+                            <condition field="selections" scope="fc32-089e-1c59-70bd" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e8a8-b526-beab-bb82" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                    <modifier type="set" field="893e-2d76-8f04-44e5" value="14">
+                      <conditionGroups>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
+                            <condition field="selections" scope="fc32-089e-1c59-70bd" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e8a8-b526-beab-bb82" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                    <modifier type="set" field="893e-2d76-8f04-44e5" value="17*">
+                      <conditionGroups>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
+                            <condition field="selections" scope="fc32-089e-1c59-70bd" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6fb4-adf6-dbe8-86af" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                    <modifier type="set" field="893e-2d76-8f04-44e5" value="16">
+                      <conditionGroups>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
+                            <condition field="selections" scope="fc32-089e-1c59-70bd" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6fb4-adf6-dbe8-86af" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                    <modifier type="set" field="893e-2d76-8f04-44e5" value="15*">
+                      <conditionGroups>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
+                            <condition field="selections" scope="fc32-089e-1c59-70bd" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e8a8-b526-beab-bb82" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                  </modifiers>
+                </modifierGroup>
+              </modifierGroups>
               <characteristics>
                 <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Character)</characteristic>
-                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
+                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7</characteristic>
                 <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
                 <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
                 <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -24522,10 +24588,15 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                     <condition field="selections" scope="f806-8a4e-d0d6-beaa" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="93af-e204-255b-b095" type="equalTo"/>
                   </conditions>
                 </modifier>
+                <modifier type="set" field="893e-2d76-8f04-44e5" value="8*">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
+                  </conditions>
+                </modifier>
               </modifiers>
               <characteristics>
                 <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Character)</characteristic>
-                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
+                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7</characteristic>
                 <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">5</characteristic>
                 <characteristic name="BS" typeId="74ae-c840-0036-d244">5</characteristic>
                 <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -25056,6 +25127,11 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                     </conditionGroup>
                   </conditionGroups>
                 </modifier>
+                <modifier type="set" field="893e-2d76-8f04-44e5" value="7*">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
+                  </conditions>
+                </modifier>
               </modifiers>
               <characteristics>
                 <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Dreadnought (Heavy)</characteristic>
@@ -25470,9 +25546,16 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
           </constraints>
           <profiles>
             <profile id="5669-278f-51c7-be2a" name="Predator" hidden="false" typeId="2fae-b053-3f78-e7b2" typeName=" Vehicle">
+              <modifiers>
+                <modifier type="set" field="3614-4a2d-bffb-90e4" value="15*">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
               <characteristics>
                 <characteristic name="Unit Type" typeId="e555-4aed-dfcc-c0b4">Vehicle</characteristic>
-                <characteristic name="Move" typeId="3614-4a2d-bffb-90e4">14&quot;</characteristic>
+                <characteristic name="Move" typeId="3614-4a2d-bffb-90e4">14</characteristic>
                 <characteristic name="BS" typeId="51fb-b7d9-aa59-863d">4</characteristic>
                 <characteristic name="Front" typeId="0ef8-a648-01d0-08ee">13</characteristic>
                 <characteristic name="Side" typeId="f150-c0dc-c192-9cb3">12</characteristic>
@@ -25872,6 +25955,13 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
           </constraints>
           <profiles>
             <profile id="d643-9a86-24b9-237e" name="Sicaran Arcus" hidden="false" typeId="2fae-b053-3f78-e7b2" typeName=" Vehicle">
+              <modifiers>
+                <modifier type="set" field="3614-4a2d-bffb-90e4" value="17*">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
               <characteristics>
                 <characteristic name="Unit Type" typeId="e555-4aed-dfcc-c0b4">Vehicle</characteristic>
                 <characteristic name="Move" typeId="3614-4a2d-bffb-90e4">16</characteristic>
@@ -26149,6 +26239,13 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
           </constraints>
           <profiles>
             <profile id="1deb-1384-5bed-a14a" name="Sicaran Punisher" publicationId="a716-c1c4-7b26-8424" page="72" hidden="false" typeId="2fae-b053-3f78-e7b2" typeName=" Vehicle">
+              <modifiers>
+                <modifier type="set" field="3614-4a2d-bffb-90e4" value="17*">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
               <characteristics>
                 <characteristic name="Unit Type" typeId="e555-4aed-dfcc-c0b4">Vehicle</characteristic>
                 <characteristic name="Move" typeId="3614-4a2d-bffb-90e4">16</characteristic>
@@ -26521,6 +26618,13 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
           </constraints>
           <profiles>
             <profile id="a43b-2628-0c41-5222" name="Sicaran Venator" publicationId="a716-c1c4-7b26-8424" page="73" hidden="false" typeId="2fae-b053-3f78-e7b2" typeName=" Vehicle">
+              <modifiers>
+                <modifier type="set" field="3614-4a2d-bffb-90e4" value="17*">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
               <characteristics>
                 <characteristic name="Unit Type" typeId="e555-4aed-dfcc-c0b4">Vehicle</characteristic>
                 <characteristic name="Move" typeId="3614-4a2d-bffb-90e4">16</characteristic>
@@ -26748,6 +26852,13 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
       </modifiers>
       <profiles>
         <profile id="2289-894c-5b9c-87cd" name="Land Raider Proteus Explorator" publicationId="a716-c1c4-7b26-8424" page="76" hidden="false" typeId="2fae-b053-3f78-e7b2" typeName=" Vehicle">
+          <modifiers>
+            <modifier type="set" field="3614-4a2d-bffb-90e4" value="13*">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
           <characteristics>
             <characteristic name="Unit Type" typeId="e555-4aed-dfcc-c0b4">Vehicle (Transport, Reinforced)</characteristic>
             <characteristic name="Move" typeId="3614-4a2d-bffb-90e4">12</characteristic>
@@ -27031,6 +27142,13 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
           </constraints>
           <profiles>
             <profile id="e095-4655-c564-b968" name="Vindicator" hidden="false" typeId="2fae-b053-3f78-e7b2" typeName=" Vehicle">
+              <modifiers>
+                <modifier type="set" field="3614-4a2d-bffb-90e4" value="13*">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
               <characteristics>
                 <characteristic name="Unit Type" typeId="e555-4aed-dfcc-c0b4">Vehicle (Reinforced)</characteristic>
                 <characteristic name="Move" typeId="3614-4a2d-bffb-90e4">12</characteristic>
@@ -27348,9 +27466,16 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
           </constraints>
           <profiles>
             <profile id="19aa-5883-3add-6fec" name="Arquitor" hidden="false" typeId="2fae-b053-3f78-e7b2" typeName=" Vehicle">
+              <modifiers>
+                <modifier type="set" field="3614-4a2d-bffb-90e4" value="9*">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
               <characteristics>
                 <characteristic name="Unit Type" typeId="e555-4aed-dfcc-c0b4">Vehicle (Bombard)</characteristic>
-                <characteristic name="Move" typeId="3614-4a2d-bffb-90e4">8&quot;</characteristic>
+                <characteristic name="Move" typeId="3614-4a2d-bffb-90e4">8</characteristic>
                 <characteristic name="BS" typeId="51fb-b7d9-aa59-863d">4</characteristic>
                 <characteristic name="Front" typeId="0ef8-a648-01d0-08ee">12</characteristic>
                 <characteristic name="Side" typeId="f150-c0dc-c192-9cb3">12</characteristic>
@@ -27762,6 +27887,11 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                         <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="21c3-2f28-7820-e51a" type="equalTo"/>
                       </conditions>
                     </modifier>
+                    <modifier type="set" field="893e-2d76-8f04-44e5" value="7*">
+                      <conditions>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
+                      </conditions>
+                    </modifier>
                   </modifiers>
                   <characteristics>
                     <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Heavy)</characteristic>
@@ -27800,30 +27930,9 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
               </costs>
             </selectionEntry>
             <selectionEntry id="58c7-4655-953a-640b" name="Cataphractii Standard Bearer w/Ranged Weapon" hidden="false" collective="false" import="true" type="model">
-              <profiles>
-                <profile id="d417-7501-50f6-5c76" name="Cataphractii Standard Bearer" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
-                  <modifiers>
-                    <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Infantry (Heavy, Psyker)">
-                      <conditions>
-                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="21c3-2f28-7820-e51a" type="equalTo"/>
-                      </conditions>
-                    </modifier>
-                  </modifiers>
-                  <characteristics>
-                    <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Heavy)</characteristic>
-                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">6</characteristic>
-                    <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">5</characteristic>
-                    <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
-                    <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
-                    <characteristic name="T" typeId="c32b-5fdd-3fbe-9b1f">4</characteristic>
-                    <characteristic name="W" typeId="57ee-1126-32a9-5672">2</characteristic>
-                    <characteristic name="I" typeId="62d3-22d7-2d49-52dc">4</characteristic>
-                    <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">2</characteristic>
-                    <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">8</characteristic>
-                    <characteristic name="Save" typeId="e593-6b3c-f169-04f0">2+</characteristic>
-                  </characteristics>
-                </profile>
-              </profiles>
+              <infoLinks>
+                <infoLink id="a2dc-c801-f143-91a4" name="Cataphractii Standard Bearer" hidden="false" targetId="99d4-6b3d-44da-0595" type="profile"/>
+              </infoLinks>
               <entryLinks>
                 <entryLink id="bbb6-6270-fe91-5735" name="Grenade Harness" hidden="false" collective="false" import="true" targetId="251a-860d-2c4d-62cc" type="selectionEntry">
                   <constraints>
@@ -27862,6 +27971,11 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                         <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="21c3-2f28-7820-e51a" type="equalTo"/>
                       </conditions>
                     </modifier>
+                    <modifier type="set" field="893e-2d76-8f04-44e5" value="7*">
+                      <conditions>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
+                      </conditions>
+                    </modifier>
                   </modifiers>
                   <characteristics>
                     <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Heavy)</characteristic>
@@ -27887,30 +28001,9 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
               </costs>
             </selectionEntry>
             <selectionEntry id="046d-1464-d7b7-f819" name="Cataphractii Chosen w/Lightning Claws" hidden="false" collective="false" import="true" type="model">
-              <profiles>
-                <profile id="dd58-7586-2bee-347e" name="Cataphractii Chosen" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
-                  <modifiers>
-                    <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Infantry (Heavy, Psyker)">
-                      <conditions>
-                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="21c3-2f28-7820-e51a" type="equalTo"/>
-                      </conditions>
-                    </modifier>
-                  </modifiers>
-                  <characteristics>
-                    <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Heavy)</characteristic>
-                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">6</characteristic>
-                    <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">5</characteristic>
-                    <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
-                    <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
-                    <characteristic name="T" typeId="c32b-5fdd-3fbe-9b1f">4</characteristic>
-                    <characteristic name="W" typeId="57ee-1126-32a9-5672">2</characteristic>
-                    <characteristic name="I" typeId="62d3-22d7-2d49-52dc">4</characteristic>
-                    <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">2</characteristic>
-                    <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">8</characteristic>
-                    <characteristic name="Save" typeId="e593-6b3c-f169-04f0">2+</characteristic>
-                  </characteristics>
-                </profile>
-              </profiles>
+              <infoLinks>
+                <infoLink id="1d60-743e-e023-b6d7" name="Cataphractii Chosen" hidden="false" targetId="aa0f-9154-4a0e-38c8" type="profile"/>
+              </infoLinks>
               <entryLinks>
                 <entryLink id="4c7e-a77e-6a81-2a19" name="Pair of Lightning Claws" hidden="false" collective="false" import="true" targetId="405f-030d-0343-ade8" type="selectionEntry">
                   <constraints>
@@ -27931,23 +28024,9 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                   </conditions>
                 </modifier>
               </modifiers>
-              <profiles>
-                <profile id="24b2-08c6-1a1e-6cd3" name="Cataphractii Chosen" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
-                  <characteristics>
-                    <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Heavy)</characteristic>
-                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">6</characteristic>
-                    <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">5</characteristic>
-                    <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
-                    <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
-                    <characteristic name="T" typeId="c32b-5fdd-3fbe-9b1f">4</characteristic>
-                    <characteristic name="W" typeId="57ee-1126-32a9-5672">2</characteristic>
-                    <characteristic name="I" typeId="62d3-22d7-2d49-52dc">4</characteristic>
-                    <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">2</characteristic>
-                    <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">8</characteristic>
-                    <characteristic name="Save" typeId="e593-6b3c-f169-04f0">2+</characteristic>
-                  </characteristics>
-                </profile>
-              </profiles>
+              <infoLinks>
+                <infoLink id="1a73-68fe-e26e-8f9f" name="Cataphractii Chosen" hidden="false" targetId="aa0f-9154-4a0e-38c8" type="profile"/>
+              </infoLinks>
               <entryLinks>
                 <entryLink id="2e7b-203c-0ad9-d156" name="Pair of Raven&apos;s Talons" hidden="false" collective="false" import="true" targetId="08e4-5e02-da82-f296" type="selectionEntry">
                   <constraints>
@@ -28097,6 +28176,13 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
           </constraints>
           <profiles>
             <profile id="a42c-b973-a834-810d" name="Dreadclaw Drop Pod" hidden="false" typeId="2fae-b053-3f78-e7b2" typeName=" Vehicle">
+              <modifiers>
+                <modifier type="set" field="3614-4a2d-bffb-90e4" value="16*">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
               <characteristics>
                 <characteristic name="Unit Type" typeId="e555-4aed-dfcc-c0b4">Vehicle (Transport)</characteristic>
                 <characteristic name="Move" typeId="3614-4a2d-bffb-90e4">15</characteristic>
@@ -28229,7 +28315,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                     <condition field="selections" scope="bac9-5389-e2e7-0b1f" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1c1e-d89a-a74e-5672" type="equalTo"/>
                   </conditions>
                 </modifier>
-                <modifier type="set" field="893e-2d76-8f04-44e5" value="8&quot;">
+                <modifier type="set" field="893e-2d76-8f04-44e5" value="8*">
                   <conditions>
                     <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
                   </conditions>
@@ -28247,7 +28333,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
               </modifiers>
               <characteristics>
                 <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Heavy, Character)</characteristic>
-                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
+                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7</characteristic>
                 <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
                 <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
                 <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -28740,7 +28826,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                         <condition field="selections" scope="bac9-5389-e2e7-0b1f" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1c1e-d89a-a74e-5672" type="equalTo"/>
                       </conditions>
                     </modifier>
-                    <modifier type="set" field="893e-2d76-8f04-44e5" value="8&quot;">
+                    <modifier type="set" field="893e-2d76-8f04-44e5" value="8*">
                       <conditions>
                         <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
                       </conditions>
@@ -28753,7 +28839,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                   </modifiers>
                   <characteristics>
                     <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Heavy)</characteristic>
-                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
+                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7</characteristic>
                     <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
                     <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
                     <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -28957,9 +29043,16 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
           </constraints>
           <profiles>
             <profile id="9c15-82a2-3b65-215d" name="Sabre Strike Tank" hidden="false" typeId="2fae-b053-3f78-e7b2" typeName=" Vehicle">
+              <modifiers>
+                <modifier type="set" field="3614-4a2d-bffb-90e4" value="17*">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
               <characteristics>
                 <characteristic name="Unit Type" typeId="e555-4aed-dfcc-c0b4">Vehicle (Fast)</characteristic>
-                <characteristic name="Move" typeId="3614-4a2d-bffb-90e4">16&quot;</characteristic>
+                <characteristic name="Move" typeId="3614-4a2d-bffb-90e4">16</characteristic>
                 <characteristic name="BS" typeId="51fb-b7d9-aa59-863d">4</characteristic>
                 <characteristic name="Front" typeId="0ef8-a648-01d0-08ee">12</characteristic>
                 <characteristic name="Side" typeId="f150-c0dc-c192-9cb3">11</characteristic>
@@ -29238,10 +29331,15 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                     </conditionGroup>
                   </conditionGroups>
                 </modifier>
+                <modifier type="set" field="893e-2d76-8f04-44e5" value="17*">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
+                  </conditions>
+                </modifier>
               </modifiers>
               <characteristics>
                 <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Cavalry (Antigrav)</characteristic>
-                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">16&quot;</characteristic>
+                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">16</characteristic>
                 <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
                 <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
                 <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -29412,10 +29510,15 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                     </conditionGroup>
                   </conditionGroups>
                 </modifier>
+                <modifier type="set" field="893e-2d76-8f04-44e5" value="17*">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
+                  </conditions>
+                </modifier>
               </modifiers>
               <characteristics>
                 <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Cavalry (Antigrav), Character</characteristic>
-                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">16&quot;</characteristic>
+                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">16</characteristic>
                 <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
                 <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
                 <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -29728,9 +29831,16 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
       </modifiers>
       <profiles>
         <profile id="364c-030d-be45-c981" name="Storm Eagle Gunship" hidden="false" typeId="2fae-b053-3f78-e7b2" typeName=" Vehicle">
+          <modifiers>
+            <modifier type="set" field="3614-4a2d-bffb-90e4" value="19*">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
           <characteristics>
             <characteristic name="Unit Type" typeId="e555-4aed-dfcc-c0b4">Vehicle (Flyer, Hover, Transport)</characteristic>
-            <characteristic name="Move" typeId="3614-4a2d-bffb-90e4">18&quot;</characteristic>
+            <characteristic name="Move" typeId="3614-4a2d-bffb-90e4">18</characteristic>
             <characteristic name="BS" typeId="51fb-b7d9-aa59-863d">4</characteristic>
             <characteristic name="Front" typeId="0ef8-a648-01d0-08ee">12</characteristic>
             <characteristic name="Side" typeId="f150-c0dc-c192-9cb3">12</characteristic>
@@ -29892,9 +30002,16 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
       </modifiers>
       <profiles>
         <profile id="29f8-c56d-4902-5d23" name="Xiphon Interceptor" hidden="false" typeId="2fae-b053-3f78-e7b2" typeName=" Vehicle">
+          <modifiers>
+            <modifier type="set" field="3614-4a2d-bffb-90e4" value="21*">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
           <characteristics>
             <characteristic name="Unit Type" typeId="e555-4aed-dfcc-c0b4">Vehicle (Flyer)</characteristic>
-            <characteristic name="Move" typeId="3614-4a2d-bffb-90e4">20&quot;</characteristic>
+            <characteristic name="Move" typeId="3614-4a2d-bffb-90e4">20</characteristic>
             <characteristic name="BS" typeId="51fb-b7d9-aa59-863d">4</characteristic>
             <characteristic name="Front" typeId="0ef8-a648-01d0-08ee">11</characteristic>
             <characteristic name="Side" typeId="f150-c0dc-c192-9cb3">11</characteristic>
@@ -30042,10 +30159,15 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                     <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="21c3-2f28-7820-e51a" type="equalTo"/>
                   </conditions>
                 </modifier>
+                <modifier type="set" field="893e-2d76-8f04-44e5" value="17*">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
+                  </conditions>
+                </modifier>
               </modifiers>
               <characteristics>
                 <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Cavalry (Antigrav)</characteristic>
-                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">16&quot;</characteristic>
+                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">16</characteristic>
                 <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
                 <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
                 <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -30320,10 +30442,15 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                     <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="21c3-2f28-7820-e51a" type="equalTo"/>
                   </conditions>
                 </modifier>
+                <modifier type="set" field="893e-2d76-8f04-44e5" value="15*">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
+                  </conditions>
+                </modifier>
               </modifiers>
               <characteristics>
                 <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Cavalry (Antigrav, Heavy)</characteristic>
-                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">14&quot;</characteristic>
+                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">14</characteristic>
                 <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
                 <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
                 <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -30546,9 +30673,16 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
           </constraints>
           <profiles>
             <profile id="676b-8b33-a00b-ef40" name="Cerberus" hidden="false" typeId="2fae-b053-3f78-e7b2" typeName=" Vehicle">
+              <modifiers>
+                <modifier type="set" field="3614-4a2d-bffb-90e4" value="11*">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
               <characteristics>
                 <characteristic name="Unit Type" typeId="e555-4aed-dfcc-c0b4">Vehicle (Bombard, Reinforced)</characteristic>
-                <characteristic name="Move" typeId="3614-4a2d-bffb-90e4">10&quot;</characteristic>
+                <characteristic name="Move" typeId="3614-4a2d-bffb-90e4">10</characteristic>
                 <characteristic name="BS" typeId="51fb-b7d9-aa59-863d">4</characteristic>
                 <characteristic name="Front" typeId="0ef8-a648-01d0-08ee">14</characteristic>
                 <characteristic name="Side" typeId="f150-c0dc-c192-9cb3">14</characteristic>
@@ -30895,9 +31029,16 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
           </constraints>
           <profiles>
             <profile id="1e05-36e3-42c3-446d" name="Typhon" hidden="false" typeId="2fae-b053-3f78-e7b2" typeName=" Vehicle">
+              <modifiers>
+                <modifier type="set" field="3614-4a2d-bffb-90e4" value="11*">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
               <characteristics>
                 <characteristic name="Unit Type" typeId="e555-4aed-dfcc-c0b4">Vehicle (Bombard, Reinforced)</characteristic>
-                <characteristic name="Move" typeId="3614-4a2d-bffb-90e4">10&quot;</characteristic>
+                <characteristic name="Move" typeId="3614-4a2d-bffb-90e4">10</characteristic>
                 <characteristic name="BS" typeId="51fb-b7d9-aa59-863d">4</characteristic>
                 <characteristic name="Front" typeId="0ef8-a648-01d0-08ee">14</characteristic>
                 <characteristic name="Side" typeId="f150-c0dc-c192-9cb3">14</characteristic>
@@ -31185,9 +31326,16 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
       </modifiers>
       <profiles>
         <profile id="0b05-2dc7-b9e1-5a3e" name="Glaive" hidden="false" typeId="2fae-b053-3f78-e7b2" typeName=" Vehicle">
+          <modifiers>
+            <modifier type="set" field="3614-4a2d-bffb-90e4" value="13*">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
           <characteristics>
             <characteristic name="Unit Type" typeId="e555-4aed-dfcc-c0b4">Vehicle (Super-heavy)</characteristic>
-            <characteristic name="Move" typeId="3614-4a2d-bffb-90e4">12&quot;</characteristic>
+            <characteristic name="Move" typeId="3614-4a2d-bffb-90e4">12</characteristic>
             <characteristic name="BS" typeId="51fb-b7d9-aa59-863d">4</characteristic>
             <characteristic name="Front" typeId="0ef8-a648-01d0-08ee">14</characteristic>
             <characteristic name="Side" typeId="f150-c0dc-c192-9cb3">13</characteristic>
@@ -31474,9 +31622,16 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
       </modifiers>
       <profiles>
         <profile id="f471-f5a8-001a-2a5e" name="Thunderhawk Gunship" hidden="false" typeId="2fae-b053-3f78-e7b2" typeName=" Vehicle">
+          <modifiers>
+            <modifier type="set" field="3614-4a2d-bffb-90e4" value="19*">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
           <characteristics>
             <characteristic name="Unit Type" typeId="e555-4aed-dfcc-c0b4">Vehicle (Flyer, Hover, Lumbering, Transport)</characteristic>
-            <characteristic name="Move" typeId="3614-4a2d-bffb-90e4">18&quot;</characteristic>
+            <characteristic name="Move" typeId="3614-4a2d-bffb-90e4">18</characteristic>
             <characteristic name="BS" typeId="51fb-b7d9-aa59-863d">4</characteristic>
             <characteristic name="Front" typeId="0ef8-a648-01d0-08ee">12</characteristic>
             <characteristic name="Side" typeId="f150-c0dc-c192-9cb3">12</characteristic>
@@ -31662,9 +31817,16 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
       </modifiers>
       <profiles>
         <profile id="09eb-b5e9-6ceb-86f6" name="Fellblade" hidden="false" typeId="2fae-b053-3f78-e7b2" typeName=" Vehicle">
+          <modifiers>
+            <modifier type="set" field="3614-4a2d-bffb-90e4" value="13*">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
           <characteristics>
             <characteristic name="Unit Type" typeId="e555-4aed-dfcc-c0b4">Vehicle (Super-heavy)</characteristic>
-            <characteristic name="Move" typeId="3614-4a2d-bffb-90e4">12&quot;</characteristic>
+            <characteristic name="Move" typeId="3614-4a2d-bffb-90e4">12</characteristic>
             <characteristic name="BS" typeId="51fb-b7d9-aa59-863d">4</characteristic>
             <characteristic name="Front" typeId="0ef8-a648-01d0-08ee">14</characteristic>
             <characteristic name="Side" typeId="f150-c0dc-c192-9cb3">13</characteristic>
@@ -31970,9 +32132,16 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
       </modifiers>
       <profiles>
         <profile id="b7fb-1e71-e236-0be2" name="Mastodon" hidden="false" typeId="2fae-b053-3f78-e7b2" typeName=" Vehicle">
+          <modifiers>
+            <modifier type="set" field="3614-4a2d-bffb-90e4" value="11*">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
           <characteristics>
             <characteristic name="Unit Type" typeId="e555-4aed-dfcc-c0b4">Vehicle (Super-heavy, Transport)</characteristic>
-            <characteristic name="Move" typeId="3614-4a2d-bffb-90e4">10&quot;</characteristic>
+            <characteristic name="Move" typeId="3614-4a2d-bffb-90e4">10</characteristic>
             <characteristic name="BS" typeId="51fb-b7d9-aa59-863d">4</characteristic>
             <characteristic name="Front" typeId="0ef8-a648-01d0-08ee">14</characteristic>
             <characteristic name="Side" typeId="f150-c0dc-c192-9cb3">14</characteristic>
@@ -32163,9 +32332,16 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
       </modifiers>
       <profiles>
         <profile id="0fa9-daba-a5f2-074f" name="Falchion" hidden="false" typeId="2fae-b053-3f78-e7b2" typeName=" Vehicle">
+          <modifiers>
+            <modifier type="set" field="3614-4a2d-bffb-90e4" value="13*">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
           <characteristics>
             <characteristic name="Unit Type" typeId="e555-4aed-dfcc-c0b4">Vehicle (Super-heavy)</characteristic>
-            <characteristic name="Move" typeId="3614-4a2d-bffb-90e4">12&quot;</characteristic>
+            <characteristic name="Move" typeId="3614-4a2d-bffb-90e4">12</characteristic>
             <characteristic name="BS" typeId="51fb-b7d9-aa59-863d">4</characteristic>
             <characteristic name="Front" typeId="0ef8-a648-01d0-08ee">14</characteristic>
             <characteristic name="Side" typeId="f150-c0dc-c192-9cb3">13</characteristic>
@@ -32441,9 +32617,16 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
       </modifiers>
       <profiles>
         <profile id="5fb3-5546-93f0-c504" name="Sokar Stormbird" hidden="false" typeId="2fae-b053-3f78-e7b2" typeName=" Vehicle">
+          <modifiers>
+            <modifier type="set" field="3614-4a2d-bffb-90e4" value="17*">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
           <characteristics>
             <characteristic name="Unit Type" typeId="e555-4aed-dfcc-c0b4">Vehicle (Flyer, Hover, Lumbering, Transport)</characteristic>
-            <characteristic name="Move" typeId="3614-4a2d-bffb-90e4">16&quot;</characteristic>
+            <characteristic name="Move" typeId="3614-4a2d-bffb-90e4">16</characteristic>
             <characteristic name="BS" typeId="51fb-b7d9-aa59-863d">4</characteristic>
             <characteristic name="Front" typeId="0ef8-a648-01d0-08ee">14</characteristic>
             <characteristic name="Side" typeId="f150-c0dc-c192-9cb3">13</characteristic>
@@ -32642,9 +32825,16 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
       </modifiers>
       <profiles>
         <profile id="4edb-4679-a1c3-5786" name="Shadowsword" hidden="false" typeId="2fae-b053-3f78-e7b2" typeName=" Vehicle">
+          <modifiers>
+            <modifier type="set" field="3614-4a2d-bffb-90e4" value="11*">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
           <characteristics>
             <characteristic name="Unit Type" typeId="e555-4aed-dfcc-c0b4">Vehicle (Super-heavy)</characteristic>
-            <characteristic name="Move" typeId="3614-4a2d-bffb-90e4">10&quot;</characteristic>
+            <characteristic name="Move" typeId="3614-4a2d-bffb-90e4">10</characteristic>
             <characteristic name="BS" typeId="51fb-b7d9-aa59-863d">4</characteristic>
             <characteristic name="Front" typeId="0ef8-a648-01d0-08ee">13</characteristic>
             <characteristic name="Side" typeId="f150-c0dc-c192-9cb3">13</characteristic>
@@ -32895,6 +33085,13 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
       </modifiers>
       <profiles>
         <profile id="2a46-a372-d986-d0eb" name="Land Raider Proteus Carrier" publicationId="a716-c1c4-7b26-8424" page="76" hidden="false" typeId="2fae-b053-3f78-e7b2" typeName=" Vehicle">
+          <modifiers>
+            <modifier type="set" field="3614-4a2d-bffb-90e4" value="13*">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
           <characteristics>
             <characteristic name="Unit Type" typeId="e555-4aed-dfcc-c0b4">Vehicle (Transport, Reinforced)</characteristic>
             <characteristic name="Move" typeId="3614-4a2d-bffb-90e4">12</characteristic>
@@ -33338,30 +33535,9 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                     <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="87d0-7568-20b6-ac7f" type="min"/>
                     <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ecdf-1426-fe85-be74" type="max"/>
                   </constraints>
-                  <profiles>
-                    <profile id="a888-18d0-580d-9b64" name="Gunner" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
-                      <modifiers>
-                        <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Infantry (Heavy, Psyker)">
-                          <conditions>
-                            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="21c3-2f28-7820-e51a" type="equalTo"/>
-                          </conditions>
-                        </modifier>
-                      </modifiers>
-                      <characteristics>
-                        <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Heavy)</characteristic>
-                        <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
-                        <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
-                        <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
-                        <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
-                        <characteristic name="T" typeId="c32b-5fdd-3fbe-9b1f">4</characteristic>
-                        <characteristic name="W" typeId="57ee-1126-32a9-5672">1</characteristic>
-                        <characteristic name="I" typeId="62d3-22d7-2d49-52dc">4</characteristic>
-                        <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">1</characteristic>
-                        <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">7</characteristic>
-                        <characteristic name="Save" typeId="e593-6b3c-f169-04f0">3+</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
+                  <infoLinks>
+                    <infoLink id="b97a-b5b6-371a-0d26" name="Gunner" hidden="false" targetId="c620-7992-58b3-1b23" type="profile"/>
+                  </infoLinks>
                   <selectionEntryGroups>
                     <selectionEntryGroup id="d8d9-a14e-8e73-43fe" name="1) Bolt Pistol Options" hidden="false" collective="false" import="true" defaultSelectionEntryId="7992-471c-9579-a05f">
                       <constraints>
@@ -33427,23 +33603,6 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1a3f-29e4-28ca-773d" type="max"/>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f6f2-8240-d40a-d446" type="min"/>
                   </constraints>
-                  <profiles>
-                    <profile id="8aa2-1597-b0c0-1366" name="Rapier Carrier" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
-                      <characteristics>
-                        <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Artillery, Heavy)</characteristic>
-                        <characteristic name="Move" typeId="893e-2d76-8f04-44e5">4&quot;</characteristic>
-                        <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">1</characteristic>
-                        <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
-                        <characteristic name="S" typeId="e478-41d4-a092-48a8">1</characteristic>
-                        <characteristic name="T" typeId="c32b-5fdd-3fbe-9b1f">5</characteristic>
-                        <characteristic name="W" typeId="57ee-1126-32a9-5672">2</characteristic>
-                        <characteristic name="I" typeId="62d3-22d7-2d49-52dc">1</characteristic>
-                        <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">1</characteristic>
-                        <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">-</characteristic>
-                        <characteristic name="Save" typeId="e593-6b3c-f169-04f0">3+</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
                   <infoLinks>
                     <infoLink id="62a4-d403-bc0d-f82d" name="Bulky (X)" hidden="false" targetId="676c-7b75-4b6f-9405" type="rule">
                       <modifiers>
@@ -33451,6 +33610,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                       </modifiers>
                     </infoLink>
                     <infoLink id="cd45-0e6b-4f96-66d7" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule"/>
+                    <infoLink id="ac86-545c-819f-b9c6" name="Rapier Carrier" hidden="false" targetId="9f3f-2847-adf1-01b7" type="profile"/>
                   </infoLinks>
                   <costs>
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
@@ -33490,10 +33650,15 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                             <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="21c3-2f28-7820-e51a" type="equalTo"/>
                           </conditions>
                         </modifier>
+                        <modifier type="set" field="893e-2d76-8f04-44e5" value="8*">
+                          <conditions>
+                            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
+                          </conditions>
+                        </modifier>
                       </modifiers>
                       <characteristics>
                         <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Heavy)</characteristic>
-                        <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
+                        <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7</characteristic>
                         <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
                         <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
                         <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -33531,9 +33696,16 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                   </constraints>
                   <profiles>
                     <profile id="9f3f-2847-adf1-01b7" name="Rapier Carrier" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
+                      <modifiers>
+                        <modifier type="set" field="893e-2d76-8f04-44e5" value="5*">
+                          <conditions>
+                            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
+                          </conditions>
+                        </modifier>
+                      </modifiers>
                       <characteristics>
                         <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Artillery, Heavy)</characteristic>
-                        <characteristic name="Move" typeId="893e-2d76-8f04-44e5">4&quot;</characteristic>
+                        <characteristic name="Move" typeId="893e-2d76-8f04-44e5">4</characteristic>
                         <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">1</characteristic>
                         <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
                         <characteristic name="S" typeId="e478-41d4-a092-48a8">1</characteristic>
@@ -33671,10 +33843,15 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                     <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="21c3-2f28-7820-e51a" type="equalTo"/>
                   </conditions>
                 </modifier>
+                <modifier type="set" field="893e-2d76-8f04-44e5" value="7*">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
+                  </conditions>
+                </modifier>
               </modifiers>
               <characteristics>
                 <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Heavy)</characteristic>
-                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">6&quot;</characteristic>
+                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">6</characteristic>
                 <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
                 <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
                 <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -33754,10 +33931,15 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                     <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="21c3-2f28-7820-e51a" type="equalTo"/>
                   </conditions>
                 </modifier>
+                <modifier type="set" field="893e-2d76-8f04-44e5" value="7*">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
+                  </conditions>
+                </modifier>
               </modifiers>
               <characteristics>
                 <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Heavy, Character)</characteristic>
-                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">6&quot;</characteristic>
+                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">6</characteristic>
                 <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
                 <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
                 <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -34108,6 +34290,11 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                 <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Dreadnought (Corrupted)">
                   <conditions>
                     <condition field="selections" scope="daf7-b23b-5474-5836" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="555f-3998-a06e-f415" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="set" field="893e-2d76-8f04-44e5" value="7*">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
                   </conditions>
                 </modifier>
               </modifiers>
@@ -34674,35 +34861,9 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
           </infoLinks>
           <selectionEntries>
             <selectionEntry id="5a9a-e44d-ddcd-463b" name=" Indomitus Sergeant w/Lightning Claws" hidden="false" collective="false" import="true" type="model">
-              <profiles>
-                <profile id="2476-a093-0ff4-900e" name="Indomitus Sergeant" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
-                  <modifiers>
-                    <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Infantry (Heavy, Character, Psyker)">
-                      <conditions>
-                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="21c3-2f28-7820-e51a" type="equalTo"/>
-                      </conditions>
-                    </modifier>
-                    <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Infantry (Heavy,  Character, Corrupted)">
-                      <conditions>
-                        <condition field="selections" scope="aa7f-bd4c-5231-d459" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="555f-3998-a06e-f415" type="equalTo"/>
-                      </conditions>
-                    </modifier>
-                  </modifiers>
-                  <characteristics>
-                    <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Heavy, Character)</characteristic>
-                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">6</characteristic>
-                    <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
-                    <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
-                    <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
-                    <characteristic name="T" typeId="c32b-5fdd-3fbe-9b1f">4</characteristic>
-                    <characteristic name="W" typeId="57ee-1126-32a9-5672">2</characteristic>
-                    <characteristic name="I" typeId="62d3-22d7-2d49-52dc">4</characteristic>
-                    <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">3</characteristic>
-                    <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">8</characteristic>
-                    <characteristic name="Save" typeId="e593-6b3c-f169-04f0">2+</characteristic>
-                  </characteristics>
-                </profile>
-              </profiles>
+              <infoLinks>
+                <infoLink id="31d8-f07b-d561-1fb4" name="Indomitus Sergeant" hidden="false" targetId="95b6-5138-ea6a-f10e" type="profile"/>
+              </infoLinks>
               <categoryLinks>
                 <categoryLink id="a497-c238-690f-16a5" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
               </categoryLinks>
@@ -34836,6 +34997,11 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                     <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Infantry (Heavy,  Character, Corrupted)">
                       <conditions>
                         <condition field="selections" scope="aa7f-bd4c-5231-d459" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="555f-3998-a06e-f415" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="set" field="893e-2d76-8f04-44e5" value="7*">
+                      <conditions>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
                       </conditions>
                     </modifier>
                   </modifiers>
@@ -35040,35 +35206,9 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
           </constraints>
           <selectionEntries>
             <selectionEntry id="1907-54e1-7936-0395" name="Indomitus w/Lightning Claws" hidden="false" collective="false" import="true" type="model">
-              <profiles>
-                <profile id="ef53-cfee-38e1-0174" name="Indomitus" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
-                  <modifiers>
-                    <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Infantry (Heavy, Psyker)">
-                      <conditions>
-                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="21c3-2f28-7820-e51a" type="equalTo"/>
-                      </conditions>
-                    </modifier>
-                    <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Infantry (Heavy, Corrupted)">
-                      <conditions>
-                        <condition field="selections" scope="aa7f-bd4c-5231-d459" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="555f-3998-a06e-f415" type="equalTo"/>
-                      </conditions>
-                    </modifier>
-                  </modifiers>
-                  <characteristics>
-                    <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Heavy)</characteristic>
-                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">6</characteristic>
-                    <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
-                    <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
-                    <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
-                    <characteristic name="T" typeId="c32b-5fdd-3fbe-9b1f">4</characteristic>
-                    <characteristic name="W" typeId="57ee-1126-32a9-5672">2</characteristic>
-                    <characteristic name="I" typeId="62d3-22d7-2d49-52dc">4</characteristic>
-                    <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">2</characteristic>
-                    <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">7</characteristic>
-                    <characteristic name="Save" typeId="e593-6b3c-f169-04f0">2+</characteristic>
-                  </characteristics>
-                </profile>
-              </profiles>
+              <infoLinks>
+                <infoLink id="b95b-24a5-e52f-2079" name="Indomitus" hidden="false" targetId="91ea-705e-8062-f938" type="profile"/>
+              </infoLinks>
               <entryLinks>
                 <entryLink id="d6ea-550d-949d-a842" name="Pair of Lightning Claws" hidden="false" collective="false" import="true" targetId="405f-030d-0343-ade8" type="selectionEntry">
                   <constraints>
@@ -35093,35 +35233,9 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                 <constraint field="selections" scope="aa7f-bd4c-5231-d459" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0eed-d98b-ab0a-9945" type="max"/>
                 <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1ec3-acad-0f9e-b80e" type="max"/>
               </constraints>
-              <profiles>
-                <profile id="b72f-c7c8-a4c7-8b4e" name="Indomitus" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
-                  <modifiers>
-                    <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Infantry (Heavy, Psyker)">
-                      <conditions>
-                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="21c3-2f28-7820-e51a" type="equalTo"/>
-                      </conditions>
-                    </modifier>
-                    <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Infantry (Heavy, Corrupted)">
-                      <conditions>
-                        <condition field="selections" scope="aa7f-bd4c-5231-d459" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="555f-3998-a06e-f415" type="equalTo"/>
-                      </conditions>
-                    </modifier>
-                  </modifiers>
-                  <characteristics>
-                    <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Heavy)</characteristic>
-                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">6</characteristic>
-                    <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
-                    <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
-                    <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
-                    <characteristic name="T" typeId="c32b-5fdd-3fbe-9b1f">4</characteristic>
-                    <characteristic name="W" typeId="57ee-1126-32a9-5672">2</characteristic>
-                    <characteristic name="I" typeId="62d3-22d7-2d49-52dc">4</characteristic>
-                    <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">2</characteristic>
-                    <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">7</characteristic>
-                    <characteristic name="Save" typeId="e593-6b3c-f169-04f0">2+</characteristic>
-                  </characteristics>
-                </profile>
-              </profiles>
+              <infoLinks>
+                <infoLink id="f313-b2a0-e8df-c6f3" name="Indomitus" hidden="false" targetId="91ea-705e-8062-f938" type="profile"/>
+              </infoLinks>
               <selectionEntryGroups>
                 <selectionEntryGroup id="abf4-311e-5079-7267" name="2) Melee Options" hidden="false" collective="false" import="true" defaultSelectionEntryId="7c2b-7c17-48ec-576e">
                   <constraints>
@@ -35197,6 +35311,11 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                     <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Infantry (Heavy, Psyker)">
                       <conditions>
                         <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="21c3-2f28-7820-e51a" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="set" field="893e-2d76-8f04-44e5" value="7*">
+                      <conditions>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
                       </conditions>
                     </modifier>
                   </modifiers>
@@ -35290,23 +35409,9 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                   </conditions>
                 </modifier>
               </modifiers>
-              <profiles>
-                <profile id="a276-c236-e2b2-a678" name="Indomitus" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
-                  <characteristics>
-                    <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Heavy)</characteristic>
-                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">6</characteristic>
-                    <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
-                    <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
-                    <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
-                    <characteristic name="T" typeId="c32b-5fdd-3fbe-9b1f">4</characteristic>
-                    <characteristic name="W" typeId="57ee-1126-32a9-5672">2</characteristic>
-                    <characteristic name="I" typeId="62d3-22d7-2d49-52dc">4</characteristic>
-                    <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">2</characteristic>
-                    <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">7</characteristic>
-                    <characteristic name="Save" typeId="e593-6b3c-f169-04f0">2+</characteristic>
-                  </characteristics>
-                </profile>
-              </profiles>
+              <infoLinks>
+                <infoLink id="4b66-2d2c-812e-ef11" name="Indomitus" hidden="false" targetId="91ea-705e-8062-f938" type="profile"/>
+              </infoLinks>
               <entryLinks>
                 <entryLink id="6708-d49d-bb43-e070" name="Pair of Raven&apos;s Talons" hidden="false" collective="false" import="true" targetId="08e4-5e02-da82-f296" type="selectionEntry">
                   <constraints>
@@ -35519,6 +35624,13 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
           </constraints>
           <profiles>
             <profile id="4ef3-f1d2-b3d5-60e4" name="Scorpius" hidden="false" typeId="2fae-b053-3f78-e7b2" typeName=" Vehicle">
+              <modifiers>
+                <modifier type="set" field="3614-4a2d-bffb-90e4" value="13*">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
               <characteristics>
                 <characteristic name="Unit Type" typeId="e555-4aed-dfcc-c0b4">Vehicle</characteristic>
                 <characteristic name="Move" typeId="3614-4a2d-bffb-90e4">12</characteristic>
@@ -35812,9 +35924,16 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
           </constraints>
           <profiles>
             <profile id="1ff9-a191-f619-ce45" name="Kratos" hidden="false" typeId="2fae-b053-3f78-e7b2" typeName=" Vehicle">
+              <modifiers>
+                <modifier type="set" field="3614-4a2d-bffb-90e4" value="11*">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
               <characteristics>
                 <characteristic name="Unit Type" typeId="e555-4aed-dfcc-c0b4">Vehicle (Reinforced)</characteristic>
-                <characteristic name="Move" typeId="3614-4a2d-bffb-90e4">10&quot;</characteristic>
+                <characteristic name="Move" typeId="3614-4a2d-bffb-90e4">10</characteristic>
                 <characteristic name="BS" typeId="51fb-b7d9-aa59-863d">4</characteristic>
                 <characteristic name="Front" typeId="0ef8-a648-01d0-08ee">14</characteristic>
                 <characteristic name="Side" typeId="f150-c0dc-c192-9cb3">14</characteristic>
@@ -36340,9 +36459,16 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
       </modifiers>
       <profiles>
         <profile id="4959-9399-a289-cf17" name="Kharybdis Assault Claw" hidden="false" typeId="2fae-b053-3f78-e7b2" typeName=" Vehicle">
+          <modifiers>
+            <modifier type="set" field="3614-4a2d-bffb-90e4" value="17*">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
           <characteristics>
             <characteristic name="Unit Type" typeId="e555-4aed-dfcc-c0b4">Vehicle (Flyer, Hover, Transport)</characteristic>
-            <characteristic name="Move" typeId="3614-4a2d-bffb-90e4">16&quot;</characteristic>
+            <characteristic name="Move" typeId="3614-4a2d-bffb-90e4">16</characteristic>
             <characteristic name="BS" typeId="51fb-b7d9-aa59-863d">4</characteristic>
             <characteristic name="Front" typeId="0ef8-a648-01d0-08ee">12</characteristic>
             <characteristic name="Side" typeId="f150-c0dc-c192-9cb3">12</characteristic>
@@ -36463,7 +36589,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
           <profiles>
             <profile id="ec4e-7b77-6469-8279" name="Legion Deathstorm Drop Pod" hidden="false" typeId="2fae-b053-3f78-e7b2" typeName=" Vehicle">
               <characteristics>
-                <characteristic name="Unit Type" typeId="e555-4aed-dfcc-c0b4"/>
+                <characteristic name="Unit Type" typeId="e555-4aed-dfcc-c0b4">Vehicle</characteristic>
                 <characteristic name="Move" typeId="3614-4a2d-bffb-90e4">-</characteristic>
                 <characteristic name="BS" typeId="51fb-b7d9-aa59-863d">2</characteristic>
                 <characteristic name="Front" typeId="0ef8-a648-01d0-08ee">12</characteristic>
@@ -36750,7 +36876,7 @@ Additionally, at the end of any Phase in which a model with Gorgon Terminator ar
           <profiles>
             <profile id="8e0d-7e2f-c5f8-431c" name="Legion Spatha Attack Bike" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
               <modifiers>
-                <modifier type="set" field="893e-2d76-8f04-44e5" value="15&quot;">
+                <modifier type="set" field="893e-2d76-8f04-44e5" value="15*">
                   <conditions>
                     <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
                   </conditions>
@@ -36763,7 +36889,7 @@ Additionally, at the end of any Phase in which a model with Gorgon Terminator ar
               </modifiers>
               <characteristics>
                 <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Cavalry (Skirmish)</characteristic>
-                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">14&quot;</characteristic>
+                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">14</characteristic>
                 <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
                 <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
                 <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -37207,9 +37333,16 @@ containing the model that failed its Check. If the Psyker survives Perils of the
       </modifiers>
       <profiles>
         <profile id="2054-6e80-540c-fd7f" name="Banehammer" hidden="false" typeId="2fae-b053-3f78-e7b2" typeName=" Vehicle">
+          <modifiers>
+            <modifier type="set" field="3614-4a2d-bffb-90e4" value="11*">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
           <characteristics>
             <characteristic name="Unit Type" typeId="e555-4aed-dfcc-c0b4">Vehicle (Super-heavy, Transport)</characteristic>
-            <characteristic name="Move" typeId="3614-4a2d-bffb-90e4">10&quot;</characteristic>
+            <characteristic name="Move" typeId="3614-4a2d-bffb-90e4">10</characteristic>
             <characteristic name="BS" typeId="51fb-b7d9-aa59-863d">4</characteristic>
             <characteristic name="Front" typeId="0ef8-a648-01d0-08ee">13</characteristic>
             <characteristic name="Side" typeId="f150-c0dc-c192-9cb3">13</characteristic>
@@ -37457,9 +37590,16 @@ containing the model that failed its Check. If the Psyker survives Perils of the
       </modifiers>
       <profiles>
         <profile id="054d-bad1-5823-a55e" name="Baneblade" hidden="false" typeId="2fae-b053-3f78-e7b2" typeName=" Vehicle">
+          <modifiers>
+            <modifier type="set" field="3614-4a2d-bffb-90e4" value="11*">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
           <characteristics>
             <characteristic name="Unit Type" typeId="e555-4aed-dfcc-c0b4">Vehicle (Super-heavy)</characteristic>
-            <characteristic name="Move" typeId="3614-4a2d-bffb-90e4">10&quot;</characteristic>
+            <characteristic name="Move" typeId="3614-4a2d-bffb-90e4">10</characteristic>
             <characteristic name="BS" typeId="51fb-b7d9-aa59-863d">4</characteristic>
             <characteristic name="Front" typeId="0ef8-a648-01d0-08ee">13</characteristic>
             <characteristic name="Side" typeId="f150-c0dc-c192-9cb3">13</characteristic>
@@ -37725,9 +37865,16 @@ containing the model that failed its Check. If the Psyker survives Perils of the
       </modifiers>
       <profiles>
         <profile id="ea3f-b365-8ddb-d484" name="Stormblade" hidden="false" typeId="2fae-b053-3f78-e7b2" typeName=" Vehicle">
+          <modifiers>
+            <modifier type="set" field="3614-4a2d-bffb-90e4" value="11*">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
           <characteristics>
             <characteristic name="Unit Type" typeId="e555-4aed-dfcc-c0b4">Vehicle (Super-heavy)</characteristic>
-            <characteristic name="Move" typeId="3614-4a2d-bffb-90e4">10&quot;</characteristic>
+            <characteristic name="Move" typeId="3614-4a2d-bffb-90e4">10</characteristic>
             <characteristic name="BS" typeId="51fb-b7d9-aa59-863d">4</characteristic>
             <characteristic name="Front" typeId="0ef8-a648-01d0-08ee">13</characteristic>
             <characteristic name="Side" typeId="f150-c0dc-c192-9cb3">13</characteristic>
@@ -37931,9 +38078,16 @@ containing the model that failed its Check. If the Psyker survives Perils of the
       </modifiers>
       <profiles>
         <profile id="6706-c4ba-06ba-bda3" name="Stormlord" hidden="false" typeId="2fae-b053-3f78-e7b2" typeName=" Vehicle">
+          <modifiers>
+            <modifier type="set" field="3614-4a2d-bffb-90e4" value="11*">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
           <characteristics>
             <characteristic name="Unit Type" typeId="e555-4aed-dfcc-c0b4">Vehicle (Super-heavy, Transport)</characteristic>
-            <characteristic name="Move" typeId="3614-4a2d-bffb-90e4">10&quot;</characteristic>
+            <characteristic name="Move" typeId="3614-4a2d-bffb-90e4">10</characteristic>
             <characteristic name="BS" typeId="51fb-b7d9-aa59-863d">4</characteristic>
             <characteristic name="Front" typeId="0ef8-a648-01d0-08ee">13</characteristic>
             <characteristic name="Side" typeId="f150-c0dc-c192-9cb3">13</characteristic>
@@ -38152,9 +38306,16 @@ containing the model that failed its Check. If the Psyker survives Perils of the
       </modifiers>
       <profiles>
         <profile id="b40a-4fa3-7b99-6518" name="Stormsword" hidden="false" typeId="2fae-b053-3f78-e7b2" typeName=" Vehicle">
+          <modifiers>
+            <modifier type="set" field="3614-4a2d-bffb-90e4" value="11*">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
           <characteristics>
             <characteristic name="Unit Type" typeId="e555-4aed-dfcc-c0b4">Vehicle (Super-heavy)</characteristic>
-            <characteristic name="Move" typeId="3614-4a2d-bffb-90e4">10&quot;</characteristic>
+            <characteristic name="Move" typeId="3614-4a2d-bffb-90e4">10</characteristic>
             <characteristic name="BS" typeId="51fb-b7d9-aa59-863d">4</characteristic>
             <characteristic name="Front" typeId="0ef8-a648-01d0-08ee">13</characteristic>
             <characteristic name="Side" typeId="f150-c0dc-c192-9cb3">13</characteristic>
@@ -38392,6 +38553,13 @@ containing the model that failed its Check. If the Psyker survives Perils of the
       </modifiers>
       <profiles>
         <profile id="caa5-278d-5d8f-c074" name="Whirlwind" publicationId="d0df-7166-5cd3-89fd" page="27" hidden="false" typeId="2fae-b053-3f78-e7b2" typeName=" Vehicle">
+          <modifiers>
+            <modifier type="set" field="3614-4a2d-bffb-90e4" value="13*">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
           <characteristics>
             <characteristic name="Unit Type" typeId="e555-4aed-dfcc-c0b4">Vehicle (Bombard)</characteristic>
             <characteristic name="Move" typeId="3614-4a2d-bffb-90e4">12&quot;</characteristic>
@@ -38542,15 +38710,6 @@ containing the model that failed its Check. If the Psyker survives Perils of the
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a61f-426b-da97-3ff9" type="max"/>
           </constraints>
         </entryLink>
-        <entryLink id="e5b2-b954-bf85-3345" name="New (Placeholders X)" hidden="false" collective="false" import="true" targetId="8849-160f-9a3b-be54" type="selectionEntry">
-          <modifiers>
-            <modifier type="set" field="name" value="Turret Mounted Whirlwind missile launcher"/>
-          </modifiers>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b1b5-13c4-94d1-da82" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9c6c-bb52-398e-4906" type="max"/>
-          </constraints>
-        </entryLink>
         <entryLink id="1fda-b997-5759-d48a" name="Hexagrammaton Choice:" hidden="false" collective="false" import="true" targetId="61a2-7005-1e6c-c08e" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
@@ -38598,9 +38757,16 @@ containing the model that failed its Check. If the Psyker survives Perils of the
           </constraints>
           <profiles>
             <profile id="3005-7d72-5a9b-2113" name="Medusa" publicationId="d0df-7166-5cd3-89fd" page="26" hidden="false" typeId="2fae-b053-3f78-e7b2" typeName=" Vehicle">
+              <modifiers>
+                <modifier type="set" field="3614-4a2d-bffb-90e4" value="11*">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
               <characteristics>
                 <characteristic name="Unit Type" typeId="e555-4aed-dfcc-c0b4">Vehicle (Bombard)</characteristic>
-                <characteristic name="Move" typeId="3614-4a2d-bffb-90e4">10&quot;</characteristic>
+                <characteristic name="Move" typeId="3614-4a2d-bffb-90e4">10</characteristic>
                 <characteristic name="BS" typeId="51fb-b7d9-aa59-863d">4</characteristic>
                 <characteristic name="Front" typeId="0ef8-a648-01d0-08ee">13</characteristic>
                 <characteristic name="Side" typeId="f150-c0dc-c192-9cb3">12</characteristic>
@@ -38900,9 +39066,16 @@ containing the model that failed its Check. If the Psyker survives Perils of the
           </constraints>
           <profiles>
             <profile id="0a20-86dd-e82f-db0d" name="Basilisk" publicationId="d0df-7166-5cd3-89fd" page="25" hidden="false" typeId="2fae-b053-3f78-e7b2" typeName=" Vehicle">
+              <modifiers>
+                <modifier type="set" field="3614-4a2d-bffb-90e4" value="11*">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
               <characteristics>
                 <characteristic name="Unit Type" typeId="e555-4aed-dfcc-c0b4">Vehicle (Bombard)</characteristic>
-                <characteristic name="Move" typeId="3614-4a2d-bffb-90e4">10&quot;</characteristic>
+                <characteristic name="Move" typeId="3614-4a2d-bffb-90e4">10</characteristic>
                 <characteristic name="BS" typeId="51fb-b7d9-aa59-863d">4</characteristic>
                 <characteristic name="Front" typeId="0ef8-a648-01d0-08ee">13</characteristic>
                 <characteristic name="Side" typeId="f150-c0dc-c192-9cb3">12</characteristic>
@@ -39175,6 +39348,13 @@ containing the model that failed its Check. If the Psyker survives Perils of the
       </modifiers>
       <profiles>
         <profile id="8319-4d8b-93a8-53d9" name="Thunderbolt Fighter" hidden="false" typeId="2fae-b053-3f78-e7b2" typeName=" Vehicle">
+          <modifiers>
+            <modifier type="set" field="3614-4a2d-bffb-90e4" value="23*">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
           <characteristics>
             <characteristic name="Unit Type" typeId="e555-4aed-dfcc-c0b4">Vehicle (Flyer)</characteristic>
             <characteristic name="Move" typeId="3614-4a2d-bffb-90e4">22&quot;</characteristic>
@@ -39294,9 +39474,16 @@ containing the model that failed its Check. If the Psyker survives Perils of the
       </modifiers>
       <profiles>
         <profile id="7734-ee3f-d6f4-ed4b" name="Avenger Strike Fighter" hidden="false" typeId="2fae-b053-3f78-e7b2" typeName=" Vehicle">
+          <modifiers>
+            <modifier type="set" field="3614-4a2d-bffb-90e4" value="23*">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
           <characteristics>
             <characteristic name="Unit Type" typeId="e555-4aed-dfcc-c0b4">Vehicle (Flyer)</characteristic>
-            <characteristic name="Move" typeId="3614-4a2d-bffb-90e4">22&quot;</characteristic>
+            <characteristic name="Move" typeId="3614-4a2d-bffb-90e4">22</characteristic>
             <characteristic name="BS" typeId="51fb-b7d9-aa59-863d">4</characteristic>
             <characteristic name="Front" typeId="0ef8-a648-01d0-08ee">11</characteristic>
             <characteristic name="Side" typeId="f150-c0dc-c192-9cb3">10</characteristic>
@@ -39459,9 +39646,16 @@ containing the model that failed its Check. If the Psyker survives Perils of the
       </modifiers>
       <profiles>
         <profile id="cf86-91cb-432a-176b" name="Primaris-Lightning Strike Fighter" hidden="false" typeId="2fae-b053-3f78-e7b2" typeName=" Vehicle">
+          <modifiers>
+            <modifier type="set" field="3614-4a2d-bffb-90e4" value="27*">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
           <characteristics>
             <characteristic name="Unit Type" typeId="e555-4aed-dfcc-c0b4">Vehicle (Flyer)</characteristic>
-            <characteristic name="Move" typeId="3614-4a2d-bffb-90e4">26&quot;</characteristic>
+            <characteristic name="Move" typeId="3614-4a2d-bffb-90e4">26</characteristic>
             <characteristic name="BS" typeId="51fb-b7d9-aa59-863d">4</characteristic>
             <characteristic name="Front" typeId="0ef8-a648-01d0-08ee">11</characteristic>
             <characteristic name="Side" typeId="f150-c0dc-c192-9cb3">11</characteristic>
@@ -39700,23 +39894,9 @@ containing the model that failed its Check. If the Psyker survives Perils of the
               <constraints>
                 <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4655-8a7c-3459-744b" type="max"/>
               </constraints>
-              <profiles>
-                <profile id="fffb-1df3-8e2e-73b6" name="Tarantula Sentry Gun" publicationId="d0df-7166-5cd3-89fd" page="16" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
-                  <characteristics>
-                    <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e"> Infantry (Automated Artillery)</characteristic>
-                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">-</characteristic>
-                    <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">1</characteristic>
-                    <characteristic name="BS" typeId="74ae-c840-0036-d244">2</characteristic>
-                    <characteristic name="S" typeId="e478-41d4-a092-48a8">1</characteristic>
-                    <characteristic name="T" typeId="c32b-5fdd-3fbe-9b1f">4</characteristic>
-                    <characteristic name="W" typeId="57ee-1126-32a9-5672">2</characteristic>
-                    <characteristic name="I" typeId="62d3-22d7-2d49-52dc">1</characteristic>
-                    <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">1</characteristic>
-                    <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">5</characteristic>
-                    <characteristic name="Save" typeId="e593-6b3c-f169-04f0">3+</characteristic>
-                  </characteristics>
-                </profile>
-              </profiles>
+              <infoLinks>
+                <infoLink id="df86-47d2-259f-ea7e" name="Tarantula Sentry Gun" hidden="false" targetId="633b-ed59-22a7-663d" type="profile"/>
+              </infoLinks>
               <categoryLinks>
                 <categoryLink id="09dc-9427-6c58-5a7e" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
               </categoryLinks>
@@ -39739,23 +39919,9 @@ containing the model that failed its Check. If the Psyker survives Perils of the
               <constraints>
                 <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3553-bbd8-7f10-f1cd" type="max"/>
               </constraints>
-              <profiles>
-                <profile id="c6d4-398c-7efc-5372" name="Tarantula Sentry Gun" publicationId="d0df-7166-5cd3-89fd" page="16" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
-                  <characteristics>
-                    <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e"> Infantry (Automated Artillery)</characteristic>
-                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">-</characteristic>
-                    <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">1</characteristic>
-                    <characteristic name="BS" typeId="74ae-c840-0036-d244">2</characteristic>
-                    <characteristic name="S" typeId="e478-41d4-a092-48a8">1</characteristic>
-                    <characteristic name="T" typeId="c32b-5fdd-3fbe-9b1f">4</characteristic>
-                    <characteristic name="W" typeId="57ee-1126-32a9-5672">2</characteristic>
-                    <characteristic name="I" typeId="62d3-22d7-2d49-52dc">1</characteristic>
-                    <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">1</characteristic>
-                    <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">5</characteristic>
-                    <characteristic name="Save" typeId="e593-6b3c-f169-04f0">3+</characteristic>
-                  </characteristics>
-                </profile>
-              </profiles>
+              <infoLinks>
+                <infoLink id="6137-9714-c544-adca" name="Tarantula Sentry Gun" hidden="false" targetId="633b-ed59-22a7-663d" type="profile"/>
+              </infoLinks>
               <categoryLinks>
                 <categoryLink id="97dc-4f30-fb2c-fac1" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
               </categoryLinks>
@@ -39949,9 +40115,16 @@ containing the model that failed its Check. If the Psyker survives Perils of the
           </constraints>
           <profiles>
             <profile id="c3ae-4428-5f79-c094" name="Land Raider Phobos" hidden="false" typeId="2fae-b053-3f78-e7b2" typeName=" Vehicle">
+              <modifiers>
+                <modifier type="set" field="3614-4a2d-bffb-90e4" value="13*">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
               <characteristics>
                 <characteristic name="Unit Type" typeId="e555-4aed-dfcc-c0b4">Vehicle (Transport, Reinforced)</characteristic>
-                <characteristic name="Move" typeId="3614-4a2d-bffb-90e4">12&quot;</characteristic>
+                <characteristic name="Move" typeId="3614-4a2d-bffb-90e4">12</characteristic>
                 <characteristic name="BS" typeId="51fb-b7d9-aa59-863d">4</characteristic>
                 <characteristic name="Front" typeId="0ef8-a648-01d0-08ee">14</characteristic>
                 <characteristic name="Side" typeId="f150-c0dc-c192-9cb3">14</characteristic>
@@ -40225,9 +40398,16 @@ containing the model that failed its Check. If the Psyker survives Perils of the
           </constraints>
           <profiles>
             <profile id="9417-18c8-4fdf-9018" name="Land Raider Achilles" hidden="false" typeId="2fae-b053-3f78-e7b2" typeName=" Vehicle">
+              <modifiers>
+                <modifier type="set" field="3614-4a2d-bffb-90e4" value="13*">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
               <characteristics>
                 <characteristic name="Unit Type" typeId="e555-4aed-dfcc-c0b4">Vehicle (Transport, Reinforced)</characteristic>
-                <characteristic name="Move" typeId="3614-4a2d-bffb-90e4">12&quot;</characteristic>
+                <characteristic name="Move" typeId="3614-4a2d-bffb-90e4">12</characteristic>
                 <characteristic name="BS" typeId="51fb-b7d9-aa59-863d">4</characteristic>
                 <characteristic name="Front" typeId="0ef8-a648-01d0-08ee">14</characteristic>
                 <characteristic name="Side" typeId="f150-c0dc-c192-9cb3">14</characteristic>
@@ -40502,6 +40682,13 @@ containing the model that failed its Check. If the Psyker survives Perils of the
       </modifiers>
       <profiles>
         <profile id="63f9-a8e5-ab16-deaf" name="Caestus Assault Ram" hidden="false" typeId="2fae-b053-3f78-e7b2" typeName=" Vehicle">
+          <modifiers>
+            <modifier type="set" field="3614-4a2d-bffb-90e4" value="15*">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
           <characteristics>
             <characteristic name="Unit Type" typeId="e555-4aed-dfcc-c0b4">Vehicle (Flyer, Hover, Transport)</characteristic>
             <characteristic name="Move" typeId="3614-4a2d-bffb-90e4">14&quot;</characteristic>
@@ -40613,9 +40800,16 @@ containing the model that failed its Check. If the Psyker survives Perils of the
           </constraints>
           <profiles>
             <profile id="fe18-0b79-f1ac-ccbd" name="Macharius Heavy Tank" hidden="false" typeId="2fae-b053-3f78-e7b2" typeName=" Vehicle">
+              <modifiers>
+                <modifier type="set" field="3614-4a2d-bffb-90e4" value="11*">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
               <characteristics>
                 <characteristic name="Unit Type" typeId="e555-4aed-dfcc-c0b4">Vehicle (Super-heavy)</characteristic>
-                <characteristic name="Move" typeId="3614-4a2d-bffb-90e4">10&quot;</characteristic>
+                <characteristic name="Move" typeId="3614-4a2d-bffb-90e4">10</characteristic>
                 <characteristic name="BS" typeId="51fb-b7d9-aa59-863d">4</characteristic>
                 <characteristic name="Front" typeId="0ef8-a648-01d0-08ee">13</characteristic>
                 <characteristic name="Side" typeId="f150-c0dc-c192-9cb3">12</characteristic>
@@ -40937,9 +41131,16 @@ containing the model that failed its Check. If the Psyker survives Perils of the
           </constraints>
           <profiles>
             <profile id="ed3c-21b0-7847-ba7a" name="Minotaur" hidden="false" typeId="2fae-b053-3f78-e7b2" typeName=" Vehicle">
+              <modifiers>
+                <modifier type="set" field="3614-4a2d-bffb-90e4" value="9*">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
               <characteristics>
                 <characteristic name="Unit Type" typeId="e555-4aed-dfcc-c0b4">Vehicle (Slow, Reinforced)</characteristic>
-                <characteristic name="Move" typeId="3614-4a2d-bffb-90e4">8&quot;</characteristic>
+                <characteristic name="Move" typeId="3614-4a2d-bffb-90e4">8</characteristic>
                 <characteristic name="BS" typeId="51fb-b7d9-aa59-863d">4</characteristic>
                 <characteristic name="Front" typeId="0ef8-a648-01d0-08ee">13</characteristic>
                 <characteristic name="Side" typeId="f150-c0dc-c192-9cb3">12</characteristic>
@@ -41090,9 +41291,16 @@ containing the model that failed its Check. If the Psyker survives Perils of the
           </constraints>
           <profiles>
             <profile id="beb7-c373-88d1-eaf4" name="Malcador Assault Tank" hidden="false" typeId="2fae-b053-3f78-e7b2" typeName=" Vehicle">
+              <modifiers>
+                <modifier type="set" field="3614-4a2d-bffb-90e4" value="15*">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
               <characteristics>
                 <characteristic name="Unit Type" typeId="e555-4aed-dfcc-c0b4">Vehicle (Reinforced)</characteristic>
-                <characteristic name="Move" typeId="3614-4a2d-bffb-90e4">14&quot;</characteristic>
+                <characteristic name="Move" typeId="3614-4a2d-bffb-90e4">14</characteristic>
                 <characteristic name="BS" typeId="51fb-b7d9-aa59-863d">4</characteristic>
                 <characteristic name="Front" typeId="0ef8-a648-01d0-08ee">13</characteristic>
                 <characteristic name="Side" typeId="f150-c0dc-c192-9cb3">13</characteristic>
@@ -41456,7 +41664,7 @@ containing the model that failed its Check. If the Psyker survives Perils of the
           <profiles>
             <profile id="2508-147c-133b-3487" name="Destroyer Sergeant" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
               <modifiers>
-                <modifier type="set" field="893e-2d76-8f04-44e5" value="8&quot;">
+                <modifier type="set" field="893e-2d76-8f04-44e5" value="8*">
                   <conditions>
                     <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
                   </conditions>
@@ -41474,7 +41682,7 @@ containing the model that failed its Check. If the Psyker survives Perils of the
               </modifiers>
               <characteristics>
                 <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Character)</characteristic>
-                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
+                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7</characteristic>
                 <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
                 <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
                 <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -41947,7 +42155,7 @@ containing the model that failed its Check. If the Psyker survives Perils of the
               <profiles>
                 <profile id="70e9-f5bb-aaba-9bc4" name="Destroyer" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
                   <modifiers>
-                    <modifier type="set" field="893e-2d76-8f04-44e5" value="8&quot;">
+                    <modifier type="set" field="893e-2d76-8f04-44e5" value="8*">
                       <conditions>
                         <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
                       </conditions>
@@ -41960,7 +42168,7 @@ containing the model that failed its Check. If the Psyker survives Perils of the
                   </modifiers>
                   <characteristics>
                     <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry</characteristic>
-                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
+                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7</characteristic>
                     <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
                     <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
                     <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -43098,7 +43306,7 @@ During a Reaction made in any Phase, a player may not choose to activate a model
           <profiles>
             <profile id="a1b1-9f9e-401a-8336" name="Legion Assault Sergeant" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
               <modifiers>
-                <modifier type="set" field="893e-2d76-8f04-44e5" value="8&quot;">
+                <modifier type="set" field="893e-2d76-8f04-44e5" value="8*">
                   <conditions>
                     <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
                   </conditions>
@@ -43116,7 +43324,7 @@ During a Reaction made in any Phase, a player may not choose to activate a model
               </modifiers>
               <characteristics>
                 <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Character, Line)</characteristic>
-                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
+                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7</characteristic>
                 <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
                 <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
                 <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -43621,7 +43829,7 @@ During a Reaction made in any Phase, a player may not choose to activate a model
               <profiles>
                 <profile id="0fa8-abbe-bc5b-1bf4" name="Legionary" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
                   <modifiers>
-                    <modifier type="set" field="893e-2d76-8f04-44e5" value="8&quot;">
+                    <modifier type="set" field="893e-2d76-8f04-44e5" value="8*">
                       <conditions>
                         <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
                       </conditions>
@@ -43639,7 +43847,7 @@ During a Reaction made in any Phase, a player may not choose to activate a model
                   </modifiers>
                   <characteristics>
                     <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Line)</characteristic>
-                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
+                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7</characteristic>
                     <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
                     <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
                     <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -44064,7 +44272,7 @@ During a Reaction made in any Phase, a player may not choose to activate a model
           <profiles>
             <profile id="2976-f278-20e1-8844" name="Destroyer Sergeant" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
               <modifiers>
-                <modifier type="set" field="893e-2d76-8f04-44e5" value="8&quot;">
+                <modifier type="set" field="893e-2d76-8f04-44e5" value="8*">
                   <conditions>
                     <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
                   </conditions>
@@ -44082,7 +44290,7 @@ During a Reaction made in any Phase, a player may not choose to activate a model
               </modifiers>
               <characteristics>
                 <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Character)</characteristic>
-                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
+                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7</characteristic>
                 <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
                 <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
                 <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -44560,7 +44768,7 @@ During a Reaction made in any Phase, a player may not choose to activate a model
               <profiles>
                 <profile id="8097-3e18-04e6-0cb8" name="Destroyer" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
                   <modifiers>
-                    <modifier type="set" field="893e-2d76-8f04-44e5" value="8&quot;">
+                    <modifier type="set" field="893e-2d76-8f04-44e5" value="8*">
                       <conditions>
                         <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
                       </conditions>
@@ -44573,7 +44781,7 @@ During a Reaction made in any Phase, a player may not choose to activate a model
                   </modifiers>
                   <characteristics>
                     <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry</characteristic>
-                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
+                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7</characteristic>
                     <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
                     <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
                     <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -45725,6 +45933,11 @@ During a Reaction made in any Phase, a player may not choose to activate a model
                 </conditionGroup>
               </conditionGroups>
             </modifier>
+            <modifier type="set" field="893e-2d76-8f04-44e5" value="9*">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
+              </conditions>
+            </modifier>
           </modifiers>
           <characteristics>
             <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Dreadnought</characteristic>
@@ -46158,9 +46371,16 @@ During a Reaction made in any Phase, a player may not choose to activate a model
       </modifiers>
       <profiles>
         <profile id="8926-acf6-9983-dd9c" name="Thunderhawk Transporter" hidden="false" typeId="2fae-b053-3f78-e7b2" typeName=" Vehicle">
+          <modifiers>
+            <modifier type="set" field="3614-4a2d-bffb-90e4" value="19*">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
           <characteristics>
             <characteristic name="Unit Type" typeId="e555-4aed-dfcc-c0b4">Vehicle (Flyer, Hover, Lumbering, Transport)</characteristic>
-            <characteristic name="Move" typeId="3614-4a2d-bffb-90e4">18&quot;</characteristic>
+            <characteristic name="Move" typeId="3614-4a2d-bffb-90e4">18</characteristic>
             <characteristic name="BS" typeId="51fb-b7d9-aa59-863d">4</characteristic>
             <characteristic name="Front" typeId="0ef8-a648-01d0-08ee">12</characteristic>
             <characteristic name="Side" typeId="f150-c0dc-c192-9cb3">12</characteristic>
@@ -46293,9 +46513,16 @@ During a Reaction made in any Phase, a player may not choose to activate a model
       </modifiers>
       <profiles>
         <profile id="790f-7fc8-2d03-d8f7" name="Marauder Bomber" hidden="false" typeId="2fae-b053-3f78-e7b2" typeName=" Vehicle">
+          <modifiers>
+            <modifier type="set" field="3614-4a2d-bffb-90e4" value="19*">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
           <characteristics>
             <characteristic name="Unit Type" typeId="e555-4aed-dfcc-c0b4">Vehicle (Flyer, Lumbering)</characteristic>
-            <characteristic name="Move" typeId="3614-4a2d-bffb-90e4">18&quot;</characteristic>
+            <characteristic name="Move" typeId="3614-4a2d-bffb-90e4">18</characteristic>
             <characteristic name="BS" typeId="51fb-b7d9-aa59-863d">4</characteristic>
             <characteristic name="Front" typeId="0ef8-a648-01d0-08ee">12</characteristic>
             <characteristic name="Side" typeId="f150-c0dc-c192-9cb3">11</characteristic>
@@ -46435,9 +46662,16 @@ During a Reaction made in any Phase, a player may not choose to activate a model
       </modifiers>
       <profiles>
         <profile id="8142-7d14-75d1-89b7" name="Macharius Omega Heavy Tank" hidden="false" typeId="2fae-b053-3f78-e7b2" typeName=" Vehicle">
+          <modifiers>
+            <modifier type="set" field="3614-4a2d-bffb-90e4" value="11*">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
           <characteristics>
             <characteristic name="Unit Type" typeId="e555-4aed-dfcc-c0b4">Vehicle (Super-heavy)</characteristic>
-            <characteristic name="Move" typeId="3614-4a2d-bffb-90e4">10&quot;</characteristic>
+            <characteristic name="Move" typeId="3614-4a2d-bffb-90e4">10</characteristic>
             <characteristic name="BS" typeId="51fb-b7d9-aa59-863d">4</characteristic>
             <characteristic name="Front" typeId="0ef8-a648-01d0-08ee">13</characteristic>
             <characteristic name="Side" typeId="f150-c0dc-c192-9cb3">11</characteristic>
@@ -46589,9 +46823,16 @@ During a Reaction made in any Phase, a player may not choose to activate a model
       </modifiers>
       <profiles>
         <profile id="0938-7d9a-d992-a5ac" name="Crassus Armoured Assault Transport" hidden="false" typeId="2fae-b053-3f78-e7b2" typeName=" Vehicle">
+          <modifiers>
+            <modifier type="set" field="3614-4a2d-bffb-90e4" value="11*">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
           <characteristics>
             <characteristic name="Unit Type" typeId="e555-4aed-dfcc-c0b4">Vehicle (Super-heavy, Transport)</characteristic>
-            <characteristic name="Move" typeId="3614-4a2d-bffb-90e4">10&quot;</characteristic>
+            <characteristic name="Move" typeId="3614-4a2d-bffb-90e4">10</characteristic>
             <characteristic name="BS" typeId="51fb-b7d9-aa59-863d">4</characteristic>
             <characteristic name="Front" typeId="0ef8-a648-01d0-08ee">13</characteristic>
             <characteristic name="Side" typeId="f150-c0dc-c192-9cb3">12</characteristic>
@@ -46826,9 +47067,16 @@ During a Reaction made in any Phase, a player may not choose to activate a model
       </modifiers>
       <profiles>
         <profile id="b405-c7a4-2b77-b9c1" name="Praetor Armoured Assault Transport" hidden="false" typeId="2fae-b053-3f78-e7b2" typeName=" Vehicle">
+          <modifiers>
+            <modifier type="set" field="3614-4a2d-bffb-90e4" value="11*">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
           <characteristics>
             <characteristic name="Unit Type" typeId="e555-4aed-dfcc-c0b4">Vehicle (Super-heavy)</characteristic>
-            <characteristic name="Move" typeId="3614-4a2d-bffb-90e4">10&quot;</characteristic>
+            <characteristic name="Move" typeId="3614-4a2d-bffb-90e4">10</characteristic>
             <characteristic name="BS" typeId="51fb-b7d9-aa59-863d">4</characteristic>
             <characteristic name="Front" typeId="0ef8-a648-01d0-08ee">13</characteristic>
             <characteristic name="Side" typeId="f150-c0dc-c192-9cb3">12</characteristic>
@@ -47014,9 +47262,16 @@ During a Reaction made in any Phase, a player may not choose to activate a model
       </modifiers>
       <profiles>
         <profile id="c27f-0ac1-1410-4946" name="Marauder Destroyer" hidden="false" typeId="2fae-b053-3f78-e7b2" typeName=" Vehicle">
+          <modifiers>
+            <modifier type="set" field="3614-4a2d-bffb-90e4" value="19*">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
           <characteristics>
             <characteristic name="Unit Type" typeId="e555-4aed-dfcc-c0b4">Vehicle (Flyer, Lumbering)</characteristic>
-            <characteristic name="Move" typeId="3614-4a2d-bffb-90e4">18&quot;</characteristic>
+            <characteristic name="Move" typeId="3614-4a2d-bffb-90e4">18</characteristic>
             <characteristic name="BS" typeId="51fb-b7d9-aa59-863d">4</characteristic>
             <characteristic name="Front" typeId="0ef8-a648-01d0-08ee">12</characteristic>
             <characteristic name="Side" typeId="f150-c0dc-c192-9cb3">11</characteristic>
@@ -48140,6 +48395,11 @@ Invulnerable saves granted by a combat shield or boarding shield do not stack wi
                   </conditionGroups>
                 </conditionGroup>
               </conditionGroups>
+            </modifier>
+            <modifier type="set" field="893e-2d76-8f04-44e5" value="9*">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
+              </conditions>
             </modifier>
           </modifiers>
           <characteristics>


### PR DESCRIPTION
Custodes on their jetbikes now get Solarite Lances WS movement should now be modified on all units. Previously it only seemed to be on random ones. Allies in RoW now have the RoW restrictions for HQ/Elite/Troops/FA/HS.
