### PR TITLE
Removed fearless if they already had stubborn from Day of Sorrows

### DIFF
--- a/2022 - Horus Heresy.gst
+++ b/2022 - Horus Heresy.gst
@@ -340,16 +340,6 @@ During Reactions made in any Phase, a unit equipped with Jump PAcks may not acti
             <modifier type="set" field="name" value="Heart of the Legion (if at 50% of less of unit size)"/>
           </modifiers>
         </infoLink>
-        <infoLink id="0aec-717a-af00-d33e" name="Stubborn" hidden="false" targetId="7989-1f2c-a43d-82ae" type="rule">
-          <modifiers>
-            <modifier type="set" field="hidden" value="true">
-              <conditions>
-                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d8e9-ff9b-f862-b065" type="equalTo"/>
-              </conditions>
-            </modifier>
-            <modifier type="set" field="name" value="Fearless (in 6&quot; of Objective if they didn&apos;t already have Stubborn)"/>
-          </modifiers>
-        </infoLink>
         <infoLink id="9afe-5527-9b81-e837" name="Line Sub-type" hidden="false" targetId="bc1e-9c95-f971-cd7b" type="rule">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
@@ -1583,7 +1573,20 @@ Reactions:
             <constraint field="selections" scope="force" value="2" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8810-8109-85db-93e4" type="min"/>
           </constraints>
         </categoryLink>
-        <categoryLink id="2545-86dd-f928-73f3" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="2545-86dd-f928-73f3" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false">
+          <infoLinks>
+            <infoLink name="Stubborn" hidden="false" type="rule" id="986d-7ecf-f212-2602" targetId="7989-1f2c-a43d-82ae">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d8e9-ff9b-f862-b065" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="set" value="Stubborn (if one model is within 6&quot; of an objective)" field="name"/>
+              </modifiers>
+            </infoLink>
+          </infoLinks>
+        </categoryLink>
         <categoryLink id="dc87-6668-f349-2a8c" name="LoW &amp; Primarchs (25% Limit)" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false">
           <modifiers>
             <modifier type="increment" field="d9f7-954e-b8d3-7a39" value="1">

--- a/2022 - Horus Heresy.gst
+++ b/2022 - Horus Heresy.gst
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<gameSystem id="28d4-bd2e-4858-ece6" name="(HH V2) Horus Heresy (2022)" revision="86" battleScribeVersion="2.03" xmlns="http://www.battlescribe.net/schema/gameSystemSchema" type="gameSystem">
+<gameSystem id="28d4-bd2e-4858-ece6" name="(HH V2) Horus Heresy (2022)" revision="87" battleScribeVersion="2.03" xmlns="http://www.battlescribe.net/schema/gameSystemSchema" type="gameSystem">
   <publications>
     <publication name="GitHub" hidden="false" id="e2a4-ac85-1bef-22f5" publisherUrl="https://github.com/BSData/horus-heresy"/>
     <publication id="e77a-823a-da94-16b9" name="Warhammer: The Horus Heresy - Age of Darkness Rulebook" shortName="Main Rules" publicationDate="June 2022"/>
@@ -348,16 +348,6 @@ During Reactions made in any Phase, a unit equipped with Jump PAcks may not acti
               </conditions>
             </modifier>
             <modifier type="set" field="name" value="Fearless (in 6&quot; of Objective if they didn&apos;t already have Stubborn)"/>
-          </modifiers>
-        </infoLink>
-        <infoLink id="4aea-a583-a545-cbc8" name="Fearless" hidden="false" targetId="b48c-d7e1-2a83-2f5b" type="rule">
-          <modifiers>
-            <modifier type="set" field="hidden" value="true">
-              <conditions>
-                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d8e9-ff9b-f862-b065" type="equalTo"/>
-              </conditions>
-            </modifier>
-            <modifier type="set" field="name" value="Fearless (in 6&quot; of Objective if they had already had Stubborn)"/>
           </modifiers>
         </infoLink>
         <infoLink id="9afe-5527-9b81-e837" name="Line Sub-type" hidden="false" targetId="bc1e-9c95-f971-cd7b" type="rule">


### PR DESCRIPTION
Removed the addition of fearless to units in Day of Sorrows if they had stubborn as that isn't how it works

Linked rule properly and added renaming to explain where stubborn was from

Fixes #2992 
