### PR TITLE
4d6/militia lotgc fix

### DIFF
--- a/2022 - Imperialis Militia.cat
+++ b/2022 - Imperialis Militia.cat
@@ -2094,11 +2094,6 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
                     <condition field="selections" scope="force" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b192-2b6f-ad8c-959f" type="equalTo"/>
                   </conditions>
                 </modifier>
-                <modifier type="increment" field="74ae-c840-0036-d244" value="1">
-                  <conditions>
-                    <condition field="selections" scope="force" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b669-a356-d5d1-53b8" type="equalTo"/>
-                  </conditions>
-                </modifier>
               </modifiers>
               <modifierGroups>
                 <modifierGroup>

--- a/2022 - Imperialis Militia.cat
+++ b/2022 - Imperialis Militia.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="f84d-94cf-5ce6-b393" name="2022 - Imperialis Militia" revision="24" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="71" xmlns="http://www.battlescribe.net/schema/catalogueSchema" type="catalogue">
+<catalogue id="f84d-94cf-5ce6-b393" name="2022 - Imperialis Militia" revision="25" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="71" xmlns="http://www.battlescribe.net/schema/catalogueSchema" type="catalogue">
   <categoryEntries>
     <categoryEntry id="58b3-196a-9732-2165" name="Rogue Psyker Daemons Restriction" publicationId="48c2-d023-0069-001a" page="15" hidden="false">
       <modifiers>

--- a/2022 - Imperialis Militia.cat
+++ b/2022 - Imperialis Militia.cat
@@ -650,7 +650,7 @@
           <profiles>
             <profile id="174e-2999-6d47-b5e6" name="Force Commander" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName="Unit">
               <modifiers>
-                <modifier type="increment" field="62d3-22d7-2d49-52dc" value="1">
+                <modifier type="set" field="62d3-22d7-2d49-52dc" value="5">
                   <conditions>
                     <condition field="selections" scope="force" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b669-a356-d5d1-53b8" type="equalTo"/>
                   </conditions>


### PR DESCRIPTION
- Militia Force Commanders now correctly get Initiative 5 under Legacy of the Great Crusade
- Militia Lieutenants now do _not_ get BS5 under Legacy of the Great Crusade