### PR TITLE
Tactical Inductii

### DIFF
--- a/2022 - Legiones Astartes.cat
+++ b/2022 - Legiones Astartes.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="6393-649c-7213-a327" name="(HH V2) Legions Astartes" revision="137" battleScribeVersion="2.03" authorName="Various" authorUrl="https://github.com/BSData/horus-heresy" library="true" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="68" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="6393-649c-7213-a327" name="(HH V2) Legions Astartes" revision="138" battleScribeVersion="2.03" authorName="Various" authorUrl="https://github.com/BSData/horus-heresy" library="true" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="68" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="0594-a9b0-6f10-090e" name="Legion Javelin Squadron Updade" publisher="Warhammer Community Downloads" publicationDate="May 2023" publisherUrl="https://www.warhammer-community.com/wp-content/uploads/2023/05/hd7WOnm2lKCHkskG.pdf"/>
     <publication id="acdb-27b7-6b7e-932f" name="Legion Mastodon Updade" publisher="Warhammer Community Downloads" publicationDate="May 2023" publisherUrl="https://www.warhammer-community.com/wp-content/uploads/2023/05/AopGHpxowuowkwJw.pdf"/>
@@ -207,6 +207,17 @@
       <constraints>
         <constraint field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a6a3-10fc-a22d-153e" type="max"/>
       </constraints>
+    </categoryEntry>
+    <categoryEntry id="aadc-a0cf-e49e-0358" name="Inductii Sub-type" publicationId="53a4-0d21-2f8a-2c45" page="225-234" hidden="false">
+      <rules>
+        <rule id="a25e-8e3a-f368-4ac7" name="Inductii Sub-type" publicationId="53a4-0d21-2f8a-2c45" page="225" hidden="false">
+          <description>The following rules apply to all models with the Inductii Unit Sub-type:
+• A unit that includes any models with the Inductii Unit Sub-type cannot be joined by any other models or have any other models assigned to it.
+• No model in a unit that includes any models with the Inductii Unit Sub-type can exchange their power armour for artificer armour.
+• A unit that includes any models with the Inductii Unit Sub-type has the Support Squad special rule.
+Additional rules are given to units based on Legion and Unit.</description>
+        </rule>
+      </rules>
     </categoryEntry>
   </categoryEntries>
   <selectionEntries>
@@ -4238,6 +4249,21 @@ When a model has two Raven’s Talons, that model gains +2 Attacks instead of th
             </conditionGroup>
           </conditionGroups>
         </modifier>
+        <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+          <conditions>
+            <condition field="selections" scope="aa72-63e4-bc60-4611" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8e05-7d1e-16e4-1669" type="equalTo"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" field="name" value="(Inductii)">
+          <conditions>
+            <condition field="selections" scope="aa72-63e4-bc60-4611" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8e05-7d1e-16e4-1669" type="equalTo"/>
+          </conditions>
+        </modifier>
+        <modifier type="add" field="category" value="aadc-a0cf-e49e-0358">
+          <conditions>
+            <condition field="selections" scope="aa72-63e4-bc60-4611" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8e05-7d1e-16e4-1669" type="equalTo"/>
+          </conditions>
+        </modifier>
       </modifiers>
       <modifierGroups>
         <modifierGroup>
@@ -4281,13 +4307,57 @@ When a model has two Raven’s Talons, that model gains +2 Attacks instead of th
         <infoLink id="5af3-9ace-5f52-ec8b" name="Fury of the Legion" hidden="false" targetId="56e4-5bbb-91bd-13e0" type="rule">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
-              <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1d51-72ff-c102-09d3" type="equalTo"/>
-              </conditions>
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1d51-72ff-c102-09d3" type="equalTo"/>
+                  </conditions>
+                  <conditionGroups>
+                    <conditionGroup type="and">
+                      <conditions>
+                        <condition field="selections" scope="aa72-63e4-bc60-4611" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8e05-7d1e-16e4-1669" type="equalTo"/>
+                      </conditions>
+                      <conditionGroups>
+                        <conditionGroup type="or">
+                          <conditions>
+                            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="21c3-2f28-7820-e51a" type="equalTo"/>
+                            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8e0f-3552-8842-f281" type="equalTo"/>
+                            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b2b4-2198-0b90-dd9f" type="equalTo"/>
+                            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bfc9-c99c-bf8a-3917" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </conditionGroup>
+                  </conditionGroups>
+                </conditionGroup>
+              </conditionGroups>
             </modifier>
           </modifiers>
         </infoLink>
-        <infoLink id="95f0-d144-1ce5-89c1" name="Heart of the Legion" hidden="false" targetId="c0dd-9002-2ebd-f96d" type="rule"/>
+        <infoLink id="95f0-d144-1ce5-89c1" name="Heart of the Legion" hidden="false" targetId="c0dd-9002-2ebd-f96d" type="rule">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditionGroups>
+                <conditionGroup type="and">
+                  <conditions>
+                    <condition field="selections" scope="aa72-63e4-bc60-4611" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8e05-7d1e-16e4-1669" type="equalTo"/>
+                  </conditions>
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dd1f-1c51-706c-e5f7" type="equalTo"/>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5f54-457a-fbb9-6730" type="equalTo"/>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a0e1-f2c4-8bcd-0723" type="equalTo"/>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c0df-c1fa-5ddc-9ee5" type="equalTo"/>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dc34-fe08-dd44-fb99" type="equalTo"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
+        </infoLink>
         <infoLink id="aa1b-df62-64b9-be58" name="Outflank" hidden="false" targetId="bfbf-e75c-49a2-0285" type="rule">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
@@ -4299,6 +4369,29 @@ When a model has two Raven’s Talons, that model gains +2 Attacks instead of th
                   </conditions>
                 </conditionGroup>
               </conditionGroups>
+            </modifier>
+          </modifiers>
+        </infoLink>
+        <infoLink id="c787-28bf-977d-643f" name="Inexorable" hidden="false" targetId="d863-8a5e-ddb6-d5a4" type="rule">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="aa72-63e4-bc60-4611" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8e05-7d1e-16e4-1669" type="equalTo"/>
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8e0f-3552-8842-f281" type="equalTo"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
+        </infoLink>
+        <infoLink id="ee05-b9e9-df3b-871d" name="Support Squad" hidden="false" targetId="768e-56d6-ca52-24ae" type="rule">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="aa72-63e4-bc60-4611" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8e05-7d1e-16e4-1669" type="equalTo"/>
+              </conditions>
             </modifier>
           </modifiers>
         </infoLink>
@@ -4338,6 +4431,16 @@ When a model has two Raven’s Talons, that model gains +2 Attacks instead of th
                       <conditions>
                         <condition field="selections" scope="aa72-63e4-bc60-4611" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f783-f0ea-fe35-cdeb" type="equalTo"/>
                         <condition field="selections" scope="aa72-63e4-bc60-4611" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="555f-3998-a06e-f415" type="equalTo"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+                <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Heavy)">
+                  <conditionGroups>
+                    <conditionGroup type="and">
+                      <conditions>
+                        <condition field="selections" scope="aa72-63e4-bc60-4611" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8e05-7d1e-16e4-1669" type="equalTo"/>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bfc9-c99c-bf8a-3917" type="equalTo"/>
                       </conditions>
                     </conditionGroup>
                   </conditionGroups>
@@ -4500,31 +4603,103 @@ When a model has two Raven’s Talons, that model gains +2 Attacks instead of th
               </constraints>
               <entryLinks>
                 <entryLink id="a367-3e76-e4ed-ac05" name="Magna Combi-Weapon - Meltagun" hidden="false" collective="false" import="true" targetId="0d1c-227e-a3f8-cd63" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="true">
+                      <conditionGroups>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="aa72-63e4-bc60-4611" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8e05-7d1e-16e4-1669" type="equalTo"/>
+                            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b2b4-2198-0b90-dd9f" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                  </modifiers>
                   <costs>
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
                   </costs>
                 </entryLink>
                 <entryLink id="48d2-0b3d-8913-cd6f" name="Magna Combi-Weapon - Plasma Gun" hidden="false" collective="false" import="true" targetId="cc98-8596-c713-516c" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="true">
+                      <conditionGroups>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="aa72-63e4-bc60-4611" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8e05-7d1e-16e4-1669" type="equalTo"/>
+                            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b2b4-2198-0b90-dd9f" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                  </modifiers>
                   <costs>
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
                   </costs>
                 </entryLink>
                 <entryLink id="848c-b847-4e79-5ed1" name="Minor Combi-Weapon - Flamer" hidden="false" collective="false" import="true" targetId="34c4-db99-db36-0f2a" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="true">
+                      <conditionGroups>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="aa72-63e4-bc60-4611" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8e05-7d1e-16e4-1669" type="equalTo"/>
+                            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b2b4-2198-0b90-dd9f" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                  </modifiers>
                   <costs>
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
                   </costs>
                 </entryLink>
                 <entryLink id="0781-d2ec-21c0-8ce2" name="Minor Combi-Weapon - Grenade Launcher" hidden="false" collective="false" import="true" targetId="aa3c-f5a5-9ce9-1497" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="true">
+                      <conditionGroups>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="aa72-63e4-bc60-4611" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8e05-7d1e-16e4-1669" type="equalTo"/>
+                            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b2b4-2198-0b90-dd9f" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                  </modifiers>
                   <costs>
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
                   </costs>
                 </entryLink>
                 <entryLink id="2a0d-dd03-0655-2c69" name="Minor Combi-Weapon - Volkite Charger" hidden="false" collective="false" import="true" targetId="7e5c-3d25-5c88-32e0" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="true">
+                      <conditionGroups>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="aa72-63e4-bc60-4611" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8e05-7d1e-16e4-1669" type="equalTo"/>
+                            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b2b4-2198-0b90-dd9f" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                  </modifiers>
                   <costs>
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
                   </costs>
                 </entryLink>
                 <entryLink id="af7d-53ea-8af1-bd06" name="Minor Combi-Weapon - Alchem Flamer" hidden="false" collective="false" import="true" targetId="b941-687c-c95e-31a6" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="true">
+                      <conditionGroups>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="aa72-63e4-bc60-4611" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8e05-7d1e-16e4-1669" type="equalTo"/>
+                            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b2b4-2198-0b90-dd9f" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                  </modifiers>
                   <costs>
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
                   </costs>
@@ -4548,10 +4723,45 @@ When a model has two Raven’s Talons, that model gains +2 Attacks instead of th
                             <condition field="selections" scope="aa72-63e4-bc60-4611" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="db53-8568-775f-1ab9" type="atLeast"/>
                             <condition field="selections" scope="aa72-63e4-bc60-4611" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1941-21b5-932c-74d6" type="atLeast"/>
                           </conditions>
+                          <conditionGroups>
+                            <conditionGroup type="and">
+                              <conditions>
+                                <condition field="selections" scope="aa72-63e4-bc60-4611" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8e05-7d1e-16e4-1669" type="equalTo"/>
+                                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b2b4-2198-0b90-dd9f" type="equalTo"/>
+                              </conditions>
+                            </conditionGroup>
+                          </conditionGroups>
                         </conditionGroup>
                       </conditionGroups>
                     </modifier>
                   </modifiers>
+                </entryLink>
+                <entryLink id="2dc0-62a6-66c1-6ba9" name="Volkite Charger" hidden="false" collective="false" import="true" targetId="5c82-c306-9c5c-5908" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="291e-c8c9-1759-7d7d" value="1.0">
+                      <conditionGroups>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="aa72-63e4-bc60-4611" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8e05-7d1e-16e4-1669" type="equalTo"/>
+                            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b2b4-2198-0b90-dd9f" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                    <modifier type="set" field="hidden" value="true">
+                      <conditionGroups>
+                        <conditionGroup type="or">
+                          <conditions>
+                            <condition field="selections" scope="aa72-63e4-bc60-4611" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8e05-7d1e-16e4-1669" type="equalTo"/>
+                            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b2b4-2198-0b90-dd9f" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="291e-c8c9-1759-7d7d" type="min"/>
+                  </constraints>
                 </entryLink>
               </entryLinks>
             </selectionEntryGroup>
@@ -4612,7 +4822,7 @@ When a model has two Raven’s Talons, that model gains +2 Attacks instead of th
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
                   </costs>
                 </entryLink>
-                <entryLink id="c73b-2ab3-7263-abb5" name="Cult Arcana:" hidden="false" collective="false" import="true" targetId="e6a0-3ea2-f7ca-411f" type="selectionEntryGroup"/>
+                <entryLink id="c73b-2ab3-7263-abb5" name="Prosperine Arcana:" hidden="false" collective="false" import="true" targetId="e6a0-3ea2-f7ca-411f" type="selectionEntryGroup"/>
                 <entryLink id="98b2-0701-ed54-dd04" name="Surgical Augment (Unit Character)" hidden="false" collective="false" import="true" targetId="aeb3-6a73-da1d-2b90" type="selectionEntryGroup">
                   <modifiers>
                     <modifier type="set" field="fdb8-3892-38d6-d7f8" value="1.0">
@@ -4658,6 +4868,23 @@ When a model has two Raven’s Talons, that model gains +2 Attacks instead of th
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
                   </costs>
                 </entryLink>
+                <entryLink id="1df1-5dc7-eb17-3b52" name="Phosphex Bomb" hidden="true" collective="false" import="true" targetId="4188-13ff-cb03-109e" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="false">
+                      <conditionGroups>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="aa72-63e4-bc60-4611" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8e05-7d1e-16e4-1669" type="equalTo"/>
+                            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bfc9-c99c-bf8a-3917" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d754-d87e-7c8b-cd31" type="max"/>
+                  </constraints>
+                </entryLink>
               </entryLinks>
             </selectionEntryGroup>
             <selectionEntryGroup id="4302-142c-0a3c-fd5c" name="4) Armor:" hidden="false" collective="false" import="true" defaultSelectionEntryId="baad-4707-3cd4-2c27">
@@ -4672,6 +4899,18 @@ When a model has two Raven’s Talons, that model gains +2 Attacks instead of th
                   </constraints>
                 </entryLink>
                 <entryLink id="4a6d-2892-69ef-920a" name="Artificer Armour" hidden="false" collective="false" import="true" targetId="583e-62cb-53f1-f952" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="true">
+                      <conditions>
+                        <condition field="selections" scope="aa72-63e4-bc60-4611" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8e05-7d1e-16e4-1669" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="set" field="fbf2-aeb7-4532-d24c" value="1.0">
+                      <conditions>
+                        <condition field="selections" scope="aa72-63e4-bc60-4611" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8e05-7d1e-16e4-1669" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fbf2-aeb7-4532-d24c" type="max"/>
                   </constraints>
@@ -4684,9 +4923,21 @@ When a model has two Raven’s Talons, that model gains +2 Attacks instead of th
             <selectionEntryGroup id="b2de-10d9-f7de-c517" name="1.5) Bayonet:" hidden="false" collective="false" import="true">
               <modifiers>
                 <modifier type="set" field="hidden" value="true">
-                  <conditions>
-                    <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="1ade-0c02-5612-252b" type="lessThan"/>
-                  </conditions>
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="1ade-0c02-5612-252b" type="lessThan"/>
+                      </conditions>
+                      <conditionGroups>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="aa72-63e4-bc60-4611" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8e05-7d1e-16e4-1669" type="equalTo"/>
+                            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b2b4-2198-0b90-dd9f" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </conditionGroup>
+                  </conditionGroups>
                 </modifier>
               </modifiers>
               <constraints>
@@ -4899,10 +5150,36 @@ When a model has two Raven’s Talons, that model gains +2 Attacks instead of th
         </selectionEntryGroup>
         <selectionEntryGroup id="f115-cfc4-4199-f8be" name="0) Legionaries" hidden="false" collective="false" import="true" defaultSelectionEntryId="8b28-bdec-1540-5a47">
           <modifiers>
-            <modifier type="set" field="71df-60e6-c9cb-7776" value="14.0">
-              <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7b69-bf2f-4547-e83b" type="atLeast"/>
-              </conditions>
+            <modifier type="decrement" field="71df-60e6-c9cb-7776" value="10.0">
+              <conditionGroups>
+                <conditionGroup type="and">
+                  <conditions>
+                    <condition field="selections" scope="aa72-63e4-bc60-4611" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8e05-7d1e-16e4-1669" type="equalTo"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8e0f-3552-8842-f281" type="equalTo"/>
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7b69-bf2f-4547-e83b" type="equalTo"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+            <modifier type="decrement" field="71df-60e6-c9cb-7776" value="5.0">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7b69-bf2f-4547-e83b" type="atLeast"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+            <modifier type="decrement" field="71df-60e6-c9cb-7776" value="5.0">
+              <conditionGroups>
+                <conditionGroup type="and">
+                  <conditions>
+                    <condition field="selections" scope="aa72-63e4-bc60-4611" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8e05-7d1e-16e4-1669" type="equalTo"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8e0f-3552-8842-f281" type="equalTo"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7b69-bf2f-4547-e83b" type="atLeast"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
             </modifier>
           </modifiers>
           <constraints>
@@ -4911,6 +5188,9 @@ When a model has two Raven’s Talons, that model gains +2 Attacks instead of th
           </constraints>
           <selectionEntries>
             <selectionEntry id="dc0d-09ea-cb42-dc75" name="Legionary w/ Options:" hidden="false" collective="false" import="true" type="model">
+              <constraints>
+                <constraint field="selections" scope="parent" value="19.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="01a8-1938-3c87-a279" type="max"/>
+              </constraints>
               <infoLinks>
                 <infoLink id="34a6-a2af-2152-d43d" name="Legionary" hidden="false" targetId="5bf2-8597-cc05-f7c5" type="profile"/>
               </infoLinks>
@@ -4954,6 +5234,140 @@ When a model has two Raven’s Talons, that model gains +2 Attacks instead of th
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8771-3ce1-f5fd-9788" type="max"/>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1a62-234d-8f11-2129" type="min"/>
                   </constraints>
+                  <selectionEntryGroups>
+                    <selectionEntryGroup id="e515-ce67-f49e-08dc" name="1 in 10 may exchange his Bolter for:" hidden="false" collective="false" import="true">
+                      <modifiers>
+                        <modifier type="increment" field="84e0-7329-3b7c-bbbc" value="1.0">
+                          <repeats>
+                            <repeat field="selections" scope="aa72-63e4-bc60-4611" value="10.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+                          </repeats>
+                        </modifier>
+                        <modifier type="set" field="hidden" value="true">
+                          <conditionGroups>
+                            <conditionGroup type="or">
+                              <conditions>
+                                <condition field="selections" scope="aa72-63e4-bc60-4611" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8e05-7d1e-16e4-1669" type="equalTo"/>
+                                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a0e1-f2c4-8bcd-0723" type="equalTo"/>
+                              </conditions>
+                            </conditionGroup>
+                          </conditionGroups>
+                        </modifier>
+                      </modifiers>
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8dfa-2958-36c0-d220" type="max"/>
+                        <constraint field="selections" scope="aa72-63e4-bc60-4611" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="84e0-7329-3b7c-bbbc" type="max"/>
+                      </constraints>
+                      <entryLinks>
+                        <entryLink id="c67d-00ef-6d2f-3250" name="Heavy Bolter" hidden="false" collective="false" import="true" targetId="07fd-c24a-9235-4206" type="selectionEntry">
+                          <constraints>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ca31-c057-5f13-dd7b" type="max"/>
+                          </constraints>
+                          <costs>
+                            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                          </costs>
+                        </entryLink>
+                        <entryLink id="23bf-c375-bf6f-f125" name="Autocannon" hidden="false" collective="false" import="true" targetId="56b3-de09-9fea-deb6" type="selectionEntry">
+                          <constraints>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9885-cbbe-ac8b-9fd9" type="max"/>
+                          </constraints>
+                          <costs>
+                            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                          </costs>
+                        </entryLink>
+                      </entryLinks>
+                    </selectionEntryGroup>
+                    <selectionEntryGroup id="e08b-7324-bdf2-b227" name="1 in 5 may exchange his Bolter for:" hidden="false" collective="false" import="true">
+                      <modifiers>
+                        <modifier type="increment" field="ecac-a97c-0d40-f30b" value="1.0">
+                          <repeats>
+                            <repeat field="selections" scope="aa72-63e4-bc60-4611" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+                          </repeats>
+                        </modifier>
+                        <modifier type="set" field="hidden" value="true">
+                          <conditionGroups>
+                            <conditionGroup type="or">
+                              <conditions>
+                                <condition field="selections" scope="aa72-63e4-bc60-4611" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8e05-7d1e-16e4-1669" type="equalTo"/>
+                              </conditions>
+                              <conditionGroups>
+                                <conditionGroup type="and">
+                                  <conditions>
+                                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dd1f-1c51-706c-e5f7" type="equalTo"/>
+                                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8e0f-3552-8842-f281" type="equalTo"/>
+                                  </conditions>
+                                </conditionGroup>
+                              </conditionGroups>
+                            </conditionGroup>
+                          </conditionGroups>
+                        </modifier>
+                      </modifiers>
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f348-736b-70cc-1de3" type="max"/>
+                        <constraint field="selections" scope="aa72-63e4-bc60-4611" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ecac-a97c-0d40-f30b" type="max"/>
+                      </constraints>
+                      <entryLinks>
+                        <entryLink id="037e-b141-3efa-c8b7" name="Alchem Flamer" hidden="false" collective="false" import="true" targetId="0d08-eaaf-3793-0a70" type="selectionEntry">
+                          <constraints>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0d85-0a41-59c0-9709" type="max"/>
+                          </constraints>
+                          <costs>
+                            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                          </costs>
+                        </entryLink>
+                        <entryLink id="f43f-60cb-cf40-a280" name="Flamer" hidden="false" collective="false" import="true" targetId="9f41-82e2-90f6-973a" type="selectionEntry">
+                          <modifiers>
+                            <modifier type="set" field="hidden" value="true">
+                              <conditionGroups>
+                                <conditionGroup type="or">
+                                  <conditions>
+                                    <condition field="selections" scope="aa72-63e4-bc60-4611" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8e05-7d1e-16e4-1669" type="equalTo"/>
+                                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8e0f-3552-8842-f281" type="equalTo"/>
+                                  </conditions>
+                                </conditionGroup>
+                              </conditionGroups>
+                            </modifier>
+                          </modifiers>
+                          <costs>
+                            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                          </costs>
+                        </entryLink>
+                        <entryLink id="cba8-53de-46cd-e8ad" name="Plasma Gun" hidden="false" collective="false" import="true" targetId="f0d1-332b-c719-ede7" type="selectionEntry">
+                          <modifiers>
+                            <modifier type="set" field="hidden" value="true">
+                              <conditionGroups>
+                                <conditionGroup type="or">
+                                  <conditions>
+                                    <condition field="selections" scope="aa72-63e4-bc60-4611" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8e05-7d1e-16e4-1669" type="equalTo"/>
+                                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8e0f-3552-8842-f281" type="equalTo"/>
+                                  </conditions>
+                                </conditionGroup>
+                              </conditionGroups>
+                            </modifier>
+                          </modifiers>
+                          <costs>
+                            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                          </costs>
+                        </entryLink>
+                        <entryLink id="b8da-5a69-8fb0-ab3c" name="Meltagun" hidden="false" collective="false" import="true" targetId="4ebd-57e0-3560-e568" type="selectionEntry">
+                          <modifiers>
+                            <modifier type="set" field="hidden" value="true">
+                              <conditionGroups>
+                                <conditionGroup type="or">
+                                  <conditions>
+                                    <condition field="selections" scope="aa72-63e4-bc60-4611" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8e05-7d1e-16e4-1669" type="equalTo"/>
+                                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8e0f-3552-8842-f281" type="equalTo"/>
+                                  </conditions>
+                                </conditionGroup>
+                              </conditionGroups>
+                            </modifier>
+                          </modifiers>
+                          <costs>
+                            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                          </costs>
+                        </entryLink>
+                      </entryLinks>
+                    </selectionEntryGroup>
+                  </selectionEntryGroups>
                   <entryLinks>
                     <entryLink id="2468-9746-e997-217e" name="Bolter" hidden="false" collective="false" import="true" targetId="1ade-0c02-5612-252b" type="selectionEntry">
                       <modifiers>
@@ -4964,6 +5378,14 @@ When a model has two Raven’s Talons, that model gains +2 Attacks instead of th
                                 <condition field="selections" scope="aa72-63e4-bc60-4611" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="db53-8568-775f-1ab9" type="atLeast"/>
                                 <condition field="selections" scope="aa72-63e4-bc60-4611" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1941-21b5-932c-74d6" type="atLeast"/>
                               </conditions>
+                              <conditionGroups>
+                                <conditionGroup type="and">
+                                  <conditions>
+                                    <condition field="selections" scope="aa72-63e4-bc60-4611" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8e05-7d1e-16e4-1669" type="equalTo"/>
+                                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b2b4-2198-0b90-dd9f" type="equalTo"/>
+                                  </conditions>
+                                </conditionGroup>
+                              </conditionGroups>
                             </conditionGroup>
                           </conditionGroups>
                         </modifier>
@@ -4987,6 +5409,34 @@ When a model has two Raven’s Talons, that model gains +2 Attacks instead of th
                       <costs>
                         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2.0"/>
                       </costs>
+                    </entryLink>
+                    <entryLink id="3f5a-2871-640e-6a38" name="Volkite Charger" hidden="false" collective="false" import="true" targetId="6f6e-ad55-e093-6503" type="selectionEntry">
+                      <modifiers>
+                        <modifier type="set" field="hidden" value="true">
+                          <conditionGroups>
+                            <conditionGroup type="or">
+                              <conditions>
+                                <condition field="selections" scope="aa72-63e4-bc60-4611" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8e05-7d1e-16e4-1669" type="equalTo"/>
+                                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b2b4-2198-0b90-dd9f" type="equalTo"/>
+                              </conditions>
+                            </conditionGroup>
+                          </conditionGroups>
+                        </modifier>
+                        <modifier type="set" field="c891-885d-6eb8-92d7" value="1.0">
+                          <conditionGroups>
+                            <conditionGroup type="and">
+                              <conditions>
+                                <condition field="selections" scope="aa72-63e4-bc60-4611" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8e05-7d1e-16e4-1669" type="equalTo"/>
+                                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b2b4-2198-0b90-dd9f" type="equalTo"/>
+                              </conditions>
+                            </conditionGroup>
+                          </conditionGroups>
+                        </modifier>
+                      </modifiers>
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c891-885d-6eb8-92d7" type="min"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c5f0-f97d-a7ba-49dc" type="max"/>
+                      </constraints>
                     </entryLink>
                   </entryLinks>
                 </selectionEntryGroup>
@@ -5098,6 +5548,9 @@ When a model has two Raven’s Talons, that model gains +2 Attacks instead of th
               </costs>
             </selectionEntry>
             <selectionEntry id="8b28-bdec-1540-5a47" name=" Legionaries (collective)" hidden="false" collective="false" import="true" type="model">
+              <constraints>
+                <constraint field="selections" scope="parent" value="19.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9335-7640-bc00-d1b7" type="max"/>
+              </constraints>
               <profiles>
                 <profile id="5bf2-8597-cc05-f7c5" name="Legionary" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
                   <modifiers>
@@ -5121,6 +5574,16 @@ When a model has two Raven’s Talons, that model gains +2 Attacks instead of th
                         <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="21c3-2f28-7820-e51a" type="equalTo"/>
                       </conditions>
                     </modifier>
+                    <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Heavy)">
+                      <conditionGroups>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="aa72-63e4-bc60-4611" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8e05-7d1e-16e4-1669" type="equalTo"/>
+                            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bfc9-c99c-bf8a-3917" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
                   </modifiers>
                   <characteristics>
                     <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Line)</characteristic>
@@ -5139,6 +5602,18 @@ When a model has two Raven’s Talons, that model gains +2 Attacks instead of th
               </profiles>
               <selectionEntryGroups>
                 <selectionEntryGroup id="9457-2898-a9ce-2588" name="Bayonet:" hidden="false" collective="false" import="true">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="true">
+                      <conditionGroups>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="aa72-63e4-bc60-4611" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8e05-7d1e-16e4-1669" type="equalTo"/>
+                            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b2b4-2198-0b90-dd9f" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                  </modifiers>
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="92aa-d7b4-2362-79d4" type="max"/>
                   </constraints>
@@ -5199,6 +5674,13 @@ When a model has two Raven’s Talons, that model gains +2 Attacks instead of th
                   </constraints>
                   <entryLinks>
                     <entryLink id="44d8-7cd8-879c-32d8" name="Asphyx Bolt Pistol" hidden="false" collective="false" import="true" targetId="f751-2e0d-353e-3886" type="selectionEntry">
+                      <modifiers>
+                        <modifier type="set" field="hidden" value="true">
+                          <conditions>
+                            <condition field="selections" scope="aa72-63e4-bc60-4611" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8e05-7d1e-16e4-1669" type="equalTo"/>
+                          </conditions>
+                        </modifier>
+                      </modifiers>
                       <constraints>
                         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2eb6-6d52-49de-9019" type="max"/>
                       </constraints>
@@ -5248,6 +5730,14 @@ When a model has two Raven’s Talons, that model gains +2 Attacks instead of th
                                 <condition field="selections" scope="aa72-63e4-bc60-4611" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="db53-8568-775f-1ab9" type="atLeast"/>
                                 <condition field="selections" scope="aa72-63e4-bc60-4611" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1941-21b5-932c-74d6" type="atLeast"/>
                               </conditions>
+                              <conditionGroups>
+                                <conditionGroup type="and">
+                                  <conditions>
+                                    <condition field="selections" scope="aa72-63e4-bc60-4611" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8e05-7d1e-16e4-1669" type="equalTo"/>
+                                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b2b4-2198-0b90-dd9f" type="equalTo"/>
+                                  </conditions>
+                                </conditionGroup>
+                              </conditionGroups>
                             </conditionGroup>
                           </conditionGroups>
                         </modifier>
@@ -5257,6 +5747,13 @@ When a model has two Raven’s Talons, that model gains +2 Attacks instead of th
                       </constraints>
                     </entryLink>
                     <entryLink id="f92c-e8e4-0748-a09c" name="Asphyx Bolter" hidden="false" collective="false" import="true" targetId="dcef-d670-b47a-adfa" type="selectionEntry">
+                      <modifiers>
+                        <modifier type="set" field="hidden" value="true">
+                          <conditions>
+                            <condition field="selections" scope="aa72-63e4-bc60-4611" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8e05-7d1e-16e4-1669" type="equalTo"/>
+                          </conditions>
+                        </modifier>
+                      </modifiers>
                       <constraints>
                         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c3d3-25b1-cc5c-8064" type="max"/>
                       </constraints>
@@ -5271,6 +5768,34 @@ When a model has two Raven’s Talons, that model gains +2 Attacks instead of th
                       <costs>
                         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2.0"/>
                       </costs>
+                    </entryLink>
+                    <entryLink id="be1c-d5b7-d71f-4b3f" name="Volkite Charger" hidden="false" collective="false" import="true" targetId="5c82-c306-9c5c-5908" type="selectionEntry">
+                      <modifiers>
+                        <modifier type="set" field="4c0f-f43a-dab0-3ec8" value="1.0">
+                          <conditionGroups>
+                            <conditionGroup type="and">
+                              <conditions>
+                                <condition field="selections" scope="aa72-63e4-bc60-4611" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8e05-7d1e-16e4-1669" type="equalTo"/>
+                                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b2b4-2198-0b90-dd9f" type="equalTo"/>
+                              </conditions>
+                            </conditionGroup>
+                          </conditionGroups>
+                        </modifier>
+                        <modifier type="set" field="hidden" value="true">
+                          <conditionGroups>
+                            <conditionGroup type="or">
+                              <conditions>
+                                <condition field="selections" scope="aa72-63e4-bc60-4611" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8e05-7d1e-16e4-1669" type="equalTo"/>
+                                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b2b4-2198-0b90-dd9f" type="equalTo"/>
+                              </conditions>
+                            </conditionGroup>
+                          </conditionGroups>
+                        </modifier>
+                      </modifiers>
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4c0f-f43a-dab0-3ec8" type="min"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bf0a-0a9f-a8dc-03a4" type="max"/>
+                      </constraints>
                     </entryLink>
                   </entryLinks>
                 </selectionEntryGroup>
@@ -5301,7 +5826,231 @@ When a model has two Raven’s Talons, that model gains +2 Attacks instead of th
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="956b-31f1-dd44-67cc" type="min"/>
           </constraints>
         </entryLink>
-        <entryLink id="ccb3-845e-c34b-459b" name="Hexagrammaton Choice:" hidden="false" collective="false" import="true" targetId="61a2-7005-1e6c-c08e" type="selectionEntryGroup"/>
+        <entryLink id="ccb3-845e-c34b-459b" name="Hexagrammaton Choice:" hidden="false" collective="false" import="true" targetId="61a2-7005-1e6c-c08e" type="selectionEntryGroup">
+          <modifiers>
+            <modifier type="set" field="41ff-12f0-9676-ce29" value="0.0">
+              <conditions>
+                <condition field="selections" scope="aa72-63e4-bc60-4611" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8e05-7d1e-16e4-1669" type="equalTo"/>
+              </conditions>
+            </modifier>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="aa72-63e4-bc60-4611" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8e05-7d1e-16e4-1669" type="equalTo"/>
+              </conditions>
+            </modifier>
+            <modifier type="set" field="a590-7c00-0ec0-dce9" value="0.0">
+              <conditions>
+                <condition field="selections" scope="aa72-63e4-bc60-4611" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8e05-7d1e-16e4-1669" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </entryLink>
+        <entryLink id="1519-cd4a-2df8-31ef" name="Inductii" hidden="true" collective="false" import="true" targetId="8e05-7d1e-16e4-1669" type="selectionEntry">
+          <modifiers>
+            <modifier type="set" field="hidden" value="false">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c0df-c1fa-5ddc-9ee5" type="equalTo"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b2b4-2198-0b90-dd9f" type="equalTo"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dd1f-1c51-706c-e5f7" type="equalTo"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a0e1-f2c4-8bcd-0723" type="equalTo"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bfc9-c99c-bf8a-3917" type="equalTo"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5f54-457a-fbb9-6730" type="equalTo"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dc34-fe08-dd44-fb99" type="equalTo"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="21c3-2f28-7820-e51a" type="equalTo"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8e0f-3552-8842-f281" type="equalTo"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
+          <rules>
+            <rule id="e765-0db1-bceb-bc6a" name="Dark Angels Legion Inductii Template" publicationId="53a4-0d21-2f8a-2c45" page="226" hidden="false">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b2b4-2198-0b90-dd9f" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <description>• Unit Sub-type: All models in a unit modified by the Dark Angels Legion Inductii template must replace the Hexagrammaton Unit Sub-type selected for them as part of the Legiones Astartes (Dark Angels) special rule with the Inductii Unit Sub-type.
+• Wargear: All models in a unit modified by the Dark Angels Legion Inductii template must exchange their bolter for a volkite charger at no additional cost.
+• Special Rules: All models in a unit modified by the Dark Angels Legion Inductii template lose the Fury of the Legion special rule.</description>
+            </rule>
+            <rule id="8c68-20ec-6cef-2a28" name="Iron Warriors Legion Inductii Template" publicationId="53a4-0d21-2f8a-2c45" page="227" hidden="false">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5f54-457a-fbb9-6730" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <description>• Unit Sub-type: All models in a unit modified by the Iron Warriors Legion Inductii template gain the Inductii Unit Sub-types.
+• Special Rules: All models in a unit modified by the Iron Warriors Legion Inductii template must replace the Heart of the Legion special rule with the Souls of Iron special rule.</description>
+            </rule>
+            <rule id="8103-cfbe-237a-50f9" name="Imperial Fists Legion Inductii Template" publicationId="53a4-0d21-2f8a-2c45" page="228" hidden="false">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a0e1-f2c4-8bcd-0723" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <description>• Unit Sub-type: All models in a unit modified by the Imperial Fists Legion Inductii template gain the Inductii Unit Sub-type.
+• Wargear: For every ten models in a unit modified by the Imperial Fists Legion Inductii template, one Legionary may exchange his bolter for one of the following:
+-	Heavy bolter ....................................+10 points per model
+-	Autocannon .....................................+15 points per model
+• Special Rules: All models in a unit modified by the Imperial Fists Legion Inductii template must replace the Heart of the Legion special rule with the Supporting Fire special rule.</description>
+            </rule>
+            <rule id="93c3-ba23-11d4-69b5" name="Iron Hands Legion Inductii Template" publicationId="53a4-0d21-2f8a-2c45" page="230" hidden="false">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bfc9-c99c-bf8a-3917" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <description>• Unit Sub-type: All models in a unit modified by the Iron Hands Legion Inductii template gain the Heavy and Inductii Unit Sub-types.
+• Wargear: The Legion Tactical Sergeant in a unit modified by the Iron Hands Legion Inductii template may take one phosphex bomb for +10 points.
+• Special Rules: All models in a unit modified by the Iron Hands Legion Inductii template replace the Fury of the Legion special rule with the Forbidden Augmentations special rule.</description>
+            </rule>
+            <rule id="4df1-42db-5ea9-1c5f" name="Ultramarines Legion Inductii Template" publicationId="53a4-0d21-2f8a-2c45" page="231" hidden="false">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8e0f-3552-8842-f281" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <description>• Unit Composition: A unit modified by the Ultramarines Legion Inductii template may not take additional Legionaries.
+• Unit Sub-type: All models in a unit modified by the Ultramarines Legion Inductii template gain the Inductii Unit Sub-type.
+• Wargear: For every five models in the unit modified by the Ultramarines Legion Inductii template, one Legionary may exchange his bolter for one of the following:
+-	Flamer ........................................................+5 points each
+-	Plasma gun ..............................................+10 points each
+-	Meltagun ...................................................+15 points each
+• Special Rules: All models in a unit modified by the Ultramarines Legion Inductii template replace the Fury of the Legion special rule with the Inexorable special rule.</description>
+            </rule>
+            <rule id="2697-71b4-2e02-684f" name="Death Guard Legion Inductii Template" publicationId="53a4-0d21-2f8a-2c45" page="231" hidden="false">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dd1f-1c51-706c-e5f7" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <description>• Unit Sub-type: All models in a unit modified by the Death Guard Legion Inductii template gain the Inductii Unit Sub-type.
+• Wargear: For every five models in the unit modified by the Death Guard Legion Inductii template, one Legionary may exchange his bolter for an Alchem flamer for +5 points.
+• Special Rules: All models in a unit modified by the Death Guard Legion Inductii template replace the Heart of the Legion special rule with the Barbaran Resilience special rule.</description>
+            </rule>
+            <rule id="f6b8-3e14-2d40-c705" name="Thousand Sons Legion Inductii Template" publicationId="53a4-0d21-2f8a-2c45" page="232" hidden="false">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="21c3-2f28-7820-e51a" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <description>• Unit Sub-type: All models in a unit modified by the Thousand Sons Legion Inductii template gain the Inductii Unit Sub-type.
+• Wargear: Models in a unit modified by the Thousand Sons Legion Inductii template cannot exchange their bolt pistols or bolters for Asphyx bolt pistols or Asphyx bolters.
+• Special Rules: All models in a unit modified by the Thousand Sons Inductii template replace the Fury of the Legion special rule with the Unattuned Practitioners special rule.</description>
+            </rule>
+            <rule id="c131-d0a5-2609-0289" name="Raven Guard Legion Inductii Template" publicationId="53a4-0d21-2f8a-2c45" page="234" hidden="false">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dc34-fe08-dd44-fb99" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <description>• Unit Sub-type: All models in a unit modified by the Raven Guard Legion Inductii template gain the Inductii Unit Sub-type.
+• Special Rules: All models in a unit modified by the Raven Guard Legion Inductii template replace the Heart of the Legion special rule with the Unchained Conviction special rule.</description>
+            </rule>
+            <rule id="b588-b45b-3e2f-3f58" name="Alpha Legion Legion Inductii Template" publicationId="53a4-0d21-2f8a-2c45" page="234" hidden="false">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c0df-c1fa-5ddc-9ee5" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <description>• Unit Sub-type: All models in a unit modified by the Alpha Legion Legion Inductii template gain the Inductii Unit Sub-type.
+• Special Rules: All models in a unit modified by the Alpha Legion Inductii template replace the Heart of the Legion special rule with the Treacherous Lure special rule.</description>
+            </rule>
+            <rule id="24fe-d2cd-0b19-c3a8" name="Souls of Iron" publicationId="53a4-0d21-2f8a-2c45" page="227" hidden="false">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5f54-457a-fbb9-6730" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <description>During the controlling player’s Shooting phase, a unit with this special rule must attempt a Shooting Attack if there is an enemy unit within range, and must target the closest enemy unit possible that is within its line of sight and is a valid target for a Shooting Attack. If two or more targets are equally close then the controlling player chooses which will be the target of a Shooting Attack. In addition, this unit automatically passes any Pinning tests it is required to take.</description>
+            </rule>
+            <rule id="cdde-df00-6059-541b" name="Supporting Fire" publicationId="53a4-0d21-2f8a-2c45" page="228" hidden="false">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a0e1-f2c4-8bcd-0723" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <description>Once per battle, the controlling player of a unit that includes any models with this special rule may declare a Supporting Fire before making a Shooting Attack with that unit. Until that Shooting Attack is resolved, weapons with the Heavy type in that unit gain the Pinning special rule in addition to any other effects their weapons might have.</description>
+            </rule>
+            <rule id="1faf-27e4-9a55-b72e" name="Forbidden Augmentations" publicationId="53a4-0d21-2f8a-2c45" page="230" hidden="false">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bfc9-c99c-bf8a-3917" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <description>At the start of the controlling player’s turn as the Active player, before the beginning of the Movement phase, roll one dice for each unit that includes one or more models with this special rule. On the roll of a 5+, all models in that unit with this special rule gain +1 WS and +1 BS until the end of that player turn, however, on the roll of a 1 or 2 the unit suffer D3 Wounds with an AP value of ‘-’, allocated by the unit’s controlling player.</description>
+            </rule>
+            <rule id="b465-e18e-2239-5f01" name="Barbaran Resilience" publicationId="53a4-0d21-2f8a-2c45" page="231" hidden="false">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dd1f-1c51-706c-e5f7" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <description>When a model with this special rule suffers an unsaved Wound, it can make a special Barbaran Resilience roll to avoid suffering the Wound. Barbaran Resilience rolls may not be made against Wounds that have the Instant Death special rule.
+Roll a D6 each time an unsaved Wound is suffered. If a unit with this special rule includes ten or more models at the start of a given Phase, this rule has no effect. If a unit with this special rule includes less than ten models at the start of a given Phase, then on a roll of 6+ the unsaved Wound is discounted. If a unit with this special rule includes less than five models at the start of a given Phase, then on a roll of 5+, the unsaved Wound is discounted. Treat discounted Wounds as having been saved. On any other result the Wound is taken as normal.
+This is a Damage Mitigation roll – any model may make only a single Damage Mitigation roll of any type for any given Wound.</description>
+            </rule>
+            <rule id="01ef-a54e-8582-b79c" name="Unchained Conviction" publicationId="53a4-0d21-2f8a-2c45" page="234" hidden="false">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dc34-fe08-dd44-fb99" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <description>A unit composed entirely of models with this special rule whose controlling player fails a Pinning check made for it is not Pinned, but instead must immediately move 7&quot; directly away from the enemy unit that caused the Pinning test, moving each model in the unit directly away from that enemy unit by the shortest available path. If this would bring the unit into contact with the edge of the battlefield, do not move it any further. Once all models in the unit have been moved, there are no further effects and the unit is not Pinned. If the unit is required to make this move during a Charge, then the Charge automatically fails and the unit is Displaced from the position it occupied when the Charge was declared.</description>
+            </rule>
+            <rule id="db80-8dc8-c616-506d" name="Treacherous Lure" publicationId="53a4-0d21-2f8a-2c45" page="234" hidden="false">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c0df-c1fa-5ddc-9ee5" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <description>A unit made up entirely of models with this special rule may not be selected as the target of Shooting Attacks in any Phase of the first Game Turn of the battle. However, the unit may be the target of a Shooting Attack made as part of the Interceptor Advanced Reaction, and it may suffer Hits and Wounds from attacks that scatter onto it, or are otherwise allocated to it due to the effects of another special rule.</description>
+            </rule>
+            <rule id="deb5-9934-435f-4c48" name="Unattuned Practitioners" publicationId="53a4-0d21-2f8a-2c45" page="232" hidden="false">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="21c3-2f28-7820-e51a" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <description>A model with this special rule gains the Ætheric Guidance Psychic Power and may not select a Minor Arcana from those presented by the Prosperine Arcana special rule.</description>
+            </rule>
+          </rules>
+        </entryLink>
       </entryLinks>
       <costs>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
@@ -51637,6 +52386,14 @@ may choose to activate the Power of Chaos Eternal. Onc eactivated, Horus Ascende
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
       </costs>
     </selectionEntry>
+    <selectionEntry id="8e05-7d1e-16e4-1669" name="Inductii" publicationId="53a4-0d21-2f8a-2c45" page="225-234" hidden="false" collective="false" import="true" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b424-663d-b989-99e0" type="max"/>
+      </constraints>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
   </sharedSelectionEntries>
   <sharedSelectionEntryGroups>
     <selectionEntryGroup id="61a2-7005-1e6c-c08e" name="Hexagrammaton Choice:" hidden="true" collective="false" import="true">
@@ -51836,12 +52593,117 @@ may choose to activate the Power of Chaos Eternal. Onc eactivated, Horus Ascende
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8f32-98a0-2bca-6dc0" type="max"/>
         <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4b2b-d777-7ebe-300f" type="min"/>
       </constraints>
+      <selectionEntries>
+        <selectionEntry id="c4c9-7479-fe46-d798" name="Ætheric Guidance" hidden="true" collective="false" import="true" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="false">
+              <conditionGroups>
+                <conditionGroup type="and">
+                  <conditions>
+                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="aadc-a0cf-e49e-0358" type="instanceOf"/>
+                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="aa72-63e4-bc60-4611" type="instanceOf"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+            <modifier type="set" field="87e1-c7c1-cbad-1e4d" value="1.0">
+              <conditionGroups>
+                <conditionGroup type="and">
+                  <conditions>
+                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="aadc-a0cf-e49e-0358" type="instanceOf"/>
+                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="aa72-63e4-bc60-4611" type="instanceOf"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="21c3-2f28-7820-e51a" type="equalTo"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="87e1-c7c1-cbad-1e4d" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="14ce-61a4-d72d-ea28" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="40a9-e37c-02d2-3f4d" name="Ætheric Guidance" publicationId="53a4-0d21-2f8a-2c45" page="232" hidden="false" typeId="7002-2f9a-59c4-2742" typeName="Prosperine Arcana">
+              <characteristics>
+                <characteristic name="Description" typeId="931f-3b2d-da54-8d8d">When a unit that includes a Psyker with this power makes a Shooting Attack, the controlling player may make a Psychic check for the Psyker with this power before any rolls To Hit are made.
+
+If the Psychic check is successful then until that Shooting Attack is resolved, attacks made by this unit have the Breaching (6+) special rule. If the Psychic check is failed then the unit suffers Perils of the Warp and receives 1 additional wound when it does so.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+        </selectionEntry>
+      </selectionEntries>
       <entryLinks>
-        <entryLink id="91d6-f45b-1959-f54e" name="Athanaen" hidden="false" collective="false" import="true" targetId="a06f-f3f7-ba92-365d" type="selectionEntry"/>
-        <entryLink id="0807-9349-5843-46b6" name="Raptora" hidden="false" collective="false" import="true" targetId="1aa4-4557-f274-2ba1" type="selectionEntry"/>
-        <entryLink id="86c3-6de2-0c84-2be9" name="Pyrae" hidden="false" collective="false" import="true" targetId="78eb-adbb-1cc2-b002" type="selectionEntry"/>
-        <entryLink id="4246-4ef1-047e-2535" name="Corvidae" hidden="false" collective="false" import="true" targetId="f040-f723-e145-9e1f" type="selectionEntry"/>
-        <entryLink id="78be-935f-1458-e8fd" name="Pavoni" hidden="false" collective="false" import="true" targetId="5532-04aa-8302-2038" type="selectionEntry"/>
+        <entryLink id="91d6-f45b-1959-f54e" name="Athanaen" hidden="false" collective="false" import="true" targetId="a06f-f3f7-ba92-365d" type="selectionEntry">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditionGroups>
+                <conditionGroup type="and">
+                  <conditions>
+                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="aadc-a0cf-e49e-0358" type="instanceOf"/>
+                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="aa72-63e4-bc60-4611" type="instanceOf"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
+        </entryLink>
+        <entryLink id="0807-9349-5843-46b6" name="Raptora" hidden="false" collective="false" import="true" targetId="1aa4-4557-f274-2ba1" type="selectionEntry">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditionGroups>
+                <conditionGroup type="and">
+                  <conditions>
+                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="aadc-a0cf-e49e-0358" type="instanceOf"/>
+                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="aa72-63e4-bc60-4611" type="instanceOf"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
+        </entryLink>
+        <entryLink id="86c3-6de2-0c84-2be9" name="Pyrae" hidden="false" collective="false" import="true" targetId="78eb-adbb-1cc2-b002" type="selectionEntry">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditionGroups>
+                <conditionGroup type="and">
+                  <conditions>
+                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="aadc-a0cf-e49e-0358" type="instanceOf"/>
+                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="aa72-63e4-bc60-4611" type="instanceOf"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
+        </entryLink>
+        <entryLink id="4246-4ef1-047e-2535" name="Corvidae" hidden="false" collective="false" import="true" targetId="f040-f723-e145-9e1f" type="selectionEntry">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditionGroups>
+                <conditionGroup type="and">
+                  <conditions>
+                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="aadc-a0cf-e49e-0358" type="instanceOf"/>
+                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="aa72-63e4-bc60-4611" type="instanceOf"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
+        </entryLink>
+        <entryLink id="78be-935f-1458-e8fd" name="Pavoni" hidden="false" collective="false" import="true" targetId="5532-04aa-8302-2038" type="selectionEntry">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditionGroups>
+                <conditionGroup type="and">
+                  <conditions>
+                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="aadc-a0cf-e49e-0358" type="instanceOf"/>
+                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="aa72-63e4-bc60-4611" type="instanceOf"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
+        </entryLink>
       </entryLinks>
     </selectionEntryGroup>
     <selectionEntryGroup id="aeb3-6a73-da1d-2b90" name="Surgical Augment (Unit Character)" hidden="true" collective="false" import="true">

--- a/2022 - Legiones Astartes.cat
+++ b/2022 - Legiones Astartes.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="6393-649c-7213-a327" name="(HH V2) Legions Astartes" revision="138" battleScribeVersion="2.03" authorName="Various" authorUrl="https://github.com/BSData/horus-heresy" library="true" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="68" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="6393-649c-7213-a327" name="(HH V2) Legions Astartes" revision="139" battleScribeVersion="2.03" authorName="Various" authorUrl="https://github.com/BSData/horus-heresy" library="true" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="68" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="0594-a9b0-6f10-090e" name="Legion Javelin Squadron Updade" publisher="Warhammer Community Downloads" publicationDate="May 2023" publisherUrl="https://www.warhammer-community.com/wp-content/uploads/2023/05/hd7WOnm2lKCHkskG.pdf"/>
     <publication id="acdb-27b7-6b7e-932f" name="Legion Mastodon Updade" publisher="Warhammer Community Downloads" publicationDate="May 2023" publisherUrl="https://www.warhammer-community.com/wp-content/uploads/2023/05/AopGHpxowuowkwJw.pdf"/>
@@ -31425,11 +31425,6 @@ This is a Damage Mitigation roll – any model may make only a single Damage Mit
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
                   </costs>
                 </entryLink>
-                <entryLink id="9fc5-4485-2c6f-a01c" name="Magna Combi-Weapon - Disintegrator" hidden="false" collective="false" import="true" targetId="1d05-f467-b0aa-88b2" type="selectionEntry">
-                  <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
-                  </costs>
-                </entryLink>
                 <entryLink id="797b-1ad8-2b4f-7c89" name="Magna Combi-Weapon - Meltagun" hidden="false" collective="false" import="true" targetId="0d1c-227e-a3f8-cd63" type="selectionEntry">
                   <costs>
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
@@ -32470,7 +32465,7 @@ This is a Damage Mitigation roll – any model may make only a single Damage Mit
         <selectionEntry id="e6da-2d8a-93c6-16fc" name="Proteus Land Speeder" publicationId="a716-c1c4-7b26-8424" page="61" hidden="false" collective="false" import="true" type="model">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d601-a4ec-cfbe-537a" type="min"/>
-            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="93e6-f5c9-248c-d998" type="max"/>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="93e6-f5c9-248c-d998" type="max"/>
           </constraints>
           <profiles>
             <profile id="cdb3-bb69-462f-cf43" name="Proteus Land Speeder" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
@@ -52631,6 +52626,9 @@ If the Psychic check is successful then until that Shooting Attack is resolved, 
               </characteristics>
             </profile>
           </profiles>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+          </costs>
         </selectionEntry>
       </selectionEntries>
       <entryLinks>


### PR DESCRIPTION
All Tactical Inductii added

What was done...
Added new category sub-type for Inductii which explains the sub-type rules.

All stuff for Tacticals - Inductii
Modifier Max 1 to Max 0 and hidden for Arty armour
Added Support squad rule with a hidden modifier to hide it if not inductii
added modifier to add inductii sub-type category if inductii is selected.
added modifier to remove compulsory troops category if inductii is selected.
Hidden FotL for DA, IH, UM, TS when they are Inductii
Hidden HotL for IW, IF DG, RG, AL when they are inductii
Hexigrammiton set min/max to 0 for Inductii.
Added all supporting rules to tick box for inductii such as supporting fire, forbidden augmentations... These are set to hidden if not both the correct legion and inductii is ticked.
Added description of the modifications inductii does to the unit in the new inductii tickbox.
Added Volkite Chargers to the Serg, Collective and w/ options selections which is hidden if not DA & Inductii. Also has a min 0 with a modifier for min 1 if DA & Inductii.
Added a 1 in 10 or 1 in 5 to the IH, UM, DG "w/ options" selection to allow them to take the new weapons with limitations set. These will only show if Inductii and the correct legion.
Set hidden for Asphyx weapons if Inductii TS.
Added new "Ætheric Guidance" to Prosperine Arcana. This will only show for Tactical Inductii. The others are now set to hide if Tactical Inductii. There is also a min 1 set on this for Tactical, Inductii who are TS.
UM tactical inductii have a max limit of 10 models. This meant changing the formatting of how this interacts with ZM. ZM now reduces the max by 5, in ZM FOC with Tactical Inductii of UM reduces it by a further 5 (to make the total reduction 10). Tactical inductii not in ZM FOC just reduces by 10.