### PR TITLE
Number force entries to ensure users find the crusade force

### DIFF
--- a/2022 - Horus Heresy.gst
+++ b/2022 - Horus Heresy.gst
@@ -1308,7 +1308,7 @@ Reactions:
     <categoryEntry name="Primus Medicae" hidden="false" id="b81a-8f4a-ff50-ef99"/>
   </categoryEntries>
   <forceEntries>
-    <forceEntry id="d926-652f-8436-30ce" name="Crusade Force Organisation Chart" hidden="false">
+    <forceEntry id="d926-652f-8436-30ce" name="1. Crusade Force Organisation Chart" hidden="false">
       <categoryLinks>
         <categoryLink id="d65e-4a0a-fa1a-7ec6" name="Expanded Army Lists" hidden="false" targetId="e8ed-ca49-ad6d-5688" primary="false"/>
         <categoryLink id="17a5-4c80-0c5d-df4d" name="Allegiance:" hidden="false" targetId="e90d-e5a8-f42d-da84" primary="false">
@@ -1651,7 +1651,7 @@ Reactions:
         <constraint type="max" value="1" field="forces" scope="roster" shared="true" id="f3d1-165c-4e16-e5fc"/>
       </constraints>
     </forceEntry>
-    <forceEntry id="d4f2-6da5-b6de-06ec" name="Allied Detachment" hidden="false">
+    <forceEntry id="d4f2-6da5-b6de-06ec" name="3. Allied Detachment" hidden="false">
       <categoryLinks>
         <categoryLink id="45cc-4d1d-6d5e-cdc9" name="Allegiance:" hidden="false" targetId="e90d-e5a8-f42d-da84" primary="false">
           <constraints>
@@ -1871,7 +1871,7 @@ Reactions:
         <constraint type="max" value="1" field="forces" scope="roster" shared="true" id="a036-22f7-6cbf-6ebd"/>
       </constraints>
     </forceEntry>
-    <forceEntry id="5430-5be1-1613-be44" name="Mortalis Assault Force Organisation Chart" hidden="false">
+    <forceEntry id="5430-5be1-1613-be44" name="ZM 1. Mortalis Assault Force Organisation Chart" hidden="false">
       <categoryLinks>
         <categoryLink id="e7a4-a234-6cc7-f1b7" name="Expanded Army Lists" hidden="false" targetId="e8ed-ca49-ad6d-5688" primary="false"/>
         <categoryLink id="3ce7-6f89-a347-b6ad" name="Allegiance:" hidden="false" targetId="e90d-e5a8-f42d-da84" primary="false">
@@ -2126,7 +2126,7 @@ Reactions:
         <constraint type="max" value="1" field="forces" scope="roster" shared="true" id="ce4d-7e2a-4698-b234"/>
       </constraints>
     </forceEntry>
-    <forceEntry name="Lord of War Detachment" hidden="false" id="58a7-8821-3cd9-c73">
+    <forceEntry name="2. Lord of War Detachment" hidden="false" id="58a7-8821-3cd9-c73">
       <categoryLinks>
         <categoryLink id="e24b-bfb4-de7b-706c" name="Expanded Army Lists" hidden="false" targetId="e8ed-ca49-ad6d-5688" primary="false"/>
         <categoryLink id="e3e4-a857-9bd2-3a33" name="Allegiance:" hidden="false" targetId="e90d-e5a8-f42d-da84" primary="false">

--- a/2022 - Questoris Household.cat
+++ b/2022 - Questoris Household.cat
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <catalogue id="92b4-d476-8b4c-e7ef" name="2022 - Questoris Household" revision="7" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="66" xmlns="http://www.battlescribe.net/schema/catalogueSchema" type="catalogue">
   <forceEntries>
-    <forceEntry id="28d3-4be2-608d-bf8a" name="Questoris Household Force Organisation Chart" hidden="false">
+    <forceEntry id="28d3-4be2-608d-bf8a" name="0. Questoris Household Force Organisation Chart" hidden="false">
       <categoryLinks>
         <categoryLink id="f631-f41f-891c-211e" name="Expanded Army Lists" hidden="false" targetId="e8ed-ca49-ad6d-5688" primary="false"/>
         <categoryLink id="2aac-bb02-6cd3-89e2" name="Allegiance:" hidden="false" targetId="e90d-e5a8-f42d-da84" primary="false">

--- a/2022 - Titan Legions.cat
+++ b/2022 - Titan Legions.cat
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <catalogue id="c01b-0224-f806-0d23" name="2022 - Titan Legions" revision="12" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="70" xmlns="http://www.battlescribe.net/schema/catalogueSchema" type="catalogue">
   <forceEntries>
-    <forceEntry id="aebe-bed9-b32f-a8ea" name="Titan Maniple" hidden="false">
+    <forceEntry id="aebe-bed9-b32f-a8ea" name="0. Titan Maniple" hidden="false">
       <categoryLinks>
         <categoryLink id="20a9-5d4b-e686-aa09" name="Allegiance:" hidden="false" targetId="e90d-e5a8-f42d-da84" primary="false">
           <constraints>


### PR DESCRIPTION
This probably makes output look slightly worse, but it ensures that the default entry selected is "Crusade Force Organization Chart" or the specific force org chart for questoris knights/titans

Renamed Crusade Force Organisation Chart to "1. Crusade Force Organisation Chart", etc. Zone Mortalis now starts with ZM. Entries that override the crusade chart now start with "0. " so they pop up first.