### PR TITLE
Patch 1

### DIFF
--- a/2022 - Imperialis Militia.cat
+++ b/2022 - Imperialis Militia.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="f84d-94cf-5ce6-b393" name="2022 - Imperialis Militia" revision="4" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="61" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="f84d-94cf-5ce6-b393" name="2022 - Imperialis Militia" revision="5" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="61" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <selectionEntries>
     <selectionEntry id="37de-ba3c-f798-5bcb" name="Provenances of War" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
@@ -315,18 +315,6 @@
     </entryLink>
   </entryLinks>
   <sharedSelectionEntries>
-    <selectionEntry id="93b2-d957-e325-39e2" name="Frenzon" hidden="false" collective="false" import="true" type="upgrade">
-      <infoLinks>
-        <infoLink id="bcfd-f0ce-5613-1ea2" name="Furious Charge (X)" hidden="false" targetId="2821-9269-862f-0554" type="rule">
-          <modifiers>
-            <modifier type="set" field="name" value="Furious Charge (1)"/>
-          </modifiers>
-        </infoLink>
-      </infoLinks>
-      <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0"/>
-      </costs>
-    </selectionEntry>
     <selectionEntry id="e230-cdd4-113a-006f" name="Militia Jet Pack" hidden="false" collective="false" import="true" type="upgrade">
       <profiles>
         <profile id="751c-266d-93d4-dbc7" name="Militia Jet Pack" publicationId="48c2-d023-0069-001a" page="10" hidden="false" typeId="2a1f-7837-f0ef-be44" typeName="Wargear Item">
@@ -342,50 +330,347 @@ A model with a Militia jet pack may still Run, if it would normally be able to R
       </costs>
     </selectionEntry>
     <selectionEntry id="aa19-eda7-e81e-9868" name="01) IM - Force Commander" publicationId="48c2-d023-0069-001a" hidden="false" collective="false" import="true" type="unit">
-      <categoryLinks>
-        <categoryLink id="7889-635d-836c-f82f" name="Militia Unit Sub-type" hidden="false" targetId="66b2-c457-4d5e-8041" primary="false"/>
-      </categoryLinks>
-      <selectionEntries>
-        <selectionEntry id="9ec2-9d61-4f5a-a8eb" name="Force Commander" hidden="false" collective="false" import="true" type="model">
+      <modifiers>
+        <modifier type="add" field="category" value="6d79-a3e4-381f-7b0f">
+          <conditions>
+            <condition field="selections" scope="aa19-eda7-e81e-9868" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3649-267f-07b4-fab4" type="equalTo"/>
+          </conditions>
+        </modifier>
+        <modifier type="add" field="category" value="8b4f-bfe2-ce7b-f1b1">
+          <conditions>
+            <condition field="selections" scope="aa19-eda7-e81e-9868" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3649-267f-07b4-fab4" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <profiles>
+        <profile id="c431-f322-973d-b6ae" name="Force Commander" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
           <modifiers>
-            <modifier type="add" field="category" value="8b4f-bfe2-ce7b-f1b1">
+            <modifier type="set" field="893e-2d76-8f04-44e5" value="14">
               <conditions>
-                <condition field="selections" scope="9ec2-9d61-4f5a-a8eb" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8bdb-4c50-eaca-5811" type="equalTo"/>
+                <condition field="selections" scope="aa19-eda7-e81e-9868" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3649-267f-07b4-fab4" type="equalTo"/>
               </conditions>
             </modifier>
-            <modifier type="add" field="category" value="6d79-a3e4-381f-7b0f">
+            <modifier type="set" field="name" value="Mounted Force Commander">
               <conditions>
-                <condition field="selections" scope="9ec2-9d61-4f5a-a8eb" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8bdb-4c50-eaca-5811" type="equalTo"/>
+                <condition field="selections" scope="aa19-eda7-e81e-9868" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3649-267f-07b4-fab4" type="equalTo"/>
+              </conditions>
+            </modifier>
+            <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Cavalry (Militia, Character)">
+              <conditions>
+                <condition field="selections" scope="aa19-eda7-e81e-9868" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3649-267f-07b4-fab4" type="equalTo"/>
               </conditions>
             </modifier>
           </modifiers>
+          <modifierGroups>
+            <modifierGroup>
+              <modifiers>
+                <modifier type="increment" field="62d3-22d7-2d49-52dc" value="1">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b669-a356-d5d1-53b8" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="increment" field="e8a6-1da9-d384-8727" value="1">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b192-2b6f-ad8c-959f" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+            </modifierGroup>
+          </modifierGroups>
+          <characteristics>
+            <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Militia, Character)</characteristic>
+            <characteristic name="Move" typeId="893e-2d76-8f04-44e5">6</characteristic>
+            <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
+            <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
+            <characteristic name="S" typeId="e478-41d4-a092-48a8">3</characteristic>
+            <characteristic name="T" typeId="c32b-5fdd-3fbe-9b1f">3</characteristic>
+            <characteristic name="W" typeId="57ee-1126-32a9-5672">3</characteristic>
+            <characteristic name="I" typeId="62d3-22d7-2d49-52dc">3</characteristic>
+            <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">3</characteristic>
+            <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">8</characteristic>
+            <characteristic name="Save" typeId="e593-6b3c-f169-04f0">5+</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules>
+        <rule id="f147-b182-3b21-9e8b" name="The Muster of Worlds" publicationId="48c2-d023-0069-001a" page="9" hidden="false">
+          <description>The Muster of Worlds
+If the Detachment contains a Force Commander then it may also possess up to two Provenances. Unless noted, the effects of these apply to any and all units in the same Detachment with the Militia Unit Sub-type.
+
+Muster of Worlds: Provenances of War
+The following Provenances of War are facets of a particular force which represents the nature of the world from which it originates or the particular character and background of the warriors themselves. The presence of a Force Commander in the Detachment allows up to two different Provenances to be selected for the Detachment via their Muster of Worlds special rule. Any single Detachment can never have more than two Provenances however, regardless of the number of Force Commanders present.
+Unless noted, the effects of any rules featured in the Provenance’s description apply to any and all units in the same Detachment as the Force Commander with the Militia Unit Sub-type – however, any unit with the Mechanised Unit Sub-type may never benefit from the effects of a Provenance unless that Provenance specifically states otherwise. In addition, certain Provenances may not be taken in combination or have other limitations which taking them imposes on the rest of the army, which means it is advisable to choose your Force Commander and any Provenances you wish for the Detachment before selecting the rest of your army. Certain Provenances will also allow access to special equipment options or unit options which must be paid for separately on a unit by unit basis.</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="a262-721d-87f2-fcf7" name="Feel No Pain (X)" hidden="false" targetId="ec46-ff29-32e0-c2aa" type="rule">
+          <modifiers>
+            <modifier type="set" field="name" value="Feel No Pain (6+)"/>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ec5e-00ea-dd9c-3313" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+        <infoLink id="7bc6-3358-6b86-195b" name="Slow and Purposeful" hidden="false" targetId="d69a-cfb3-db43-32c5" type="rule">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ec5e-00ea-dd9c-3313" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="7889-635d-836c-f82f" name="Militia Unit Sub-type" hidden="false" targetId="66b2-c457-4d5e-8041" primary="false"/>
+        <categoryLink id="8df8-b23a-7e3f-97b3" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
+        <categoryLink id="38d3-5565-e146-625d" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
+      </categoryLinks>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="b48a-30d2-741c-d38b" name="1) Weapons" hidden="false" collective="false" import="true" defaultSelectionEntryId="e109-21b3-f9c8-f4b6">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="0517-41d3-892a-359c" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="d0b7-74b3-b9a0-1d2f" type="max"/>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="906f-d6a3-ba97-f48f" type="min"/>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2176-3a82-c784-b570" type="max"/>
           </constraints>
-          <categoryLinks>
-            <categoryLink id="0903-def7-68fa-c3a9" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
-            <categoryLink id="4bcb-9cd8-fa57-5a32" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
-          </categoryLinks>
+          <entryLinks>
+            <entryLink id="d5a5-ed02-9fbe-0efc" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="e5ae-6872-37aa-8600" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d584-8a93-2f8b-bea2" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="d09e-fa93-3233-7860" name="Chainsword" hidden="false" collective="false" import="true" targetId="06e7-a6ae-ed1c-eb03" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c634-9d1d-7622-02c6" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="12fb-f24d-aa92-77d1" name="Charnabal Glaive" hidden="false" collective="false" import="true" targetId="c07c-35e6-4616-ef25" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="238d-a08d-99dc-4c4b" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="5f12-bbdc-26ec-25de" name="Charnabal Sabre" hidden="false" collective="false" import="true" targetId="30c2-57eb-5bbe-be0b" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="85f0-2119-4a2c-40a9" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="faa9-4d45-a3c5-8e42" name="Charnabal Tabar" hidden="false" collective="false" import="true" targetId="4611-c33e-f360-7246" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d977-97ef-65d1-0a27" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="c4cd-65eb-c03c-800b" name="Blast Pistol" hidden="false" collective="false" import="true" targetId="2460-375d-31f4-4bdf" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f81c-15e3-a670-a99a" type="max"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="68bc-6875-45af-9764" name="Needle Pistol" hidden="false" collective="false" import="true" targetId="fdd4-06c7-4608-b07f" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cbdb-fd15-7ce5-a062" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="de1f-fa29-cb82-01eb" name="Hand Flamer" hidden="false" collective="false" import="true" targetId="e337-adf4-a11f-0280" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8db4-4b61-b1e6-66a1" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="8c83-276a-aea2-922e" name="Plasma Pistol" hidden="false" collective="false" import="true" targetId="717f-cf0a-1593-4bd8" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5b96-62ae-cb49-95fc" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="244b-fb07-fe50-9169" name="Power Axe" hidden="false" collective="false" import="true" targetId="c066-2ace-f68c-e440" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7dcd-b89a-08d8-348d" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="e794-858b-6b6f-a5f2" name="Power Maul" hidden="false" collective="false" import="true" targetId="0df4-c67e-cf64-82e0" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2a11-7eca-aedd-0943" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="1aa3-9272-60aa-8342" name="Power Lance" hidden="false" collective="false" import="true" targetId="a4c8-c8ff-87f2-1ac9" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="daed-7313-1985-5c22" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="630d-cff0-4f0c-bc59" name="Power Sword" hidden="false" collective="false" import="true" targetId="a3cd-aa97-a148-2309" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7a5a-0975-7f7d-60c3" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="4fea-128f-bff0-6cc5" name="Power Fist" hidden="false" collective="false" import="true" targetId="768d-b89b-7328-d749" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0c36-d3f3-d0d1-ba92" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="415b-fcd4-a931-d601" name="Militia Lance" hidden="true" collective="false" import="true" targetId="2304-c98f-01a8-f0c1" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="a3b4-8c90-cec9-0068" value="0.0">
+                  <conditions>
+                    <condition field="selections" scope="aa19-eda7-e81e-9868" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3d50-2f85-06ff-6aee" type="greaterThan"/>
+                  </conditions>
+                </modifier>
+                <modifier type="set" field="hidden" value="false">
+                  <conditions>
+                    <condition field="selections" scope="aa19-eda7-e81e-9868" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3649-267f-07b4-fab4" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a3b4-8c90-cec9-0068" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="7fef-87b2-1ce5-c6d4" name="Laspistol" hidden="false" collective="false" import="true" targetId="654d-be88-b0a8-7ae5" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="d574-4c37-8096-5bf9" value="0.0"/>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="10da-104a-9276-e3ba" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d574-4c37-8096-5bf9" type="min"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="e109-21b3-f9c8-f4b6" name="Close Combat Weapon" hidden="false" collective="false" import="true" targetId="3d50-2f85-06ff-6aee" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="71b2-651c-af55-adc6" value="0.0">
+                  <conditions>
+                    <condition field="selections" scope="aa19-eda7-e81e-9868" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2304-c98f-01a8-f0c1" type="greaterThan"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="71b2-651c-af55-adc6" type="max"/>
+              </constraints>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="c005-915e-5273-9e46" name="2) May Take" hidden="false" collective="false" import="true">
+          <entryLinks>
+            <entryLink id="ac4b-7261-6dd3-27d0" name="Meltabombs" hidden="false" collective="false" import="true" targetId="b9dd-3b21-f3f8-78e3" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b6b7-6e75-823b-eb86" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="d454-4777-cd47-9d4e" name="Cyber-Familiar" hidden="false" collective="false" import="true" targetId="6c85-4601-cf58-7b35" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ef20-1060-0e9e-3863" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="0a4b-febc-127d-ff15" name="3) Armour" hidden="false" collective="false" import="true" defaultSelectionEntryId="3e05-3e44-1fe0-fc46">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3e9b-7b0e-20fa-ee31" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="345b-bebb-12e5-71cb" type="min"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="308a-0be6-063c-536e" name="Carapace Armour" hidden="false" collective="false" import="true" targetId="9ba1-7b0c-23d0-2e6b" type="selectionEntry">
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="b93b-d3b2-b776-297e" name="Power Armour" hidden="false" collective="false" import="true" targetId="2d9d-480e-7c14-1a6f" type="selectionEntry">
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="3e05-3e44-1fe0-fc46" name="Flak Armour" hidden="false" collective="false" import="true" targetId="f02b-00e7-b68c-3be0" type="selectionEntry"/>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="5795-d8b8-0e84-66c9" name="4) Fields/Shields" hidden="false" collective="false" import="true" defaultSelectionEntryId="18cf-fc3a-9558-5bc1">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e2c6-91a5-9e3a-d5a0" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="702a-617f-64ff-8ce1" type="min"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="18cf-fc3a-9558-5bc1" name="Refractor Field" hidden="false" collective="false" import="true" targetId="a06a-55a5-070b-1d0e" type="selectionEntry"/>
+            <entryLink id="bf3f-eabf-1f38-45f3" name="Iron Halo" hidden="false" collective="false" import="true" targetId="b081-bf3c-f43d-4bd5" type="selectionEntry">
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="d4a8-bc39-3dc5-2bdf" name="5) On Foot / Mounted Force Commander*" hidden="false" collective="false" import="true" defaultSelectionEntryId="dac8-66aa-145b-187f">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c4cd-fdc7-72a1-c80b" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ca98-39ef-321e-ae65" type="min"/>
+          </constraints>
           <selectionEntries>
-            <selectionEntry id="8bdb-4c50-eaca-5811" name="Mounted Force Commander*" hidden="false" collective="false" import="true" type="upgrade">
+            <selectionEntry id="3649-267f-07b4-fab4" name="Mounted Force Commander*" hidden="false" collective="false" import="true" type="upgrade">
+              <infoLinks>
+                <infoLink id="cbfb-e356-a425-d671" name="Militia Cavalry Mount" hidden="false" targetId="ac7b-72f5-82f9-23d6" type="rule"/>
+                <infoLink id="77cd-ea96-b829-6be8" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule"/>
+                <infoLink id="2448-8db7-dc2e-1b11" name="Scout" hidden="false" targetId="aacf-9a7e-982d-b793" type="rule"/>
+                <infoLink id="275e-e003-973b-fdaf" name="Hammer of Wrath (X)" hidden="false" targetId="aec0-c3aa-1e4e-1779" type="rule">
+                  <modifiers>
+                    <modifier type="set" field="name" value="Hammer of Wrath (1)"/>
+                  </modifiers>
+                </infoLink>
+              </infoLinks>
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0"/>
               </costs>
             </selectionEntry>
+            <selectionEntry id="dac8-66aa-145b-187f" name="On Foot" hidden="false" collective="false" import="true" type="upgrade"/>
           </selectionEntries>
-          <entryLinks>
-            <entryLink id="5e82-0f7d-0d32-482b" name="Warlord" hidden="false" collective="false" import="true" targetId="0176-56a3-d590-b103" type="selectionEntry"/>
-            <entryLink id="45b6-ec50-fbd0-d314" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="088d-527f-114b-afd4" type="selectionEntryGroup"/>
-          </entryLinks>
-          <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
       <entryLinks>
         <entryLink id="d516-8e38-dfe0-1fa8" name="Placeholder Pts" hidden="false" collective="false" import="true" targetId="f82d-e121-05a8-7a37" type="selectionEntry"/>
         <entryLink id="d95b-b629-0a55-e530" name="Liberation Force Allies Restriction" hidden="false" collective="false" import="true" targetId="e75d-6a73-3087-6846" type="selectionEntry"/>
+        <entryLink id="7927-2a7b-95e5-ba60" name="Warlord" hidden="false" collective="false" import="true" targetId="0176-56a3-d590-b103" type="selectionEntry"/>
+        <entryLink id="4017-cf02-0d17-201d" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="088d-527f-114b-afd4" type="selectionEntryGroup"/>
+        <entryLink id="92d4-4571-e0d7-2346" name="Provenance Options" hidden="false" collective="false" import="true" targetId="5fb4-282e-7957-1492" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="100.0"/>
@@ -1261,6 +1546,9 @@ A model with a Militia jet pack may still Run, if it would normally be able to R
           </characteristics>
         </profile>
       </profiles>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="f02b-00e7-b68c-3be0" name="Flak Armour" publicationId="48c2-d023-0069-001a" page="37" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
@@ -1273,6 +1561,9 @@ A model with a Militia jet pack may still Run, if it would normally be able to R
           </characteristics>
         </profile>
       </profiles>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="202b-d674-de59-7d85" name="Militia Standard" publicationId="48c2-d023-0069-001a" page="37" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
@@ -1285,6 +1576,9 @@ A model with a Militia jet pack may still Run, if it would normally be able to R
           </characteristics>
         </profile>
       </profiles>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="dd91-0c2e-0890-1673" name="Militia Vexilla" publicationId="48c2-d023-0069-001a" page="37" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
@@ -1297,6 +1591,9 @@ A model with a Militia jet pack may still Run, if it would normally be able to R
           </characteristics>
         </profile>
       </profiles>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
     </selectionEntry>
   </sharedSelectionEntries>
   <sharedSelectionEntryGroups>
@@ -1389,7 +1686,7 @@ A model with a Militia jet pack may still Run, if it would normally be able to R
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="b42c-ce81-95f4-1200" name="Marcher Lord" publicationId="48c2-d023-0069-001a" page="6" hidden="true" collective="false" import="true" type="upgrade">
+            <selectionEntry id="b42c-ce81-95f4-1200" name="Marcher Lord" publicationId="48c2-d023-0069-001a" page="6" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9b88-9510-21fd-e550" type="max"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6f52-47dd-8c4d-6493" type="max"/>
@@ -1492,9 +1789,31 @@ In addition, an army whose Warlord has this Trait may make an additional Reactio
         <entryLink id="6044-3400-e5f0-e274" name="    Generic Warlord Traits" hidden="false" collective="false" import="true" targetId="c064-819f-d9ef-1775" type="selectionEntryGroup"/>
       </entryLinks>
     </selectionEntryGroup>
+    <selectionEntryGroup id="5fb4-282e-7957-1492" name="Provenance Options" hidden="false" collective="false" import="true">
+      <selectionEntries>
+        <selectionEntry id="593e-3b86-48fa-bdeb" name="Frenzon" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cea0-f6e1-d4c1-eab3" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="8b05-2844-9450-32b1" name="Furious Charge (X)" hidden="false" targetId="2821-9269-862f-0554" type="rule">
+              <modifiers>
+                <modifier type="set" field="name" value="Furious Charge (1)"/>
+              </modifiers>
+            </infoLink>
+          </infoLinks>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+    </selectionEntryGroup>
   </sharedSelectionEntryGroups>
   <sharedRules>
     <rule id="ac7b-72f5-82f9-23d6" name="Militia Cavalry Mount" publicationId="48c2-d023-0069-001a" page="37" hidden="false"/>
+    <rule id="e626-c3b1-e724-c6fc" name="Provenance" hidden="false">
+      <description>Provenance</description>
+    </rule>
   </sharedRules>
   <catalogueLinks>
     <catalogueLink id="5f24-4626-71c3-0511" name="2022 - Mech Library" targetId="3129-da35-55e0-642d" type="catalogue" importRootEntries="true"/>

--- a/2022 - LA - Sons of Horus.cat
+++ b/2022 - LA - Sons of Horus.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="62c7-42f4-5523-af1b" name="LA -  XVI: Sons of Horus" revision="26" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="60" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="62c7-42f4-5523-af1b" name="LA -  XVI: Sons of Horus" revision="28" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="61" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entryLinks>
     <entryLink id="c2a2-9b6d-b384-3f43" name="  XVI: Sons of Horus" hidden="false" collective="false" import="false" targetId="01b4-57c7-bf61-2abf" type="selectionEntry">
       <modifiers>
@@ -3080,6 +3080,13 @@
   </entryLinks>
   <sharedSelectionEntries>
     <selectionEntry id="0c73-9141-d1b4-6a40" name="Chieftain Squad" hidden="false" collective="false" import="true" type="unit">
+      <modifiers>
+        <modifier type="add" field="category" value="9055-7410-8ffd-b8e7">
+          <conditions>
+            <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f783-f0ea-fe35-cdeb" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile id="805b-0e2e-edfb-fcac" name="Kingslayers" hidden="false" typeId="b46c-270c-d29e-f0ff" typeName="Ability">
           <characteristics>
@@ -3114,6 +3121,11 @@
                 <modifier type="set" field="e593-6b3c-f169-04f0" value="2+">
                   <conditions>
                     <condition field="selections" scope="0c73-9141-d1b4-6a40" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="583e-62cb-53f1-f952" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Corrupted)">
+                  <conditions>
+                    <condition field="selections" scope="0c73-9141-d1b4-6a40" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f783-f0ea-fe35-cdeb" type="equalTo"/>
                   </conditions>
                 </modifier>
               </modifiers>
@@ -3201,6 +3213,11 @@
                 <modifier type="set" field="e593-6b3c-f169-04f0" value="2+">
                   <conditions>
                     <condition field="selections" scope="0c73-9141-d1b4-6a40" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="583e-62cb-53f1-f952" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Corrupted)">
+                  <conditions>
+                    <condition field="selections" scope="0c73-9141-d1b4-6a40" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f783-f0ea-fe35-cdeb" type="equalTo"/>
                   </conditions>
                 </modifier>
               </modifiers>
@@ -3326,6 +3343,7 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a53d-ec69-da6d-44a6" type="max"/>
           </constraints>
         </entryLink>
+        <entryLink id="b4af-64f6-b01c-885b" name="The Spreading Corruption" hidden="false" collective="false" import="true" targetId="f783-f0ea-fe35-cdeb" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="45.0"/>
@@ -3459,64 +3477,10 @@
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="4a11-c7c1-e1a1-d067" name="Horus Ascended" hidden="false" collective="false" import="true" type="model">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f3b5-10bc-7885-c908" type="max"/>
-              </constraints>
-              <profiles>
-                <profile id="7152-ae03-3008-4647" name="Horus Ascended" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
-                  <characteristics>
-                    <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Primarch (Unique, Corrupted)</characteristic>
-                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">8</characteristic>
-                    <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">8</characteristic>
-                    <characteristic name="BS" typeId="74ae-c840-0036-d244">6</characteristic>
-                    <characteristic name="S" typeId="e478-41d4-a092-48a8">8</characteristic>
-                    <characteristic name="T" typeId="c32b-5fdd-3fbe-9b1f">8</characteristic>
-                    <characteristic name="W" typeId="57ee-1126-32a9-5672">8</characteristic>
-                    <characteristic name="I" typeId="62d3-22d7-2d49-52dc">6</characteristic>
-                    <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">6</characteristic>
-                    <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">10</characteristic>
-                    <characteristic name="Save" typeId="e593-6b3c-f169-04f0">2+</characteristic>
-                  </characteristics>
-                </profile>
-              </profiles>
-              <rules>
-                <rule id="dd1b-0330-aab1-7188" name="A Dark Fate" hidden="false">
-                  <description>The first time in any battle that Horus Ascended loses his last Wound, or is otherwise removed from play as a casualty, the model is instead placed into Reserves with a single Wound remaining – any unit Horus Ascended was part of remains in play, even a Retinue or other unit that would normally not allow the removal of a model from the unit. After having been placed in Reserves due to this special rule, Horus Ascended may choose to re-enter play, with the controlling player making Reserves rolls for the model as per the normal rules. If the Slay the Warlord objective, or any other objective that requires the enemy Warlord be removed as a casualty to score Victory points, is in effect then it is still triggered when Horus Ascended is moved into Reserves due to this special rule – and may be triggered a second time if Horus Ascended returns to play and is removed as a casualty again</description>
-                </rule>
-                <rule id="3f6d-8e47-55b5-3f8b" name="The Power of Chaos Eternal" hidden="false">
-                  <description>Once per battle, at the start of any Assault phase (whether Horus Ascended’s controlling player is the Active or Reactive player), Horus Ascended’s controlling player
-may choose to activate the Power of Chaos Eternal. Onc eactivated, Horus Ascended increases his Strength and Toughness Characteristics to 10 for the duration of the Assault phase and ignores all the effects of the Unwieldy special rule on attacks made with Worldbreaker. Once the Assault phase is ended, all combats being fought have been resolved and the effects of the Power of Chaos Eternal have ended, Horus Ascended automatically suffers Perils of the Warp – but any Wounds caused must be allocated to friendly models in the same unit as Horus Ascended, if any such models exist, before they are allocated to Horus Ascended</description>
-                </rule>
-                <rule id="d859-aa19-1907-0790" name="The Spreading Corruption" hidden="false">
-                  <description>All models in a unit made up entirely of models withthe Infantry, Cavalry or Dreadnought Unit Types inthesame Detachment as Horus Ascended may be giiven the Corrupted Unit Sub-type at a cost of +25 points per unit . If this upgrade is selected for a unit then all models in the unit must gain the Corrupted Sub-type – models that are attached to units, such as Apothecaries or Techmarines, must be upgraded separately. For Apothecary Detachments, Techmarine Covenants and other units which are bought as a single Force Organisation slot and then separated, divided or attached to other units (including units bought using the Retinue special rule or any variant of that rule which allows a unit to be counted as part of the same Force Organisation slot as a Leader model), the upgrade is bought once for
-the entire set of models before they are separated and must be applied to all models chosen as part of that Force Organisation slot.</description>
-                </rule>
-                <rule id="9445-c0b8-f082-54cb" name="Master of War" hidden="false">
-                  <description>Once per battle, at the start of any turn where Horus Lupercal’s controlling player is the Reactive player, this special rule may be activated. For the duration of the turn on which this special rule is activated, the Reaction Allotment of the army that includes Horus is increased by +1 in every Phase.</description>
-                </rule>
-                <rule id="ade0-2be2-4fad-a2b9" name="Master of Weapons" hidden="false">
-                  <description>During the Assault phase Horus Lupercal can never be hit by a Melee Attack on a score of better than 4+, regardless of the Weapon Skill of his opponent. In addition, during the Assault phase Horus Lupercal may choose to split his Attacks between any of the weapons he is equipped with, declaring which attacks will be used with which weaponprofiles before any of his attacks are rolled.</description>
-                </rule>
-              </rules>
-              <infoLinks>
-                <infoLink id="6ecc-afc9-a699-ce44" name="Feel No Pain (X)" hidden="false" targetId="ec46-ff29-32e0-c2aa" type="rule">
-                  <modifiers>
-                    <modifier type="set" field="name" value="Feel No Pain (4+)"/>
-                  </modifiers>
-                </infoLink>
-                <infoLink id="6bfb-c229-3493-acb0" name="Rage (X)" hidden="false" targetId="564d-3550-ae44-2f99" type="rule">
-                  <modifiers>
-                    <modifier type="set" field="name" value="Rage (3)"/>
-                  </modifiers>
-                </infoLink>
-                <infoLink id="63c5-a1e6-28a4-8fab" name="Deep Strike" hidden="false" targetId="f1e1-986f-c783-ca9e" type="rule"/>
-              </infoLinks>
-              <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="400.0"/>
-              </costs>
-            </selectionEntry>
           </selectionEntries>
+          <entryLinks>
+            <entryLink id="2dbc-d1f7-16b6-436d" name="Horus Ascended" hidden="false" collective="false" import="true" targetId="4a11-c7c1-e1a1-d067" type="selectionEntry"/>
+          </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
@@ -3557,6 +3521,13 @@ the entire set of models before they are separated and must be applied to all mo
       </costs>
     </selectionEntry>
     <selectionEntry id="8b29-bf2a-a814-5642" name="Reaver Attack Squad" hidden="false" collective="false" import="true" type="unit">
+      <modifiers>
+        <modifier type="add" field="category" value="9055-7410-8ffd-b8e7">
+          <conditions>
+            <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f783-f0ea-fe35-cdeb" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <infoLinks>
         <infoLink id="75f8-aafa-4322-7748" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule"/>
         <infoLink id="2e29-50f0-b4bc-8fbe" name="Chosen Warriors" hidden="false" targetId="13d1-9270-6539-08ed" type="rule"/>
@@ -3592,6 +3563,11 @@ the entire set of models before they are separated and must be applied to all mo
                 <modifier type="set" field="e593-6b3c-f169-04f0" value="2+">
                   <conditions>
                     <condition field="selections" scope="8b29-bf2a-a814-5642" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="9d64-3950-9bfb-e312" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Corrupted)">
+                  <conditions>
+                    <condition field="selections" scope="8b29-bf2a-a814-5642" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f783-f0ea-fe35-cdeb" type="equalTo"/>
                   </conditions>
                 </modifier>
               </modifiers>
@@ -3912,23 +3888,9 @@ the entire set of models before they are separated and must be applied to all mo
           </constraints>
           <selectionEntries>
             <selectionEntry id="9a78-22bd-c5e6-f60b" name="Reavers (Collective)" hidden="false" collective="false" import="true" type="model">
-              <profiles>
-                <profile id="1592-ade6-005a-add2" name="Reaver" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
-                  <characteristics>
-                    <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry</characteristic>
-                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
-                    <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">5</characteristic>
-                    <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
-                    <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
-                    <characteristic name="T" typeId="c32b-5fdd-3fbe-9b1f">4</characteristic>
-                    <characteristic name="W" typeId="57ee-1126-32a9-5672">2</characteristic>
-                    <characteristic name="I" typeId="62d3-22d7-2d49-52dc">4</characteristic>
-                    <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">2</characteristic>
-                    <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">8</characteristic>
-                    <characteristic name="Save" typeId="e593-6b3c-f169-04f0">3+</characteristic>
-                  </characteristics>
-                </profile>
-              </profiles>
+              <infoLinks>
+                <infoLink id="e8b0-1f94-823d-ad4b" name="Reaver" hidden="false" targetId="c465-d069-d874-1381" type="profile"/>
+              </infoLinks>
               <selectionEntryGroups>
                 <selectionEntryGroup id="3d99-aca1-0911-248d" name="Bolt Pistol:" hidden="false" collective="false" import="true" defaultSelectionEntryId="ffb6-d9af-ced1-89bf">
                   <modifiers>
@@ -4074,6 +4036,13 @@ the entire set of models before they are separated and must be applied to all mo
             <selectionEntry id="2fc2-12f4-a68f-111d" name="Reaver w/ Options" hidden="false" collective="false" import="true" type="model">
               <profiles>
                 <profile id="c465-d069-d874-1381" name="Reaver" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
+                  <modifiers>
+                    <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Corrupted)">
+                      <conditions>
+                        <condition field="selections" scope="8b29-bf2a-a814-5642" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f783-f0ea-fe35-cdeb" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
                   <characteristics>
                     <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry</characteristic>
                     <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
@@ -4322,6 +4291,7 @@ the entire set of models before they are separated and must be applied to all mo
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="499d-cd39-402f-a07a" type="min"/>
           </constraints>
         </entryLink>
+        <entryLink id="0d89-6a33-b80c-0ec3" name="The Spreading Corruption" hidden="false" collective="false" import="true" targetId="f783-f0ea-fe35-cdeb" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="47.0"/>
@@ -4686,6 +4656,13 @@ remains in play and regains 1D3 Wounds.</description>
       </costs>
     </selectionEntry>
     <selectionEntry id="c45d-ade3-6b28-68a2" name="Justaerin Terminator Squad" hidden="false" collective="false" import="true" type="unit">
+      <modifiers>
+        <modifier type="add" field="category" value="9055-7410-8ffd-b8e7">
+          <conditions>
+            <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f783-f0ea-fe35-cdeb" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <rules>
         <rule id="7c0d-6e3e-9350-dc1c" name="Justaerin Retinue" hidden="true">
           <description>A Justaerin Terminator Squad may be selected as a Retinue Squad in a Detachment that includes one model with both the Master of the Legion and the Legiones Astartes (Sons of Horus) special rules, instead of as an Elites choice, A unit selected a a Retinue Squad must have one model with both the Master of the Legion and Legiones Astartes (Sons of Horus) special rules from the same Detachment selected by the controlling player as the Justaerin Terminator Squad&apos;s Leader for the purposes of this special rule. A Justaerin Terminator Squad selected as a Retinue Squad does not use up a Force Organisation slot and is considered part of the same unit as the model selected as its Leader. A Justearin Terminator Squad selected as a Retinue Squad must be deployed with the model selected as its Leader as part of the unit and the Leader may not voluntarly leave the Retinue Squad during play. If that Leader has the Deep Strike special rule then all models in the Justaerin Terminator Squad selected as a Retinue Squad gain the Deep Strike special rule as well. One Justaerin in a Justaerin Terminator Squad selected as a Retinue may exchange a Banestrike combi-weapon for a Legion standard for +15 points.</description>
@@ -4746,6 +4723,13 @@ remains in play and regains 1D3 Wounds.</description>
             <selectionEntry id="d9c2-8eaa-a071-6524" name="Justaerin" hidden="false" collective="false" import="true" type="model">
               <profiles>
                 <profile id="46b2-7f6f-7859-c042" name="Justaerin" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
+                  <modifiers>
+                    <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Corrupted)">
+                      <conditions>
+                        <condition field="selections" scope="c45d-ade3-6b28-68a2" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f783-f0ea-fe35-cdeb" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
                   <characteristics>
                     <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Heavy)</characteristic>
                     <characteristic name="Move" typeId="893e-2d76-8f04-44e5">6</characteristic>
@@ -5063,7 +5047,13 @@ remains in play and regains 1D3 Wounds.</description>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="b445-5f56-6379-d473" name="Cataphractii Terminator Armour" hidden="false" collective="false" import="true" targetId="7c9b-b9ab-9a40-8eb5" type="selectionEntry"/>
+        <entryLink id="b445-5f56-6379-d473" name="Cataphractii Terminator Armour" hidden="false" collective="false" import="true" targetId="7c9b-b9ab-9a40-8eb5" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3cba-0221-4614-3373" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4367-770f-d8e4-a22f" type="max"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="59b8-d485-b6f3-c6dd" name="The Spreading Corruption" hidden="false" collective="false" import="true" targetId="f783-f0ea-fe35-cdeb" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0"/>
@@ -5195,6 +5185,13 @@ remains in play and regains 1D3 Wounds.</description>
       </costs>
     </selectionEntry>
     <selectionEntry id="af3a-334f-152f-d55f" name="Reaver Aggressor Squad" hidden="false" collective="false" import="true" type="unit">
+      <modifiers>
+        <modifier type="add" field="category" value="9055-7410-8ffd-b8e7">
+          <conditions>
+            <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f783-f0ea-fe35-cdeb" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <infoLinks>
         <infoLink id="30fa-9b63-8ecb-6a86" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule"/>
         <infoLink id="164a-6447-95d6-7e7c" name="Chosen Warriors" hidden="false" targetId="13d1-9270-6539-08ed" type="rule"/>
@@ -5230,6 +5227,11 @@ remains in play and regains 1D3 Wounds.</description>
                 <modifier type="set" field="e593-6b3c-f169-04f0" value="2+">
                   <conditions>
                     <condition field="selections" scope="ce86-cb58-16b1-219d" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7651-9307-69ad-00ae" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Corrupted)">
+                  <conditions>
+                    <condition field="selections" scope="af3a-334f-152f-d55f" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f783-f0ea-fe35-cdeb" type="equalTo"/>
                   </conditions>
                 </modifier>
               </modifiers>
@@ -5448,6 +5450,13 @@ remains in play and regains 1D3 Wounds.</description>
             <selectionEntry id="e0c0-8529-c8e5-310e" name="Reavers (Collective)" hidden="false" collective="false" import="true" type="model">
               <profiles>
                 <profile id="5ba1-244a-e6f0-9727" name="Reaver" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
+                  <modifiers>
+                    <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Corrupted)">
+                      <conditions>
+                        <condition field="selections" scope="af3a-334f-152f-d55f" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f783-f0ea-fe35-cdeb" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
                   <characteristics>
                     <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry</characteristic>
                     <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
@@ -5606,23 +5615,9 @@ remains in play and regains 1D3 Wounds.</description>
               </costs>
             </selectionEntry>
             <selectionEntry id="8149-8fa6-c6b9-c3db" name="Reaver w/ Options" hidden="false" collective="false" import="true" type="model">
-              <profiles>
-                <profile id="31e2-14f5-6668-8811" name="Reaver" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
-                  <characteristics>
-                    <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry</characteristic>
-                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
-                    <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">5</characteristic>
-                    <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
-                    <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
-                    <characteristic name="T" typeId="c32b-5fdd-3fbe-9b1f">4</characteristic>
-                    <characteristic name="W" typeId="57ee-1126-32a9-5672">2</characteristic>
-                    <characteristic name="I" typeId="62d3-22d7-2d49-52dc">4</characteristic>
-                    <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">2</characteristic>
-                    <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">8</characteristic>
-                    <characteristic name="Save" typeId="e593-6b3c-f169-04f0">3+</characteristic>
-                  </characteristics>
-                </profile>
-              </profiles>
+              <infoLinks>
+                <infoLink id="4b49-eb8d-2c47-212e" name="Reaver" hidden="false" targetId="5ba1-244a-e6f0-9727" type="profile"/>
+              </infoLinks>
               <selectionEntryGroups>
                 <selectionEntryGroup id="c5de-a48b-e97b-180f" name="Bolt Pistol:" hidden="false" collective="false" import="true" defaultSelectionEntryId="2feb-5e81-0480-0450">
                   <modifiers>
@@ -5862,6 +5857,7 @@ remains in play and regains 1D3 Wounds.</description>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9993-f103-e8b1-6a6d" type="min"/>
           </constraints>
         </entryLink>
+        <entryLink id="1dde-b6e2-299e-629c" name="The Spreading Corruption" hidden="false" collective="false" import="true" targetId="f783-f0ea-fe35-cdeb" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="45.0"/>

--- a/2022 - Legiones Astartes.cat
+++ b/2022 - Legiones Astartes.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="6393-649c-7213-a327" name="(HH V2) Legions Astartes" revision="130" battleScribeVersion="2.03" authorName="Various" authorUrl="https://github.com/BSData/horus-heresy" library="true" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="61" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="6393-649c-7213-a327" name="(HH V2) Legions Astartes" revision="131" battleScribeVersion="2.03" authorName="Various" authorUrl="https://github.com/BSData/horus-heresy" library="true" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="61" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="0594-a9b0-6f10-090e" name="Legion Javelin Squadron Updade" publisher="Warhammer Community Downloads" publicationDate="May 2023" publisherUrl="https://www.warhammer-community.com/wp-content/uploads/2023/05/hd7WOnm2lKCHkskG.pdf"/>
     <publication id="acdb-27b7-6b7e-932f" name="Legion Mastodon Updade" publisher="Warhammer Community Downloads" publicationDate="May 2023" publisherUrl="https://www.warhammer-community.com/wp-content/uploads/2023/05/AopGHpxowuowkwJw.pdf"/>
@@ -4257,6 +4257,18 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
       </costs>
     </selectionEntry>
     <selectionEntry id="aa72-63e4-bc60-4611" name="Tactical Squad" hidden="false" collective="false" import="true" type="unit">
+      <modifiers>
+        <modifier type="add" field="category" value="9055-7410-8ffd-b8e7">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="aa72-63e4-bc60-4611" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f783-f0ea-fe35-cdeb" type="equalTo"/>
+                <condition field="selections" scope="aa72-63e4-bc60-4611" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="555f-3998-a06e-f415" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <modifierGroups>
         <modifierGroup>
           <modifiers>
@@ -4345,15 +4357,20 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                     <condition field="selections" scope="aa72-63e4-bc60-4611" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="583e-62cb-53f1-f952" type="equalTo"/>
                   </conditions>
                 </modifier>
-                <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Infantry (Character, Line, Psyker)">
+                <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Psyker)">
                   <conditions>
                     <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="21c3-2f28-7820-e51a" type="equalTo"/>
                   </conditions>
                 </modifier>
-                <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Infantry (Character, Line, Corrupted)">
-                  <conditions>
-                    <condition field="selections" scope="aa72-63e4-bc60-4611" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="555f-3998-a06e-f415" type="equalTo"/>
-                  </conditions>
+                <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Corrupted)">
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="aa72-63e4-bc60-4611" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f783-f0ea-fe35-cdeb" type="equalTo"/>
+                        <condition field="selections" scope="aa72-63e4-bc60-4611" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="555f-3998-a06e-f415" type="equalTo"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
                 </modifier>
               </modifiers>
               <characteristics>
@@ -4907,6 +4924,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                 </modifier>
               </modifiers>
             </entryLink>
+            <entryLink id="9f4e-3809-2b70-fb99" name="The Spreading Corruption" hidden="false" collective="false" import="true" targetId="f783-f0ea-fe35-cdeb" type="selectionEntry"/>
           </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="f115-cfc4-4199-f8be" name="0) Legionaries" hidden="false" collective="false" import="true" defaultSelectionEntryId="8b28-bdec-1540-5a47">
@@ -5118,14 +5136,19 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                         <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
                       </conditions>
                     </modifier>
-                    <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Infantry (Line, Psyker)">
+                    <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Corrupted)">
+                      <conditionGroups>
+                        <conditionGroup type="or">
+                          <conditions>
+                            <condition field="selections" scope="aa72-63e4-bc60-4611" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f783-f0ea-fe35-cdeb" type="equalTo"/>
+                            <condition field="selections" scope="aa72-63e4-bc60-4611" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="555f-3998-a06e-f415" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                    <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Psyker)">
                       <conditions>
                         <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="21c3-2f28-7820-e51a" type="equalTo"/>
-                      </conditions>
-                    </modifier>
-                    <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Infantry (Line, Corrupted)">
-                      <conditions>
-                        <condition field="selections" scope="aa72-63e4-bc60-4611" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="555f-3998-a06e-f415" type="equalTo"/>
                       </conditions>
                     </modifier>
                   </modifiers>
@@ -5759,6 +5782,16 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
             </conditionGroup>
           </conditionGroups>
         </modifier>
+        <modifier type="add" field="category" value="9055-7410-8ffd-b8e7">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="50ed-5869-643d-1ac5" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f783-f0ea-fe35-cdeb" type="equalTo"/>
+                <condition field="selections" scope="50ed-5869-643d-1ac5" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="555f-3998-a06e-f415" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
       </modifiers>
       <modifierGroups>
         <modifierGroup>
@@ -5816,10 +5849,15 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
           <profiles>
             <profile id="86b1-a1fc-a5a1-37b0" name="Legion Tactical Support Sergeant" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
               <modifiers>
-                <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Infantry (Character, Corrupted)">
-                  <conditions>
-                    <condition field="selections" scope="50ed-5869-643d-1ac5" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="555f-3998-a06e-f415" type="equalTo"/>
-                  </conditions>
+                <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Corrupted)">
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="50ed-5869-643d-1ac5" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f783-f0ea-fe35-cdeb" type="equalTo"/>
+                        <condition field="selections" scope="50ed-5869-643d-1ac5" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="555f-3998-a06e-f415" type="equalTo"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
                 </modifier>
                 <modifier type="set" field="893e-2d76-8f04-44e5" value="8*">
                   <conditions>
@@ -5831,7 +5869,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                     <condition field="selections" scope="50ed-5869-643d-1ac5" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="583e-62cb-53f1-f952" type="equalTo"/>
                   </conditions>
                 </modifier>
-                <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Infantry (Character, Psyker)">
+                <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Psyker)">
                   <conditions>
                     <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="21c3-2f28-7820-e51a" type="equalTo"/>
                   </conditions>
@@ -6393,6 +6431,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                 </modifier>
               </modifiers>
             </entryLink>
+            <entryLink id="e802-4bc6-843b-8717" name="The Spreading Corruption" hidden="false" collective="false" import="true" targetId="f783-f0ea-fe35-cdeb" type="selectionEntry"/>
           </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="097a-5712-c173-0477" name="0) Legionaries" hidden="false" collective="false" import="true" defaultSelectionEntryId="596b-7051-6378-ac8a">
@@ -6405,17 +6444,22 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
               <profiles>
                 <profile id="8bcd-d233-e477-f14c" name="Legionary" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
                   <modifiers>
-                    <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Infantry (Corrupted)">
-                      <conditions>
-                        <condition field="selections" scope="50ed-5869-643d-1ac5" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="555f-3998-a06e-f415" type="equalTo"/>
-                      </conditions>
-                    </modifier>
                     <modifier type="set" field="893e-2d76-8f04-44e5" value="8*">
                       <conditions>
                         <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
                       </conditions>
                     </modifier>
-                    <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Infantry (Psyker)">
+                    <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Corrupted)">
+                      <conditionGroups>
+                        <conditionGroup type="or">
+                          <conditions>
+                            <condition field="selections" scope="50ed-5869-643d-1ac5" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f783-f0ea-fe35-cdeb" type="equalTo"/>
+                            <condition field="selections" scope="50ed-5869-643d-1ac5" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="555f-3998-a06e-f415" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                    <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Psyker)">
                       <conditions>
                         <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="21c3-2f28-7820-e51a" type="equalTo"/>
                       </conditions>
@@ -6729,6 +6773,11 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
             <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c83-69fb-8066-a773" type="equalTo"/>
           </conditions>
         </modifier>
+        <modifier type="add" field="category" value="9055-7410-8ffd-b8e7">
+          <conditions>
+            <condition field="selections" scope="70eb-e4da-8b3f-f065" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f783-f0ea-fe35-cdeb" type="equalTo"/>
+          </conditions>
+        </modifier>
       </modifiers>
       <infoLinks>
         <infoLink id="ea28-4e70-3907-dd03" name="Scout" hidden="false" targetId="aacf-9a7e-982d-b793" type="rule"/>
@@ -6768,9 +6817,14 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                     <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
                   </conditions>
                 </modifier>
-                <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Cavalry (Skirmish, Psyker)">
+                <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Psyker)">
                   <conditions>
                     <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="21c3-2f28-7820-e51a" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Corrupted)">
+                  <conditions>
+                    <condition field="selections" scope="70eb-e4da-8b3f-f065" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f783-f0ea-fe35-cdeb" type="equalTo"/>
                   </conditions>
                 </modifier>
               </modifiers>
@@ -6926,14 +6980,19 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                     <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
                   </conditions>
                 </modifier>
-                <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Cavalry (Skirmish, Character, Psyker)">
-                  <conditions>
-                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="21c3-2f28-7820-e51a" type="equalTo"/>
-                  </conditions>
-                </modifier>
                 <modifier type="set" field="e593-6b3c-f169-04f0" value="2+">
                   <conditions>
                     <condition field="selections" scope="cd38-bce1-8bb2-6822" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="583e-62cb-53f1-f952" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Corrupted)">
+                  <conditions>
+                    <condition field="selections" scope="70eb-e4da-8b3f-f065" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f783-f0ea-fe35-cdeb" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Psyker)">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="21c3-2f28-7820-e51a" type="equalTo"/>
                   </conditions>
                 </modifier>
               </modifiers>
@@ -7192,6 +7251,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
               </costs>
             </entryLink>
+            <entryLink id="df5e-54e0-0c56-fdc3" name="The Spreading Corruption" hidden="false" collective="false" import="true" targetId="f783-f0ea-fe35-cdeb" type="selectionEntry"/>
           </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="3366-dd98-90d9-ff40" name="4) Bike Weapon Choice" hidden="false" collective="false" import="true" defaultSelectionEntryId="0f17-5170-666e-e589">
@@ -8130,6 +8190,16 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
             <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c83-69fb-8066-a773" type="equalTo"/>
           </conditions>
         </modifier>
+        <modifier type="add" field="category" value="9055-7410-8ffd-b8e7">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="bfdf-831f-2171-c1e7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f783-f0ea-fe35-cdeb" type="equalTo"/>
+                <condition field="selections" scope="bfdf-831f-2171-c1e7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="555f-3998-a06e-f415" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
       </modifiers>
       <categoryLinks>
         <categoryLink id="9d47-a878-735c-c251" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
@@ -8149,6 +8219,16 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                   <conditions>
                     <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
                   </conditions>
+                </modifier>
+                <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Corrupted)">
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="bfdf-831f-2171-c1e7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f783-f0ea-fe35-cdeb" type="equalTo"/>
+                        <condition field="selections" scope="bfdf-831f-2171-c1e7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="555f-3998-a06e-f415" type="equalTo"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
                 </modifier>
               </modifiers>
               <characteristics>
@@ -8259,6 +8339,15 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
               </constraints>
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="4298-1722-02e5-ceb4" name="The Spreading Corruption" hidden="false" collective="false" import="true" targetId="f783-f0ea-fe35-cdeb" type="selectionEntry"/>
+            <entryLink id="70a0-eb79-d743-c61f" name="Dark Channeling" hidden="false" collective="false" import="true" targetId="555f-3998-a06e-f415" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="aad4-726f-b68c-18bc" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0"/>
               </costs>
             </entryLink>
           </entryLinks>
@@ -9083,9 +9172,14 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
           </conditions>
         </modifier>
         <modifier type="add" field="category" value="9055-7410-8ffd-b8e7">
-          <conditions>
-            <condition field="selections" scope="d664-5692-cd41-f9be" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="555f-3998-a06e-f415" type="equalTo"/>
-          </conditions>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="d664-5692-cd41-f9be" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f783-f0ea-fe35-cdeb" type="equalTo"/>
+                <condition field="selections" scope="d664-5692-cd41-f9be" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="555f-3998-a06e-f415" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
         </modifier>
         <modifier type="add" field="category" value="2bcf-6bbe-58a1-e082">
           <conditions>
@@ -9142,10 +9236,15 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                     <condition field="selections" scope="d664-5692-cd41-f9be" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d5ac-3da6-a69b-f6b8" type="greaterThan"/>
                   </conditions>
                 </modifier>
-                <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Dreadnought (Corrupted)">
-                  <conditions>
-                    <condition field="selections" scope="d664-5692-cd41-f9be" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="555f-3998-a06e-f415" type="equalTo"/>
-                  </conditions>
+                <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Corrupted)">
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="d664-5692-cd41-f9be" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f783-f0ea-fe35-cdeb" type="equalTo"/>
+                        <condition field="selections" scope="d664-5692-cd41-f9be" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="555f-3998-a06e-f415" type="equalTo"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
                 </modifier>
                 <modifier type="set" field="893e-2d76-8f04-44e5" value="9*">
                   <conditions>
@@ -9534,6 +9633,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0"/>
               </costs>
             </entryLink>
+            <entryLink id="7739-1c2b-d2bc-52a7" name="The Spreading Corruption" hidden="false" collective="false" import="true" targetId="f783-f0ea-fe35-cdeb" type="selectionEntry"/>
           </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="6c58-1316-14a1-6dc0" name="Dedicated Transport" hidden="false" collective="false" import="true">
@@ -9958,9 +10058,14 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
               </conditions>
             </modifier>
             <modifier type="add" field="category" value="9055-7410-8ffd-b8e7">
-              <conditions>
-                <condition field="selections" scope="03be-5d55-d05a-771d" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fd55-9459-b3b3-5d20" type="equalTo"/>
-              </conditions>
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="03be-5d55-d05a-771d" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f783-f0ea-fe35-cdeb" type="equalTo"/>
+                    <condition field="selections" scope="03be-5d55-d05a-771d" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fd55-9459-b3b3-5d20" type="equalTo"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
             </modifier>
             <modifier type="set" field="name" value="Warsmith">
               <conditions>
@@ -10121,27 +10226,105 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
           <profiles>
             <profile id="e796-8850-9890-245c" name="Legion Praetor" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
               <modifiers>
-                <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Infantry (Character, Psyker)">
-                  <conditions>
-                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="21c3-2f28-7820-e51a" type="equalTo"/>
-                  </conditions>
-                </modifier>
-                <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Infantry (Character, Skirmish)">
-                  <conditions>
-                    <condition field="selections" scope="03be-5d55-d05a-771d" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0759-a4bb-a15b-7cef" type="equalTo"/>
-                  </conditions>
-                </modifier>
-                <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Cavalry (Character, Psyker, Antigrav)">
+                <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Psyker)">
                   <conditionGroups>
-                    <conditionGroup type="and">
+                    <conditionGroup type="or">
                       <conditions>
-                        <condition field="selections" scope="d862-5767-da41-cff0" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6fb4-adf6-dbe8-86af" type="equalTo"/>
                         <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="21c3-2f28-7820-e51a" type="equalTo"/>
+                        <condition field="selections" scope="03be-5d55-d05a-771d" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fd55-9459-b3b3-5d20" type="equalTo"/>
                       </conditions>
                     </conditionGroup>
                   </conditionGroups>
                 </modifier>
-                <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Cavalry (Character, Antigrav)">
+                <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Skirmish)">
+                  <conditions>
+                    <condition field="selections" scope="03be-5d55-d05a-771d" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0759-a4bb-a15b-7cef" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="increment" field="57ee-1126-32a9-5672" value="1">
+                  <conditions>
+                    <condition field="selections" scope="03be-5d55-d05a-771d" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3125-5faa-cb08-e4ec" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="increment" field="f111-2ce5-dd12-d6b0" value="1">
+                  <conditions>
+                    <condition field="selections" scope="03be-5d55-d05a-771d" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="93af-e204-255b-b095" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Corrupted)">
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="03be-5d55-d05a-771d" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f783-f0ea-fe35-cdeb" type="equalTo"/>
+                        <condition field="selections" scope="03be-5d55-d05a-771d" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fd55-9459-b3b3-5d20" type="equalTo"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+                <modifier type="set" field="hidden" value="true">
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="d862-5767-da41-cff0" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e8a8-b526-beab-bb82" type="equalTo"/>
+                        <condition field="selections" scope="d862-5767-da41-cff0" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="567d-4386-3196-ca89" type="equalTo"/>
+                        <condition field="selections" scope="d862-5767-da41-cff0" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6fb4-adf6-dbe8-86af" type="equalTo"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+                <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Heavy)">
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="03be-5d55-d05a-771d" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0c0f-f751-cc4e-4951" type="atLeast"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
+              <modifierGroups>
+                <modifierGroup>
+                  <modifiers>
+                    <modifier type="append" field="893e-2d76-8f04-44e5" value="*">
+                      <conditions>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="increment" field="893e-2d76-8f04-44e5" value="1">
+                      <conditions>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                </modifierGroup>
+              </modifierGroups>
+              <characteristics>
+                <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Character)</characteristic>
+                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7</characteristic>
+                <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">6</characteristic>
+                <characteristic name="BS" typeId="74ae-c840-0036-d244">5</characteristic>
+                <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
+                <characteristic name="T" typeId="c32b-5fdd-3fbe-9b1f">4</characteristic>
+                <characteristic name="W" typeId="57ee-1126-32a9-5672">3</characteristic>
+                <characteristic name="I" typeId="62d3-22d7-2d49-52dc">5</characteristic>
+                <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">4</characteristic>
+                <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">10</characteristic>
+                <characteristic name="Save" typeId="e593-6b3c-f169-04f0">2+</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="bd27-5640-b8a7-fbb3" name="Legion Praetor" hidden="true" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
+              <modifiers>
+                <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Psyker)">
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="21c3-2f28-7820-e51a" type="equalTo"/>
+                        <condition field="selections" scope="03be-5d55-d05a-771d" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fd55-9459-b3b3-5d20" type="equalTo"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+                <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Antigrav)">
                   <conditionGroups>
                     <conditionGroup type="or">
                       <conditions>
@@ -10161,42 +10344,33 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                     <condition field="selections" scope="03be-5d55-d05a-771d" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="93af-e204-255b-b095" type="equalTo"/>
                   </conditions>
                 </modifier>
-                <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Cavalry (Character, Skirmish)">
-                  <conditions>
-                    <condition field="selections" scope="d862-5767-da41-cff0" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e8a8-b526-beab-bb82" type="equalTo"/>
-                  </conditions>
-                </modifier>
-                <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Infantry (Character, Psyker, Corrupted)">
-                  <conditions>
-                    <condition field="selections" scope="03be-5d55-d05a-771d" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fd55-9459-b3b3-5d20" type="equalTo"/>
-                  </conditions>
-                </modifier>
-                <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Cavalry (Character, Psyker, Antigrav)">
+                <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Skirmish)">
                   <conditionGroups>
-                    <conditionGroup type="and">
+                    <conditionGroup type="or">
                       <conditions>
-                        <condition field="selections" scope="d862-5767-da41-cff0" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6fb4-adf6-dbe8-86af" type="equalTo"/>
-                        <condition field="selections" scope="03be-5d55-d05a-771d" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fd55-9459-b3b3-5d20" type="equalTo"/>
-                      </conditions>
-                    </conditionGroup>
-                  </conditionGroups>
-                </modifier>
-                <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Cavalry (Character, Skirmish, Antigrav)">
-                  <conditionGroups>
-                    <conditionGroup type="and">
-                      <conditions>
-                        <condition field="selections" scope="d862-5767-da41-cff0" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6fb4-adf6-dbe8-86af" type="equalTo"/>
+                        <condition field="selections" scope="d862-5767-da41-cff0" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e8a8-b526-beab-bb82" type="equalTo"/>
                         <condition field="selections" scope="03be-5d55-d05a-771d" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0759-a4bb-a15b-7cef" type="equalTo"/>
                       </conditions>
                     </conditionGroup>
                   </conditionGroups>
                 </modifier>
-                <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Cavalry (Character, Psyker)">
+                <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Corrupted)">
                   <conditionGroups>
-                    <conditionGroup type="and">
+                    <conditionGroup type="or">
                       <conditions>
-                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="21c3-2f28-7820-e51a" type="equalTo"/>
+                        <condition field="selections" scope="03be-5d55-d05a-771d" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f783-f0ea-fe35-cdeb" type="equalTo"/>
+                        <condition field="selections" scope="03be-5d55-d05a-771d" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fd55-9459-b3b3-5d20" type="equalTo"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+                <modifier type="set" field="hidden" value="false">
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
                         <condition field="selections" scope="d862-5767-da41-cff0" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e8a8-b526-beab-bb82" type="equalTo"/>
+                        <condition field="selections" scope="d862-5767-da41-cff0" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="567d-4386-3196-ca89" type="equalTo"/>
+                        <condition field="selections" scope="d862-5767-da41-cff0" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6fb4-adf6-dbe8-86af" type="equalTo"/>
                       </conditions>
                     </conditionGroup>
                   </conditionGroups>
@@ -10234,7 +10408,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                 </modifierGroup>
               </modifierGroups>
               <characteristics>
-                <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Character)</characteristic>
+                <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Cavalry (Character)</characteristic>
                 <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7</characteristic>
                 <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">6</characteristic>
                 <characteristic name="BS" typeId="74ae-c840-0036-d244">5</characteristic>
@@ -11101,6 +11275,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2.0"/>
                   </costs>
                 </entryLink>
+                <entryLink id="78be-86cc-b4bf-7aa0" name="The Spreading Corruption" hidden="false" collective="false" import="true" targetId="f783-f0ea-fe35-cdeb" type="selectionEntry"/>
               </entryLinks>
             </selectionEntryGroup>
             <selectionEntryGroup id="8f1c-19e3-51c3-6ed6" name="5) Armor Choice" hidden="false" collective="false" import="true" defaultSelectionEntryId="102d-3f7d-958d-f5d7">
@@ -11249,9 +11424,14 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
     <selectionEntry id="1b79-1951-5a63-4b9e" name="Praetor, Cataphractii" hidden="false" collective="false" import="true" type="unit">
       <modifiers>
         <modifier type="add" field="category" value="9055-7410-8ffd-b8e7">
-          <conditions>
-            <condition field="selections" scope="1b79-1951-5a63-4b9e" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fd55-9459-b3b3-5d20" type="equalTo"/>
-          </conditions>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="1b79-1951-5a63-4b9e" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fd55-9459-b3b3-5d20" type="equalTo"/>
+                <condition field="selections" scope="1b79-1951-5a63-4b9e" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f783-f0ea-fe35-cdeb" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
         </modifier>
         <modifier type="add" field="category" value="5472-b476-dcbd-c215">
           <conditionGroups>
@@ -11345,12 +11525,17 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
           <profiles>
             <profile id="ffec-ae09-cb35-c948" name="Legion Cataphractii Praetor" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
               <modifiers>
-                <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Infantry (Heavy, Character, Psyker)">
-                  <conditions>
-                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="21c3-2f28-7820-e51a" type="equalTo"/>
-                  </conditions>
+                <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Psyker)">
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="1b79-1951-5a63-4b9e" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fd55-9459-b3b3-5d20" type="equalTo"/>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="21c3-2f28-7820-e51a" type="equalTo"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
                 </modifier>
-                <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Infantry (Heavy, Character, Skirmish)">
+                <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Skirmish)">
                   <conditions>
                     <condition field="selections" scope="1b79-1951-5a63-4b9e" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0759-a4bb-a15b-7cef" type="equalTo"/>
                   </conditions>
@@ -11360,10 +11545,15 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                     <condition field="selections" scope="1b79-1951-5a63-4b9e" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="93af-e204-255b-b095" type="equalTo"/>
                   </conditions>
                 </modifier>
-                <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Infantry (Character, Psyker, Corrupted)">
-                  <conditions>
-                    <condition field="selections" scope="1b79-1951-5a63-4b9e" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fd55-9459-b3b3-5d20" type="equalTo"/>
-                  </conditions>
+                <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Corrupted)">
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="1b79-1951-5a63-4b9e" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f783-f0ea-fe35-cdeb" type="equalTo"/>
+                        <condition field="selections" scope="1b79-1951-5a63-4b9e" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fd55-9459-b3b3-5d20" type="equalTo"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
                 </modifier>
                 <modifier type="set" field="893e-2d76-8f04-44e5" value="7*">
                   <conditions>
@@ -11693,6 +11883,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
                   </costs>
                 </entryLink>
+                <entryLink id="273e-9163-7d1a-49f5" name="The Spreading Corruption" hidden="false" collective="false" import="true" targetId="f783-f0ea-fe35-cdeb" type="selectionEntry"/>
               </entryLinks>
             </selectionEntryGroup>
             <selectionEntryGroup id="5ac7-91ec-6c49-64cc" name="1) Armour Choice" hidden="false" collective="false" import="true" defaultSelectionEntryId="65ca-51eb-5464-7a87">
@@ -11757,9 +11948,14 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
     <selectionEntry id="3760-204e-444c-1044" name="Praetor, Tartaros" hidden="false" collective="false" import="true" type="unit">
       <modifiers>
         <modifier type="add" field="category" value="9055-7410-8ffd-b8e7">
-          <conditions>
-            <condition field="selections" scope="3760-204e-444c-1044" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fd55-9459-b3b3-5d20" type="equalTo"/>
-          </conditions>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="3760-204e-444c-1044" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fd55-9459-b3b3-5d20" type="equalTo"/>
+                <condition field="selections" scope="3760-204e-444c-1044" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f783-f0ea-fe35-cdeb" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
         </modifier>
         <modifier type="add" field="category" value="5472-b476-dcbd-c215">
           <conditionGroups>
@@ -11852,12 +12048,17 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
           <profiles>
             <profile id="6cc6-eee1-010d-182c" name="Legion Tartaros Praetor" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
               <modifiers>
-                <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Infantry (Character, Psyker)">
-                  <conditions>
-                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="21c3-2f28-7820-e51a" type="equalTo"/>
-                  </conditions>
+                <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Psyker)">
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="3760-204e-444c-1044" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fd55-9459-b3b3-5d20" type="equalTo"/>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="21c3-2f28-7820-e51a" type="equalTo"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
                 </modifier>
-                <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Infantry (Character, Skirmish)">
+                <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Skirmish)">
                   <conditions>
                     <condition field="selections" scope="3760-204e-444c-1044" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0759-a4bb-a15b-7cef" type="equalTo"/>
                   </conditions>
@@ -11867,10 +12068,15 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                     <condition field="selections" scope="3760-204e-444c-1044" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="93af-e204-255b-b095" type="equalTo"/>
                   </conditions>
                 </modifier>
-                <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Infantry (Character, Psyker, Corrupted)">
-                  <conditions>
-                    <condition field="selections" scope="3760-204e-444c-1044" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fd55-9459-b3b3-5d20" type="equalTo"/>
-                  </conditions>
+                <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Corrupted)">
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="3760-204e-444c-1044" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f783-f0ea-fe35-cdeb" type="equalTo"/>
+                        <condition field="selections" scope="3760-204e-444c-1044" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fd55-9459-b3b3-5d20" type="equalTo"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
                 </modifier>
                 <modifier type="set" field="893e-2d76-8f04-44e5" value="8*">
                   <conditions>
@@ -12200,6 +12406,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
                   </costs>
                 </entryLink>
+                <entryLink id="9cdb-4b6a-08ce-8337" name="The Spreading Corruption" hidden="false" collective="false" import="true" targetId="f783-f0ea-fe35-cdeb" type="selectionEntry"/>
               </entryLinks>
             </selectionEntryGroup>
           </selectionEntryGroups>
@@ -12387,6 +12594,16 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                   <conditions>
                     <condition field="selections" scope="25a2-7a52-632a-6b2c" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1a3f-5c9e-f4d6-c92d" type="equalTo"/>
                     <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7857-5f9d-6c9e-50c1" type="equalTo"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+            <modifier type="add" field="category" value="9055-7410-8ffd-b8e7">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f783-f0ea-fe35-cdeb" type="equalTo"/>
+                    <condition field="selections" scope="25a2-7a52-632a-6b2c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4e1a-275e-e691-5b92" type="equalTo"/>
                   </conditions>
                 </conditionGroup>
               </conditionGroups>
@@ -12618,6 +12835,127 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                         <condition field="selections" scope="25a2-7a52-632a-6b2c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b1c4-f1e2-2f66-6d38" type="equalTo"/>
                         <condition field="selections" scope="25a2-7a52-632a-6b2c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a28d-408e-c833-9055" type="equalTo"/>
                         <condition field="selections" scope="25a2-7a52-632a-6b2c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c2a0-636c-9918-f851" type="equalTo"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+                <modifier type="set" field="cc42-7ed5-7092-5c84" value="6">
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="25a2-7a52-632a-6b2c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6f69-f2bd-fe7e-12c4" type="equalTo"/>
+                        <condition field="selections" scope="25a2-7a52-632a-6b2c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="05a2-a69e-0c9e-1544" type="equalTo"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+                <modifier type="set" field="e8a6-1da9-d384-8727" value="10">
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="25a2-7a52-632a-6b2c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6f69-f2bd-fe7e-12c4" type="equalTo"/>
+                        <condition field="selections" scope="25a2-7a52-632a-6b2c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4831-6948-851c-3925" type="equalTo"/>
+                        <condition field="selections" scope="25a2-7a52-632a-6b2c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e9ab-2cc5-4507-eded" type="equalTo"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+                <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Psyker)">
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="25a2-7a52-632a-6b2c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8846-2f93-a2be-18dc" type="equalTo"/>
+                        <condition field="selections" scope="25a2-7a52-632a-6b2c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d332-0e64-7ecf-6c35" type="equalTo"/>
+                        <condition field="selections" scope="25a2-7a52-632a-6b2c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d71e-10a6-216f-d796" type="equalTo"/>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="21c3-2f28-7820-e51a" type="equalTo"/>
+                        <condition field="selections" scope="25a2-7a52-632a-6b2c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b625-1cef-3057-156c" type="equalTo"/>
+                        <condition field="selections" scope="25a2-7a52-632a-6b2c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4e1a-275e-e691-5b92" type="equalTo"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+                <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Corrupted)">
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="25a2-7a52-632a-6b2c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f783-f0ea-fe35-cdeb" type="equalTo"/>
+                        <condition field="selections" scope="25a2-7a52-632a-6b2c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4e1a-275e-e691-5b92" type="equalTo"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+                <modifier type="set" field="57ee-1126-32a9-5672" value="3">
+                  <conditions>
+                    <condition field="selections" scope="25a2-7a52-632a-6b2c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3125-5faa-cb08-e4ec" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="increment" field="f111-2ce5-dd12-d6b0" value="1">
+                  <conditions>
+                    <condition field="selections" scope="25a2-7a52-632a-6b2c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="93af-e204-255b-b095" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="set" field="hidden" value="true">
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="c681-938e-6d11-cd43" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="567d-4386-3196-ca89" type="equalTo"/>
+                        <condition field="selections" scope="c681-938e-6d11-cd43" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6fb4-adf6-dbe8-86af" type="equalTo"/>
+                        <condition field="selections" scope="c681-938e-6d11-cd43" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e8a8-b526-beab-bb82" type="equalTo"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
+              <modifierGroups>
+                <modifierGroup>
+                  <modifiers>
+                    <modifier type="append" field="893e-2d76-8f04-44e5" value="*">
+                      <conditions>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="increment" field="893e-2d76-8f04-44e5" value="1">
+                      <conditions>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                </modifierGroup>
+              </modifierGroups>
+              <characteristics>
+                <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Character)</characteristic>
+                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7</characteristic>
+                <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">5</characteristic>
+                <characteristic name="BS" typeId="74ae-c840-0036-d244">5</characteristic>
+                <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
+                <characteristic name="T" typeId="c32b-5fdd-3fbe-9b1f">4</characteristic>
+                <characteristic name="W" typeId="57ee-1126-32a9-5672">2</characteristic>
+                <characteristic name="I" typeId="62d3-22d7-2d49-52dc">5</characteristic>
+                <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">3</characteristic>
+                <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">9</characteristic>
+                <characteristic name="Save" typeId="e593-6b3c-f169-04f0">2+</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="6de5-135d-bf7e-c7c2" name="Legion Centurion" publicationId="a716-c1c4-7b26-8424" page="22" hidden="true" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
+              <modifiers>
+                <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Heavy)">
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="25a2-7a52-632a-6b2c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="31f5-cbc4-58e0-ed6e" type="equalTo"/>
+                        <condition field="selections" scope="25a2-7a52-632a-6b2c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0c0f-f751-cc4e-4951" type="atLeast"/>
+                        <condition field="selections" scope="25a2-7a52-632a-6b2c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7962-e835-2ae5-c6f1" type="equalTo"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+                <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Skirmish)">
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="25a2-7a52-632a-6b2c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b1c4-f1e2-2f66-6d38" type="equalTo"/>
+                        <condition field="selections" scope="25a2-7a52-632a-6b2c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a28d-408e-c833-9055" type="equalTo"/>
+                        <condition field="selections" scope="25a2-7a52-632a-6b2c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c2a0-636c-9918-f851" type="equalTo"/>
                         <condition field="selections" scope="c681-938e-6d11-cd43" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e8a8-b526-beab-bb82" type="equalTo"/>
                       </conditions>
                     </conditionGroup>
@@ -12644,23 +12982,28 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                     </conditionGroup>
                   </conditionGroups>
                 </modifier>
-                <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Infantry (Character, Psyker)">
+                <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Psyker)">
                   <conditionGroups>
                     <conditionGroup type="or">
                       <conditions>
                         <condition field="selections" scope="25a2-7a52-632a-6b2c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8846-2f93-a2be-18dc" type="equalTo"/>
                         <condition field="selections" scope="25a2-7a52-632a-6b2c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d332-0e64-7ecf-6c35" type="equalTo"/>
-                        <condition field="selections" scope="25a2-7a52-632a-6b2c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d71e-10a6-216f-d796" type="equalTo"/>
                         <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="21c3-2f28-7820-e51a" type="equalTo"/>
                         <condition field="selections" scope="25a2-7a52-632a-6b2c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b625-1cef-3057-156c" type="equalTo"/>
+                        <condition field="selections" scope="25a2-7a52-632a-6b2c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4e1a-275e-e691-5b92" type="equalTo"/>
                       </conditions>
                     </conditionGroup>
                   </conditionGroups>
                 </modifier>
-                <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Infantry (Character, Corrupted, Psyker)">
-                  <conditions>
-                    <condition field="selections" scope="25a2-7a52-632a-6b2c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4e1a-275e-e691-5b92" type="equalTo"/>
-                  </conditions>
+                <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Corrupted)">
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="25a2-7a52-632a-6b2c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f783-f0ea-fe35-cdeb" type="equalTo"/>
+                        <condition field="selections" scope="25a2-7a52-632a-6b2c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4e1a-275e-e691-5b92" type="equalTo"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
                 </modifier>
                 <modifier type="set" field="57ee-1126-32a9-5672" value="3">
                   <conditions>
@@ -12671,6 +13014,17 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                   <conditions>
                     <condition field="selections" scope="25a2-7a52-632a-6b2c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="93af-e204-255b-b095" type="equalTo"/>
                   </conditions>
+                </modifier>
+                <modifier type="set" field="hidden" value="false">
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="c681-938e-6d11-cd43" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="567d-4386-3196-ca89" type="equalTo"/>
+                        <condition field="selections" scope="c681-938e-6d11-cd43" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6fb4-adf6-dbe8-86af" type="equalTo"/>
+                        <condition field="selections" scope="c681-938e-6d11-cd43" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e8a8-b526-beab-bb82" type="equalTo"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
                 </modifier>
               </modifiers>
               <modifierGroups>
@@ -12705,7 +13059,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                 </modifierGroup>
               </modifierGroups>
               <characteristics>
-                <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Character)</characteristic>
+                <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Cavalry (Character)</characteristic>
                 <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7</characteristic>
                 <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">5</characteristic>
                 <characteristic name="BS" typeId="74ae-c840-0036-d244">5</characteristic>
@@ -13915,6 +14269,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                     </modifier>
                   </modifiers>
                 </entryLink>
+                <entryLink id="1b75-8229-64e5-75b5" name="The Spreading Corruption" hidden="false" collective="false" import="true" targetId="f783-f0ea-fe35-cdeb" type="selectionEntry"/>
               </entryLinks>
             </selectionEntryGroup>
             <selectionEntryGroup id="93d8-d92a-5e97-4c38" name="6) Jetbike Weapon" hidden="false" collective="false" import="true">
@@ -14031,9 +14386,14 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
           </conditions>
         </modifier>
         <modifier type="add" field="category" value="9055-7410-8ffd-b8e7">
-          <conditions>
-            <condition field="selections" scope="1a8e-0ded-a4dc-2b4e" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="555f-3998-a06e-f415" type="equalTo"/>
-          </conditions>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="1a8e-0ded-a4dc-2b4e" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="555f-3998-a06e-f415" type="equalTo"/>
+                <condition field="selections" scope="1a8e-0ded-a4dc-2b4e" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f783-f0ea-fe35-cdeb" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
         </modifier>
       </modifiers>
       <modifierGroups>
@@ -14357,15 +14717,20 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
               <profiles>
                 <profile id="1bde-413a-7f98-a39e" name="Tartaros Sergeant" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
                   <modifiers>
-                    <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Infantry (Character, Psyker)">
+                    <modifier type="set" field="ddd7-6f5c-a939-b69e" value="(Psyker)">
                       <conditions>
                         <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="21c3-2f28-7820-e51a" type="equalTo"/>
                       </conditions>
                     </modifier>
-                    <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Infantry (Character, Corrupted)">
-                      <conditions>
-                        <condition field="selections" scope="1a8e-0ded-a4dc-2b4e" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="555f-3998-a06e-f415" type="equalTo"/>
-                      </conditions>
+                    <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Corrupted)">
+                      <conditionGroups>
+                        <conditionGroup type="or">
+                          <conditions>
+                            <condition field="selections" scope="1a8e-0ded-a4dc-2b4e" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="555f-3998-a06e-f415" type="equalTo"/>
+                            <condition field="selections" scope="1a8e-0ded-a4dc-2b4e" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f783-f0ea-fe35-cdeb" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
                     </modifier>
                     <modifier type="set" field="893e-2d76-8f04-44e5" value="8*">
                       <conditions>
@@ -14569,15 +14934,20 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
               <profiles>
                 <profile id="7aea-92c5-6016-dfaf" name="Tartaros" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
                   <modifiers>
-                    <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Infantry (Psyker)">
+                    <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Psyker)">
                       <conditions>
                         <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="21c3-2f28-7820-e51a" type="equalTo"/>
                       </conditions>
                     </modifier>
-                    <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Infantry (Corrupted)">
-                      <conditions>
-                        <condition field="selections" scope="1a8e-0ded-a4dc-2b4e" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="555f-3998-a06e-f415" type="equalTo"/>
-                      </conditions>
+                    <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Corrupted)">
+                      <conditionGroups>
+                        <conditionGroup type="or">
+                          <conditions>
+                            <condition field="selections" scope="1a8e-0ded-a4dc-2b4e" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="555f-3998-a06e-f415" type="equalTo"/>
+                            <condition field="selections" scope="1a8e-0ded-a4dc-2b4e" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f783-f0ea-fe35-cdeb" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
                     </modifier>
                     <modifier type="set" field="893e-2d76-8f04-44e5" value="8*">
                       <conditions>
@@ -14674,6 +15044,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                 </modifier>
               </modifiers>
             </entryLink>
+            <entryLink id="af9c-1bff-03dd-c8ce" name="The Spreading Corruption" hidden="false" collective="false" import="true" targetId="f783-f0ea-fe35-cdeb" type="selectionEntry"/>
           </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
@@ -14807,9 +15178,14 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
           </conditions>
         </modifier>
         <modifier type="add" field="category" value="9055-7410-8ffd-b8e7">
-          <conditions>
-            <condition field="selections" scope="d91a-a3c7-d7be-4293" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="555f-3998-a06e-f415" type="equalTo"/>
-          </conditions>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="d91a-a3c7-d7be-4293" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f783-f0ea-fe35-cdeb" type="equalTo"/>
+                <condition field="selections" scope="d91a-a3c7-d7be-4293" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="555f-3998-a06e-f415" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
         </modifier>
       </modifiers>
       <modifierGroups>
@@ -15017,15 +15393,20 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
               <profiles>
                 <profile id="9767-9cdc-ef59-6d7f" name="Cataphractii" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
                   <modifiers>
-                    <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Infantry (Heavy, Psyker)">
+                    <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Psyker)">
                       <conditions>
                         <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="21c3-2f28-7820-e51a" type="equalTo"/>
                       </conditions>
                     </modifier>
-                    <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Infantry (Heavy, Corrupted)">
-                      <conditions>
-                        <condition field="selections" scope="d91a-a3c7-d7be-4293" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="555f-3998-a06e-f415" type="equalTo"/>
-                      </conditions>
+                    <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Corrupted)">
+                      <conditionGroups>
+                        <conditionGroup type="or">
+                          <conditions>
+                            <condition field="selections" scope="d91a-a3c7-d7be-4293" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f783-f0ea-fe35-cdeb" type="equalTo"/>
+                            <condition field="selections" scope="d91a-a3c7-d7be-4293" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="555f-3998-a06e-f415" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
                     </modifier>
                     <modifier type="set" field="893e-2d76-8f04-44e5" value="7*">
                       <conditions>
@@ -15269,19 +15650,24 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
               <profiles>
                 <profile id="768c-34e9-1ed4-3229" name="Cataphractii Sergeant" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
                   <modifiers>
-                    <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Infantry (Heavy, Character, Psyker)">
-                      <conditions>
-                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="21c3-2f28-7820-e51a" type="equalTo"/>
-                      </conditions>
-                    </modifier>
-                    <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Infantry (Heavy, Character, Corrupted)">
-                      <conditions>
-                        <condition field="selections" scope="d91a-a3c7-d7be-4293" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="555f-3998-a06e-f415" type="equalTo"/>
-                      </conditions>
-                    </modifier>
                     <modifier type="set" field="893e-2d76-8f04-44e5" value="7*">
                       <conditions>
                         <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Corrupted)">
+                      <conditionGroups>
+                        <conditionGroup type="or">
+                          <conditions>
+                            <condition field="selections" scope="d91a-a3c7-d7be-4293" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f783-f0ea-fe35-cdeb" type="equalTo"/>
+                            <condition field="selections" scope="d91a-a3c7-d7be-4293" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="555f-3998-a06e-f415" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                    <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Psyker)">
+                      <conditions>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="21c3-2f28-7820-e51a" type="equalTo"/>
                       </conditions>
                     </modifier>
                   </modifiers>
@@ -15461,6 +15847,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                 </modifier>
               </modifiers>
             </entryLink>
+            <entryLink id="da52-e020-59b8-5c33" name="The Spreading Corruption" hidden="false" collective="false" import="true" targetId="f783-f0ea-fe35-cdeb" type="selectionEntry"/>
           </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
@@ -15479,6 +15866,18 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
       </costs>
     </selectionEntry>
     <selectionEntry id="4357-930e-165a-a6e3" name="Despoiler Squad" publicationId="a716-c1c4-7b26-8424" hidden="false" collective="false" import="true" type="unit">
+      <modifiers>
+        <modifier type="add" field="category" value="9055-7410-8ffd-b8e7">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="4357-930e-165a-a6e3" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f783-f0ea-fe35-cdeb" type="equalTo"/>
+                <condition field="selections" scope="4357-930e-165a-a6e3" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="555f-3998-a06e-f415" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <modifierGroups>
         <modifierGroup>
           <modifiers>
@@ -15542,14 +15941,24 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                     <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
                   </conditions>
                 </modifier>
-                <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Infantry (Character, Line, Psyker)">
-                  <conditions>
-                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="21c3-2f28-7820-e51a" type="equalTo"/>
-                  </conditions>
-                </modifier>
                 <modifier type="set" field="e593-6b3c-f169-04f0" value="2+">
                   <conditions>
                     <condition field="selections" scope="4357-930e-165a-a6e3" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="583e-62cb-53f1-f952" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Corrupted)">
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="4357-930e-165a-a6e3" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f783-f0ea-fe35-cdeb" type="equalTo"/>
+                        <condition field="selections" scope="4357-930e-165a-a6e3" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="555f-3998-a06e-f415" type="equalTo"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+                <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Psyker)">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="21c3-2f28-7820-e51a" type="equalTo"/>
                   </conditions>
                 </modifier>
               </modifiers>
@@ -15960,6 +16369,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                 </modifier>
               </modifiers>
             </entryLink>
+            <entryLink id="b286-4e73-e142-3cf1" name="The Spreading Corruption" hidden="false" collective="false" import="true" targetId="f783-f0ea-fe35-cdeb" type="selectionEntry"/>
           </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="ef54-aab4-53ae-d96c" name="2) Dedicated Transport:" hidden="false" collective="false" import="true">
@@ -16128,12 +16538,17 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                         <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
                       </conditions>
                     </modifier>
-                    <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Infantry (Line, Corrupted)">
-                      <conditions>
-                        <condition field="selections" scope="4357-930e-165a-a6e3" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="65c0-9376-164b-90e9" type="equalTo"/>
-                      </conditions>
+                    <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Corrupted)">
+                      <conditionGroups>
+                        <conditionGroup type="or">
+                          <conditions>
+                            <condition field="selections" scope="4357-930e-165a-a6e3" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f783-f0ea-fe35-cdeb" type="equalTo"/>
+                            <condition field="selections" scope="4357-930e-165a-a6e3" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="555f-3998-a06e-f415" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
                     </modifier>
-                    <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Infantry (Line, Psyker)">
+                    <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Psyker)">
                       <conditions>
                         <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="21c3-2f28-7820-e51a" type="equalTo"/>
                       </conditions>
@@ -16517,6 +16932,18 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
       </costs>
     </selectionEntry>
     <selectionEntry id="ad97-c090-fa67-696f" name="Breacher Squad" hidden="false" collective="false" import="true" type="unit">
+      <modifiers>
+        <modifier type="add" field="category" value="9055-7410-8ffd-b8e7">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="ad97-c090-fa67-696f" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f783-f0ea-fe35-cdeb" type="equalTo"/>
+                <condition field="selections" scope="ad97-c090-fa67-696f" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="555f-3998-a06e-f415" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <modifierGroups>
         <modifierGroup>
           <modifiers>
@@ -16584,15 +17011,20 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                     <condition field="selections" scope="ad97-c090-fa67-696f" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="583e-62cb-53f1-f952" type="equalTo"/>
                   </conditions>
                 </modifier>
-                <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Infantry (Character, Heavy, Line, Psyker)">
+                <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Psyker)">
                   <conditions>
                     <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="21c3-2f28-7820-e51a" type="equalTo"/>
                   </conditions>
                 </modifier>
-                <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Infantry (Character, Heavy, Line, Corrupted)">
-                  <conditions>
-                    <condition field="selections" scope="ad97-c090-fa67-696f" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="85bf-438d-08e5-8c79" type="equalTo"/>
-                  </conditions>
+                <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Corrupted)">
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="ad97-c090-fa67-696f" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f783-f0ea-fe35-cdeb" type="equalTo"/>
+                        <condition field="selections" scope="ad97-c090-fa67-696f" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="555f-3998-a06e-f415" type="equalTo"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
                 </modifier>
               </modifiers>
               <characteristics>
@@ -17083,6 +17515,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                 </modifier>
               </modifiers>
             </entryLink>
+            <entryLink id="9d0d-fd66-e848-4fa8" name="The Spreading Corruption" hidden="false" collective="false" import="true" targetId="f783-f0ea-fe35-cdeb" type="selectionEntry"/>
           </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="7baf-18d9-aa70-9ba8" name="0) Breachers" hidden="false" collective="false" import="true" defaultSelectionEntryId="a742-dbba-6c92-7db5">
@@ -17107,14 +17540,19 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                         <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
                       </conditions>
                     </modifier>
-                    <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Infantry (Line, Heavy, Psyker)">
+                    <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Corrupted)">
+                      <conditionGroups>
+                        <conditionGroup type="or">
+                          <conditions>
+                            <condition field="selections" scope="ad97-c090-fa67-696f" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f783-f0ea-fe35-cdeb" type="equalTo"/>
+                            <condition field="selections" scope="ad97-c090-fa67-696f" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="555f-3998-a06e-f415" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                    <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Psyker)">
                       <conditions>
                         <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="21c3-2f28-7820-e51a" type="equalTo"/>
-                      </conditions>
-                    </modifier>
-                    <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Infantry (Line, Heavy, Corrupted)">
-                      <conditions>
-                        <condition field="selections" scope="ad97-c090-fa67-696f" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="85bf-438d-08e5-8c79" type="equalTo"/>
                       </conditions>
                     </modifier>
                   </modifiers>
@@ -17495,6 +17933,18 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
       </costs>
     </selectionEntry>
     <selectionEntry id="6db7-6e88-877e-35ca" name="Reconnaissance Squad" hidden="false" collective="false" import="true" type="unit">
+      <modifiers>
+        <modifier type="add" field="category" value="9055-7410-8ffd-b8e7">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="6db7-6e88-877e-35ca" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f783-f0ea-fe35-cdeb" type="equalTo"/>
+                <condition field="selections" scope="6db7-6e88-877e-35ca" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="555f-3998-a06e-f415" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <modifierGroups>
         <modifierGroup>
           <modifiers>
@@ -17568,15 +18018,20 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                     <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
                   </conditions>
                 </modifier>
-                <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Infantry (Character, Skirmish, Line, Psyker)">
+                <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Psyker)">
                   <conditions>
                     <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="21c3-2f28-7820-e51a" type="equalTo"/>
                   </conditions>
                 </modifier>
-                <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Infantry (Character, Skirmish, Line, Corrupted)">
-                  <conditions>
-                    <condition field="selections" scope="6db7-6e88-877e-35ca" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fd49-4447-d0a3-2dd9" type="equalTo"/>
-                  </conditions>
+                <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Corrupted)">
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="6db7-6e88-877e-35ca" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f783-f0ea-fe35-cdeb" type="equalTo"/>
+                        <condition field="selections" scope="6db7-6e88-877e-35ca" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="555f-3998-a06e-f415" type="equalTo"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
                 </modifier>
               </modifiers>
               <characteristics>
@@ -17932,14 +18387,19 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                     <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
                   </conditions>
                 </modifier>
-                <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Infantry (Skirmish, Line, Psyker)">
+                <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Corrupted)">
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="6db7-6e88-877e-35ca" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f783-f0ea-fe35-cdeb" type="equalTo"/>
+                        <condition field="selections" scope="6db7-6e88-877e-35ca" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="555f-3998-a06e-f415" type="equalTo"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+                <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Psyker)">
                   <conditions>
                     <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="21c3-2f28-7820-e51a" type="equalTo"/>
-                  </conditions>
-                </modifier>
-                <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Infantry (Skirmish, Line, Corrupted)">
-                  <conditions>
-                    <condition field="selections" scope="6db7-6e88-877e-35ca" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fd49-4447-d0a3-2dd9" type="equalTo"/>
                   </conditions>
                 </modifier>
               </modifiers>
@@ -18237,6 +18697,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                 </modifier>
               </modifiers>
             </entryLink>
+            <entryLink id="3e89-f564-16f8-b325" name="The Spreading Corruption" hidden="false" collective="false" import="true" targetId="f783-f0ea-fe35-cdeb" type="selectionEntry"/>
           </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="ca4b-245e-a8e2-160b" name="0) The Entire unit may take:" hidden="false" collective="false" import="true">
@@ -18294,6 +18755,16 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
             <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c83-69fb-8066-a773" type="equalTo"/>
           </conditions>
         </modifier>
+        <modifier type="add" field="category" value="9055-7410-8ffd-b8e7">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="9b10-b657-a65a-9d60" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f783-f0ea-fe35-cdeb" type="equalTo"/>
+                <condition field="selections" scope="9b10-b657-a65a-9d60" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="555f-3998-a06e-f415" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
       </modifiers>
       <infoLinks>
         <infoLink id="1e59-9bd4-20c6-6183" name="Scout" hidden="false" targetId="aacf-9a7e-982d-b793" type="rule"/>
@@ -18342,14 +18813,19 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                     <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
                   </conditions>
                 </modifier>
-                <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Infantry (Light, Skirmish, Line, Psyker)">
+                <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Corrupted)">
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="9b10-b657-a65a-9d60" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f783-f0ea-fe35-cdeb" type="equalTo"/>
+                        <condition field="selections" scope="9b10-b657-a65a-9d60" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="555f-3998-a06e-f415" type="equalTo"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+                <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Psyker)">
                   <conditions>
                     <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="21c3-2f28-7820-e51a" type="equalTo"/>
-                  </conditions>
-                </modifier>
-                <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Infantry (Light, Skirmish, Line, Corrupted)">
-                  <conditions>
-                    <condition field="selections" scope="9b10-b657-a65a-9d60" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5d66-054e-e1c7-e8d8" type="equalTo"/>
                   </conditions>
                 </modifier>
               </modifiers>
@@ -18511,15 +18987,20 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                     <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
                   </conditions>
                 </modifier>
-                <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Infantry (Character, Light, Skirmish, Line, Psyker)">
+                <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Psyker)">
                   <conditions>
                     <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="21c3-2f28-7820-e51a" type="equalTo"/>
                   </conditions>
                 </modifier>
-                <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Infantry (Character,Light, Skirmish, Line, Corrupted)">
-                  <conditions>
-                    <condition field="selections" scope="9b10-b657-a65a-9d60" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5d66-054e-e1c7-e8d8" type="equalTo"/>
-                  </conditions>
+                <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Corrupted)">
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="9b10-b657-a65a-9d60" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f783-f0ea-fe35-cdeb" type="equalTo"/>
+                        <condition field="selections" scope="9b10-b657-a65a-9d60" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="555f-3998-a06e-f415" type="equalTo"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
                 </modifier>
               </modifiers>
               <characteristics>
@@ -18860,6 +19341,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                 </modifier>
               </modifiers>
             </entryLink>
+            <entryLink id="3db6-853b-bb8e-0c56" name="The Spreading Corruption" hidden="false" collective="false" import="true" targetId="f783-f0ea-fe35-cdeb" type="selectionEntry"/>
           </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="6665-318e-4f3e-5ff0" name="0) The entire unit may take:" hidden="false" collective="false" import="true">
@@ -18971,6 +19453,16 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
             </conditionGroup>
           </conditionGroups>
         </modifier>
+        <modifier type="add" field="category" value="9055-7410-8ffd-b8e7">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="0aca-632d-1642-8af9" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f783-f0ea-fe35-cdeb" type="equalTo"/>
+                <condition field="selections" scope="0aca-632d-1642-8af9" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="555f-3998-a06e-f415" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
       </modifiers>
       <infoLinks>
         <infoLink id="02d5-3877-a9dc-a549" name="Chosen Warriors" hidden="false" targetId="13d1-9270-6539-08ed" type="rule"/>
@@ -19010,7 +19502,105 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
           <profiles>
             <profile id="0d03-4eed-4494-a899" name="Legion Chosen" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
               <modifiers>
-                <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Infantry (Heavy)">
+                <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Heavy)">
+                  <conditions>
+                    <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0c0f-f751-cc4e-4951" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Corrupted)">
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="0aca-632d-1642-8af9" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f783-f0ea-fe35-cdeb" type="equalTo"/>
+                        <condition field="selections" scope="0aca-632d-1642-8af9" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="555f-3998-a06e-f415" type="equalTo"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+                <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Psyker)">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="21c3-2f28-7820-e51a" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="set" field="hidden" value="true">
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="0aca-632d-1642-8af9" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e8a8-b526-beab-bb82" type="equalTo"/>
+                        <condition field="selections" scope="0aca-632d-1642-8af9" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="6fb4-adf6-dbe8-86af" type="equalTo"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
+              <modifierGroups>
+                <modifierGroup>
+                  <modifiers>
+                    <modifier type="append" field="893e-2d76-8f04-44e5" value="*">
+                      <conditions>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="increment" field="893e-2d76-8f04-44e5" value="1">
+                      <conditions>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                </modifierGroup>
+              </modifierGroups>
+              <characteristics>
+                <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry</characteristic>
+                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7</characteristic>
+                <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">5</characteristic>
+                <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
+                <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
+                <characteristic name="T" typeId="c32b-5fdd-3fbe-9b1f">4</characteristic>
+                <characteristic name="W" typeId="57ee-1126-32a9-5672">2</characteristic>
+                <characteristic name="I" typeId="62d3-22d7-2d49-52dc">4</characteristic>
+                <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">2</characteristic>
+                <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">8</characteristic>
+                <characteristic name="Save" typeId="e593-6b3c-f169-04f0">2+</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="3d3e-c9f5-8a84-1ab2" name="Legion Chosen" hidden="true" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
+              <modifiers>
+                <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Antigrav)">
+                  <conditions>
+                    <condition field="selections" scope="0aca-632d-1642-8af9" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="6fb4-adf6-dbe8-86af" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Corrupted)">
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="0aca-632d-1642-8af9" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f783-f0ea-fe35-cdeb" type="equalTo"/>
+                        <condition field="selections" scope="0aca-632d-1642-8af9" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="555f-3998-a06e-f415" type="equalTo"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+                <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Psyker)">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="21c3-2f28-7820-e51a" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="set" field="hidden" value="false">
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="0aca-632d-1642-8af9" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e8a8-b526-beab-bb82" type="equalTo"/>
+                        <condition field="selections" scope="0aca-632d-1642-8af9" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="6fb4-adf6-dbe8-86af" type="equalTo"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+                <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Skirmish)">
+                  <conditions>
+                    <condition field="selections" scope="0aca-632d-1642-8af9" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e8a8-b526-beab-bb82" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Heavy)">
                   <conditions>
                     <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0c0f-f751-cc4e-4951" type="equalTo"/>
                   </conditions>
@@ -19043,7 +19633,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                 </modifierGroup>
               </modifierGroups>
               <characteristics>
-                <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry</characteristic>
+                <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Cavalry</characteristic>
                 <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7</characteristic>
                 <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">5</characteristic>
                 <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
@@ -19422,10 +20012,108 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
           <profiles>
             <profile id="cd69-4824-196d-84ba" name="Legion Standard Bearer" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
               <modifiers>
-                <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Infantry (Heavy)">
+                <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Heavy)">
                   <conditions>
                     <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0c0f-f751-cc4e-4951" type="equalTo"/>
                   </conditions>
+                </modifier>
+                <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Corrupted)">
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="0aca-632d-1642-8af9" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f783-f0ea-fe35-cdeb" type="equalTo"/>
+                        <condition field="selections" scope="0aca-632d-1642-8af9" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="555f-3998-a06e-f415" type="equalTo"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+                <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Psyker)">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="21c3-2f28-7820-e51a" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="set" field="hidden" value="true">
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="0aca-632d-1642-8af9" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e8a8-b526-beab-bb82" type="equalTo"/>
+                        <condition field="selections" scope="0aca-632d-1642-8af9" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="6fb4-adf6-dbe8-86af" type="equalTo"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
+              <modifierGroups>
+                <modifierGroup>
+                  <modifiers>
+                    <modifier type="append" field="893e-2d76-8f04-44e5" value="*">
+                      <conditions>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="increment" field="893e-2d76-8f04-44e5" value="1">
+                      <conditions>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                </modifierGroup>
+              </modifierGroups>
+              <characteristics>
+                <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry</characteristic>
+                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7</characteristic>
+                <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">5</characteristic>
+                <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
+                <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
+                <characteristic name="T" typeId="c32b-5fdd-3fbe-9b1f">4</characteristic>
+                <characteristic name="W" typeId="57ee-1126-32a9-5672">2</characteristic>
+                <characteristic name="I" typeId="62d3-22d7-2d49-52dc">4</characteristic>
+                <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">2</characteristic>
+                <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">8</characteristic>
+                <characteristic name="Save" typeId="e593-6b3c-f169-04f0">2+</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="ac9d-ba87-d72f-03c2" name="Legion Standard Bearer" hidden="true" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
+              <modifiers>
+                <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Heavy)">
+                  <conditions>
+                    <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0c0f-f751-cc4e-4951" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Corrupted)">
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="0aca-632d-1642-8af9" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f783-f0ea-fe35-cdeb" type="equalTo"/>
+                        <condition field="selections" scope="0aca-632d-1642-8af9" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="555f-3998-a06e-f415" type="equalTo"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+                <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Psyker)">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="21c3-2f28-7820-e51a" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Antigrav)">
+                  <conditions>
+                    <condition field="selections" scope="0aca-632d-1642-8af9" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="6fb4-adf6-dbe8-86af" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Skirmish)">
+                  <conditions>
+                    <condition field="selections" scope="0aca-632d-1642-8af9" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e8a8-b526-beab-bb82" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="set" field="hidden" value="false">
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="0aca-632d-1642-8af9" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e8a8-b526-beab-bb82" type="equalTo"/>
+                        <condition field="selections" scope="0aca-632d-1642-8af9" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="6fb4-adf6-dbe8-86af" type="equalTo"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
                 </modifier>
               </modifiers>
               <modifierGroups>
@@ -19455,7 +20143,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                 </modifierGroup>
               </modifierGroups>
               <characteristics>
-                <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry</characteristic>
+                <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Cavalry</characteristic>
                 <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7</characteristic>
                 <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">5</characteristic>
                 <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
@@ -19966,6 +20654,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                 </modifier>
               </modifiers>
             </entryLink>
+            <entryLink id="578e-4e66-da07-4524" name="The Spreading Corruption" hidden="false" collective="false" import="true" targetId="f783-f0ea-fe35-cdeb" type="selectionEntry"/>
           </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
@@ -20043,6 +20732,16 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
           <conditions>
             <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7857-5f9d-6c9e-50c1" type="equalTo"/>
           </conditions>
+        </modifier>
+        <modifier type="add" field="category" value="9055-7410-8ffd-b8e7">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f783-f0ea-fe35-cdeb" type="equalTo"/>
+                <condition field="selections" scope="3766-ea98-0aa7-62d0" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4e1a-275e-e691-5b92" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
         </modifier>
       </modifiers>
       <infoLinks>
@@ -20205,6 +20904,11 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                 <modifier type="set" field="893e-2d76-8f04-44e5" value="7*">
                   <conditions>
                     <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Corrupted)">
+                  <conditions>
+                    <condition field="selections" scope="da79-9588-cc7f-e02f" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f783-f0ea-fe35-cdeb" type="equalTo"/>
                   </conditions>
                 </modifier>
               </modifiers>
@@ -20744,6 +21448,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                     </modifier>
                   </modifiers>
                 </entryLink>
+                <entryLink id="8cd1-c705-7c0c-b806" name="The Spreading Corruption" hidden="false" collective="false" import="true" targetId="f783-f0ea-fe35-cdeb" type="selectionEntry"/>
               </entryLinks>
             </selectionEntryGroup>
             <selectionEntryGroup id="05da-62ba-0153-fdc6" name="1) Armour Choice" hidden="false" collective="false" import="true" defaultSelectionEntryId="ce38-573e-cf56-fedd">
@@ -20810,6 +21515,16 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
               <conditions>
                 <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c83-69fb-8066-a773" type="equalTo"/>
                 <condition field="selections" scope="58d0-a0fd-d20b-cb1b" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f059-2405-bfa0-11cf" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+        <modifier type="add" field="category" value="9055-7410-8ffd-b8e7">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="58d0-a0fd-d20b-cb1b" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f783-f0ea-fe35-cdeb" type="equalTo"/>
+                <condition field="selections" scope="58d0-a0fd-d20b-cb1b" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="555f-3998-a06e-f415" type="equalTo"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
@@ -20906,6 +21621,16 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                         <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
                       </conditions>
                     </modifier>
+                    <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Corrupted)">
+                      <conditionGroups>
+                        <conditionGroup type="or">
+                          <conditions>
+                            <condition field="selections" scope="58d0-a0fd-d20b-cb1b" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f783-f0ea-fe35-cdeb" type="equalTo"/>
+                            <condition field="selections" scope="58d0-a0fd-d20b-cb1b" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="555f-3998-a06e-f415" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
                   </modifiers>
                   <characteristics>
                     <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry</characteristic>
@@ -21001,6 +21726,21 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                         <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
                       </conditions>
                     </modifier>
+                    <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Corrupted)">
+                      <conditionGroups>
+                        <conditionGroup type="or">
+                          <conditions>
+                            <condition field="selections" scope="58d0-a0fd-d20b-cb1b" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f783-f0ea-fe35-cdeb" type="equalTo"/>
+                            <condition field="selections" scope="58d0-a0fd-d20b-cb1b" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="555f-3998-a06e-f415" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                    <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Infantry (Psyker)">
+                      <conditions>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="21c3-2f28-7820-e51a" type="equalTo"/>
+                      </conditions>
+                    </modifier>
                   </modifiers>
                   <characteristics>
                     <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry</characteristic>
@@ -21091,6 +21831,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                 </modifier>
               </modifiers>
             </entryLink>
+            <entryLink id="6e6f-a3d7-b9d6-d683" name="The Spreading Corruption" hidden="false" collective="false" import="true" targetId="f783-f0ea-fe35-cdeb" type="selectionEntry"/>
           </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
@@ -21114,6 +21855,16 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
               <conditions>
                 <condition field="selections" scope="a423-7dd8-3f1b-3e28" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8c3a-f99e-4226-e519" type="equalTo"/>
                 <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="06cc-c559-d71e-b75e" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+        <modifier type="add" field="category" value="9055-7410-8ffd-b8e7">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="a423-7dd8-3f1b-3e28" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f783-f0ea-fe35-cdeb" type="equalTo"/>
+                <condition field="selections" scope="a423-7dd8-3f1b-3e28" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="555f-3998-a06e-f415" type="equalTo"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
@@ -21215,6 +21966,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                 </modifier>
               </modifiers>
             </entryLink>
+            <entryLink id="af48-ee55-2d0d-e655" name="The Spreading Corruption" hidden="false" collective="false" import="true" targetId="f783-f0ea-fe35-cdeb" type="selectionEntry"/>
           </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="8fbf-dba5-5b44-1875" name="2) Dedicated Transport:" hidden="false" collective="false" import="true">
@@ -21390,15 +22142,20 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                         <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
                       </conditions>
                     </modifier>
-                    <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Infantry (Psyker)">
+                    <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Psyker)">
                       <conditions>
                         <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="21c3-2f28-7820-e51a" type="equalTo"/>
                       </conditions>
                     </modifier>
-                    <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Infantry (Corrupted)">
-                      <conditions>
-                        <condition field="selections" scope="a423-7dd8-3f1b-3e28" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bc7e-1e83-8e1a-afab" type="equalTo"/>
-                      </conditions>
+                    <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Corrupted)">
+                      <conditionGroups>
+                        <conditionGroup type="or">
+                          <conditions>
+                            <condition field="selections" scope="a423-7dd8-3f1b-3e28" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bc7e-1e83-8e1a-afab" type="equalTo"/>
+                            <condition field="selections" scope="a423-7dd8-3f1b-3e28" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f783-f0ea-fe35-cdeb" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
                     </modifier>
                   </modifiers>
                   <characteristics>
@@ -22206,15 +22963,20 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                         <condition field="selections" scope="a423-7dd8-3f1b-3e28" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="583e-62cb-53f1-f952" type="equalTo"/>
                       </conditions>
                     </modifier>
-                    <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Infantry (Character, Psyker)">
+                    <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Psyker)">
                       <conditions>
                         <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="21c3-2f28-7820-e51a" type="equalTo"/>
                       </conditions>
                     </modifier>
-                    <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Infantry (Character, Corrupted)">
-                      <conditions>
-                        <condition field="selections" scope="a423-7dd8-3f1b-3e28" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bc7e-1e83-8e1a-afab" type="equalTo"/>
-                      </conditions>
+                    <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Corrupted)">
+                      <conditionGroups>
+                        <conditionGroup type="or">
+                          <conditions>
+                            <condition field="selections" scope="a423-7dd8-3f1b-3e28" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bc7e-1e83-8e1a-afab" type="equalTo"/>
+                            <condition field="selections" scope="a423-7dd8-3f1b-3e28" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f783-f0ea-fe35-cdeb" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
                     </modifier>
                   </modifiers>
                   <characteristics>
@@ -22653,9 +23415,14 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
     <selectionEntry id="81df-ffd4-a32b-b4a1" name="Apothecarion Detachment" publicationId="a716-c1c4-7b26-8424" hidden="false" collective="false" import="true" type="unit">
       <modifiers>
         <modifier type="add" field="category" value="9055-7410-8ffd-b8e7">
-          <conditions>
-            <condition field="selections" scope="81df-ffd4-a32b-b4a1" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="555f-3998-a06e-f415" type="equalTo"/>
-          </conditions>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="81df-ffd4-a32b-b4a1" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f783-f0ea-fe35-cdeb" type="equalTo"/>
+                <condition field="selections" scope="81df-ffd4-a32b-b4a1" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="555f-3998-a06e-f415" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
         </modifier>
       </modifiers>
       <constraints>
@@ -22710,30 +23477,107 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                   </conditions>
                 </modifier>
                 <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Corrupted)">
-                  <conditions>
-                    <condition field="selections" scope="415c-6834-f4d2-d967" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="555f-3998-a06e-f415" type="equalTo"/>
-                  </conditions>
-                </modifier>
-                <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Cavalry (Character)">
-                  <conditions>
-                    <condition field="selections" scope="415c-6834-f4d2-d967" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e8a8-b526-beab-bb82" type="equalTo"/>
-                  </conditions>
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="81df-ffd4-a32b-b4a1" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f783-f0ea-fe35-cdeb" type="equalTo"/>
+                        <condition field="selections" scope="81df-ffd4-a32b-b4a1" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="555f-3998-a06e-f415" type="equalTo"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
                 </modifier>
                 <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Psyker)">
                   <conditions>
                     <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="21c3-2f28-7820-e51a" type="equalTo"/>
                   </conditions>
                 </modifier>
-                <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Cavalry (Character, Antigrav)">
+                <modifier type="set" field="hidden" value="true">
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="415c-6834-f4d2-d967" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e8a8-b526-beab-bb82" type="equalTo"/>
+                        <condition field="selections" scope="415c-6834-f4d2-d967" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6fb4-adf6-dbe8-86af" type="equalTo"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
+              <modifierGroups>
+                <modifierGroup>
+                  <modifiers>
+                    <modifier type="increment" field="893e-2d76-8f04-44e5" value="1">
+                      <conditions>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="append" field="893e-2d76-8f04-44e5" value="*">
+                      <conditions>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                </modifierGroup>
+              </modifierGroups>
+              <characteristics>
+                <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Character)</characteristic>
+                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7</characteristic>
+                <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
+                <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
+                <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
+                <characteristic name="T" typeId="c32b-5fdd-3fbe-9b1f">4</characteristic>
+                <characteristic name="W" typeId="57ee-1126-32a9-5672">1</characteristic>
+                <characteristic name="I" typeId="62d3-22d7-2d49-52dc">4</characteristic>
+                <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">2</characteristic>
+                <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">8</characteristic>
+                <characteristic name="Save" typeId="e593-6b3c-f169-04f0">3+</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="5fce-8580-4751-932a" name="Apothecary" hidden="true" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
+              <modifiers>
+                <modifier type="set" field="e593-6b3c-f169-04f0" value="2+">
                   <conditions>
-                    <condition field="selections" scope="415c-6834-f4d2-d967" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6fb4-adf6-dbe8-86af" type="equalTo"/>
+                    <condition field="selections" scope="415c-6834-f4d2-d967" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="583e-62cb-53f1-f952" type="equalTo"/>
                   </conditions>
+                </modifier>
+                <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Corrupted)">
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="81df-ffd4-a32b-b4a1" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f783-f0ea-fe35-cdeb" type="equalTo"/>
+                        <condition field="selections" scope="81df-ffd4-a32b-b4a1" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="555f-3998-a06e-f415" type="equalTo"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+                <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Psyker)">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="21c3-2f28-7820-e51a" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Antigrav)">
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="415c-6834-f4d2-d967" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6fb4-adf6-dbe8-86af" type="equalTo"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
                 </modifier>
                 <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Skirmish)">
                   <conditionGroups>
-                    <conditionGroup type="and">
+                    <conditionGroup type="or">
                       <conditions>
                         <condition field="selections" scope="415c-6834-f4d2-d967" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e8a8-b526-beab-bb82" type="equalTo"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+                <modifier type="set" field="hidden" value="false">
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="415c-6834-f4d2-d967" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e8a8-b526-beab-bb82" type="equalTo"/>
+                        <condition field="selections" scope="415c-6834-f4d2-d967" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6fb4-adf6-dbe8-86af" type="equalTo"/>
                       </conditions>
                     </conditionGroup>
                   </conditionGroups>
@@ -22766,7 +23610,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                 </modifierGroup>
               </modifierGroups>
               <characteristics>
-                <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Character)</characteristic>
+                <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Cavalry (Character)</characteristic>
                 <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7</characteristic>
                 <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
                 <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
@@ -23161,6 +24005,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                 </modifier>
               </modifiers>
             </entryLink>
+            <entryLink id="be21-cb40-5089-0304" name="The Spreading Corruption" hidden="false" collective="false" import="true" targetId="f783-f0ea-fe35-cdeb" type="selectionEntry"/>
           </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
@@ -23178,6 +24023,16 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
           <conditions>
             <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
           </conditions>
+        </modifier>
+        <modifier type="add" field="category" value="9055-7410-8ffd-b8e7">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="58e6-f9cc-4c46-e258" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f783-f0ea-fe35-cdeb" type="equalTo"/>
+                <condition field="selections" scope="58e6-f9cc-4c46-e258" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="555f-3998-a06e-f415" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
         </modifier>
       </modifiers>
       <modifierGroups>
@@ -23257,14 +24112,19 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                     <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
                   </conditions>
                 </modifier>
-                <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Infantry (Skirmish, Psyker)">
+                <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Corrupted)">
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="58e6-f9cc-4c46-e258" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f783-f0ea-fe35-cdeb" type="equalTo"/>
+                        <condition field="selections" scope="58e6-f9cc-4c46-e258" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="555f-3998-a06e-f415" type="equalTo"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+                <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Psyker)">
                   <conditions>
                     <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="21c3-2f28-7820-e51a" type="equalTo"/>
-                  </conditions>
-                </modifier>
-                <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Infantry (Skirmish, Corrupted)">
-                  <conditions>
-                    <condition field="selections" scope="58e6-f9cc-4c46-e258" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ea11-2253-c3e5-ce9b" type="equalTo"/>
                   </conditions>
                 </modifier>
               </modifiers>
@@ -23458,15 +24318,20 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                     <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
                   </conditions>
                 </modifier>
-                <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Infantry (Character, Skirmish, Psyker)">
+                <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Psyker)">
                   <conditions>
                     <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="21c3-2f28-7820-e51a" type="equalTo"/>
                   </conditions>
                 </modifier>
-                <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Infantry (Character, Skirmish, Corrupted)">
-                  <conditions>
-                    <condition field="selections" scope="58e6-f9cc-4c46-e258" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ea11-2253-c3e5-ce9b" type="equalTo"/>
-                  </conditions>
+                <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Corrupted)">
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="58e6-f9cc-4c46-e258" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f783-f0ea-fe35-cdeb" type="equalTo"/>
+                        <condition field="selections" scope="58e6-f9cc-4c46-e258" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="555f-3998-a06e-f415" type="equalTo"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
                 </modifier>
                 <modifier type="set" field="e593-6b3c-f169-04f0" value="2+">
                   <conditions>
@@ -23848,6 +24713,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                 </modifier>
               </modifiers>
             </entryLink>
+            <entryLink id="401c-a92a-a287-9eae" name="The Spreading Corruption" hidden="false" collective="false" import="true" targetId="f783-f0ea-fe35-cdeb" type="selectionEntry"/>
           </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="d2e7-625e-f0a4-dc20" name="0) The entire unit may take:" hidden="false" collective="false" import="true">
@@ -24059,9 +24925,14 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
               </conditions>
             </modifier>
             <modifier type="add" field="category" value="9055-7410-8ffd-b8e7">
-              <conditions>
-                <condition field="selections" scope="d39f-99d5-f7a4-7b86" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="555f-3998-a06e-f415" type="equalTo"/>
-              </conditions>
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="d39f-99d5-f7a4-7b86" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f783-f0ea-fe35-cdeb" type="equalTo"/>
+                    <condition field="selections" scope="d39f-99d5-f7a4-7b86" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="555f-3998-a06e-f415" type="equalTo"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
             </modifier>
           </modifiers>
           <constraints>
@@ -24082,24 +24953,102 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                   </conditions>
                 </modifier>
                 <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Corrupted)">
-                  <conditions>
-                    <condition field="selections" scope="d39f-99d5-f7a4-7b86" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="555f-3998-a06e-f415" type="equalTo"/>
-                  </conditions>
-                </modifier>
-                <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Cavalry (Character, Antigrav)">
-                  <conditions>
-                    <condition field="selections" scope="fc32-089e-1c59-70bd" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6fb4-adf6-dbe8-86af" type="equalTo"/>
-                  </conditions>
-                </modifier>
-                <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Cavalry (Character)">
-                  <conditions>
-                    <condition field="selections" scope="fc32-089e-1c59-70bd" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e8a8-b526-beab-bb82" type="equalTo"/>
-                  </conditions>
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="d39f-99d5-f7a4-7b86" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f783-f0ea-fe35-cdeb" type="equalTo"/>
+                        <condition field="selections" scope="d39f-99d5-f7a4-7b86" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="555f-3998-a06e-f415" type="equalTo"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
                 </modifier>
                 <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Skirmish)">
                   <conditionGroups>
                     <conditionGroup type="and">
                       <conditions>
+                        <condition field="selections" scope="fc32-089e-1c59-70bd" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e8a8-b526-beab-bb82" type="equalTo"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+                <modifier type="set" field="hidden" value="true">
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="fc32-089e-1c59-70bd" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6fb4-adf6-dbe8-86af" type="equalTo"/>
+                        <condition field="selections" scope="fc32-089e-1c59-70bd" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e8a8-b526-beab-bb82" type="equalTo"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
+              <modifierGroups>
+                <modifierGroup>
+                  <modifiers>
+                    <modifier type="append" field="893e-2d76-8f04-44e5" value="*">
+                      <conditions>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="increment" field="893e-2d76-8f04-44e5" value="1">
+                      <conditions>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                </modifierGroup>
+              </modifierGroups>
+              <characteristics>
+                <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Character)</characteristic>
+                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7</characteristic>
+                <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
+                <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
+                <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
+                <characteristic name="T" typeId="c32b-5fdd-3fbe-9b1f">4</characteristic>
+                <characteristic name="W" typeId="57ee-1126-32a9-5672">1</characteristic>
+                <characteristic name="I" typeId="62d3-22d7-2d49-52dc">4</characteristic>
+                <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">2</characteristic>
+                <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">8</characteristic>
+                <characteristic name="Save" typeId="e593-6b3c-f169-04f0">2+</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="1364-1cb9-229a-e7d2" name="Techmarine" hidden="true" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
+              <modifiers>
+                <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Psyker)">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="21c3-2f28-7820-e51a" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Heavy)">
+                  <conditions>
+                    <condition field="selections" scope="fc32-089e-1c59-70bd" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0c0f-f751-cc4e-4951" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Corrupted)">
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="d39f-99d5-f7a4-7b86" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f783-f0ea-fe35-cdeb" type="equalTo"/>
+                        <condition field="selections" scope="d39f-99d5-f7a4-7b86" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="555f-3998-a06e-f415" type="equalTo"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+                <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Antigrav)">
+                  <conditions>
+                    <condition field="selections" scope="fc32-089e-1c59-70bd" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6fb4-adf6-dbe8-86af" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Skirmish)">
+                  <conditions>
+                    <condition field="selections" scope="fc32-089e-1c59-70bd" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e8a8-b526-beab-bb82" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="set" field="hidden" value="false">
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="fc32-089e-1c59-70bd" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6fb4-adf6-dbe8-86af" type="equalTo"/>
                         <condition field="selections" scope="fc32-089e-1c59-70bd" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e8a8-b526-beab-bb82" type="equalTo"/>
                       </conditions>
                     </conditionGroup>
@@ -24133,7 +25082,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                 </modifierGroup>
               </modifierGroups>
               <characteristics>
-                <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Character)</characteristic>
+                <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Cavalry (Character)</characteristic>
                 <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7</characteristic>
                 <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
                 <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
@@ -24730,7 +25679,6 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
                   </costs>
                 </entryLink>
-                <entryLink id="d8b1-cddc-058d-9a59" name="Surgical Augment (Unit Character)" hidden="false" collective="false" import="true" targetId="aeb3-6a73-da1d-2b90" type="selectionEntryGroup"/>
                 <entryLink id="260d-b7dc-4573-f19c" name="Cyber-Familiar" hidden="false" collective="false" import="true" targetId="6c85-4601-cf58-7b35" type="selectionEntry">
                   <modifiers>
                     <modifier type="set" field="hidden" value="true">
@@ -24887,6 +25835,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                 </modifier>
               </modifiers>
             </entryLink>
+            <entryLink id="ff2f-921c-f6de-2ad4" name="The Spreading Corruption" hidden="false" collective="false" import="true" targetId="f783-f0ea-fe35-cdeb" type="selectionEntry"/>
           </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
@@ -24936,6 +25885,16 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
           <conditions>
             <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7857-5f9d-6c9e-50c1" type="equalTo"/>
           </conditions>
+        </modifier>
+        <modifier type="add" field="category" value="9055-7410-8ffd-b8e7">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f783-f0ea-fe35-cdeb" type="equalTo"/>
+                <condition field="selections" scope="f806-8a4e-d0d6-beaa" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4e1a-275e-e691-5b92" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
         </modifier>
       </modifiers>
       <infoLinks>
@@ -25097,6 +26056,11 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                 <modifier type="set" field="893e-2d76-8f04-44e5" value="8*">
                   <conditions>
                     <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Corrupted)">
+                  <conditions>
+                    <condition field="selections" scope="f806-8a4e-d0d6-beaa" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f783-f0ea-fe35-cdeb" type="equalTo"/>
                   </conditions>
                 </modifier>
               </modifiers>
@@ -25408,7 +26372,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                     </modifier>
                   </modifiers>
                 </entryLink>
-                <entryLink id="eb1a-46ec-b7be-8aa1" name="Argyrum pattern boarding shield" hidden="false" collective="false" import="true" targetId="f670-7544-e4f3-f5fa" type="selectionEntry">
+                <entryLink id="eb1a-46ec-b7be-8aa1" name="Argyrum-pattern Boarding Shield" hidden="false" collective="false" import="true" targetId="f670-7544-e4f3-f5fa" type="selectionEntry">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d6e8-70aa-30fa-80bc" type="max"/>
                   </constraints>
@@ -25575,6 +26539,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                     </modifier>
                   </modifiers>
                 </entryLink>
+                <entryLink id="4297-9865-1b2a-d8c4" name="The Spreading Corruption" hidden="false" collective="false" import="true" targetId="f783-f0ea-fe35-cdeb" type="selectionEntry"/>
               </entryLinks>
             </selectionEntryGroup>
           </selectionEntryGroups>
@@ -25626,6 +26591,16 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
             <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c83-69fb-8066-a773" type="equalTo"/>
           </conditions>
         </modifier>
+        <modifier type="add" field="category" value="9055-7410-8ffd-b8e7">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="c2a7-9e2c-fc65-1b78" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f783-f0ea-fe35-cdeb" type="equalTo"/>
+                <condition field="selections" scope="c2a7-9e2c-fc65-1b78" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="555f-3998-a06e-f415" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
       </modifiers>
       <categoryLinks>
         <categoryLink id="c543-976f-ef9d-d41e" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
@@ -25656,6 +26631,16 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                   <conditions>
                     <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
                   </conditions>
+                </modifier>
+                <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Corrupted)">
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="c2a7-9e2c-fc65-1b78" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f783-f0ea-fe35-cdeb" type="equalTo"/>
+                        <condition field="selections" scope="c2a7-9e2c-fc65-1b78" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="555f-3998-a06e-f415" type="equalTo"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
                 </modifier>
               </modifiers>
               <characteristics>
@@ -25997,6 +26982,15 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
               </constraints>
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="86de-29f0-f4ab-bb53" name="The Spreading Corruption" hidden="false" collective="false" import="true" targetId="f783-f0ea-fe35-cdeb" type="selectionEntry"/>
+            <entryLink id="b2dc-7ba6-b9c2-4b09" name="Dark Channeling" hidden="false" collective="false" import="true" targetId="555f-3998-a06e-f415" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4835-42e0-b1b3-71b8" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0"/>
               </costs>
             </entryLink>
           </entryLinks>
@@ -28358,6 +29352,16 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
             </conditionGroup>
           </conditionGroups>
         </modifier>
+        <modifier type="add" field="category" value="9055-7410-8ffd-b8e7">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="1b17-dcd6-0153-3efe" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f783-f0ea-fe35-cdeb" type="equalTo"/>
+                <condition field="selections" scope="1b17-dcd6-0153-3efe" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="555f-3998-a06e-f415" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
       </modifiers>
       <infoLinks>
         <infoLink id="9979-d687-399a-d9fd" name="Chosen Warriors" hidden="false" targetId="13d1-9270-6539-08ed" type="rule"/>
@@ -28441,7 +29445,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
               <profiles>
                 <profile id="99d4-6b3d-44da-0595" name="Cataphractii Standard Bearer" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
                   <modifiers>
-                    <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Infantry (Heavy, Psyker)">
+                    <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Psyker)">
                       <conditions>
                         <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="21c3-2f28-7820-e51a" type="equalTo"/>
                       </conditions>
@@ -28450,6 +29454,16 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                       <conditions>
                         <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
                       </conditions>
+                    </modifier>
+                    <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Corrupted)">
+                      <conditionGroups>
+                        <conditionGroup type="or">
+                          <conditions>
+                            <condition field="selections" scope="1b17-dcd6-0153-3efe" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f783-f0ea-fe35-cdeb" type="equalTo"/>
+                            <condition field="selections" scope="1b17-dcd6-0153-3efe" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="555f-3998-a06e-f415" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
                     </modifier>
                   </modifiers>
                   <characteristics>
@@ -28525,15 +29539,25 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
               <profiles>
                 <profile id="aa0f-9154-4a0e-38c8" name="Cataphractii Chosen" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
                   <modifiers>
-                    <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Infantry (Heavy, Psyker)">
-                      <conditions>
-                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="21c3-2f28-7820-e51a" type="equalTo"/>
-                      </conditions>
-                    </modifier>
                     <modifier type="set" field="893e-2d76-8f04-44e5" value="7*">
                       <conditions>
                         <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
                       </conditions>
+                    </modifier>
+                    <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Psyker)">
+                      <conditions>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="21c3-2f28-7820-e51a" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Corrupted)">
+                      <conditionGroups>
+                        <conditionGroup type="or">
+                          <conditions>
+                            <condition field="selections" scope="1b17-dcd6-0153-3efe" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f783-f0ea-fe35-cdeb" type="equalTo"/>
+                            <condition field="selections" scope="1b17-dcd6-0153-3efe" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="555f-3998-a06e-f415" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
                     </modifier>
                   </modifiers>
                   <characteristics>
@@ -28641,6 +29665,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                 </modifier>
               </modifiers>
             </entryLink>
+            <entryLink id="e4b2-913b-1990-f47f" name="The Spreading Corruption" hidden="false" collective="false" import="true" targetId="f783-f0ea-fe35-cdeb" type="selectionEntry"/>
           </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
@@ -28821,6 +29846,16 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
             <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
           </conditions>
         </modifier>
+        <modifier type="add" field="category" value="9055-7410-8ffd-b8e7">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="bac9-5389-e2e7-0b1f" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f783-f0ea-fe35-cdeb" type="equalTo"/>
+                <condition field="selections" scope="bac9-5389-e2e7-0b1f" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="555f-3998-a06e-f415" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
       </modifiers>
       <modifierGroups>
         <modifierGroup>
@@ -28873,11 +29908,6 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
           <profiles>
             <profile id="5e55-c64d-4b7e-a8ae" name="Legion Support Sergeant" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
               <modifiers>
-                <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Infantry (Character, Corrupted)">
-                  <conditions>
-                    <condition field="selections" scope="bac9-5389-e2e7-0b1f" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1c1e-d89a-a74e-5672" type="equalTo"/>
-                  </conditions>
-                </modifier>
                 <modifier type="set" field="893e-2d76-8f04-44e5" value="8*">
                   <conditions>
                     <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
@@ -28888,7 +29918,17 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                     <condition field="selections" scope="bac9-5389-e2e7-0b1f" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="583e-62cb-53f1-f952" type="equalTo"/>
                   </conditions>
                 </modifier>
-                <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Infantry (Character, Psyker)">
+                <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Corrupted)">
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="bac9-5389-e2e7-0b1f" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f783-f0ea-fe35-cdeb" type="equalTo"/>
+                        <condition field="selections" scope="bac9-5389-e2e7-0b1f" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="555f-3998-a06e-f415" type="equalTo"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+                <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Psyker)">
                   <conditions>
                     <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="21c3-2f28-7820-e51a" type="equalTo"/>
                   </conditions>
@@ -29379,6 +30419,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                 </modifier>
               </modifiers>
             </entryLink>
+            <entryLink id="e554-b59c-c013-a27a" name="The Spreading Corruption" hidden="false" collective="false" import="true" targetId="f783-f0ea-fe35-cdeb" type="selectionEntry"/>
           </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="1f87-b709-2c56-cefd" name="0) Legionaries" hidden="false" collective="false" import="true" defaultSelectionEntryId="3eac-9c35-8778-a74c">
@@ -29391,20 +30432,25 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
               <profiles>
                 <profile id="f222-ae78-14d5-8ed6" name="Legionary" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
                   <modifiers>
-                    <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Infantry (Heavy, Corrupted)">
-                      <conditions>
-                        <condition field="selections" scope="bac9-5389-e2e7-0b1f" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1c1e-d89a-a74e-5672" type="equalTo"/>
-                      </conditions>
-                    </modifier>
                     <modifier type="set" field="893e-2d76-8f04-44e5" value="8*">
                       <conditions>
                         <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
                       </conditions>
                     </modifier>
-                    <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Infantry (Heavy, Psyker)">
+                    <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Psyker)">
                       <conditions>
                         <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="21c3-2f28-7820-e51a" type="equalTo"/>
                       </conditions>
+                    </modifier>
+                    <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Corrupted)">
+                      <conditionGroups>
+                        <conditionGroup type="or">
+                          <conditions>
+                            <condition field="selections" scope="bac9-5389-e2e7-0b1f" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f783-f0ea-fe35-cdeb" type="equalTo"/>
+                            <condition field="selections" scope="bac9-5389-e2e7-0b1f" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="555f-3998-a06e-f415" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
                     </modifier>
                   </modifiers>
                   <characteristics>
@@ -29842,6 +30888,11 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
             <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c83-69fb-8066-a773" type="equalTo"/>
           </conditions>
         </modifier>
+        <modifier type="add" field="category" value="9055-7410-8ffd-b8e7">
+          <conditions>
+            <condition field="selections" scope="6263-c696-2f2e-c105" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f783-f0ea-fe35-cdeb" type="equalTo"/>
+          </conditions>
+        </modifier>
       </modifiers>
       <infoLinks>
         <infoLink id="ff8e-99c2-a83a-246d" name="Deep Strike" hidden="false" targetId="f1e1-986f-c783-ca9e" type="rule"/>
@@ -29886,7 +30937,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
           <profiles>
             <profile id="1b8b-e470-69c4-4942" name="Legion Sky-Hunter" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
               <modifiers>
-                <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Cavalry (Antigrav, Psyker)">
+                <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Psyker)">
                   <conditions>
                     <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="21c3-2f28-7820-e51a" type="equalTo"/>
                   </conditions>
@@ -29904,6 +30955,11 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                 <modifier type="set" field="893e-2d76-8f04-44e5" value="17*">
                   <conditions>
                     <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Corrupted)">
+                  <conditions>
+                    <condition field="selections" scope="6263-c696-2f2e-c105" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f783-f0ea-fe35-cdeb" type="equalTo"/>
                   </conditions>
                 </modifier>
               </modifiers>
@@ -30071,7 +31127,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                     <condition field="selections" scope="6263-c696-2f2e-c105" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dc77-cee6-a79b-4f64" type="equalTo"/>
                   </conditions>
                 </modifier>
-                <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Cavalry (Antigrav, Character, Psyker)">
+                <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Psyker)">
                   <conditions>
                     <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="21c3-2f28-7820-e51a" type="equalTo"/>
                   </conditions>
@@ -30091,9 +31147,14 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                     <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
                   </conditions>
                 </modifier>
+                <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Corrupted)">
+                  <conditions>
+                    <condition field="selections" scope="6263-c696-2f2e-c105" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f783-f0ea-fe35-cdeb" type="equalTo"/>
+                  </conditions>
+                </modifier>
               </modifiers>
               <characteristics>
-                <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Cavalry (Antigrav), Character</characteristic>
+                <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Cavalry (Antigrav, Character)</characteristic>
                 <characteristic name="Move" typeId="893e-2d76-8f04-44e5">16</characteristic>
                 <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
                 <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
@@ -30341,6 +31402,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
               </costs>
             </entryLink>
+            <entryLink id="59f2-2e35-6ae5-570b" name="The Spreading Corruption" hidden="false" collective="false" import="true" targetId="f783-f0ea-fe35-cdeb" type="selectionEntry"/>
           </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
@@ -30705,6 +31767,11 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
             <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c83-69fb-8066-a773" type="equalTo"/>
           </conditions>
         </modifier>
+        <modifier type="add" field="category" value="9055-7410-8ffd-b8e7">
+          <conditions>
+            <condition field="selections" scope="a736-43ca-ed95-a08f" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f783-f0ea-fe35-cdeb" type="equalTo"/>
+          </conditions>
+        </modifier>
       </modifiers>
       <infoLinks>
         <infoLink id="26e5-42ae-300b-82e5" name="Deep Strike" hidden="false" targetId="f1e1-986f-c783-ca9e" type="rule"/>
@@ -30732,7 +31799,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
           <profiles>
             <profile id="cdb3-bb69-462f-cf43" name="Proteus Land Speeder" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
               <modifiers>
-                <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Cavalry (Antigrav, Psyker)">
+                <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Psyker)">
                   <conditions>
                     <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="21c3-2f28-7820-e51a" type="equalTo"/>
                   </conditions>
@@ -30740,6 +31807,11 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                 <modifier type="set" field="893e-2d76-8f04-44e5" value="17*">
                   <conditions>
                     <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Corrupted)">
+                  <conditions>
+                    <condition field="selections" scope="a736-43ca-ed95-a08f" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f783-f0ea-fe35-cdeb" type="equalTo"/>
                   </conditions>
                 </modifier>
               </modifiers>
@@ -30952,6 +32024,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
               </costs>
             </entryLink>
+            <entryLink id="8681-fa70-2a61-620e" name="The Spreading Corruption" hidden="false" collective="false" import="true" targetId="f783-f0ea-fe35-cdeb" type="selectionEntry"/>
           </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
@@ -30987,6 +32060,11 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
             <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c83-69fb-8066-a773" type="equalTo"/>
           </conditions>
         </modifier>
+        <modifier type="add" field="category" value="9055-7410-8ffd-b8e7">
+          <conditions>
+            <condition field="selections" scope="deea-102f-8fbe-e2e5" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f783-f0ea-fe35-cdeb" type="equalTo"/>
+          </conditions>
+        </modifier>
       </modifiers>
       <infoLinks>
         <infoLink id="6688-04fe-0ef8-ff29" name="Deep Strike" hidden="false" targetId="f1e1-986f-c783-ca9e" type="rule"/>
@@ -31015,7 +32093,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
           <profiles>
             <profile id="1584-57b9-12a5-aade" name="Javelin" publicationId="0594-a9b0-6f10-090e" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
               <modifiers>
-                <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Cavalry (Antigrav, Heavy, Psyker)">
+                <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Psyker)">
                   <conditions>
                     <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="21c3-2f28-7820-e51a" type="equalTo"/>
                   </conditions>
@@ -31023,6 +32101,11 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                 <modifier type="set" field="893e-2d76-8f04-44e5" value="15*">
                   <conditions>
                     <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Corrupted)">
+                  <conditions>
+                    <condition field="selections" scope="deea-102f-8fbe-e2e5" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f783-f0ea-fe35-cdeb" type="equalTo"/>
                   </conditions>
                 </modifier>
               </modifiers>
@@ -31169,6 +32252,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
               </costs>
             </entryLink>
+            <entryLink id="4689-3e03-d7d2-5d12" name="The Spreading Corruption" hidden="false" collective="false" import="true" targetId="f783-f0ea-fe35-cdeb" type="selectionEntry"/>
           </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
@@ -34022,6 +35106,16 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
             <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c83-69fb-8066-a773" type="equalTo"/>
           </conditions>
         </modifier>
+        <modifier type="add" field="category" value="9055-7410-8ffd-b8e7">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="23e4-c64b-65b4-c8a5" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f783-f0ea-fe35-cdeb" type="equalTo"/>
+                <condition field="selections" scope="23e4-c64b-65b4-c8a5" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="555f-3998-a06e-f415" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
       </modifiers>
       <categoryLinks>
         <categoryLink id="6beb-8854-14dd-3db9" name="Artillery Sub-type:" hidden="false" targetId="6f99-c178-6f9d-fb63" primary="false"/>
@@ -34197,6 +35291,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0"/>
               </costs>
             </entryLink>
+            <entryLink id="0068-548b-115c-9028" name="The Spreading Corruption" hidden="false" collective="false" import="true" targetId="f783-f0ea-fe35-cdeb" type="selectionEntry"/>
           </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="ad63-a5cc-c883-17c6" name="0) Batteries:" hidden="false" collective="false" import="true" defaultSelectionEntryId="4b49-fbfe-8078-cae8">
@@ -34325,7 +35420,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                   <profiles>
                     <profile id="c620-7992-58b3-1b23" name="Gunner" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
                       <modifiers>
-                        <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Infantry (Heavy, Psyker)">
+                        <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Psyker)">
                           <conditions>
                             <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="21c3-2f28-7820-e51a" type="equalTo"/>
                           </conditions>
@@ -34334,6 +35429,15 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                           <conditions>
                             <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
                           </conditions>
+                        </modifier>
+                        <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Corrupted)">
+                          <conditionGroups>
+                            <conditionGroup type="or">
+                              <conditions>
+                                <condition field="selections" scope="23e4-c64b-65b4-c8a5" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f783-f0ea-fe35-cdeb" type="equalTo"/>
+                              </conditions>
+                            </conditionGroup>
+                          </conditionGroups>
                         </modifier>
                       </modifiers>
                       <characteristics>
@@ -34381,6 +35485,15 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                           <conditions>
                             <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
                           </conditions>
+                        </modifier>
+                        <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Corrupted)">
+                          <conditionGroups>
+                            <conditionGroup type="or">
+                              <conditions>
+                                <condition field="selections" scope="23e4-c64b-65b4-c8a5" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f783-f0ea-fe35-cdeb" type="atLeast"/>
+                              </conditions>
+                            </conditionGroup>
+                          </conditionGroups>
                         </modifier>
                       </modifiers>
                       <characteristics>
@@ -34434,6 +35547,16 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
           <conditions>
             <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d71e-10a6-216f-d796" type="greaterThan"/>
           </conditions>
+        </modifier>
+        <modifier type="add" field="category" value="9055-7410-8ffd-b8e7">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="954d-cf8e-eefd-27a6" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f783-f0ea-fe35-cdeb" type="equalTo"/>
+                <condition field="selections" scope="954d-cf8e-eefd-27a6" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="555f-3998-a06e-f415" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
         </modifier>
       </modifiers>
       <modifierGroups>
@@ -34518,15 +35641,25 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
           <profiles>
             <profile id="62e1-0acf-fd9b-3c69" name="Nullificator" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
               <modifiers>
-                <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Infantry (Heavy, Psyker)">
-                  <conditions>
-                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="21c3-2f28-7820-e51a" type="equalTo"/>
-                  </conditions>
-                </modifier>
                 <modifier type="set" field="893e-2d76-8f04-44e5" value="7*">
                   <conditions>
                     <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
                   </conditions>
+                </modifier>
+                <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Psyker)">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="21c3-2f28-7820-e51a" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Corrupted)">
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="954d-cf8e-eefd-27a6" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f783-f0ea-fe35-cdeb" type="equalTo"/>
+                        <condition field="selections" scope="954d-cf8e-eefd-27a6" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="555f-3998-a06e-f415" type="equalTo"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
                 </modifier>
               </modifiers>
               <characteristics>
@@ -34606,7 +35739,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
           <profiles>
             <profile id="76ba-0c88-e3b3-411e" name="Nullificator Sergeant" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
               <modifiers>
-                <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Infantry (Heavy, Character, Psyker)">
+                <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Psyker)">
                   <conditions>
                     <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="21c3-2f28-7820-e51a" type="equalTo"/>
                   </conditions>
@@ -34615,6 +35748,16 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                   <conditions>
                     <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
                   </conditions>
+                </modifier>
+                <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Corrupted)">
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="954d-cf8e-eefd-27a6" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f783-f0ea-fe35-cdeb" type="equalTo"/>
+                        <condition field="selections" scope="954d-cf8e-eefd-27a6" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="555f-3998-a06e-f415" type="equalTo"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
                 </modifier>
               </modifiers>
               <characteristics>
@@ -34807,7 +35950,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
             </entryLink>
           </entryLinks>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="45.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
@@ -34891,6 +36034,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                 </modifier>
               </modifiers>
             </entryLink>
+            <entryLink id="4e7a-79a2-2b22-8b58" name="The Spreading Corruption" hidden="false" collective="false" import="true" targetId="f783-f0ea-fe35-cdeb" type="selectionEntry"/>
           </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
@@ -34905,15 +36049,20 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
         <entryLink id="298d-d488-70ad-3609" name="Hexagrammaton Choice:" hidden="false" collective="false" import="true" targetId="61a2-7005-1e6c-c08e" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="65.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="daf7-b23b-5474-5836" name="Castra Ferrum Dreadnought Talon" hidden="false" collective="false" import="true" type="unit">
       <modifiers>
         <modifier type="add" field="category" value="9055-7410-8ffd-b8e7">
-          <conditions>
-            <condition field="selections" scope="daf7-b23b-5474-5836" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="555f-3998-a06e-f415" type="equalTo"/>
-          </conditions>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="daf7-b23b-5474-5836" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="555f-3998-a06e-f415" type="equalTo"/>
+                <condition field="selections" scope="daf7-b23b-5474-5836" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f783-f0ea-fe35-cdeb" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
         </modifier>
         <modifier type="add" field="category" value="2bcf-6bbe-58a1-e082">
           <conditions>
@@ -34974,10 +36123,15 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                     </conditionGroup>
                   </conditionGroups>
                 </modifier>
-                <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Dreadnought (Corrupted)">
-                  <conditions>
-                    <condition field="selections" scope="daf7-b23b-5474-5836" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="555f-3998-a06e-f415" type="equalTo"/>
-                  </conditions>
+                <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Corrupted)">
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="daf7-b23b-5474-5836" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="555f-3998-a06e-f415" type="equalTo"/>
+                        <condition field="selections" scope="daf7-b23b-5474-5836" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f783-f0ea-fe35-cdeb" type="equalTo"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
                 </modifier>
                 <modifier type="set" field="893e-2d76-8f04-44e5" value="7*">
                   <conditions>
@@ -35307,6 +36461,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0"/>
               </costs>
             </entryLink>
+            <entryLink id="b19f-bc36-3d56-da54" name="The Spreading Corruption" hidden="false" collective="false" import="true" targetId="f783-f0ea-fe35-cdeb" type="selectionEntry"/>
           </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="c295-5daf-1f12-e7d8" name="Dedicated Transport" hidden="false" collective="false" import="true">
@@ -35375,9 +36530,14 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
           </conditions>
         </modifier>
         <modifier type="add" field="category" value="9055-7410-8ffd-b8e7">
-          <conditions>
-            <condition field="selections" scope="aa7f-bd4c-5231-d459" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="555f-3998-a06e-f415" type="equalTo"/>
-          </conditions>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="aa7f-bd4c-5231-d459" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f783-f0ea-fe35-cdeb" type="equalTo"/>
+                <condition field="selections" scope="aa7f-bd4c-5231-d459" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="555f-3998-a06e-f415" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
         </modifier>
       </modifiers>
       <modifierGroups>
@@ -35681,19 +36841,24 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
               <profiles>
                 <profile id="95b6-5138-ea6a-f10e" name="Indomitus Sergeant" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
                   <modifiers>
-                    <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Infantry (Heavy, Character, Psyker)">
-                      <conditions>
-                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="21c3-2f28-7820-e51a" type="equalTo"/>
-                      </conditions>
-                    </modifier>
-                    <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Infantry (Heavy,  Character, Corrupted)">
-                      <conditions>
-                        <condition field="selections" scope="aa7f-bd4c-5231-d459" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="555f-3998-a06e-f415" type="equalTo"/>
-                      </conditions>
-                    </modifier>
                     <modifier type="set" field="893e-2d76-8f04-44e5" value="7*">
                       <conditions>
                         <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Corrupted)">
+                      <conditionGroups>
+                        <conditionGroup type="or">
+                          <conditions>
+                            <condition field="selections" scope="aa7f-bd4c-5231-d459" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f783-f0ea-fe35-cdeb" type="equalTo"/>
+                            <condition field="selections" scope="aa7f-bd4c-5231-d459" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="555f-3998-a06e-f415" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                    <modifier type="set" field="ddd7-6f5c-a939-b69e" value="(Psyker)">
+                      <conditions>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="21c3-2f28-7820-e51a" type="equalTo"/>
                       </conditions>
                     </modifier>
                   </modifiers>
@@ -35953,7 +37118,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                     </entryLink>
                   </entryLinks>
                 </selectionEntryGroup>
-                <selectionEntryGroup id="ee4f-0f71-73a2-5b11" name="1) Heavy Weapon Options" hidden="false" collective="false" import="true" defaultSelectionEntryId="1be7-81be-a0db-4aed">
+                <selectionEntryGroup id="ee4f-0f71-73a2-5b11" name="1) Heavy Weapon Options" hidden="false" collective="false" import="true" defaultSelectionEntryId="c139-f6f1-a739-600a">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ffa9-9285-4811-1fd0" type="max"/>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="89bb-5243-5d9e-f7c6" type="min"/>
@@ -35995,12 +37160,17 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
               <profiles>
                 <profile id="91ea-705e-8062-f938" name="Indomitus" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
                   <modifiers>
-                    <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Infantry (Heavy, Corrupted)">
-                      <conditions>
-                        <condition field="selections" scope="aa7f-bd4c-5231-d459" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="555f-3998-a06e-f415" type="equalTo"/>
-                      </conditions>
+                    <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Corrupted)">
+                      <conditionGroups>
+                        <conditionGroup type="or">
+                          <conditions>
+                            <condition field="selections" scope="aa7f-bd4c-5231-d459" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f783-f0ea-fe35-cdeb" type="equalTo"/>
+                            <condition field="selections" scope="aa7f-bd4c-5231-d459" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="555f-3998-a06e-f415" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
                     </modifier>
-                    <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Infantry (Heavy, Psyker)">
+                    <modifier type="set" field="ddd7-6f5c-a939-b69e" value="(Psyker)">
                       <conditions>
                         <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="21c3-2f28-7820-e51a" type="equalTo"/>
                       </conditions>
@@ -36159,6 +37329,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                 </modifier>
               </modifiers>
             </entryLink>
+            <entryLink id="3f22-e7fb-c3fa-638c" name="The Spreading Corruption" hidden="false" collective="false" import="true" targetId="f783-f0ea-fe35-cdeb" type="selectionEntry"/>
           </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
@@ -37530,6 +38701,11 @@ Additionally, at the end of any Phase in which a model with Gorgon Terminator ar
             <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c83-69fb-8066-a773" type="equalTo"/>
           </conditions>
         </modifier>
+        <modifier type="add" field="category" value="9055-7410-8ffd-b8e7">
+          <conditions>
+            <condition field="selections" scope="4d72-1cc1-8bee-aa88" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f783-f0ea-fe35-cdeb" type="equalTo"/>
+          </conditions>
+        </modifier>
       </modifiers>
       <infoLinks>
         <infoLink id="4e5f-ff66-6b18-54e4" name="Hammer of Wrath (X)" hidden="false" targetId="aec0-c3aa-1e4e-1779" type="rule">
@@ -37577,9 +38753,14 @@ Additionally, at the end of any Phase in which a model with Gorgon Terminator ar
                     <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
                   </conditions>
                 </modifier>
-                <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Cavalry (Skirmish, Psyker)">
+                <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Psyker)">
                   <conditions>
                     <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="21c3-2f28-7820-e51a" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Corrupted)">
+                  <conditions>
+                    <condition field="selections" scope="4d72-1cc1-8bee-aa88" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f783-f0ea-fe35-cdeb" type="equalTo"/>
                   </conditions>
                 </modifier>
               </modifiers>
@@ -37679,6 +38860,7 @@ Additionally, at the end of any Phase in which a model with Gorgon Terminator ar
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
               </costs>
             </entryLink>
+            <entryLink id="6560-fee9-5d44-e755" name="The Spreading Corruption" hidden="false" collective="false" import="true" targetId="f783-f0ea-fe35-cdeb" type="selectionEntry"/>
           </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="17e4-41b2-ab13-65be" name="2) Bolt Pistol Options:" hidden="false" collective="false" import="true" defaultSelectionEntryId="d861-d2fc-5945-51a0">
@@ -40694,6 +41876,16 @@ containing the model that failed its Check. If the Psyker survives Perils of the
             </conditionGroup>
           </conditionGroups>
         </modifier>
+        <modifier type="add" field="category" value="9055-7410-8ffd-b8e7">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="124f-0ced-9231-bba4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f783-f0ea-fe35-cdeb" type="equalTo"/>
+                <condition field="selections" scope="124f-0ced-9231-bba4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="555f-3998-a06e-f415" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
       </modifiers>
       <infoLinks>
         <infoLink id="bc9a-a8db-6452-5063" name="Automated Artillery Sub-type" hidden="false" targetId="c036-66e2-4e07-c2b8" type="rule"/>
@@ -40748,6 +41940,18 @@ containing the model that failed its Check. If the Psyker survives Perils of the
               </constraints>
               <profiles>
                 <profile id="633b-ed59-22a7-663d" name="Tarantula Sentry Gun" publicationId="d0df-7166-5cd3-89fd" page="16" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
+                  <modifiers>
+                    <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Corrupted)">
+                      <conditionGroups>
+                        <conditionGroup type="or">
+                          <conditions>
+                            <condition field="selections" scope="124f-0ced-9231-bba4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f783-f0ea-fe35-cdeb" type="equalTo"/>
+                            <condition field="selections" scope="124f-0ced-9231-bba4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="555f-3998-a06e-f415" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                  </modifiers>
                   <characteristics>
                     <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e"> Infantry (Automated Artillery)</characteristic>
                     <characteristic name="Move" typeId="893e-2d76-8f04-44e5">-</characteristic>
@@ -40829,6 +42033,77 @@ containing the model that failed its Check. If the Psyker survives Perils of the
               </costs>
             </selectionEntry>
           </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="c047-0fa8-d8c0-73ea" name="Legiones Unit Upgrades:" hidden="false" collective="false" import="true">
+          <selectionEntryGroups>
+            <selectionEntryGroup id="ea03-d14c-a28a-16c7" name="Surgical Augment (unit)" hidden="true" collective="false" import="true">
+              <modifiers>
+                <modifier type="set" field="hidden" value="false">
+                  <conditionGroups>
+                    <conditionGroup type="and">
+                      <conditions>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3edc-a1b9-6dc6-b1ea" type="equalTo"/>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo"/>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e221-0a54-9f94-988f" type="equalTo"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e01d-4caf-5b50-688b" type="max"/>
+                <constraint field="selections" scope="parent" value="-1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9bc6-174d-ce5f-822c" type="min"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="c873-f4f9-d114-4b58" name="Sonic Shriekers (Unit)" hidden="false" collective="false" import="true" targetId="7200-efa6-c232-eb74" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="60e1-20db-fd52-639c" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="30.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="e548-5845-2509-36ba" name="Sonic Lance (Unit)" hidden="false" collective="false" import="true" targetId="b8b5-3d56-8f42-4b4d" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="45a3-08d6-84fe-f2c6" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="30.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="5417-3700-fc8f-25dd" name="Sub-sonic Pulser Unit)" hidden="false" collective="false" import="true" targetId="a3c0-860a-2b71-c53e" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="name" value="Sub-sonic Pulser (Unit)"/>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7e32-c49c-f980-5420" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="30.0"/>
+                  </costs>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks>
+            <entryLink id="d9ec-9721-7691-6487" name="Preysight" hidden="false" collective="false" import="true" targetId="b905-4d78-c141-4e63" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5b95-b2c7-01d2-0f10" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="8607-00f0-a086-b067" name="Dark Channeling" hidden="false" collective="false" import="true" targetId="555f-3998-a06e-f415" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b535-060b-fa90-f149" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="5908-4378-65d6-5b3a" name="The Spreading Corruption" hidden="false" collective="false" import="true" targetId="f783-f0ea-fe35-cdeb" type="selectionEntry"/>
+          </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <costs>
@@ -42527,6 +43802,16 @@ containing the model that failed its Check. If the Psyker survives Perils of the
             <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c83-69fb-8066-a773" type="equalTo"/>
           </conditions>
         </modifier>
+        <modifier type="add" field="category" value="9055-7410-8ffd-b8e7">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="d30b-59bb-8ae0-36d1" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f783-f0ea-fe35-cdeb" type="equalTo"/>
+                <condition field="selections" scope="d30b-59bb-8ae0-36d1" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="555f-3998-a06e-f415" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
       </modifiers>
       <infoLinks>
         <infoLink id="3821-3eb2-2940-2179" name="Bitter Duty" hidden="false" targetId="d1b8-31da-c53c-4fe2" type="rule"/>
@@ -42583,10 +43868,20 @@ containing the model that failed its Check. If the Psyker survives Perils of the
                     <condition field="selections" scope="a58b-3293-d55c-ebc2" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="583e-62cb-53f1-f952" type="equalTo"/>
                   </conditions>
                 </modifier>
-                <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Infantry (Character, Psyker)">
+                <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Psyker)">
                   <conditions>
                     <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="21c3-2f28-7820-e51a" type="equalTo"/>
                   </conditions>
+                </modifier>
+                <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Corrupted)">
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="d30b-59bb-8ae0-36d1" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f783-f0ea-fe35-cdeb" type="equalTo"/>
+                        <condition field="selections" scope="d30b-59bb-8ae0-36d1" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="555f-3998-a06e-f415" type="equalTo"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
                 </modifier>
               </modifiers>
               <characteristics>
@@ -42935,6 +44230,7 @@ containing the model that failed its Check. If the Psyker survives Perils of the
                 </modifier>
               </modifiers>
             </entryLink>
+            <entryLink id="c03e-608f-1968-0042" name="The Spreading Corruption" hidden="false" collective="false" import="true" targetId="f783-f0ea-fe35-cdeb" type="selectionEntry"/>
           </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="f10d-023a-41b8-1c31" name=" Destroyers" hidden="false" collective="false" import="true" defaultSelectionEntryId="2adb-c2ba-7b2a-54b7">
@@ -43069,10 +44365,20 @@ containing the model that failed its Check. If the Psyker survives Perils of the
                         <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
                       </conditions>
                     </modifier>
-                    <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Infantry (Psyker)">
+                    <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Psyker)">
                       <conditions>
                         <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="21c3-2f28-7820-e51a" type="equalTo"/>
                       </conditions>
+                    </modifier>
+                    <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Corrupted)">
+                      <conditionGroups>
+                        <conditionGroup type="or">
+                          <conditions>
+                            <condition field="selections" scope="d30b-59bb-8ae0-36d1" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f783-f0ea-fe35-cdeb" type="equalTo"/>
+                            <condition field="selections" scope="d30b-59bb-8ae0-36d1" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="555f-3998-a06e-f415" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
                     </modifier>
                   </modifiers>
                   <characteristics>
@@ -44183,6 +45489,16 @@ During a Reaction made in any Phase, a player may not choose to activate a model
             <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c83-69fb-8066-a773" type="equalTo"/>
           </conditions>
         </modifier>
+        <modifier type="add" field="category" value="9055-7410-8ffd-b8e7">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="a8e9-70e1-b8bc-8ee2" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="555f-3998-a06e-f415" type="equalTo"/>
+                <condition field="selections" scope="a8e9-70e1-b8bc-8ee2" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f783-f0ea-fe35-cdeb" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
       </modifiers>
       <infoLinks>
         <infoLink id="5854-b9b7-2fec-4911" name="Outflank" hidden="false" targetId="bfbf-e75c-49a2-0285" type="rule">
@@ -44220,15 +45536,25 @@ During a Reaction made in any Phase, a player may not choose to activate a model
                     <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
                   </conditions>
                 </modifier>
-                <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Infantry (Character, Line, Psyker)">
-                  <conditions>
-                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="21c3-2f28-7820-e51a" type="equalTo"/>
-                  </conditions>
-                </modifier>
                 <modifier type="set" field="e593-6b3c-f169-04f0" value="2+">
                   <conditions>
                     <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="583e-62cb-53f1-f952" type="equalTo"/>
                   </conditions>
+                </modifier>
+                <modifier type="set" field="ddd7-6f5c-a939-b69e" value="(Psyker)">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="21c3-2f28-7820-e51a" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Corrupted)">
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="a8e9-70e1-b8bc-8ee2" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="555f-3998-a06e-f415" type="equalTo"/>
+                        <condition field="selections" scope="a8e9-70e1-b8bc-8ee2" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f783-f0ea-fe35-cdeb" type="equalTo"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
                 </modifier>
               </modifiers>
               <characteristics>
@@ -44726,6 +46052,7 @@ During a Reaction made in any Phase, a player may not choose to activate a model
                 </modifier>
               </modifiers>
             </entryLink>
+            <entryLink id="f4a9-cc67-43b6-ff36" name="The Spreading Corruption" hidden="false" collective="false" import="true" targetId="f783-f0ea-fe35-cdeb" type="selectionEntry"/>
           </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="6650-b0cd-fb32-b405" name="0) Legionaries" hidden="false" collective="false" import="true" defaultSelectionEntryId="d491-d1b6-0c2a-ed9c">
@@ -44750,12 +46077,17 @@ During a Reaction made in any Phase, a player may not choose to activate a model
                         <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
                       </conditions>
                     </modifier>
-                    <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Infantry (Line. Corrupted)">
-                      <conditions>
-                        <condition field="selections" scope="a8e9-70e1-b8bc-8ee2" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="555f-3998-a06e-f415" type="equalTo"/>
-                      </conditions>
+                    <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Corrupted)">
+                      <conditionGroups>
+                        <conditionGroup type="or">
+                          <conditions>
+                            <condition field="selections" scope="a8e9-70e1-b8bc-8ee2" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="555f-3998-a06e-f415" type="equalTo"/>
+                            <condition field="selections" scope="a8e9-70e1-b8bc-8ee2" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f783-f0ea-fe35-cdeb" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
                     </modifier>
-                    <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Infantry (Line, Psyker)">
+                    <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Psyker)">
                       <conditions>
                         <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="21c3-2f28-7820-e51a" type="equalTo"/>
                       </conditions>
@@ -45121,6 +46453,18 @@ During a Reaction made in any Phase, a player may not choose to activate a model
       </costs>
     </selectionEntry>
     <selectionEntry id="dbd4-930e-e003-9449" name="Mortalis Destroyer Squad" publicationId="a716-c1c4-7b26-8424" hidden="false" collective="false" import="true" type="unit">
+      <modifiers>
+        <modifier type="add" field="category" value="9055-7410-8ffd-b8e7">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="dbd4-930e-e003-9449" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f783-f0ea-fe35-cdeb" type="equalTo"/>
+                <condition field="selections" scope="dbd4-930e-e003-9449" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="555f-3998-a06e-f415" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <modifierGroups>
         <modifierGroup>
           <modifiers>
@@ -45203,10 +46547,20 @@ During a Reaction made in any Phase, a player may not choose to activate a model
                     <condition field="selections" scope="dbd4-930e-e003-9449" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="583e-62cb-53f1-f952" type="equalTo"/>
                   </conditions>
                 </modifier>
-                <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Infantry (Character, Psyker)">
+                <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Psyker)">
                   <conditions>
                     <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="21c3-2f28-7820-e51a" type="equalTo"/>
                   </conditions>
+                </modifier>
+                <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Corrupted)">
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="dbd4-930e-e003-9449" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f783-f0ea-fe35-cdeb" type="equalTo"/>
+                        <condition field="selections" scope="dbd4-930e-e003-9449" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="555f-3998-a06e-f415" type="equalTo"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
                 </modifier>
               </modifiers>
               <characteristics>
@@ -45560,6 +46914,7 @@ During a Reaction made in any Phase, a player may not choose to activate a model
                 </modifier>
               </modifiers>
             </entryLink>
+            <entryLink id="c5fe-7e12-08d3-1305" name="The Spreading Corruption" hidden="false" collective="false" import="true" targetId="f783-f0ea-fe35-cdeb" type="selectionEntry"/>
           </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="da9f-0f0f-659a-93d0" name=" Destroyers" hidden="false" collective="false" import="true" defaultSelectionEntryId="c384-0076-0e95-c567">
@@ -45694,10 +47049,20 @@ During a Reaction made in any Phase, a player may not choose to activate a model
                         <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
                       </conditions>
                     </modifier>
-                    <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Infantry (Psyker)">
+                    <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Psyker)">
                       <conditions>
                         <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="21c3-2f28-7820-e51a" type="equalTo"/>
                       </conditions>
+                    </modifier>
+                    <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Corrupted)">
+                      <conditionGroups>
+                        <conditionGroup type="or">
+                          <conditions>
+                            <condition field="selections" scope="dbd4-930e-e003-9449" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f783-f0ea-fe35-cdeb" type="equalTo"/>
+                            <condition field="selections" scope="dbd4-930e-e003-9449" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="555f-3998-a06e-f415" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
                     </modifier>
                   </modifiers>
                   <characteristics>
@@ -46865,6 +48230,16 @@ During a Reaction made in any Phase, a player may not choose to activate a model
               <conditions>
                 <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
               </conditions>
+            </modifier>
+            <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Corrupted)">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="ea5b-25e4-9c56-38dd" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="555f-3998-a06e-f415" type="equalTo"/>
+                    <condition field="selections" scope="ea5b-25e4-9c56-38dd" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f783-f0ea-fe35-cdeb" type="equalTo"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
             </modifier>
           </modifiers>
           <characteristics>
@@ -50047,6 +51422,77 @@ Models with the Shackled Artificia Unit Type can never count as scoring units, n
       </infoLinks>
       <costs>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="f783-f0ea-fe35-cdeb" name="The Spreading Corruption" hidden="true" collective="false" import="true" type="upgrade">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4a11-c7c1-e1a1-d067" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="35f9-7236-2dae-286d" type="max"/>
+      </constraints>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="4a11-c7c1-e1a1-d067" name="Horus Ascended" hidden="false" collective="false" import="true" type="model">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4ef0-ae71-45f7-03e3" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="7152-ae03-3008-4647" name="Horus Ascended" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
+          <characteristics>
+            <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Primarch (Unique, Corrupted)</characteristic>
+            <characteristic name="Move" typeId="893e-2d76-8f04-44e5">8</characteristic>
+            <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">8</characteristic>
+            <characteristic name="BS" typeId="74ae-c840-0036-d244">6</characteristic>
+            <characteristic name="S" typeId="e478-41d4-a092-48a8">8</characteristic>
+            <characteristic name="T" typeId="c32b-5fdd-3fbe-9b1f">8</characteristic>
+            <characteristic name="W" typeId="57ee-1126-32a9-5672">8</characteristic>
+            <characteristic name="I" typeId="62d3-22d7-2d49-52dc">6</characteristic>
+            <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">6</characteristic>
+            <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">10</characteristic>
+            <characteristic name="Save" typeId="e593-6b3c-f169-04f0">2+</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules>
+        <rule id="dd1b-0330-aab1-7188" name="A Dark Fate" hidden="false">
+          <description>The first time in any battle that Horus Ascended loses his last Wound, or is otherwise removed from play as a casualty, the model is instead placed into Reserves with a single Wound remaining – any unit Horus Ascended was part of remains in play, even a Retinue or other unit that would normally not allow the removal of a model from the unit. After having been placed in Reserves due to this special rule, Horus Ascended may choose to re-enter play, with the controlling player making Reserves rolls for the model as per the normal rules. If the Slay the Warlord objective, or any other objective that requires the enemy Warlord be removed as a casualty to score Victory points, is in effect then it is still triggered when Horus Ascended is moved into Reserves due to this special rule – and may be triggered a second time if Horus Ascended returns to play and is removed as a casualty again</description>
+        </rule>
+        <rule id="3f6d-8e47-55b5-3f8b" name="The Power of Chaos Eternal" hidden="false">
+          <description>Once per battle, at the start of any Assault phase (whether Horus Ascended’s controlling player is the Active or Reactive player), Horus Ascended’s controlling player
+may choose to activate the Power of Chaos Eternal. Onc eactivated, Horus Ascended increases his Strength and Toughness Characteristics to 10 for the duration of the Assault phase and ignores all the effects of the Unwieldy special rule on attacks made with Worldbreaker. Once the Assault phase is ended, all combats being fought have been resolved and the effects of the Power of Chaos Eternal have ended, Horus Ascended automatically suffers Perils of the Warp – but any Wounds caused must be allocated to friendly models in the same unit as Horus Ascended, if any such models exist, before they are allocated to Horus Ascended</description>
+        </rule>
+        <rule id="d859-aa19-1907-0790" name="The Spreading Corruption" hidden="false">
+          <description>All models in a unit made up entirely of models withthe Infantry, Cavalry or Dreadnought Unit Types inthesame Detachment as Horus Ascended may be giiven the Corrupted Unit Sub-type at a cost of +25 points per unit . If this upgrade is selected for a unit then all models in the unit must gain the Corrupted Sub-type – models that are attached to units, such as Apothecaries or Techmarines, must be upgraded separately. For Apothecary Detachments, Techmarine Covenants and other units which are bought as a single Force Organisation slot and then separated, divided or attached to other units (including units bought using the Retinue special rule or any variant of that rule which allows a unit to be counted as part of the same Force Organisation slot as a Leader model), the upgrade is bought once for the entire set of models before they are separated and must be applied to all models chosen as part of that Force Organisation slot.</description>
+        </rule>
+        <rule id="9445-c0b8-f082-54cb" name="Master of War" hidden="false">
+          <description>Once per battle, at the start of any turn where Horus Lupercal’s controlling player is the Reactive player, this special rule may be activated. For the duration of the turn on which this special rule is activated, the Reaction Allotment of the army that includes Horus is increased by +1 in every Phase.</description>
+        </rule>
+        <rule id="ade0-2be2-4fad-a2b9" name="Master of Weapons" hidden="false">
+          <description>During the Assault phase Horus Lupercal can never be hit by a Melee Attack on a score of better than 4+, regardless of the Weapon Skill of his opponent. In addition, during the Assault phase Horus Lupercal may choose to split his Attacks between any of the weapons he is equipped with, declaring which attacks will be used with which weaponprofiles before any of his attacks are rolled.</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="6ecc-afc9-a699-ce44" name="Feel No Pain (X)" hidden="false" targetId="ec46-ff29-32e0-c2aa" type="rule">
+          <modifiers>
+            <modifier type="set" field="name" value="Feel No Pain (4+)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="6bfb-c229-3493-acb0" name="Rage (X)" hidden="false" targetId="564d-3550-ae44-2f99" type="rule">
+          <modifiers>
+            <modifier type="set" field="name" value="Rage (3)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="63c5-a1e6-28a4-8fab" name="Deep Strike" hidden="false" targetId="f1e1-986f-c783-ca9e" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="400.0"/>
       </costs>
     </selectionEntry>
   </sharedSelectionEntries>

--- a/2022 - Mech Library.cat
+++ b/2022 - Mech Library.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="3129-da35-55e0-642d" name="2022 - Mech Library" revision="20" battleScribeVersion="2.03" library="true" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="56" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="3129-da35-55e0-642d" name="2022 - Mech Library" revision="21" battleScribeVersion="2.03" library="true" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="61" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <categoryEntries>
     <categoryEntry id="4086-0589-f010-e688" name="Titan Legion Min Troop/LoW" hidden="false"/>
     <categoryEntry id="57a1-ae47-ff1b-36e4" name="Cybertheurgist" publicationId="bde1-6db1-163b-3b76" page="92-96" hidden="false"/>
@@ -1546,11 +1546,11 @@ Invulnerable Saves granted by a mag-inverter shield do not stack with other Invu
               <conditionGroups>
                 <conditionGroup type="or">
                   <conditions>
-                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e78c-787d-54ca-82c2" type="greaterThan"/>
-                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f4a8-b2a3-1c3c-9761" type="greaterThan"/>
-                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1682-2560-347c-e798" type="greaterThan"/>
-                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4b90-1389-3b29-3fca" type="greaterThan"/>
-                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3dc3-9018-b7a3-8cf9" type="greaterThan"/>
+                    <condition field="selections" scope="8cb2-7235-fc34-9983" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e78c-787d-54ca-82c2" type="greaterThan"/>
+                    <condition field="selections" scope="8cb2-7235-fc34-9983" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f4a8-b2a3-1c3c-9761" type="greaterThan"/>
+                    <condition field="selections" scope="8cb2-7235-fc34-9983" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1682-2560-347c-e798" type="greaterThan"/>
+                    <condition field="selections" scope="8cb2-7235-fc34-9983" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4b90-1389-3b29-3fca" type="greaterThan"/>
+                    <condition field="selections" scope="8cb2-7235-fc34-9983" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3dc3-9018-b7a3-8cf9" type="greaterThan"/>
                   </conditions>
                 </conditionGroup>
               </conditionGroups>
@@ -1559,40 +1559,40 @@ Invulnerable Saves granted by a mag-inverter shield do not stack with other Invu
               <conditionGroups>
                 <conditionGroup type="or">
                   <conditions>
-                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4b90-1389-3b29-3fca" type="greaterThan"/>
-                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e78c-787d-54ca-82c2" type="greaterThan"/>
+                    <condition field="selections" scope="8cb2-7235-fc34-9983" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4b90-1389-3b29-3fca" type="greaterThan"/>
+                    <condition field="selections" scope="8cb2-7235-fc34-9983" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e78c-787d-54ca-82c2" type="greaterThan"/>
                   </conditions>
                 </conditionGroup>
               </conditionGroups>
             </modifier>
             <modifier type="decrement" field="7f12-0cc3-9dcd-25bc" value="2">
               <conditions>
-                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7496-3ece-e6d8-6d40" type="greaterThan"/>
+                <condition field="selections" scope="8cb2-7235-fc34-9983" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7496-3ece-e6d8-6d40" type="greaterThan"/>
               </conditions>
             </modifier>
             <modifier type="decrement" field="6c5a-df71-fefa-2ee3" value="1">
               <conditions>
-                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7496-3ece-e6d8-6d40" type="greaterThan"/>
+                <condition field="selections" scope="8cb2-7235-fc34-9983" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7496-3ece-e6d8-6d40" type="greaterThan"/>
               </conditions>
             </modifier>
             <modifier type="decrement" field="4227-8eed-0c5c-a2d9" value="1">
               <conditions>
-                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7496-3ece-e6d8-6d40" type="greaterThan"/>
+                <condition field="selections" scope="8cb2-7235-fc34-9983" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7496-3ece-e6d8-6d40" type="greaterThan"/>
               </conditions>
             </modifier>
             <modifier type="increment" field="4227-8eed-0c5c-a2d9" value="1">
               <conditionGroups>
                 <conditionGroup type="or">
                   <conditions>
-                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3dc3-9018-b7a3-8cf9" type="greaterThan"/>
-                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f4a8-b2a3-1c3c-9761" type="greaterThan"/>
+                    <condition field="selections" scope="8cb2-7235-fc34-9983" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3dc3-9018-b7a3-8cf9" type="greaterThan"/>
+                    <condition field="selections" scope="8cb2-7235-fc34-9983" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f4a8-b2a3-1c3c-9761" type="greaterThan"/>
                   </conditions>
                 </conditionGroup>
               </conditionGroups>
             </modifier>
             <modifier type="increment" field="2490-aa2f-f5db-6070" value="1">
               <conditions>
-                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1682-2560-347c-e798" type="greaterThan"/>
+                <condition field="selections" scope="8cb2-7235-fc34-9983" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1682-2560-347c-e798" type="greaterThan"/>
               </conditions>
             </modifier>
           </modifiers>
@@ -1995,29 +1995,29 @@ Invulnerable Saves granted by a mag-inverter shield do not stack with other Invu
               <conditionGroups>
                 <conditionGroup type="or">
                   <conditions>
-                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e78c-787d-54ca-82c2" type="greaterThan"/>
-                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f4a8-b2a3-1c3c-9761" type="greaterThan"/>
-                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7f03-d8c0-0e83-1f6e" type="greaterThan"/>
-                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1682-2560-347c-e798" type="greaterThan"/>
-                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4b90-1389-3b29-3fca" type="greaterThan"/>
-                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3dc3-9018-b7a3-8cf9" type="greaterThan"/>
-                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="63ce-0429-b209-c3e9" type="greaterThan"/>
+                    <condition field="selections" scope="f971-ef52-5344-0b26" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e78c-787d-54ca-82c2" type="greaterThan"/>
+                    <condition field="selections" scope="f971-ef52-5344-0b26" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f4a8-b2a3-1c3c-9761" type="greaterThan"/>
+                    <condition field="selections" scope="f971-ef52-5344-0b26" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7f03-d8c0-0e83-1f6e" type="greaterThan"/>
+                    <condition field="selections" scope="f971-ef52-5344-0b26" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1682-2560-347c-e798" type="greaterThan"/>
+                    <condition field="selections" scope="f971-ef52-5344-0b26" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4b90-1389-3b29-3fca" type="greaterThan"/>
+                    <condition field="selections" scope="f971-ef52-5344-0b26" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3dc3-9018-b7a3-8cf9" type="greaterThan"/>
+                    <condition field="selections" scope="f971-ef52-5344-0b26" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="63ce-0429-b209-c3e9" type="greaterThan"/>
                   </conditions>
                 </conditionGroup>
               </conditionGroups>
             </modifier>
             <modifier type="decrement" field="7f12-0cc3-9dcd-25bc" value="2">
               <conditions>
-                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7496-3ece-e6d8-6d40" type="greaterThan"/>
+                <condition field="selections" scope="f971-ef52-5344-0b26" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7496-3ece-e6d8-6d40" type="greaterThan"/>
               </conditions>
             </modifier>
             <modifier type="increment" field="6c5a-df71-fefa-2ee3" value="1">
               <conditionGroups>
                 <conditionGroup type="or">
                   <conditions>
-                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="63ce-0429-b209-c3e9" type="greaterThan"/>
-                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e78c-787d-54ca-82c2" type="greaterThan"/>
-                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4b90-1389-3b29-3fca" type="greaterThan"/>
+                    <condition field="selections" scope="f971-ef52-5344-0b26" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="63ce-0429-b209-c3e9" type="greaterThan"/>
+                    <condition field="selections" scope="f971-ef52-5344-0b26" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e78c-787d-54ca-82c2" type="greaterThan"/>
+                    <condition field="selections" scope="f971-ef52-5344-0b26" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4b90-1389-3b29-3fca" type="greaterThan"/>
                   </conditions>
                 </conditionGroup>
               </conditionGroups>
@@ -2026,31 +2026,31 @@ Invulnerable Saves granted by a mag-inverter shield do not stack with other Invu
               <conditionGroups>
                 <conditionGroup type="or">
                   <conditions>
-                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="63ce-0429-b209-c3e9" type="greaterThan"/>
-                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3dc3-9018-b7a3-8cf9" type="greaterThan"/>
-                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f4a8-b2a3-1c3c-9761" type="greaterThan"/>
+                    <condition field="selections" scope="f971-ef52-5344-0b26" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="63ce-0429-b209-c3e9" type="greaterThan"/>
+                    <condition field="selections" scope="f971-ef52-5344-0b26" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3dc3-9018-b7a3-8cf9" type="greaterThan"/>
+                    <condition field="selections" scope="f971-ef52-5344-0b26" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f4a8-b2a3-1c3c-9761" type="greaterThan"/>
                   </conditions>
                 </conditionGroup>
               </conditionGroups>
             </modifier>
             <modifier type="decrement" field="6c5a-df71-fefa-2ee3" value="1">
               <conditions>
-                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7496-3ece-e6d8-6d40" type="greaterThan"/>
+                <condition field="selections" scope="f971-ef52-5344-0b26" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7496-3ece-e6d8-6d40" type="greaterThan"/>
               </conditions>
             </modifier>
             <modifier type="decrement" field="4227-8eed-0c5c-a2d9" value="1">
               <conditions>
-                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7496-3ece-e6d8-6d40" type="greaterThan"/>
+                <condition field="selections" scope="f971-ef52-5344-0b26" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7496-3ece-e6d8-6d40" type="greaterThan"/>
               </conditions>
             </modifier>
             <modifier type="increment" field="2490-aa2f-f5db-6070" value="1">
               <conditions>
-                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1682-2560-347c-e798" type="greaterThan"/>
+                <condition field="selections" scope="f971-ef52-5344-0b26" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1682-2560-347c-e798" type="greaterThan"/>
               </conditions>
             </modifier>
             <modifier type="increment" field="7f12-0cc3-9dcd-25bc" value="4">
               <conditions>
-                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7f03-d8c0-0e83-1f6e" type="greaterThan"/>
+                <condition field="selections" scope="f971-ef52-5344-0b26" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7f03-d8c0-0e83-1f6e" type="greaterThan"/>
               </conditions>
             </modifier>
           </modifiers>
@@ -2074,7 +2074,7 @@ Invulnerable Saves granted by a mag-inverter shield do not stack with other Invu
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7f03-d8c0-0e83-1f6e" type="equalTo"/>
+                <condition field="selections" scope="f971-ef52-5344-0b26" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7f03-d8c0-0e83-1f6e" type="equalTo"/>
               </conditions>
             </modifier>
           </modifiers>
@@ -2083,7 +2083,7 @@ Invulnerable Saves granted by a mag-inverter shield do not stack with other Invu
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7f03-d8c0-0e83-1f6e" type="equalTo"/>
+                <condition field="selections" scope="f971-ef52-5344-0b26" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7f03-d8c0-0e83-1f6e" type="equalTo"/>
               </conditions>
             </modifier>
           </modifiers>
@@ -2201,62 +2201,62 @@ Invulnerable Saves granted by a mag-inverter shield do not stack with other Invu
               <conditionGroups>
                 <conditionGroup type="or">
                   <conditions>
-                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e78c-787d-54ca-82c2" type="greaterThan"/>
-                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f4a8-b2a3-1c3c-9761" type="greaterThan"/>
-                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7f03-d8c0-0e83-1f6e" type="greaterThan"/>
-                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1682-2560-347c-e798" type="greaterThan"/>
-                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4b90-1389-3b29-3fca" type="greaterThan"/>
-                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3dc3-9018-b7a3-8cf9" type="greaterThan"/>
-                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="63ce-0429-b209-c3e9" type="greaterThan"/>
+                    <condition field="selections" scope="0a65-543c-19b2-fd34" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e78c-787d-54ca-82c2" type="greaterThan"/>
+                    <condition field="selections" scope="0a65-543c-19b2-fd34" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f4a8-b2a3-1c3c-9761" type="greaterThan"/>
+                    <condition field="selections" scope="0a65-543c-19b2-fd34" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7f03-d8c0-0e83-1f6e" type="greaterThan"/>
+                    <condition field="selections" scope="0a65-543c-19b2-fd34" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1682-2560-347c-e798" type="greaterThan"/>
+                    <condition field="selections" scope="0a65-543c-19b2-fd34" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4b90-1389-3b29-3fca" type="greaterThan"/>
+                    <condition field="selections" scope="0a65-543c-19b2-fd34" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3dc3-9018-b7a3-8cf9" type="greaterThan"/>
+                    <condition field="selections" scope="0a65-543c-19b2-fd34" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="63ce-0429-b209-c3e9" type="greaterThan"/>
                   </conditions>
                 </conditionGroup>
               </conditionGroups>
             </modifier>
             <modifier type="decrement" field="7f12-0cc3-9dcd-25bc" value="2">
               <conditions>
-                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7496-3ece-e6d8-6d40" type="greaterThan"/>
+                <condition field="selections" scope="0a65-543c-19b2-fd34" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7496-3ece-e6d8-6d40" type="greaterThan"/>
               </conditions>
             </modifier>
             <modifier type="decrement" field="6c5a-df71-fefa-2ee3" value="1">
               <conditions>
-                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7496-3ece-e6d8-6d40" type="greaterThan"/>
+                <condition field="selections" scope="0a65-543c-19b2-fd34" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7496-3ece-e6d8-6d40" type="greaterThan"/>
               </conditions>
             </modifier>
             <modifier type="decrement" field="4227-8eed-0c5c-a2d9" value="1">
               <conditions>
-                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7496-3ece-e6d8-6d40" type="greaterThan"/>
+                <condition field="selections" scope="0a65-543c-19b2-fd34" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7496-3ece-e6d8-6d40" type="greaterThan"/>
               </conditions>
             </modifier>
             <modifier type="increment" field="4227-8eed-0c5c-a2d9" value="1">
               <conditionGroups>
                 <conditionGroup type="or">
                   <conditions>
-                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="63ce-0429-b209-c3e9" type="greaterThan"/>
-                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3dc3-9018-b7a3-8cf9" type="greaterThan"/>
-                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f4a8-b2a3-1c3c-9761" type="greaterThan"/>
+                    <condition field="selections" scope="0a65-543c-19b2-fd34" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="63ce-0429-b209-c3e9" type="greaterThan"/>
+                    <condition field="selections" scope="0a65-543c-19b2-fd34" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3dc3-9018-b7a3-8cf9" type="greaterThan"/>
+                    <condition field="selections" scope="0a65-543c-19b2-fd34" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f4a8-b2a3-1c3c-9761" type="greaterThan"/>
                   </conditions>
                 </conditionGroup>
               </conditionGroups>
             </modifier>
             <modifier type="increment" field="2490-aa2f-f5db-6070" value="1">
               <conditions>
-                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1682-2560-347c-e798" type="greaterThan"/>
+                <condition field="selections" scope="0a65-543c-19b2-fd34" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1682-2560-347c-e798" type="greaterThan"/>
               </conditions>
             </modifier>
             <modifier type="increment" field="6c5a-df71-fefa-2ee3" value="1">
               <conditionGroups>
                 <conditionGroup type="or">
                   <conditions>
-                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="63ce-0429-b209-c3e9" type="greaterThan"/>
-                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e78c-787d-54ca-82c2" type="greaterThan"/>
-                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4b90-1389-3b29-3fca" type="greaterThan"/>
+                    <condition field="selections" scope="0a65-543c-19b2-fd34" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="63ce-0429-b209-c3e9" type="greaterThan"/>
+                    <condition field="selections" scope="0a65-543c-19b2-fd34" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e78c-787d-54ca-82c2" type="greaterThan"/>
+                    <condition field="selections" scope="0a65-543c-19b2-fd34" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4b90-1389-3b29-3fca" type="greaterThan"/>
                   </conditions>
                 </conditionGroup>
               </conditionGroups>
             </modifier>
             <modifier type="increment" field="7f12-0cc3-9dcd-25bc" value="4">
               <conditions>
-                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7f03-d8c0-0e83-1f6e" type="greaterThan"/>
+                <condition field="selections" scope="0a65-543c-19b2-fd34" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7f03-d8c0-0e83-1f6e" type="greaterThan"/>
               </conditions>
             </modifier>
           </modifiers>
@@ -2280,7 +2280,7 @@ Invulnerable Saves granted by a mag-inverter shield do not stack with other Invu
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7f03-d8c0-0e83-1f6e" type="equalTo"/>
+                <condition field="selections" scope="0a65-543c-19b2-fd34" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7f03-d8c0-0e83-1f6e" type="equalTo"/>
               </conditions>
             </modifier>
           </modifiers>
@@ -2289,7 +2289,7 @@ Invulnerable Saves granted by a mag-inverter shield do not stack with other Invu
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7f03-d8c0-0e83-1f6e" type="equalTo"/>
+                <condition field="selections" scope="0a65-543c-19b2-fd34" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7f03-d8c0-0e83-1f6e" type="equalTo"/>
               </conditions>
             </modifier>
           </modifiers>
@@ -2419,62 +2419,62 @@ Invulnerable Saves granted by a mag-inverter shield do not stack with other Invu
               <conditionGroups>
                 <conditionGroup type="or">
                   <conditions>
-                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e78c-787d-54ca-82c2" type="greaterThan"/>
-                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f4a8-b2a3-1c3c-9761" type="greaterThan"/>
-                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7f03-d8c0-0e83-1f6e" type="greaterThan"/>
-                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1682-2560-347c-e798" type="greaterThan"/>
-                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4b90-1389-3b29-3fca" type="greaterThan"/>
-                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3dc3-9018-b7a3-8cf9" type="greaterThan"/>
-                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="63ce-0429-b209-c3e9" type="greaterThan"/>
+                    <condition field="selections" scope="8312-7457-e7b6-fd9f" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e78c-787d-54ca-82c2" type="greaterThan"/>
+                    <condition field="selections" scope="8312-7457-e7b6-fd9f" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f4a8-b2a3-1c3c-9761" type="greaterThan"/>
+                    <condition field="selections" scope="8312-7457-e7b6-fd9f" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7f03-d8c0-0e83-1f6e" type="greaterThan"/>
+                    <condition field="selections" scope="8312-7457-e7b6-fd9f" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1682-2560-347c-e798" type="greaterThan"/>
+                    <condition field="selections" scope="8312-7457-e7b6-fd9f" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4b90-1389-3b29-3fca" type="greaterThan"/>
+                    <condition field="selections" scope="8312-7457-e7b6-fd9f" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3dc3-9018-b7a3-8cf9" type="greaterThan"/>
+                    <condition field="selections" scope="8312-7457-e7b6-fd9f" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="63ce-0429-b209-c3e9" type="greaterThan"/>
                   </conditions>
                 </conditionGroup>
               </conditionGroups>
             </modifier>
             <modifier type="decrement" field="7f12-0cc3-9dcd-25bc" value="2">
               <conditions>
-                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7496-3ece-e6d8-6d40" type="greaterThan"/>
+                <condition field="selections" scope="8312-7457-e7b6-fd9f" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7496-3ece-e6d8-6d40" type="greaterThan"/>
               </conditions>
             </modifier>
             <modifier type="decrement" field="4227-8eed-0c5c-a2d9" value="1">
               <conditions>
-                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7496-3ece-e6d8-6d40" type="greaterThan"/>
+                <condition field="selections" scope="8312-7457-e7b6-fd9f" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7496-3ece-e6d8-6d40" type="greaterThan"/>
               </conditions>
             </modifier>
             <modifier type="decrement" field="6c5a-df71-fefa-2ee3" value="1">
               <conditions>
-                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7496-3ece-e6d8-6d40" type="greaterThan"/>
+                <condition field="selections" scope="8312-7457-e7b6-fd9f" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7496-3ece-e6d8-6d40" type="greaterThan"/>
               </conditions>
             </modifier>
             <modifier type="increment" field="4227-8eed-0c5c-a2d9" value="1">
               <conditionGroups>
                 <conditionGroup type="or">
                   <conditions>
-                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="63ce-0429-b209-c3e9" type="greaterThan"/>
-                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3dc3-9018-b7a3-8cf9" type="greaterThan"/>
-                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f4a8-b2a3-1c3c-9761" type="greaterThan"/>
+                    <condition field="selections" scope="8312-7457-e7b6-fd9f" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="63ce-0429-b209-c3e9" type="greaterThan"/>
+                    <condition field="selections" scope="8312-7457-e7b6-fd9f" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3dc3-9018-b7a3-8cf9" type="greaterThan"/>
+                    <condition field="selections" scope="8312-7457-e7b6-fd9f" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f4a8-b2a3-1c3c-9761" type="greaterThan"/>
                   </conditions>
                 </conditionGroup>
               </conditionGroups>
             </modifier>
             <modifier type="increment" field="2490-aa2f-f5db-6070" value="1">
               <conditions>
-                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1682-2560-347c-e798" type="greaterThan"/>
+                <condition field="selections" scope="8312-7457-e7b6-fd9f" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1682-2560-347c-e798" type="greaterThan"/>
               </conditions>
             </modifier>
             <modifier type="increment" field="6c5a-df71-fefa-2ee3" value="1">
               <conditionGroups>
                 <conditionGroup type="or">
                   <conditions>
-                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="63ce-0429-b209-c3e9" type="greaterThan"/>
-                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e78c-787d-54ca-82c2" type="greaterThan"/>
-                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4b90-1389-3b29-3fca" type="greaterThan"/>
+                    <condition field="selections" scope="8312-7457-e7b6-fd9f" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="63ce-0429-b209-c3e9" type="greaterThan"/>
+                    <condition field="selections" scope="8312-7457-e7b6-fd9f" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e78c-787d-54ca-82c2" type="greaterThan"/>
+                    <condition field="selections" scope="8312-7457-e7b6-fd9f" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4b90-1389-3b29-3fca" type="greaterThan"/>
                   </conditions>
                 </conditionGroup>
               </conditionGroups>
             </modifier>
             <modifier type="increment" field="7f12-0cc3-9dcd-25bc" value="4">
               <conditions>
-                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7f03-d8c0-0e83-1f6e" type="greaterThan"/>
+                <condition field="selections" scope="8312-7457-e7b6-fd9f" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7f03-d8c0-0e83-1f6e" type="greaterThan"/>
               </conditions>
             </modifier>
           </modifiers>
@@ -2498,7 +2498,7 @@ Invulnerable Saves granted by a mag-inverter shield do not stack with other Invu
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7f03-d8c0-0e83-1f6e" type="equalTo"/>
+                <condition field="selections" scope="8312-7457-e7b6-fd9f" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7f03-d8c0-0e83-1f6e" type="equalTo"/>
               </conditions>
             </modifier>
           </modifiers>
@@ -2507,7 +2507,7 @@ Invulnerable Saves granted by a mag-inverter shield do not stack with other Invu
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7f03-d8c0-0e83-1f6e" type="equalTo"/>
+                <condition field="selections" scope="8312-7457-e7b6-fd9f" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7f03-d8c0-0e83-1f6e" type="equalTo"/>
               </conditions>
             </modifier>
           </modifiers>
@@ -2626,62 +2626,62 @@ Invulnerable Saves granted by a mag-inverter shield do not stack with other Invu
               <conditionGroups>
                 <conditionGroup type="or">
                   <conditions>
-                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e78c-787d-54ca-82c2" type="greaterThan"/>
-                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f4a8-b2a3-1c3c-9761" type="greaterThan"/>
-                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7f03-d8c0-0e83-1f6e" type="greaterThan"/>
-                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1682-2560-347c-e798" type="greaterThan"/>
-                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4b90-1389-3b29-3fca" type="greaterThan"/>
-                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3dc3-9018-b7a3-8cf9" type="greaterThan"/>
-                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="63ce-0429-b209-c3e9" type="greaterThan"/>
+                    <condition field="selections" scope="3706-a84c-678d-b1c6" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e78c-787d-54ca-82c2" type="greaterThan"/>
+                    <condition field="selections" scope="3706-a84c-678d-b1c6" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f4a8-b2a3-1c3c-9761" type="greaterThan"/>
+                    <condition field="selections" scope="3706-a84c-678d-b1c6" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7f03-d8c0-0e83-1f6e" type="greaterThan"/>
+                    <condition field="selections" scope="3706-a84c-678d-b1c6" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1682-2560-347c-e798" type="greaterThan"/>
+                    <condition field="selections" scope="3706-a84c-678d-b1c6" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4b90-1389-3b29-3fca" type="greaterThan"/>
+                    <condition field="selections" scope="3706-a84c-678d-b1c6" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3dc3-9018-b7a3-8cf9" type="greaterThan"/>
+                    <condition field="selections" scope="3706-a84c-678d-b1c6" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="63ce-0429-b209-c3e9" type="greaterThan"/>
                   </conditions>
                 </conditionGroup>
               </conditionGroups>
             </modifier>
             <modifier type="decrement" field="7f12-0cc3-9dcd-25bc" value="2">
               <conditions>
-                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7496-3ece-e6d8-6d40" type="greaterThan"/>
+                <condition field="selections" scope="3706-a84c-678d-b1c6" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7496-3ece-e6d8-6d40" type="greaterThan"/>
               </conditions>
             </modifier>
             <modifier type="decrement" field="6c5a-df71-fefa-2ee3" value="1">
               <conditions>
-                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7496-3ece-e6d8-6d40" type="greaterThan"/>
+                <condition field="selections" scope="3706-a84c-678d-b1c6" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7496-3ece-e6d8-6d40" type="greaterThan"/>
               </conditions>
             </modifier>
             <modifier type="decrement" field="4227-8eed-0c5c-a2d9" value="1">
               <conditions>
-                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7496-3ece-e6d8-6d40" type="greaterThan"/>
+                <condition field="selections" scope="3706-a84c-678d-b1c6" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7496-3ece-e6d8-6d40" type="greaterThan"/>
               </conditions>
             </modifier>
             <modifier type="increment" field="4227-8eed-0c5c-a2d9" value="1">
               <conditionGroups>
                 <conditionGroup type="or">
                   <conditions>
-                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="63ce-0429-b209-c3e9" type="greaterThan"/>
-                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3dc3-9018-b7a3-8cf9" type="greaterThan"/>
-                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f4a8-b2a3-1c3c-9761" type="greaterThan"/>
+                    <condition field="selections" scope="3706-a84c-678d-b1c6" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="63ce-0429-b209-c3e9" type="greaterThan"/>
+                    <condition field="selections" scope="3706-a84c-678d-b1c6" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3dc3-9018-b7a3-8cf9" type="greaterThan"/>
+                    <condition field="selections" scope="3706-a84c-678d-b1c6" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f4a8-b2a3-1c3c-9761" type="greaterThan"/>
                   </conditions>
                 </conditionGroup>
               </conditionGroups>
             </modifier>
             <modifier type="increment" field="2490-aa2f-f5db-6070" value="1">
               <conditions>
-                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1682-2560-347c-e798" type="greaterThan"/>
+                <condition field="selections" scope="3706-a84c-678d-b1c6" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1682-2560-347c-e798" type="greaterThan"/>
               </conditions>
             </modifier>
             <modifier type="increment" field="6c5a-df71-fefa-2ee3" value="1">
               <conditionGroups>
                 <conditionGroup type="or">
                   <conditions>
-                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="63ce-0429-b209-c3e9" type="greaterThan"/>
-                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e78c-787d-54ca-82c2" type="greaterThan"/>
-                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4b90-1389-3b29-3fca" type="greaterThan"/>
+                    <condition field="selections" scope="3706-a84c-678d-b1c6" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="63ce-0429-b209-c3e9" type="greaterThan"/>
+                    <condition field="selections" scope="3706-a84c-678d-b1c6" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e78c-787d-54ca-82c2" type="greaterThan"/>
+                    <condition field="selections" scope="3706-a84c-678d-b1c6" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4b90-1389-3b29-3fca" type="greaterThan"/>
                   </conditions>
                 </conditionGroup>
               </conditionGroups>
             </modifier>
             <modifier type="increment" field="7f12-0cc3-9dcd-25bc" value="4">
               <conditions>
-                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7f03-d8c0-0e83-1f6e" type="greaterThan"/>
+                <condition field="selections" scope="3706-a84c-678d-b1c6" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7f03-d8c0-0e83-1f6e" type="greaterThan"/>
               </conditions>
             </modifier>
           </modifiers>
@@ -2705,7 +2705,7 @@ Invulnerable Saves granted by a mag-inverter shield do not stack with other Invu
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7f03-d8c0-0e83-1f6e" type="equalTo"/>
+                <condition field="selections" scope="3706-a84c-678d-b1c6" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7f03-d8c0-0e83-1f6e" type="equalTo"/>
               </conditions>
             </modifier>
           </modifiers>
@@ -2714,7 +2714,7 @@ Invulnerable Saves granted by a mag-inverter shield do not stack with other Invu
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7f03-d8c0-0e83-1f6e" type="equalTo"/>
+                <condition field="selections" scope="3706-a84c-678d-b1c6" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7f03-d8c0-0e83-1f6e" type="equalTo"/>
               </conditions>
             </modifier>
           </modifiers>
@@ -2859,37 +2859,37 @@ Invulnerable Saves granted by a mag-inverter shield do not stack with other Invu
               <conditionGroups>
                 <conditionGroup type="or">
                   <conditions>
-                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e78c-787d-54ca-82c2" type="greaterThan"/>
-                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f4a8-b2a3-1c3c-9761" type="greaterThan"/>
-                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7f03-d8c0-0e83-1f6e" type="greaterThan"/>
-                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1682-2560-347c-e798" type="greaterThan"/>
-                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4b90-1389-3b29-3fca" type="greaterThan"/>
-                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3dc3-9018-b7a3-8cf9" type="greaterThan"/>
+                    <condition field="selections" scope="7b6b-49ab-d71d-e359" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e78c-787d-54ca-82c2" type="greaterThan"/>
+                    <condition field="selections" scope="7b6b-49ab-d71d-e359" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f4a8-b2a3-1c3c-9761" type="greaterThan"/>
+                    <condition field="selections" scope="7b6b-49ab-d71d-e359" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7f03-d8c0-0e83-1f6e" type="greaterThan"/>
+                    <condition field="selections" scope="7b6b-49ab-d71d-e359" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1682-2560-347c-e798" type="greaterThan"/>
+                    <condition field="selections" scope="7b6b-49ab-d71d-e359" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4b90-1389-3b29-3fca" type="greaterThan"/>
+                    <condition field="selections" scope="7b6b-49ab-d71d-e359" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3dc3-9018-b7a3-8cf9" type="greaterThan"/>
                   </conditions>
                 </conditionGroup>
               </conditionGroups>
             </modifier>
             <modifier type="decrement" field="7f12-0cc3-9dcd-25bc" value="2">
               <conditions>
-                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7496-3ece-e6d8-6d40" type="greaterThan"/>
+                <condition field="selections" scope="7b6b-49ab-d71d-e359" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7496-3ece-e6d8-6d40" type="greaterThan"/>
               </conditions>
             </modifier>
             <modifier type="decrement" field="4227-8eed-0c5c-a2d9" value="1">
               <conditions>
-                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7496-3ece-e6d8-6d40" type="greaterThan"/>
+                <condition field="selections" scope="7b6b-49ab-d71d-e359" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7496-3ece-e6d8-6d40" type="greaterThan"/>
               </conditions>
             </modifier>
             <modifier type="decrement" field="6c5a-df71-fefa-2ee3" value="1">
               <conditions>
-                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7496-3ece-e6d8-6d40" type="greaterThan"/>
+                <condition field="selections" scope="7b6b-49ab-d71d-e359" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7496-3ece-e6d8-6d40" type="greaterThan"/>
               </conditions>
             </modifier>
             <modifier type="increment" field="4227-8eed-0c5c-a2d9" value="1">
               <conditionGroups>
                 <conditionGroup type="or">
                   <conditions>
-                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3dc3-9018-b7a3-8cf9" type="greaterThan"/>
-                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f4a8-b2a3-1c3c-9761" type="greaterThan"/>
+                    <condition field="selections" scope="7b6b-49ab-d71d-e359" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3dc3-9018-b7a3-8cf9" type="greaterThan"/>
+                    <condition field="selections" scope="7b6b-49ab-d71d-e359" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f4a8-b2a3-1c3c-9761" type="greaterThan"/>
                   </conditions>
                 </conditionGroup>
               </conditionGroups>
@@ -2898,20 +2898,20 @@ Invulnerable Saves granted by a mag-inverter shield do not stack with other Invu
               <conditionGroups>
                 <conditionGroup type="or">
                   <conditions>
-                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4b90-1389-3b29-3fca" type="greaterThan"/>
-                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e78c-787d-54ca-82c2" type="greaterThan"/>
+                    <condition field="selections" scope="7b6b-49ab-d71d-e359" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4b90-1389-3b29-3fca" type="greaterThan"/>
+                    <condition field="selections" scope="7b6b-49ab-d71d-e359" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e78c-787d-54ca-82c2" type="greaterThan"/>
                   </conditions>
                 </conditionGroup>
               </conditionGroups>
             </modifier>
             <modifier type="increment" field="2490-aa2f-f5db-6070" value="1">
               <conditions>
-                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1682-2560-347c-e798" type="greaterThan"/>
+                <condition field="selections" scope="7b6b-49ab-d71d-e359" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1682-2560-347c-e798" type="greaterThan"/>
               </conditions>
             </modifier>
             <modifier type="increment" field="7f12-0cc3-9dcd-25bc" value="4">
               <conditions>
-                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7f03-d8c0-0e83-1f6e" type="greaterThan"/>
+                <condition field="selections" scope="7b6b-49ab-d71d-e359" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7f03-d8c0-0e83-1f6e" type="greaterThan"/>
               </conditions>
             </modifier>
           </modifiers>
@@ -2935,7 +2935,7 @@ Invulnerable Saves granted by a mag-inverter shield do not stack with other Invu
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7f03-d8c0-0e83-1f6e" type="equalTo"/>
+                <condition field="selections" scope="7b6b-49ab-d71d-e359" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7f03-d8c0-0e83-1f6e" type="equalTo"/>
               </conditions>
             </modifier>
           </modifiers>
@@ -2944,7 +2944,7 @@ Invulnerable Saves granted by a mag-inverter shield do not stack with other Invu
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7f03-d8c0-0e83-1f6e" type="equalTo"/>
+                <condition field="selections" scope="7b6b-49ab-d71d-e359" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7f03-d8c0-0e83-1f6e" type="equalTo"/>
               </conditions>
             </modifier>
           </modifiers>
@@ -3069,62 +3069,62 @@ Invulnerable Saves granted by a mag-inverter shield do not stack with other Invu
               <conditionGroups>
                 <conditionGroup type="or">
                   <conditions>
-                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e78c-787d-54ca-82c2" type="greaterThan"/>
-                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f4a8-b2a3-1c3c-9761" type="greaterThan"/>
-                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7f03-d8c0-0e83-1f6e" type="greaterThan"/>
-                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1682-2560-347c-e798" type="greaterThan"/>
-                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4b90-1389-3b29-3fca" type="greaterThan"/>
-                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3dc3-9018-b7a3-8cf9" type="greaterThan"/>
-                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="63ce-0429-b209-c3e9" type="greaterThan"/>
+                    <condition field="selections" scope="012b-109f-74d2-2c82" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e78c-787d-54ca-82c2" type="greaterThan"/>
+                    <condition field="selections" scope="012b-109f-74d2-2c82" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f4a8-b2a3-1c3c-9761" type="greaterThan"/>
+                    <condition field="selections" scope="012b-109f-74d2-2c82" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7f03-d8c0-0e83-1f6e" type="greaterThan"/>
+                    <condition field="selections" scope="012b-109f-74d2-2c82" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1682-2560-347c-e798" type="greaterThan"/>
+                    <condition field="selections" scope="012b-109f-74d2-2c82" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4b90-1389-3b29-3fca" type="greaterThan"/>
+                    <condition field="selections" scope="012b-109f-74d2-2c82" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3dc3-9018-b7a3-8cf9" type="greaterThan"/>
+                    <condition field="selections" scope="012b-109f-74d2-2c82" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="63ce-0429-b209-c3e9" type="greaterThan"/>
                   </conditions>
                 </conditionGroup>
               </conditionGroups>
             </modifier>
             <modifier type="decrement" field="7f12-0cc3-9dcd-25bc" value="2">
               <conditions>
-                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7496-3ece-e6d8-6d40" type="greaterThan"/>
+                <condition field="selections" scope="012b-109f-74d2-2c82" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7496-3ece-e6d8-6d40" type="greaterThan"/>
               </conditions>
             </modifier>
             <modifier type="decrement" field="6c5a-df71-fefa-2ee3" value="1">
               <conditions>
-                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7496-3ece-e6d8-6d40" type="greaterThan"/>
+                <condition field="selections" scope="012b-109f-74d2-2c82" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7496-3ece-e6d8-6d40" type="greaterThan"/>
               </conditions>
             </modifier>
             <modifier type="decrement" field="4227-8eed-0c5c-a2d9" value="1">
               <conditions>
-                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7496-3ece-e6d8-6d40" type="greaterThan"/>
+                <condition field="selections" scope="012b-109f-74d2-2c82" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7496-3ece-e6d8-6d40" type="greaterThan"/>
               </conditions>
             </modifier>
             <modifier type="increment" field="4227-8eed-0c5c-a2d9" value="1">
               <conditionGroups>
                 <conditionGroup type="or">
                   <conditions>
-                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="63ce-0429-b209-c3e9" type="greaterThan"/>
-                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3dc3-9018-b7a3-8cf9" type="greaterThan"/>
-                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f4a8-b2a3-1c3c-9761" type="greaterThan"/>
+                    <condition field="selections" scope="012b-109f-74d2-2c82" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="63ce-0429-b209-c3e9" type="greaterThan"/>
+                    <condition field="selections" scope="012b-109f-74d2-2c82" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3dc3-9018-b7a3-8cf9" type="greaterThan"/>
+                    <condition field="selections" scope="012b-109f-74d2-2c82" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f4a8-b2a3-1c3c-9761" type="greaterThan"/>
                   </conditions>
                 </conditionGroup>
               </conditionGroups>
             </modifier>
             <modifier type="increment" field="2490-aa2f-f5db-6070" value="1">
               <conditions>
-                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1682-2560-347c-e798" type="greaterThan"/>
+                <condition field="selections" scope="012b-109f-74d2-2c82" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1682-2560-347c-e798" type="greaterThan"/>
               </conditions>
             </modifier>
             <modifier type="increment" field="6c5a-df71-fefa-2ee3" value="1">
               <conditionGroups>
                 <conditionGroup type="or">
                   <conditions>
-                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="63ce-0429-b209-c3e9" type="greaterThan"/>
-                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e78c-787d-54ca-82c2" type="greaterThan"/>
-                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4b90-1389-3b29-3fca" type="greaterThan"/>
+                    <condition field="selections" scope="012b-109f-74d2-2c82" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="63ce-0429-b209-c3e9" type="greaterThan"/>
+                    <condition field="selections" scope="012b-109f-74d2-2c82" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e78c-787d-54ca-82c2" type="greaterThan"/>
+                    <condition field="selections" scope="012b-109f-74d2-2c82" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4b90-1389-3b29-3fca" type="greaterThan"/>
                   </conditions>
                 </conditionGroup>
               </conditionGroups>
             </modifier>
             <modifier type="increment" field="7f12-0cc3-9dcd-25bc" value="4">
               <conditions>
-                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7f03-d8c0-0e83-1f6e" type="greaterThan"/>
+                <condition field="selections" scope="012b-109f-74d2-2c82" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7f03-d8c0-0e83-1f6e" type="greaterThan"/>
               </conditions>
             </modifier>
           </modifiers>
@@ -3153,7 +3153,7 @@ Invulnerable Saves granted by a mag-inverter shield do not stack with other Invu
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7f03-d8c0-0e83-1f6e" type="equalTo"/>
+                <condition field="selections" scope="012b-109f-74d2-2c82" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7f03-d8c0-0e83-1f6e" type="equalTo"/>
               </conditions>
             </modifier>
           </modifiers>
@@ -3162,7 +3162,7 @@ Invulnerable Saves granted by a mag-inverter shield do not stack with other Invu
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7f03-d8c0-0e83-1f6e" type="equalTo"/>
+                <condition field="selections" scope="012b-109f-74d2-2c82" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7f03-d8c0-0e83-1f6e" type="equalTo"/>
               </conditions>
             </modifier>
           </modifiers>
@@ -3332,62 +3332,62 @@ Invulnerable Saves granted by a mag-inverter shield do not stack with other Invu
               <conditionGroups>
                 <conditionGroup type="or">
                   <conditions>
-                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e78c-787d-54ca-82c2" type="greaterThan"/>
-                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f4a8-b2a3-1c3c-9761" type="greaterThan"/>
-                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7f03-d8c0-0e83-1f6e" type="greaterThan"/>
-                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1682-2560-347c-e798" type="greaterThan"/>
-                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4b90-1389-3b29-3fca" type="greaterThan"/>
-                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3dc3-9018-b7a3-8cf9" type="greaterThan"/>
-                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="63ce-0429-b209-c3e9" type="greaterThan"/>
+                    <condition field="selections" scope="6d0e-0d72-d9e2-01d1" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e78c-787d-54ca-82c2" type="greaterThan"/>
+                    <condition field="selections" scope="6d0e-0d72-d9e2-01d1" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f4a8-b2a3-1c3c-9761" type="greaterThan"/>
+                    <condition field="selections" scope="6d0e-0d72-d9e2-01d1" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7f03-d8c0-0e83-1f6e" type="greaterThan"/>
+                    <condition field="selections" scope="6d0e-0d72-d9e2-01d1" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1682-2560-347c-e798" type="greaterThan"/>
+                    <condition field="selections" scope="6d0e-0d72-d9e2-01d1" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4b90-1389-3b29-3fca" type="greaterThan"/>
+                    <condition field="selections" scope="6d0e-0d72-d9e2-01d1" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3dc3-9018-b7a3-8cf9" type="greaterThan"/>
+                    <condition field="selections" scope="6d0e-0d72-d9e2-01d1" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="63ce-0429-b209-c3e9" type="greaterThan"/>
                   </conditions>
                 </conditionGroup>
               </conditionGroups>
             </modifier>
             <modifier type="decrement" field="7f12-0cc3-9dcd-25bc" value="2">
               <conditions>
-                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7496-3ece-e6d8-6d40" type="greaterThan"/>
+                <condition field="selections" scope="6d0e-0d72-d9e2-01d1" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7496-3ece-e6d8-6d40" type="greaterThan"/>
               </conditions>
             </modifier>
             <modifier type="decrement" field="6c5a-df71-fefa-2ee3" value="1">
               <conditions>
-                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7496-3ece-e6d8-6d40" type="greaterThan"/>
+                <condition field="selections" scope="6d0e-0d72-d9e2-01d1" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7496-3ece-e6d8-6d40" type="greaterThan"/>
               </conditions>
             </modifier>
             <modifier type="decrement" field="4227-8eed-0c5c-a2d9" value="1">
               <conditions>
-                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7496-3ece-e6d8-6d40" type="greaterThan"/>
+                <condition field="selections" scope="6d0e-0d72-d9e2-01d1" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7496-3ece-e6d8-6d40" type="greaterThan"/>
               </conditions>
             </modifier>
             <modifier type="increment" field="4227-8eed-0c5c-a2d9" value="1">
               <conditionGroups>
                 <conditionGroup type="or">
                   <conditions>
-                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="63ce-0429-b209-c3e9" type="greaterThan"/>
-                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3dc3-9018-b7a3-8cf9" type="greaterThan"/>
-                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f4a8-b2a3-1c3c-9761" type="greaterThan"/>
+                    <condition field="selections" scope="6d0e-0d72-d9e2-01d1" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="63ce-0429-b209-c3e9" type="greaterThan"/>
+                    <condition field="selections" scope="6d0e-0d72-d9e2-01d1" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3dc3-9018-b7a3-8cf9" type="greaterThan"/>
+                    <condition field="selections" scope="6d0e-0d72-d9e2-01d1" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f4a8-b2a3-1c3c-9761" type="greaterThan"/>
                   </conditions>
                 </conditionGroup>
               </conditionGroups>
             </modifier>
             <modifier type="increment" field="2490-aa2f-f5db-6070" value="1">
               <conditions>
-                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1682-2560-347c-e798" type="greaterThan"/>
+                <condition field="selections" scope="6d0e-0d72-d9e2-01d1" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1682-2560-347c-e798" type="greaterThan"/>
               </conditions>
             </modifier>
             <modifier type="increment" field="6c5a-df71-fefa-2ee3" value="1">
               <conditionGroups>
                 <conditionGroup type="or">
                   <conditions>
-                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="63ce-0429-b209-c3e9" type="greaterThan"/>
-                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e78c-787d-54ca-82c2" type="greaterThan"/>
-                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4b90-1389-3b29-3fca" type="greaterThan"/>
+                    <condition field="selections" scope="6d0e-0d72-d9e2-01d1" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="63ce-0429-b209-c3e9" type="greaterThan"/>
+                    <condition field="selections" scope="6d0e-0d72-d9e2-01d1" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e78c-787d-54ca-82c2" type="greaterThan"/>
+                    <condition field="selections" scope="6d0e-0d72-d9e2-01d1" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4b90-1389-3b29-3fca" type="greaterThan"/>
                   </conditions>
                 </conditionGroup>
               </conditionGroups>
             </modifier>
             <modifier type="increment" field="7f12-0cc3-9dcd-25bc" value="4">
               <conditions>
-                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7f03-d8c0-0e83-1f6e" type="greaterThan"/>
+                <condition field="selections" scope="6d0e-0d72-d9e2-01d1" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7f03-d8c0-0e83-1f6e" type="greaterThan"/>
               </conditions>
             </modifier>
           </modifiers>
@@ -3411,7 +3411,7 @@ Invulnerable Saves granted by a mag-inverter shield do not stack with other Invu
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7f03-d8c0-0e83-1f6e" type="equalTo"/>
+                <condition field="selections" scope="6d0e-0d72-d9e2-01d1" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7f03-d8c0-0e83-1f6e" type="equalTo"/>
               </conditions>
             </modifier>
           </modifiers>
@@ -3420,7 +3420,7 @@ Invulnerable Saves granted by a mag-inverter shield do not stack with other Invu
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7f03-d8c0-0e83-1f6e" type="equalTo"/>
+                <condition field="selections" scope="6d0e-0d72-d9e2-01d1" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7f03-d8c0-0e83-1f6e" type="equalTo"/>
               </conditions>
             </modifier>
           </modifiers>
@@ -3539,62 +3539,62 @@ Invulnerable Saves granted by a mag-inverter shield do not stack with other Invu
               <conditionGroups>
                 <conditionGroup type="or">
                   <conditions>
-                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e78c-787d-54ca-82c2" type="greaterThan"/>
-                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f4a8-b2a3-1c3c-9761" type="greaterThan"/>
-                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7f03-d8c0-0e83-1f6e" type="greaterThan"/>
-                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1682-2560-347c-e798" type="greaterThan"/>
-                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4b90-1389-3b29-3fca" type="greaterThan"/>
-                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3dc3-9018-b7a3-8cf9" type="greaterThan"/>
-                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="63ce-0429-b209-c3e9" type="greaterThan"/>
+                    <condition field="selections" scope="1944-033c-5b7e-a378" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e78c-787d-54ca-82c2" type="greaterThan"/>
+                    <condition field="selections" scope="1944-033c-5b7e-a378" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f4a8-b2a3-1c3c-9761" type="greaterThan"/>
+                    <condition field="selections" scope="1944-033c-5b7e-a378" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7f03-d8c0-0e83-1f6e" type="greaterThan"/>
+                    <condition field="selections" scope="1944-033c-5b7e-a378" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1682-2560-347c-e798" type="greaterThan"/>
+                    <condition field="selections" scope="1944-033c-5b7e-a378" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4b90-1389-3b29-3fca" type="greaterThan"/>
+                    <condition field="selections" scope="1944-033c-5b7e-a378" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3dc3-9018-b7a3-8cf9" type="greaterThan"/>
+                    <condition field="selections" scope="1944-033c-5b7e-a378" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="63ce-0429-b209-c3e9" type="greaterThan"/>
                   </conditions>
                 </conditionGroup>
               </conditionGroups>
             </modifier>
             <modifier type="decrement" field="7f12-0cc3-9dcd-25bc" value="2">
               <conditions>
-                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7496-3ece-e6d8-6d40" type="greaterThan"/>
+                <condition field="selections" scope="1944-033c-5b7e-a378" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7496-3ece-e6d8-6d40" type="greaterThan"/>
               </conditions>
             </modifier>
             <modifier type="decrement" field="6c5a-df71-fefa-2ee3" value="1">
               <conditions>
-                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7496-3ece-e6d8-6d40" type="greaterThan"/>
+                <condition field="selections" scope="1944-033c-5b7e-a378" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7496-3ece-e6d8-6d40" type="greaterThan"/>
               </conditions>
             </modifier>
             <modifier type="decrement" field="4227-8eed-0c5c-a2d9" value="1">
               <conditions>
-                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7496-3ece-e6d8-6d40" type="greaterThan"/>
+                <condition field="selections" scope="1944-033c-5b7e-a378" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7496-3ece-e6d8-6d40" type="greaterThan"/>
               </conditions>
             </modifier>
             <modifier type="increment" field="4227-8eed-0c5c-a2d9" value="1">
               <conditionGroups>
                 <conditionGroup type="or">
                   <conditions>
-                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="63ce-0429-b209-c3e9" type="greaterThan"/>
-                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3dc3-9018-b7a3-8cf9" type="greaterThan"/>
-                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f4a8-b2a3-1c3c-9761" type="greaterThan"/>
+                    <condition field="selections" scope="1944-033c-5b7e-a378" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="63ce-0429-b209-c3e9" type="greaterThan"/>
+                    <condition field="selections" scope="1944-033c-5b7e-a378" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3dc3-9018-b7a3-8cf9" type="greaterThan"/>
+                    <condition field="selections" scope="1944-033c-5b7e-a378" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f4a8-b2a3-1c3c-9761" type="greaterThan"/>
                   </conditions>
                 </conditionGroup>
               </conditionGroups>
             </modifier>
             <modifier type="increment" field="2490-aa2f-f5db-6070" value="1">
               <conditions>
-                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1682-2560-347c-e798" type="greaterThan"/>
+                <condition field="selections" scope="1944-033c-5b7e-a378" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1682-2560-347c-e798" type="greaterThan"/>
               </conditions>
             </modifier>
             <modifier type="increment" field="6c5a-df71-fefa-2ee3" value="1">
               <conditionGroups>
                 <conditionGroup type="or">
                   <conditions>
-                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="63ce-0429-b209-c3e9" type="greaterThan"/>
-                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e78c-787d-54ca-82c2" type="greaterThan"/>
-                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4b90-1389-3b29-3fca" type="greaterThan"/>
+                    <condition field="selections" scope="1944-033c-5b7e-a378" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="63ce-0429-b209-c3e9" type="greaterThan"/>
+                    <condition field="selections" scope="1944-033c-5b7e-a378" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e78c-787d-54ca-82c2" type="greaterThan"/>
+                    <condition field="selections" scope="1944-033c-5b7e-a378" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4b90-1389-3b29-3fca" type="greaterThan"/>
                   </conditions>
                 </conditionGroup>
               </conditionGroups>
             </modifier>
             <modifier type="increment" field="7f12-0cc3-9dcd-25bc" value="4">
               <conditions>
-                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7f03-d8c0-0e83-1f6e" type="greaterThan"/>
+                <condition field="selections" scope="1944-033c-5b7e-a378" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7f03-d8c0-0e83-1f6e" type="greaterThan"/>
               </conditions>
             </modifier>
           </modifiers>
@@ -3618,7 +3618,7 @@ Invulnerable Saves granted by a mag-inverter shield do not stack with other Invu
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7f03-d8c0-0e83-1f6e" type="equalTo"/>
+                <condition field="selections" scope="1944-033c-5b7e-a378" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7f03-d8c0-0e83-1f6e" type="equalTo"/>
               </conditions>
             </modifier>
           </modifiers>
@@ -3627,7 +3627,7 @@ Invulnerable Saves granted by a mag-inverter shield do not stack with other Invu
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7f03-d8c0-0e83-1f6e" type="equalTo"/>
+                <condition field="selections" scope="1944-033c-5b7e-a378" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7f03-d8c0-0e83-1f6e" type="equalTo"/>
               </conditions>
             </modifier>
           </modifiers>


### PR DESCRIPTION
Terminator Indomitus Squad default heavy weapon fixed.
Acastus Knight Asterius had Macro-extinction Targeting Protocols by mistake.
Spreading Corruption for Horus Ascended was not included in BS. Should be now. Also slight rework on some of the unit subtype additions as it was getting more complex with multiple situations. All are now added as "Append" to the name. This also means that PA/AA Centurion, Praetor, Apoth, Techmarines & Command Squads should now have a Cavalry profile and infantry profile that works. 
Nullificators cost fixed

