### PR TITLE
Corrected voidsheen cloak references

### DIFF
--- a/2022 - LI - Sisters Of Silence.cat
+++ b/2022 - LI - Sisters Of Silence.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="585a-5ac2-a233-a6a6" name="2022 - LI - Sisters of Silence" revision="18" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="70" xmlns="http://www.battlescribe.net/schema/catalogueSchema" type="catalogue">
+<catalogue id="585a-5ac2-a233-a6a6" name="2022 - LI - Sisters of Silence" revision="19" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="70" xmlns="http://www.battlescribe.net/schema/catalogueSchema" type="catalogue">
   <categoryEntries>
     <categoryEntry id="b760-8313-847f-1afa" name="Obivion HQ" hidden="false"/>
     <categoryEntry id="a9b6-f66f-e8ee-553e" name="Judgement HQ" hidden="false"/>
@@ -3336,7 +3336,7 @@
                 <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8259-ac40-4d3c-7eba" type="max"/>
               </constraints>
             </entryLink>
-            <entryLink id="1fab-975c-12ee-a134" name="Voidsheen Cloak" hidden="false" collective="false" import="true" targetId="65c1-1f76-7b8a-2aa9" type="selectionEntry">
+            <entryLink id="1fab-975c-12ee-a134" name="Voidsheen Cloak" hidden="false" collective="false" import="true" targetId="9449-eb87-30c1-43c0" type="selectionEntry">
               <constraints>
                 <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="aeae-ce36-341d-03bc" type="min"/>
                 <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7f41-5949-047b-c79e" type="max"/>
@@ -7510,7 +7510,7 @@
                     <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a522-036c-538e-9f6b" type="min"/>
                   </constraints>
                 </entryLink>
-                <entryLink id="f84e-3dc6-23d3-6cb0" name="Voidsheen Cloak" hidden="false" collective="false" import="true" targetId="65c1-1f76-7b8a-2aa9" type="selectionEntry">
+                <entryLink id="f84e-3dc6-23d3-6cb0" name="Voidsheen Cloak" hidden="false" collective="false" import="true" targetId="9449-eb87-30c1-43c0" type="selectionEntry">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4145-cafa-e268-1087" type="max"/>
                     <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2482-6990-f46b-0ad6" type="min"/>
@@ -7556,7 +7556,7 @@
                     <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4aaf-b1a2-38f7-6cae" type="min"/>
                   </constraints>
                 </entryLink>
-                <entryLink id="65b7-ef5f-6ec1-f178" name="Voidsheen Cloak" hidden="false" collective="false" import="true" targetId="65c1-1f76-7b8a-2aa9" type="selectionEntry">
+                <entryLink id="65b7-ef5f-6ec1-f178" name="Voidsheen Cloak" hidden="false" collective="false" import="true" targetId="9449-eb87-30c1-43c0" type="selectionEntry">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1819-5138-ed03-c7ca" type="max"/>
                     <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8d1f-fd5c-fa89-dbfd" type="min"/>
@@ -7614,7 +7614,7 @@
                     <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="67da-0a4f-ffad-64bd" type="min"/>
                   </constraints>
                 </entryLink>
-                <entryLink id="e29d-acd0-44ac-d5df" name="Voidsheen Cloak" hidden="false" collective="false" import="true" targetId="65c1-1f76-7b8a-2aa9" type="selectionEntry">
+                <entryLink id="e29d-acd0-44ac-d5df" name="Voidsheen Cloak" hidden="false" collective="false" import="true" targetId="9449-eb87-30c1-43c0" type="selectionEntry">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="29e6-0ba1-92d6-557e" type="max"/>
                     <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fc6e-2caa-4e51-8880" type="min"/>
@@ -7741,7 +7741,7 @@
                     <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c914-68b0-e44d-c340" type="min"/>
                   </constraints>
                 </entryLink>
-                <entryLink id="a548-192f-125c-562c" name="Voidsheen Cloak" hidden="false" collective="false" import="true" targetId="65c1-1f76-7b8a-2aa9" type="selectionEntry">
+                <entryLink id="a548-192f-125c-562c" name="Voidsheen Cloak" hidden="false" collective="false" import="true" targetId="9449-eb87-30c1-43c0" type="selectionEntry">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b824-5372-80c3-77eb" type="max"/>
                     <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2d9f-0006-128d-f400" type="min"/>

--- a/2022 - LI - Sisters Of Silence.cat
+++ b/2022 - LI - Sisters Of Silence.cat
@@ -7846,14 +7846,6 @@
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="65c1-1f76-7b8a-2aa9" name="Voidsheen Cloak" hidden="false" collective="true" import="true" type="upgrade">
-      <infoLinks>
-        <infoLink id="10ab-25bd-b862-2fcb" name="Raptora" hidden="false" targetId="f95e-9b9e-28c7-65e4" type="profile"/>
-      </infoLinks>
-      <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
-      </costs>
-    </selectionEntry>
     <selectionEntry id="91c6-82e2-3c3e-fe76" name="Vratine Armour" hidden="false" collective="true" import="true" type="upgrade">
       <infoLinks>
         <infoLink id="47b7-7aad-2508-c625" name="Vratine Armour" hidden="false" targetId="eaf9-0555-cc91-e313" type="profile"/>


### PR DESCRIPTION
Voidsheen cloaks on raptora cadres were pointing to a dead item that did nothing.

I've updated the references to point a the correct voidsheen cloak item and removed the dead one.
