### PR TITLE
Added selection to aetheric conduit

### DIFF
--- a/2022 - Daemons - Daemons of the Ruinstorm.cat
+++ b/2022 - Daemons - Daemons of the Ruinstorm.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue library="false" id="ac63-5340-2e9e-1eb6" name="2022 - Daemons - Daemons of the Ruinstorm" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="77" revision="6" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue library="false" id="ac63-5340-2e9e-1eb6" name="2022 - Daemons - Daemons of the Ruinstorm" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="77" revision="7" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entryLinks>
     <entryLink import="false" name="Daemons of the Ruinstorm" hidden="false" type="selectionEntry" id="e271-f450-1c28-5b7b" targetId="afca-3047-fb26-d097">
       <constraints>

--- a/2022 - Daemons - Daemons of the Ruinstorm.cat
+++ b/2022 - Daemons - Daemons of the Ruinstorm.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue library="false" id="ac63-5340-2e9e-1eb6" name="2022 - Daemons - Daemons of the Ruinstorm" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="77" revision="5" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue library="false" id="ac63-5340-2e9e-1eb6" name="2022 - Daemons - Daemons of the Ruinstorm" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="77" revision="6" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entryLinks>
     <entryLink import="false" name="Daemons of the Ruinstorm" hidden="false" type="selectionEntry" id="e271-f450-1c28-5b7b" targetId="afca-3047-fb26-d097">
       <constraints>
@@ -2001,6 +2001,43 @@ The End and the Death – When fighting in a Challenge, successful Invulnerable 
       <constraints>
         <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="ee05-19f1-809e-d0a0"/>
       </constraints>
+      <selectionEntryGroups>
+        <selectionEntryGroup name="Psychic Discipline" hidden="false" id="1e24-9782-7fd9-9fe2">
+          <constraints>
+            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="6a6e-f5da-92d7-93c0"/>
+            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="7b70-6b79-ac99-1650"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry type="upgrade" import="true" name="Psychic Discipline: Diabolism" hidden="false" id="a284-22ef-923f-e64f">
+              <profiles>
+                <profile name="A Dark and Terrible Power" typeId="5405-b3c6-e8d0-4e77" typeName="Psychic Power" hidden="false" id="e838-7f7d-ba1-fe40">
+                  <characteristics>
+                    <characteristic name="Description" typeId="4c0f-7e2f-586c-9305">When a Charge is declared for a model with this power, or for a unit that includes a model with this power, the Controlling player may choose to make a Psychic check for the model before any dice are rolled to determine the Charge Distance of that Charge. If the Psychic check is successful then the model with this power gains the Hammer of Wrath (3) special rule and increases both their Strength and Toughness characteristics by +1 for the duration of that Assault Phase. If the Check is failed then the model suffers Perils of the Warp, and once that has been resolved gains +1 to both its Strength and Toughness Characteristics until the start of the controlling players next turn</characteristic>
+                  </characteristics>
+                </profile>
+                <profile name="Hellfire" typeId="cede-0217-1b10-2a34" typeName="Psychic Weapon" hidden="false" id="e312-fa31-f947-3096">
+                  <characteristics>
+                    <characteristic name="Range" typeId="62ec-fbf5-5252-0d17">Template</characteristic>
+                    <characteristic name="Strength" typeId="17ff-12e7-77d3-2fbe">7</characteristic>
+                    <characteristic name="AP" typeId="f431-a7b9-d9d0-36c9">4</characteristic>
+                    <characteristic name="Type" typeId="2159-62b6-4337-d516">Assault 1, Rending (6+), Deflagrate, Psychic Focus</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <entryLinks>
+                <entryLink import="true" name="Hammer of Wrath (X)" hidden="false" type="rule" id="9251-2ac7-f3a1-1e76" targetId="aec0-c3aa-1e4e-1779"/>
+                <entryLink import="true" name="Psychic Focus" hidden="false" type="rule" id="3390-c2e5-384d-cb1c" targetId="bff3-3548-b2b8-72f1"/>
+                <entryLink import="true" name="Rending (X)" hidden="false" type="rule" id="5c93-d982-43e0-b772" targetId="0ac9-fab7-aef3-de1d"/>
+              </entryLinks>
+            </selectionEntry>
+          </selectionEntries>
+          <entryLinks>
+            <entryLink import="true" name="Psychic Discipline: Biomancy" hidden="false" type="selectionEntry" id="5b55-33a3-ebc1-906d" targetId="861c-3744-c4ff-ef6c"/>
+            <entryLink import="true" name="Psychic Discipline: Pyromancy" hidden="false" type="selectionEntry" id="ed57-38da-c088-8da5" targetId="c73a-8c52-4780-71e1"/>
+            <entryLink import="true" name="Psychic Discipline: Telepathy" hidden="false" type="selectionEntry" id="3eb1-c56b-1469-1ff6" targetId="b751-a605-75e8-dd6f"/>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
     </selectionEntry>
     <selectionEntry type="upgrade" import="true" name="Ætheric Flight" hidden="false" id="7647-8112-eaf7-fbea">
       <profiles>


### PR DESCRIPTION
Added radio button selection to the aetheric conduiit upgrade.

As it appears multiple times across the force, this is added to the root selection so it will be available to any unit that selects it.

Diabolism had to be copied in as it's own entry here as it would otherwise reference back to Legions Astartes and create a weird circular dependency.

![image](https://github.com/BSData/horus-heresy/assets/4020636/7937eb9e-ac7e-4af0-8041-27a5a92afa4a)

Fixes #3004 