### PR TITLE
Restructured Diabolism and Aetheric Conduit

### DIFF
--- a/2022 - Daemons - Daemons of the Ruinstorm.cat
+++ b/2022 - Daemons - Daemons of the Ruinstorm.cat
@@ -2007,30 +2007,6 @@ The End and the Death – When fighting in a Challenge, successful Invulnerable 
             <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="6a6e-f5da-92d7-93c0"/>
             <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="7b70-6b79-ac99-1650"/>
           </constraints>
-          <selectionEntries>
-            <selectionEntry type="upgrade" import="true" name="Psychic Discipline: Diabolism" hidden="false" id="a284-22ef-923f-e64f">
-              <profiles>
-                <profile name="A Dark and Terrible Power" typeId="5405-b3c6-e8d0-4e77" typeName="Psychic Power" hidden="false" id="e838-7f7d-ba1-fe40">
-                  <characteristics>
-                    <characteristic name="Description" typeId="4c0f-7e2f-586c-9305">When a Charge is declared for a model with this power, or for a unit that includes a model with this power, the Controlling player may choose to make a Psychic check for the model before any dice are rolled to determine the Charge Distance of that Charge. If the Psychic check is successful then the model with this power gains the Hammer of Wrath (3) special rule and increases both their Strength and Toughness characteristics by +1 for the duration of that Assault Phase. If the Check is failed then the model suffers Perils of the Warp, and once that has been resolved gains +1 to both its Strength and Toughness Characteristics until the start of the controlling players next turn</characteristic>
-                  </characteristics>
-                </profile>
-                <profile name="Hellfire" typeId="cede-0217-1b10-2a34" typeName="Psychic Weapon" hidden="false" id="e312-fa31-f947-3096">
-                  <characteristics>
-                    <characteristic name="Range" typeId="62ec-fbf5-5252-0d17">Template</characteristic>
-                    <characteristic name="Strength" typeId="17ff-12e7-77d3-2fbe">7</characteristic>
-                    <characteristic name="AP" typeId="f431-a7b9-d9d0-36c9">4</characteristic>
-                    <characteristic name="Type" typeId="2159-62b6-4337-d516">Assault 1, Rending (6+), Deflagrate, Psychic Focus</characteristic>
-                  </characteristics>
-                </profile>
-              </profiles>
-              <entryLinks>
-                <entryLink import="true" name="Hammer of Wrath (X)" hidden="false" type="rule" id="9251-2ac7-f3a1-1e76" targetId="aec0-c3aa-1e4e-1779"/>
-                <entryLink import="true" name="Psychic Focus" hidden="false" type="rule" id="3390-c2e5-384d-cb1c" targetId="bff3-3548-b2b8-72f1"/>
-                <entryLink import="true" name="Rending (X)" hidden="false" type="rule" id="5c93-d982-43e0-b772" targetId="0ac9-fab7-aef3-de1d"/>
-              </entryLinks>
-            </selectionEntry>
-          </selectionEntries>
           <entryLinks>
             <entryLink import="true" name="Psychic Discipline: Biomancy" hidden="false" type="selectionEntry" id="5b55-33a3-ebc1-906d" targetId="861c-3744-c4ff-ef6c"/>
             <entryLink import="true" name="Psychic Discipline: Pyromancy" hidden="false" type="selectionEntry" id="ed57-38da-c088-8da5" targetId="c73a-8c52-4780-71e1"/>

--- a/2022 - Daemons - Daemons of the Ruinstorm.cat
+++ b/2022 - Daemons - Daemons of the Ruinstorm.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue library="false" id="ac63-5340-2e9e-1eb6" name="2022 - Daemons - Daemons of the Ruinstorm" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="77" revision="6" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue library="false" id="ac63-5340-2e9e-1eb6" name="2022 - Daemons - Daemons of the Ruinstorm" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="77" revision="7" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entryLinks>
     <entryLink import="false" name="Daemons of the Ruinstorm" hidden="false" type="selectionEntry" id="e271-f450-1c28-5b7b" targetId="afca-3047-fb26-d097">
       <constraints>

--- a/2022 - Daemons - Daemons of the Ruinstorm.cat
+++ b/2022 - Daemons - Daemons of the Ruinstorm.cat
@@ -2011,6 +2011,7 @@ The End and the Death – When fighting in a Challenge, successful Invulnerable 
             <entryLink import="true" name="Psychic Discipline: Biomancy" hidden="false" type="selectionEntry" id="5b55-33a3-ebc1-906d" targetId="861c-3744-c4ff-ef6c"/>
             <entryLink import="true" name="Psychic Discipline: Pyromancy" hidden="false" type="selectionEntry" id="ed57-38da-c088-8da5" targetId="c73a-8c52-4780-71e1"/>
             <entryLink import="true" name="Psychic Discipline: Telepathy" hidden="false" type="selectionEntry" id="3eb1-c56b-1469-1ff6" targetId="b751-a605-75e8-dd6f"/>
+            <entryLink import="true" name="Psychic Discipline: Diabolism" hidden="false" type="selectionEntry" id="8be8-8673-ba2d-29a5" targetId="7517-a238-aecb-60e9"/>
           </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>

--- a/2022 - Daemons - Daemons of the Ruinstorm.cat
+++ b/2022 - Daemons - Daemons of the Ruinstorm.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue library="false" id="ac63-5340-2e9e-1eb6" name="2022 - Daemons - Daemons of the Ruinstorm" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="77" revision="5" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue library="false" id="ac63-5340-2e9e-1eb6" name="2022 - Daemons - Daemons of the Ruinstorm" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="77" revision="6" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entryLinks>
     <entryLink import="false" name="Daemons of the Ruinstorm" hidden="false" type="selectionEntry" id="e271-f450-1c28-5b7b" targetId="afca-3047-fb26-d097">
       <constraints>
@@ -2001,6 +2001,43 @@ The End and the Death – When fighting in a Challenge, successful Invulnerable 
       <constraints>
         <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="ee05-19f1-809e-d0a0"/>
       </constraints>
+      <selectionEntryGroups>
+        <selectionEntryGroup name="Psychic Discipline" hidden="false" id="1e24-9782-7fd9-9fe2">
+          <constraints>
+            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="6a6e-f5da-92d7-93c0"/>
+            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="7b70-6b79-ac99-1650"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry type="upgrade" import="true" name="Psychic Discipline: Diabolism" hidden="false" id="a284-22ef-923f-e64f">
+              <profiles>
+                <profile name="A Dark and Terrible Power" typeId="5405-b3c6-e8d0-4e77" typeName="Psychic Power" hidden="false" id="e838-7f7d-ba1-fe40">
+                  <characteristics>
+                    <characteristic name="Description" typeId="4c0f-7e2f-586c-9305">When a Charge is declared for a model with this power, or for a unit that includes a model with this power, the Controlling player may choose to make a Psychic check for the model before any dice are rolled to determine the Charge Distance of that Charge. If the Psychic check is successful then the model with this power gains the Hammer of Wrath (3) special rule and increases both their Strength and Toughness characteristics by +1 for the duration of that Assault Phase. If the Check is failed then the model suffers Perils of the Warp, and once that has been resolved gains +1 to both its Strength and Toughness Characteristics until the start of the controlling players next turn</characteristic>
+                  </characteristics>
+                </profile>
+                <profile name="Hellfire" typeId="cede-0217-1b10-2a34" typeName="Psychic Weapon" hidden="false" id="e312-fa31-f947-3096">
+                  <characteristics>
+                    <characteristic name="Range" typeId="62ec-fbf5-5252-0d17">Template</characteristic>
+                    <characteristic name="Strength" typeId="17ff-12e7-77d3-2fbe">7</characteristic>
+                    <characteristic name="AP" typeId="f431-a7b9-d9d0-36c9">4</characteristic>
+                    <characteristic name="Type" typeId="2159-62b6-4337-d516">Assault 1, Rending (6+), Deflagrate, Psychic Focus</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <entryLinks>
+                <entryLink import="true" name="Hammer of Wrath (X)" hidden="false" type="rule" id="9251-2ac7-f3a1-1e76" targetId="aec0-c3aa-1e4e-1779"/>
+                <entryLink import="true" name="Psychic Focus" hidden="false" type="rule" id="3390-c2e5-384d-cb1c" targetId="bff3-3548-b2b8-72f1"/>
+                <entryLink import="true" name="Rending (X)" hidden="false" type="rule" id="5c93-d982-43e0-b772" targetId="0ac9-fab7-aef3-de1d"/>
+              </entryLinks>
+            </selectionEntry>
+          </selectionEntries>
+          <entryLinks>
+            <entryLink import="true" name="Psychic Discipline: Biomancy" hidden="false" type="selectionEntry" id="5b55-33a3-ebc1-906d" targetId="861c-3744-c4ff-ef6c"/>
+            <entryLink import="true" name="Psychic Discipline: Pyromancy" hidden="false" type="selectionEntry" id="ed57-38da-c088-8da5" targetId="c73a-8c52-4780-71e1"/>
+            <entryLink import="true" name="Psychic Discipline: Telepathy" hidden="false" type="selectionEntry" id="3eb1-c56b-1469-1ff6" targetId="b751-a605-75e8-dd6f"/>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
     </selectionEntry>
     <selectionEntry type="upgrade" import="true" name="Ætheric Flight" hidden="false" id="7647-8112-eaf7-fbea">
       <profiles>

--- a/2022 - Horus Heresy.gst
+++ b/2022 - Horus Heresy.gst
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<gameSystem id="28d4-bd2e-4858-ece6" name="(HH V2) Horus Heresy (2022)" revision="86" battleScribeVersion="2.03" xmlns="http://www.battlescribe.net/schema/gameSystemSchema" type="gameSystem">
+<gameSystem id="28d4-bd2e-4858-ece6" name="(HH V2) Horus Heresy (2022)" revision="87" battleScribeVersion="2.03" xmlns="http://www.battlescribe.net/schema/gameSystemSchema" type="gameSystem">
   <publications>
     <publication name="GitHub" hidden="false" id="e2a4-ac85-1bef-22f5" publisherUrl="https://github.com/BSData/horus-heresy"/>
     <publication id="e77a-823a-da94-16b9" name="Warhammer: The Horus Heresy - Age of Darkness Rulebook" shortName="Main Rules" publicationDate="June 2022"/>
@@ -10510,6 +10510,31 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
         <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="98d5-2132-75e-8aa9" type="max"/>
         <constraint field="selections" scope="roster" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d8b3-b50c-24b2-b352" type="min"/>
       </constraints>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="7517-a238-aecb-60e9" name="Psychic Discipline: Diabolism" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="c739-c662-d9f1-c146" name="A Dark and Terrible Power" hidden="false" typeId="5405-b3c6-e8d0-4e77" typeName="Psychic Power">
+          <characteristics>
+            <characteristic name="Description" typeId="4c0f-7e2f-586c-9305">When a Charge is declared for a model with this power, or for a unit that includes a model with this power, the Controlling player may choose to make a Psychic check for the model before any dice are rolled to determine the Charge Distance of that Charge. If the Psychic check is successful then the model with this power gains the Hammer of Wrath (3) special rule and increases both their Strength and Toughness characteristics by +1 for the duration of that Assult Phase. If the Check is failed then the model suffers Perils of the Warp, and once that has been resolved gains +1 to both its Strength and Toughness Characteristics until the start of the controlling players next turn</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="4c31-2f32-2d30-fc5e" name="Hellfire" hidden="false" typeId="cede-0217-1b10-2a34" typeName="Psychic Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="62ec-fbf5-5252-0d17">Template</characteristic>
+            <characteristic name="Strength" typeId="17ff-12e7-77d3-2fbe">7</characteristic>
+            <characteristic name="AP" typeId="f431-a7b9-d9d0-36c9">4</characteristic>
+            <characteristic name="Type" typeId="2159-62b6-4337-d516">Assault 1, Rending (6+), Deflagrate, Psychic Focus</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="3380-3ab-8c69-61d8" name="Hammer of Wrath (X)" hidden="false" targetId="aec0-c3aa-1e4e-1779" type="rule"/>
+        <infoLink id="72e1-d6ce-337d-fbee" name="Rending (X)" hidden="false" targetId="0ac9-fab7-aef3-de1d" type="rule"/>
+        <infoLink id="1804-acb9-a81b-1cd1" name="Psychic Focus (?? Where is this?)" hidden="false" targetId="bff3-3548-b2b8-72f1" type="rule"/>
+      </infoLinks>
       <costs>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
       </costs>

--- a/2022 - LA - Word Bearers.cat
+++ b/2022 - LA - Word Bearers.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="1df7-bbbc-b70e-6a3f" name="LA -  XVII: Word Bearers" revision="31" battleScribeVersion="2.03" authorName="UrsinePatriarch" authorContact="BSData Developers Discord" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="67" xmlns="http://www.battlescribe.net/schema/catalogueSchema" type="catalogue">
+<catalogue id="1df7-bbbc-b70e-6a3f" name="LA -  XVII: Word Bearers" revision="32" battleScribeVersion="2.03" authorName="UrsinePatriarch" authorContact="BSData Developers Discord" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="67" xmlns="http://www.battlescribe.net/schema/catalogueSchema" type="catalogue">
   <categoryEntries>
     <categoryEntry id="821c-0c83-5ed0-ff6b" name="Harbinger of Chaos Restriction" hidden="false">
       <modifiers>
@@ -3969,7 +3969,7 @@ In addition, once per battle, one friendly unit composed entirely of models with
                     <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="5441-6776-963e-d456" type="min"/>
                   </constraints>
                 </entryLink>
-                <entryLink id="816c-e774-eae3-5cd8" name="Psychic Discipline: Diabolism" hidden="false" collective="false" import="true" targetId="cc56-0599-fe21-9352" type="selectionEntry">
+                <entryLink id="816c-e774-eae3-5cd8" name="Psychic Discipline: Diabolism" hidden="false" collective="false" import="true" targetId="7517-a238-aecb-60e9" type="selectionEntry">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a3b9-16bc-12b5-b645" type="max"/>
                     <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="77ae-9d37-22eb-568b" type="min"/>


### PR DESCRIPTION
You can now select psychic disciplines for the Aetheric Conduit upgrade in daemons.

This has been added to the root upgrade item thingy, so any unit that can select it gets to then make their selection from Aetheric Conduit. As such it creates a sub-menu rather like power weapons

Fixes #3004 

![image](https://github.com/BSData/horus-heresy/assets/4020636/d82c2e21-c97d-4201-9214-4b5c099ebf82)


[This branch and PR have been created to try to fix CI issues]