### PR TITLE
Fixed incorrect leman russ turret name

### DIFF
--- a/2022 - LI - Solar Auxilia.cat
+++ b/2022 - LI - Solar Auxilia.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="6af7-3fee-5bc1-7533" name="2022 - LI - Solar Auxilia" revision="22" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="70" xmlns="http://www.battlescribe.net/schema/catalogueSchema" type="catalogue">
+<catalogue id="6af7-3fee-5bc1-7533" name="2022 - LI - Solar Auxilia" revision="23" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="70" xmlns="http://www.battlescribe.net/schema/catalogueSchema" type="catalogue">
   <categoryEntries>
     <categoryEntry id="19f3-8727-02db-3ce5" name="Static Artillery" hidden="false">
       <rules>
@@ -6510,7 +6510,7 @@ Once assigned to a unit, the Auxilia Medicae is considered part of that unit and
                     </entryLink>
                     <entryLink id="e6b6-3a22-1d16-7036" name="Volkite Macro-Saker" hidden="false" collective="false" import="true" targetId="ff4d-6e1b-7b44-9b72" type="selectionEntry">
                       <modifiers>
-                        <modifier type="set" field="name" value="Turret Mounted Executioner Plasma Destroyer"/>
+                        <modifier type="set" field="name" value="Turret Mounted Volkite Macro-Saker"/>
                       </modifiers>
                     </entryLink>
                   </entryLinks>


### PR DESCRIPTION
## Fixed Units

Leman Russ Assault Squadron had an incorrectly named weapon option

### Related Issues

- closes #2979 [Solar Auxilia Leman Russ Assault Squad turret weapon named wrong](https://github.com/BSData/horus-heresy/issues/2979)

