### PR TITLE
v17.4.3 Release Branch

### DIFF
--- a/2022 - Daemons - Daemons of the Ruinstorm.cat
+++ b/2022 - Daemons - Daemons of the Ruinstorm.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue library="false" id="ac63-5340-2e9e-1eb6" name="2022 - Daemons - Daemons of the Ruinstorm" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="77" revision="7" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue library="false" id="ac63-5340-2e9e-1eb6" name="2022 - Daemons - Daemons of the Ruinstorm" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="77" revision="8" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entryLinks>
     <entryLink import="false" name="Daemons of the Ruinstorm" hidden="false" type="selectionEntry" id="e271-f450-1c28-5b7b" targetId="afca-3047-fb26-d097">
       <constraints>
@@ -445,7 +445,12 @@
               <modifiers>
                 <modifier type="set" field="name" value="Hammer of Wrath (1)">
                   <conditions>
-                    <condition type="atLeast" value="1" field="selections" scope="5a2e-abe2-3044-3c1c" childId="e4fb-66cd-e07d-609b" shared="true"/>
+                    <condition type="greaterThan" value="0" field="selections" scope="5a2e-abe2-3044-3c1c" childId="e4fb-66cd-e07d-609b" shared="true"/>
+                  </conditions>
+                </modifier>
+                <modifier type="set" value="true" field="hidden">
+                  <conditions>
+                    <condition type="lessThan" value="1" field="selections" scope="5a2e-abe2-3044-3c1c" childId="e4fb-66cd-e07d-609b" shared="true"/>
                   </conditions>
                 </modifier>
               </modifiers>
@@ -473,6 +478,15 @@
               <constraints>
                 <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="f45c-bfb7-f86c-bc65"/>
               </constraints>
+            </selectionEntryGroup>
+            <selectionEntryGroup name="Weapons" hidden="false" id="2b71-5e04-4b77-c072" defaultSelectionEntryId="ba69-b72-c0fc-1b18">
+              <constraints>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="8b67-b6ce-5d47-5f0"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="48ea-5e54-a731-953b"/>
+              </constraints>
+              <entryLinks>
+                <entryLink import="true" name="Harbinger Blade" hidden="false" type="selectionEntry" id="ba69-b72-c0fc-1b18" targetId="7192-6fa1-c141-41fd"/>
+              </entryLinks>
             </selectionEntryGroup>
           </selectionEntryGroups>
           <entryLinks>
@@ -524,21 +538,37 @@
               </modifiers>
             </infoLink>
             <infoLink id="9e4d-875f-444c-e9ce" name="Traitor" hidden="false" targetId="eff2-8b0e-21da-2f0d" type="rule"/>
-            <infoLink id="7326-8d18-d081-abb8" name="Hammer of Wrath (X)" hidden="false" targetId="aec0-c3aa-1e4e-1779" type="rule">
+            <infoLink id="4072-d9b0-b173-6c99" name="Hammer of Wrath (X)" hidden="false" targetId="aec0-c3aa-1e4e-1779" type="rule">
               <modifiers>
                 <modifier type="set" field="name" value="Hammer of Wrath (1)">
                   <conditions>
-                    <condition type="equalTo" value="0" field="selections" scope="5a2e-abe2-3044-3c1c" childId="e4fb-66cd-e07d-609b" shared="true"/>
+                    <condition type="equalTo" value="0" field="selections" scope="parent" childId="e4fb-66cd-e07d-609b" shared="true"/>
                   </conditions>
                 </modifier>
                 <modifier type="set" field="name" value="Hammer of Wrath (2)">
                   <conditions>
-                    <condition type="atLeast" value="1" field="selections" scope="5a2e-abe2-3044-3c1c" childId="e4fb-66cd-e07d-609b" shared="true"/>
+                    <condition type="atLeast" value="1" field="selections" scope="parent" childId="e4fb-66cd-e07d-609b" shared="true"/>
                   </conditions>
                 </modifier>
               </modifiers>
             </infoLink>
           </infoLinks>
+          <selectionEntryGroups>
+            <selectionEntryGroup name="Weapons" hidden="false" id="d8e2-4c00-fe25-76b">
+              <constraints>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="dd0a-53-fbae-6a25"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="3500-d65d-bf4f-e174"/>
+              </constraints>
+              <entryLinks>
+                <entryLink import="true" name="Infernal Armaments" hidden="false" type="selectionEntry" id="9a0e-a41d-3e37-555" targetId="9abc-11e8-9031-d104">
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="f7a9-fe36-4f38-ac48"/>
+                    <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="df9e-f7f6-68cb-2b55"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
         </selectionEntry>
       </selectionEntries>
       <costs>

--- a/2022 - LA - Emperor's Children.cat
+++ b/2022 - LA - Emperor's Children.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="72ba-61c2-37ad-c785" name="LA -   III: Emperor&apos;s Children" revision="31" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="67" xmlns="http://www.battlescribe.net/schema/catalogueSchema" type="catalogue">
+<catalogue id="72ba-61c2-37ad-c785" name="LA -   III: Emperor&apos;s Children" revision="32" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="67" xmlns="http://www.battlescribe.net/schema/catalogueSchema" type="catalogue">
   <entryLinks>
     <entryLink id="a119-3943-4b8b-b651" name="Captain Lucius" hidden="true" collective="false" import="false" targetId="0707-1e4b-27da-9cd4" type="selectionEntry">
       <modifiers>
@@ -3437,12 +3437,17 @@ A unit with this special rule gains +1 to the score used to calculate the winner
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="35"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="8299-7028-93bc-0355" name="Phoenix Terminator Standard Bearer" hidden="false" collective="false" import="true" type="model">
+        <selectionEntry id="8299-7028-93bc-0355" name="Phoenix Terminator Standard Bearer" hidden="true" collective="false" import="true" type="model">
           <modifiers>
-            <modifier type="set" field="hidden" value="true">
-              <conditions>
-                <condition field="selections" scope="primary-category" value="3" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7aee-565f-b0ae-294e" type="instanceOf"/>
-              </conditions>
+            <modifier type="set" field="hidden" value="false">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="primary-category" value="3" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="4f85-eb33-30c9-8f51" type="instanceOf"/>
+                    <condition type="instanceOf" value="1" field="selections" scope="primary-category" childId="ad5f-31db-8bc7-5c46" shared="true"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
             </modifier>
           </modifiers>
           <constraints>

--- a/2022 - LI - Sisters Of Silence.cat
+++ b/2022 - LI - Sisters Of Silence.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="585a-5ac2-a233-a6a6" name="2022 - LI - Sisters of Silence" revision="18" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="70" xmlns="http://www.battlescribe.net/schema/catalogueSchema" type="catalogue">
+<catalogue id="585a-5ac2-a233-a6a6" name="2022 - LI - Sisters of Silence" revision="19" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="70" xmlns="http://www.battlescribe.net/schema/catalogueSchema" type="catalogue">
   <categoryEntries>
     <categoryEntry id="b760-8313-847f-1afa" name="Obivion HQ" hidden="false"/>
     <categoryEntry id="a9b6-f66f-e8ee-553e" name="Judgement HQ" hidden="false"/>
@@ -3336,7 +3336,7 @@
                 <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8259-ac40-4d3c-7eba" type="max"/>
               </constraints>
             </entryLink>
-            <entryLink id="1fab-975c-12ee-a134" name="Voidsheen Cloak" hidden="false" collective="false" import="true" targetId="65c1-1f76-7b8a-2aa9" type="selectionEntry">
+            <entryLink id="1fab-975c-12ee-a134" name="Voidsheen Cloak" hidden="false" collective="false" import="true" targetId="9449-eb87-30c1-43c0" type="selectionEntry">
               <constraints>
                 <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="aeae-ce36-341d-03bc" type="min"/>
                 <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7f41-5949-047b-c79e" type="max"/>
@@ -7510,7 +7510,7 @@
                     <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a522-036c-538e-9f6b" type="min"/>
                   </constraints>
                 </entryLink>
-                <entryLink id="f84e-3dc6-23d3-6cb0" name="Voidsheen Cloak" hidden="false" collective="false" import="true" targetId="65c1-1f76-7b8a-2aa9" type="selectionEntry">
+                <entryLink id="f84e-3dc6-23d3-6cb0" name="Voidsheen Cloak" hidden="false" collective="false" import="true" targetId="9449-eb87-30c1-43c0" type="selectionEntry">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4145-cafa-e268-1087" type="max"/>
                     <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2482-6990-f46b-0ad6" type="min"/>
@@ -7556,7 +7556,7 @@
                     <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4aaf-b1a2-38f7-6cae" type="min"/>
                   </constraints>
                 </entryLink>
-                <entryLink id="65b7-ef5f-6ec1-f178" name="Voidsheen Cloak" hidden="false" collective="false" import="true" targetId="65c1-1f76-7b8a-2aa9" type="selectionEntry">
+                <entryLink id="65b7-ef5f-6ec1-f178" name="Voidsheen Cloak" hidden="false" collective="false" import="true" targetId="9449-eb87-30c1-43c0" type="selectionEntry">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1819-5138-ed03-c7ca" type="max"/>
                     <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8d1f-fd5c-fa89-dbfd" type="min"/>
@@ -7614,7 +7614,7 @@
                     <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="67da-0a4f-ffad-64bd" type="min"/>
                   </constraints>
                 </entryLink>
-                <entryLink id="e29d-acd0-44ac-d5df" name="Voidsheen Cloak" hidden="false" collective="false" import="true" targetId="65c1-1f76-7b8a-2aa9" type="selectionEntry">
+                <entryLink id="e29d-acd0-44ac-d5df" name="Voidsheen Cloak" hidden="false" collective="false" import="true" targetId="9449-eb87-30c1-43c0" type="selectionEntry">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="29e6-0ba1-92d6-557e" type="max"/>
                     <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fc6e-2caa-4e51-8880" type="min"/>
@@ -7741,7 +7741,7 @@
                     <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c914-68b0-e44d-c340" type="min"/>
                   </constraints>
                 </entryLink>
-                <entryLink id="a548-192f-125c-562c" name="Voidsheen Cloak" hidden="false" collective="false" import="true" targetId="65c1-1f76-7b8a-2aa9" type="selectionEntry">
+                <entryLink id="a548-192f-125c-562c" name="Voidsheen Cloak" hidden="false" collective="false" import="true" targetId="9449-eb87-30c1-43c0" type="selectionEntry">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b824-5372-80c3-77eb" type="max"/>
                     <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2d9f-0006-128d-f400" type="min"/>
@@ -7842,14 +7842,6 @@
           </characteristics>
         </profile>
       </profiles>
-      <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="65c1-1f76-7b8a-2aa9" name="Voidsheen Cloak" hidden="false" collective="true" import="true" type="upgrade">
-      <infoLinks>
-        <infoLink id="10ab-25bd-b862-2fcb" name="Raptora" hidden="false" targetId="f95e-9b9e-28c7-65e4" type="profile"/>
-      </infoLinks>
       <costs>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
       </costs>


### PR DESCRIPTION
All PRs have been merged in the correct order to preserve version numbers.

Issues fixed in this release:
- #3009 Daemon Harbinger and Attendants now have correctly visible weapons
- #3011 Phoenix terminators can now only take a banner if they are the retinue of an HQ choice or a primarch
- #3016 Raptora cadre units now have correctly displaying voidsheen cloaks in their wargear
- #3017 Cataphractii centurions no longer incorrectly display as Legiones Hereticus.
- Warmonger consuls are now named appropriately on your army roster