### PR TITLE
Fixes for 2912 - 2916

### DIFF
--- a/2022 - Imperialis Militia.cat
+++ b/2022 - Imperialis Militia.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="f84d-94cf-5ce6-b393" name="2022 - Imperialis Militia" revision="16" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="71" xmlns="http://www.battlescribe.net/schema/catalogueSchema" type="catalogue">
+<catalogue id="f84d-94cf-5ce6-b393" name="2022 - Imperialis Militia" revision="17" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="71" xmlns="http://www.battlescribe.net/schema/catalogueSchema" type="catalogue">
   <categoryEntries>
     <categoryEntry id="58b3-196a-9732-2165" name="Rogue Psyker Daemons Restriction" publicationId="48c2-d023-0069-001a" page="15" hidden="false">
       <modifiers>
@@ -3804,6 +3804,70 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
                             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
                           </costs>
                         </selectionEntry>
+                        <selectionEntry id="fcbf-6948-f46f-ff17" name="Autopistol &amp; Chainaxe" hidden="false" collective="false" import="true" type="model">
+                          <modifiers>
+                            <modifier type="set" field="hidden" value="true">
+                              <conditions>
+                                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5825-e777-2615-3d4d" type="equalTo"/>
+                              </conditions>
+                            </modifier>
+                          </modifiers>
+                          <constraints>
+                            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="4ae9-fa09-b6e7-01b6" type="max"/>
+                          </constraints>
+                          <entryLinks>
+                            <entryLink id="60a0-8af-54b0-241f" name="Autopistol" hidden="false" collective="false" import="true" targetId="344f-4836-c70d-29a4" type="selectionEntry">
+                              <constraints>
+                                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="1e07-2dd9-e6fe-66c8" type="min"/>
+                                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="7578-4b1c-6295-6f7d" type="max"/>
+                              </constraints>
+                            </entryLink>
+                            <entryLink id="47c2-8f87-8b69-d274" name="Chainaxe" hidden="false" collective="false" import="true" targetId="e644-9e34-f513-5995" type="selectionEntry">
+                              <constraints>
+                                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="2c6d-9e80-9036-74d6" type="min"/>
+                                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="4e8b-e655-9894-53a9" type="max"/>
+                              </constraints>
+                              <costs>
+                                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2"/>
+                              </costs>
+                            </entryLink>
+                          </entryLinks>
+                          <costs>
+                            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
+                          </costs>
+                        </selectionEntry>
+                        <selectionEntry id="ac52-8303-784f-b81e" name="Laspistol &amp; Chainaxe" hidden="false" collective="false" import="true" type="model">
+                          <modifiers>
+                            <modifier type="set" field="hidden" value="true">
+                              <conditions>
+                                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5825-e777-2615-3d4d" type="equalTo"/>
+                              </conditions>
+                            </modifier>
+                          </modifiers>
+                          <constraints>
+                            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="d369-b23b-8740-1c68" type="max"/>
+                          </constraints>
+                          <entryLinks>
+                            <entryLink id="fbcf-f177-2eb2-38c9" name="Laspistol" hidden="false" collective="false" import="true" targetId="654d-be88-b0a8-7ae5" type="selectionEntry">
+                              <constraints>
+                                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="a34f-7f41-dd62-a0df" type="min"/>
+                                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="a02b-3e38-b828-f848" type="max"/>
+                              </constraints>
+                            </entryLink>
+                            <entryLink id="1fa5-d007-4630-b532" name="Chainaxe" hidden="false" collective="false" import="true" targetId="e644-9e34-f513-5995" type="selectionEntry">
+                              <constraints>
+                                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="c64b-7d77-4e62-b1f9" type="min"/>
+                                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="2d93-1a52-22b1-2f1d" type="max"/>
+                              </constraints>
+                              <costs>
+                                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2"/>
+                              </costs>
+                            </entryLink>
+                          </entryLinks>
+                          <costs>
+                            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
+                          </costs>
+                        </selectionEntry>
                       </selectionEntries>
                       <entryLinks>
                         <entryLink id="44d7-696a-955a-6c07" name="Autorifle" hidden="false" collective="false" import="true" targetId="57dd-dff6-d173-3bf1" type="selectionEntry"/>
@@ -3913,13 +3977,13 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
                 </selectionEntry>
               </selectionEntries>
               <selectionEntryGroups>
-                <selectionEntryGroup id="fdbc-18cc-bab2-ca44" name="1) The entire squad may replace its Lasgun or Autorifle with one of the following options:" hidden="false" collective="false" import="true" defaultSelectionEntryId="a649-7630-ad3b-6c73">
+                <selectionEntryGroup id="fdbc-18cc-bab2-ca44" name="1.1) The entire squad may replace its Lasgun or Autorifle with one of the following options:" hidden="false" collective="false" import="true" defaultSelectionEntryId="a649-7630-ad3b-6c73">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="4c5e-c797-65e5-40cc" type="min"/>
                     <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="fb0b-8463-5e62-e957" type="max"/>
                   </constraints>
                   <selectionEntries>
-                    <selectionEntry id="18f6-fbe0-f43e-6a41" name="Laspistol &amp; Close Combat Weapons" hidden="false" collective="false" import="true" type="model">
+                    <selectionEntry id="18f6-fbe0-f43e-6a41" name="Laspistol &amp; Melee Weapon" hidden="false" collective="false" import="true" type="upgrade">
                       <constraints>
                         <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="aa67-9a5e-4206-bc04" type="max"/>
                       </constraints>
@@ -3930,18 +3994,12 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
                             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="7b00-9581-6d15-d558" type="max"/>
                           </constraints>
                         </entryLink>
-                        <entryLink id="873c-22e3-7c1f-898b" name="Close Combat Weapon" hidden="false" collective="false" import="true" targetId="19ab-4d64-f6a7-9f81" type="selectionEntry">
-                          <constraints>
-                            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="bcf4-d3fc-fe37-6cbb" type="min"/>
-                            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="5938-5030-a259-73c4" type="max"/>
-                          </constraints>
-                        </entryLink>
                       </entryLinks>
                       <costs>
                         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
                       </costs>
                     </selectionEntry>
-                    <selectionEntry id="5f47-1e1c-3e73-221d" name="Autopistol &amp; Close Combat Weapons" hidden="false" collective="false" import="true" type="model">
+                    <selectionEntry id="5f47-1e1c-3e73-221d" name="Autopistol &amp; Melee Weapon" hidden="false" collective="false" import="true" type="upgrade">
                       <constraints>
                         <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="132d-4bf6-4222-a48f" type="max"/>
                       </constraints>
@@ -3951,76 +4009,6 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
                             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="daa7-4cb1-c839-f7b4" type="min"/>
                             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="e011-9a89-5340-f407" type="max"/>
                           </constraints>
-                        </entryLink>
-                        <entryLink id="bc0a-d7ee-91fd-ea5b" name="Close Combat Weapon" hidden="false" collective="false" import="true" targetId="19ab-4d64-f6a7-9f81" type="selectionEntry">
-                          <constraints>
-                            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="661b-e8c7-d8a4-aef1" type="min"/>
-                            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="5817-2296-decd-782f" type="max"/>
-                          </constraints>
-                        </entryLink>
-                      </entryLinks>
-                      <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
-                      </costs>
-                    </selectionEntry>
-                    <selectionEntry id="e41a-e32a-71a8-6ed9" name="Laspistol &amp; Chainaxe" hidden="false" collective="false" import="true" type="model">
-                      <modifiers>
-                        <modifier type="set" field="hidden" value="true">
-                          <conditions>
-                            <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5825-e777-2615-3d4d" type="equalTo"/>
-                          </conditions>
-                        </modifier>
-                      </modifiers>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="d369-b23b-8740-1c68" type="max"/>
-                      </constraints>
-                      <entryLinks>
-                        <entryLink id="177b-c0e8-01a5-2316" name="Laspistol" hidden="false" collective="false" import="true" targetId="654d-be88-b0a8-7ae5" type="selectionEntry">
-                          <constraints>
-                            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="a34f-7f41-dd62-a0df" type="min"/>
-                            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="a02b-3e38-b828-f848" type="max"/>
-                          </constraints>
-                        </entryLink>
-                        <entryLink id="4cc4-7971-418a-5837" name="Chainaxe" hidden="false" collective="false" import="true" targetId="e644-9e34-f513-5995" type="selectionEntry">
-                          <constraints>
-                            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="c64b-7d77-4e62-b1f9" type="min"/>
-                            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="2d93-1a52-22b1-2f1d" type="max"/>
-                          </constraints>
-                          <costs>
-                            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2"/>
-                          </costs>
-                        </entryLink>
-                      </entryLinks>
-                      <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
-                      </costs>
-                    </selectionEntry>
-                    <selectionEntry id="b77e-bf46-334a-049c" name="Autopistol &amp; Chainaxe" hidden="false" collective="false" import="true" type="model">
-                      <modifiers>
-                        <modifier type="set" field="hidden" value="true">
-                          <conditions>
-                            <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5825-e777-2615-3d4d" type="equalTo"/>
-                          </conditions>
-                        </modifier>
-                      </modifiers>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="4ae9-fa09-b6e7-01b6" type="max"/>
-                      </constraints>
-                      <entryLinks>
-                        <entryLink id="428d-8c70-db42-c3ff" name="Autopistol" hidden="false" collective="false" import="true" targetId="344f-4836-c70d-29a4" type="selectionEntry">
-                          <constraints>
-                            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="1e07-2dd9-e6fe-66c8" type="min"/>
-                            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="7578-4b1c-6295-6f7d" type="max"/>
-                          </constraints>
-                        </entryLink>
-                        <entryLink id="66b8-47b9-0993-c207" name="Chainaxe" hidden="false" collective="false" import="true" targetId="e644-9e34-f513-5995" type="selectionEntry">
-                          <constraints>
-                            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="2c6d-9e80-9036-74d6" type="min"/>
-                            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="4e8b-e655-9894-53a9" type="max"/>
-                          </constraints>
-                          <costs>
-                            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2"/>
-                          </costs>
                         </entryLink>
                       </entryLinks>
                       <costs>
@@ -4098,6 +4086,64 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
                       </costs>
                     </entryLink>
                   </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup name="1.2) Melee Weapon" hidden="false" id="9bd3-ca5e-e3fe-b996">
+                  <entryLinks>
+                    <entryLink id="7cb6-3ba0-5592-8d2" name="Close Combat Weapon" hidden="false" collective="false" import="true" targetId="19ab-4d64-f6a7-9f81" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="50" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="f824-e118-631a-3132" type="max"/>
+                      </constraints>
+                    </entryLink>
+                    <entryLink id="c900-6912-4c1d-a424" name="Chainaxe" hidden="false" collective="false" import="true" targetId="e644-9e34-f513-5995" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="50" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="1f66-9804-ac2c-84c7" type="max"/>
+                      </constraints>
+                      <costs>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2"/>
+                      </costs>
+                      <modifiers>
+                        <modifier type="set" field="hidden" value="true">
+                          <conditions>
+                            <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5825-e777-2615-3d4d" type="equalTo"/>
+                          </conditions>
+                        </modifier>
+                      </modifiers>
+                    </entryLink>
+                  </entryLinks>
+                  <modifiers>
+                    <modifier type="set" value="true" field="hidden">
+                      <conditionGroups>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition type="equalTo" value="0" field="selections" scope="parent" childId="5f47-1e1c-3e73-221d" shared="true"/>
+                            <condition type="equalTo" value="0" field="selections" scope="parent" childId="18f6-fbe0-f43e-6a41" shared="true"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                    <modifier type="increment" value="1" field="c059-dd60-aec9-7da3">
+                      <repeats>
+                        <repeat value="1" repeats="1" field="selections" scope="40bf-b6fa-7c1e-b14a" childId="model" shared="true" roundUp="false" id="35f8-b101-2cce-5b4a" includeChildSelections="true"/>
+                      </repeats>
+                      <conditionGroups>
+                        <conditionGroup type="or">
+                          <conditions>
+                            <condition type="atLeast" value="1" field="selections" scope="40bf-b6fa-7c1e-b14a" childId="5f47-1e1c-3e73-221d" shared="true" includeChildSelections="true"/>
+                            <condition type="atLeast" value="1" field="selections" scope="40bf-b6fa-7c1e-b14a" childId="18f6-fbe0-f43e-6a41" shared="true" includeChildSelections="true"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                    <modifier type="increment" value="1" field="a9af-f1c2-bf2-5347">
+                      <repeats>
+                        <repeat value="1" repeats="1" field="selections" scope="40bf-b6fa-7c1e-b14a" childId="model" shared="true" roundUp="false" id="8892-b26a-9bd9-c51b" includeChildSelections="true"/>
+                      </repeats>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint type="min" value="0" field="selections" scope="parent" shared="true" id="c059-dd60-aec9-7da3" includeChildSelections="true"/>
+                    <constraint type="max" value="0" field="selections" scope="parent" shared="true" id="a9af-f1c2-bf2-5347" includeChildSelections="true"/>
+                  </constraints>
                 </selectionEntryGroup>
               </selectionEntryGroups>
               <entryLinks>

--- a/2022 - LA - Blood Angels.cat
+++ b/2022 - LA - Blood Angels.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="cd4d-8765-5387-8409" name="LA -  IX: Blood Angels" revision="39" battleScribeVersion="2.03" authorName="Jon K &quot;Alphalas&quot;" authorContact="Twitter: Alphalas_ Discord: Alphalas#8789" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="67" xmlns="http://www.battlescribe.net/schema/catalogueSchema" type="catalogue">
+<catalogue id="cd4d-8765-5387-8409" name="LA -  IX: Blood Angels" revision="40" battleScribeVersion="2.03" authorName="Jon K &quot;Alphalas&quot;" authorContact="Twitter: Alphalas_ Discord: Alphalas#8789" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="67" xmlns="http://www.battlescribe.net/schema/catalogueSchema" type="catalogue">
   <entryLinks>
     <entryLink id="1900-3f09-f47b-bed2" name="Praetor" hidden="false" collective="false" import="false" targetId="03be-5d55-d05a-771d" type="selectionEntry">
       <comment>template_id_5798-3fc7-4d4c-ad41</comment>
@@ -4295,6 +4295,47 @@ Characteristic when locked in combat with one or more enemy units that have the 
                   <costs>
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
                   </costs>
+                </selectionEntry>
+                <selectionEntry id="c9bd-4aa2-3814-6183" name="Bound by Glory" publicationId="53a4-0d21-2f8a-2c45" page="207" hidden="false" collective="false" import="true" type="upgrade">
+                  <profiles>
+                    <profile id="6250-7eb8-95df-b93b" name="Bound by Glory" publicationId="53a4-0d21-2f8a-2c45" page="207" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
+                      <characteristics>
+                        <characteristic name="Text" typeId="c68e-2cda-b67b-baca">The controlling player of a Warlord with this Trait may select a single variant of the Legiones Astartes (X) special rule, other than Legiones Astartes (Imperial Fists) at the start of the battle, before any models are deployed onto the battlefield, but after all players have selected their armies. The Warlord with this Trait and all models in a unit it has joined gain the Fearless special rule when locked in combat with an enemy unit that includes one or more models with that variant of the Legiones Astartes (X) special rule – but may not choose to make a Sweeping Advance against an enemy unit that includes one or more models with that variant of the Legiones Astartes (X) special rule. In addition, an army whose Warlord has this Trait may make an additional Reaction during the opposing player’s Assault phase as long as the Warlord has not been removed as a casualty.</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <infoLinks>
+                    <infoLink id="d7c7-3915-f273-bede" name="Fearless" hidden="false" targetId="b48c-d7e1-2a83-2f5b" type="rule">
+                      <modifiers>
+                        <modifier type="set" field="name" value="Fearless (In Combat - Bound by Glory)"/>
+                      </modifiers>
+                    </infoLink>
+                  </infoLinks>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b58a-8ea6-de69-6beb" type="max"/>
+                    <constraint field="selections" scope="force" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="aea5-902e-1daa-3042" type="max"/>
+                  </constraints>
+                </selectionEntry>
+                <selectionEntry id="2d17-21a-1941-f930" name="Unforgiven (Loyalist Only)" publicationId="53a4-0d21-2f8a-2c45" page="207" hidden="false" collective="false" import="true" type="upgrade">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="true">
+                      <conditions>
+                        <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <profiles>
+                    <profile id="df0d-351e-cc7d-a64b" name="Unforgiven" publicationId="53a4-0d21-2f8a-2c45" page="207" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
+                      <characteristics>
+                        <characteristic name="Text" typeId="c68e-2cda-b67b-baca">This Warlord Trait may only be selected by a model with the Loyalist Allegiance.
+While locked in combat with an enemy unit that includes the enemy Warlord, or any enemy unit that includes one or more models with the Primarch or Dreadnought Unit Types, or the Super-heavy, Knights and Titans Unit Sub-types, a Warlord that has this Trait that suffers Instant Death for any reason is not immediately removed as a casualty, but instead loses D3 Wounds. Furthermore, while locked in combat with any enemy unit a Warlord with this Warlord Trait gains the Fearless special rule, but must always declare a Charge if any enemy unit is within 12&quot; at the beginning of the Charge Sub-phase, if more than one enemy unit is within 12&quot; then a Charge for the Warlord and his unit must be declared targeting the closest enemy unit (if two or more enemy units are equally close, then the Warlord’s controlling player chooses one of those units to be the target of the Charge). An army whose Warlord has this Warlord Trait does not gain any bonus Reactions from this Warlord Trait.</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <constraints>
+                    <constraint field="selections" scope="force" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="3bc5-2707-5214-3156" type="max"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ab59-e36b-ee5c-a02a" type="max"/>
+                  </constraints>
                 </selectionEntry>
               </selectionEntries>
             </selectionEntryGroup>

--- a/2022 - LA - Iron Hands.cat
+++ b/2022 - LA - Iron Hands.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="b73e-125f-db29-17f2" name="LA -  X: Iron Hands" revision="33" battleScribeVersion="2.03" authorName="Figjam Bohica" authorContact="BSData Developers Discord" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="67" xmlns="http://www.battlescribe.net/schema/catalogueSchema" type="catalogue">
+<catalogue id="b73e-125f-db29-17f2" name="LA -  X: Iron Hands" revision="34" battleScribeVersion="2.03" authorName="Figjam Bohica" authorContact="BSData Developers Discord" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="67" xmlns="http://www.battlescribe.net/schema/catalogueSchema" type="catalogue">
   <entryLinks>
     <entryLink id="6107-168e-198e-2e94" name="X: Iron Hands" hidden="false" collective="false" import="false" targetId="bfc9-c99c-bf8a-3917" type="selectionEntry">
       <modifiers>
@@ -4654,11 +4654,6 @@
                   </modifiers>
                   <costs>
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15"/>
-                  </costs>
-                </entryLink>
-                <entryLink id="a9e6-3191-ddba-88b3" name="Volkite Culverin" hidden="false" collective="false" import="true" targetId="170d-44e0-455c-8207" type="selectionEntry">
-                  <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10"/>
                   </costs>
                 </entryLink>
                 <entryLink id="6988-8b30-7fc7-0c61" name="Legion Standard" hidden="false" collective="false" import="true" targetId="7e13-cc1f-6bd7-7ac6" type="selectionEntry">

--- a/2022 - LA - Sons of Horus.cat
+++ b/2022 - LA - Sons of Horus.cat
@@ -6349,23 +6349,7 @@ A Warlord with this Trait gains a bonus of +1 to its Leadership Characteristic w
               <profiles>
                 <profile id="e5a5-fd33-12ba-1647" name="Cast in Gold" publicationId="53a4-0d21-2f8a-2c45" page="211 (Updated in download)" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
                   <characteristics>
-                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca">When a Warlord with this Trait is engaged in a Challenge
-with an enemy model that has a Weapon Skill that is
-equal to or greater than the Weapon Skill of the Warlord
-with this Trait, then the Warlord with this Trait gains +1
-Strength and +1 Attacks for the duration of that Challenge
-(if both models in the Challenge have this Trait, then both
-models gain the bonus regardless of the Weapon Skill of
-either model). Furthermore, if the Warlord with this Trait
-causes an enemy model with a Weapon Skill equal to or
-greater than the Weapon Skill of the Warlord with this
-Trait to be removed as a casualty during a Challenge, the
-controlling player of the Warlord with this Trait gains 1
-Victory Point in addition to any gained from any other
-rule or mission objective. In addition, an army whose
-Warlord has this Trait may make an additional Reaction
-during the opposing player’s Movement phase as long as
-the Warlord has not been removed as a casualty.</characteristic>
+                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca">When a Warlord with this Trait is engaged in a Challenge with an enemy model that has a Weapon Skill that is equal to or greater than the Weapon Skill of the Warlord with this Trait, then the Warlord with this Trait gains +1 Strength and +1 Attacks for the duration of that Challenge (if both models in the Challenge have this Trait, then both models gain the bonus regardless of the Weapon Skill of either model). Furthermore, if the Warlord with this Trait causes an enemy model with a Weapon Skill equal to or greater than the Weapon Skill of the Warlord with this Trait to be removed as a casualty during a Challenge, the controlling player of the Warlord with this Trait gains 1 Victory Point in addition to any gained from any other rule or mission objective. In addition, an army whose Warlord has this Trait may make an additional Reaction during the opposing player’s Movement phase as long as the Warlord has not been removed as a casualty.</characteristic>
                   </characteristics>
                 </profile>
               </profiles>

--- a/2022 - LA - Sons of Horus.cat
+++ b/2022 - LA - Sons of Horus.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="62c7-42f4-5523-af1b" name="LA -  XVI: Sons of Horus" revision="32" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="67" xmlns="http://www.battlescribe.net/schema/catalogueSchema" type="catalogue">
+<catalogue id="62c7-42f4-5523-af1b" name="LA -  XVI: Sons of Horus" revision="33" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="67" xmlns="http://www.battlescribe.net/schema/catalogueSchema" type="catalogue">
   <entryLinks>
     <entryLink id="c2a2-9b6d-b384-3f43" name="XVI: Sons of Horus" hidden="false" collective="false" import="false" targetId="01b4-57c7-bf61-2abf" type="selectionEntry">
       <modifiers>
@@ -6347,9 +6347,25 @@ A Warlord with this Trait gains a bonus of +1 to its Leadership Characteristic w
             </selectionEntry>
             <selectionEntry id="10f5-0cbc-d0a6-bfd4" name="Cast in Gold" publicationId="53a4-0d21-2f8a-2c45" page="211" hidden="false" collective="false" import="true" type="upgrade">
               <profiles>
-                <profile id="e5a5-fd33-12ba-1647" name="Cast in Gold" publicationId="53a4-0d21-2f8a-2c45" page="211" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
+                <profile id="e5a5-fd33-12ba-1647" name="Cast in Gold" publicationId="53a4-0d21-2f8a-2c45" page="211 (Updated in download)" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
                   <characteristics>
-                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca">When a Warlord with this Trait is engaged in a Challenge with an enemy model that has a Weapon Skill that is equal to or greater than that of the Warlord with this Trait’s own Weapon Skill, then the controlling player of the Warlord with this Trait gains +1 Strength and +1 Attacks for the duration of that Challenge. Furthermore, if the Warlord with this Trait causes an enemy model with a Weapon Skill equal to or greater than the Weapon Skill of the Warlord with this Trait to be removed as a casualty during a Challenge, the controlling player gains 1 Victory point in addition to any gained from any other rule or mission objective. In addition, an army whose Warlord has this Trait may make an additional Reaction during the opposing player’s Movement phase as long as the Warlord has not been removed as a casualty.</characteristic>
+                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca">When a Warlord with this Trait is engaged in a Challenge
+with an enemy model that has a Weapon Skill that is
+equal to or greater than the Weapon Skill of the Warlord
+with this Trait, then the Warlord with this Trait gains +1
+Strength and +1 Attacks for the duration of that Challenge
+(if both models in the Challenge have this Trait, then both
+models gain the bonus regardless of the Weapon Skill of
+either model). Furthermore, if the Warlord with this Trait
+causes an enemy model with a Weapon Skill equal to or
+greater than the Weapon Skill of the Warlord with this
+Trait to be removed as a casualty during a Challenge, the
+controlling player of the Warlord with this Trait gains 1
+Victory Point in addition to any gained from any other
+rule or mission objective. In addition, an army whose
+Warlord has this Trait may make an additional Reaction
+during the opposing player’s Movement phase as long as
+the Warlord has not been removed as a casualty.</characteristic>
                   </characteristics>
                 </profile>
               </profiles>

--- a/2022 - Mech Library.cat
+++ b/2022 - Mech Library.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="3129-da35-55e0-642d" name="2022 - Mech Library" revision="23" battleScribeVersion="2.03" library="true" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="67" xmlns="http://www.battlescribe.net/schema/catalogueSchema" type="catalogue">
+<catalogue id="3129-da35-55e0-642d" name="2022 - Mech Library" revision="24" battleScribeVersion="2.03" library="true" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="67" xmlns="http://www.battlescribe.net/schema/catalogueSchema" type="catalogue">
   <categoryEntries>
     <categoryEntry id="4086-0589-f010-e688" name="Titan Legion Min Troop/LoW" hidden="false"/>
     <categoryEntry id="57a1-ae47-ff1b-36e4" name="Cybertheurgist" publicationId="bde1-6db1-163b-3b76" page="92-96" hidden="false"/>
@@ -3958,6 +3958,12 @@ Invulnerable Saves granted by a mag-inverter shield do not stack with other Invu
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="35"/>
               </costs>
             </entryLink>
+            <entryLink import="true" name="Atomantic Deflector" hidden="false" type="selectionEntry" id="585f-1b45-ae74-5f72" targetId="38fb-9a0b-edef-a497">
+              <constraints>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="6b93-2d67-30c5-50cb"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="cb9-cab7-18d2-427d"/>
+              </constraints>
+            </entryLink>
           </entryLinks>
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="85"/>
@@ -4736,6 +4742,14 @@ Invulnerable Saves granted by a mag-inverter shield do not stack with other Invu
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="65"/>
           </costs>
+          <entryLinks>
+            <entryLink import="true" name="Atomantic Deflector" hidden="false" type="selectionEntry" id="6ec3-a358-9bb3-c95" targetId="38fb-9a0b-edef-a497">
+              <constraints>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="6b93-2d67-30c5-50cb"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="cb9-cab7-18d2-427d"/>
+              </constraints>
+            </entryLink>
+          </entryLinks>
         </selectionEntry>
         <selectionEntry id="cff3-2ddf-4024-f463" name="Two Power Blade Arrays with In-Built Rotar Cannons" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>


### PR DESCRIPTION
Raldoran should have siege of cthonia wlt option #2912
Iron Hands Morlock weapon choices are wrong #2913
Castellax and Vorax do not have atomantic deflectors in their wargear displayed #2914
Iron Hands Venerable Ancient Contemptor Dreadnoughts have the incorrect option for graviton shredders #2915 
Levy Squad Chainaxes #2916