### PR TITLE
Fixed Vigil Storm Shield Issue

### DIFF
--- a/2022 - LA - Imperial Fists.cat
+++ b/2022 - LA - Imperial Fists.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="8866-00ec-715f-f21a" name="LA -   VII: Imperial Fists" revision="31" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="67" type="catalogue">
+<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="8866-00ec-715f-f21a" name="LA -   VII: Imperial Fists" revision="32" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="67" type="catalogue">
   <entryLinks>
     <entryLink id="b3e4-1487-4ab7-7515" name="Alexis Polux" hidden="false" collective="false" import="false" targetId="9229-b4f9-2213-9672" type="selectionEntry">
       <modifiers>
@@ -3658,7 +3658,6 @@
                 </condition>
               </conditions>
             </modifier>
-            <modifier type="set" field="name" value="Heart of the Legion (on any turn you disembark (not emergency disembark))"/>
           </modifiers>
         </infoLink>
       </infoLinks>


### PR DESCRIPTION
The terminator praetors use the "terminator ranged weapon" selection group for their ranged weapon.

Added a hiding condition to the vigil stormshield if the ancestor is a tartaros or cataphractii praetor.