### PR TITLE
Name cleanup (No end user changes)

### DIFF
--- a/2022 - Daemons - Bound Daemons.cat
+++ b/2022 - Daemons - Bound Daemons.cat
@@ -17,7 +17,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="ee2b-7e28-2f71-9ed7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="c770-9c09-fbe7-2fdf" name="New CategoryLink" hidden="false" targetId="bb1f-ae32-b587-c3e1" primary="false"/>
+        <categoryLink id="c770-9c09-fbe7-2fdf" name="Compulsory Elite:" hidden="false" targetId="bb1f-ae32-b587-c3e1" primary="false"/>
         <categoryLink id="f4ac-a026-144c-e6ca" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
       </categoryLinks>
     </entryLink>
@@ -38,7 +38,7 @@
       <categoryLinks>
         <categoryLink id="b633-7aaf-d6d4-eda0" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
         <categoryLink id="1c9f-f9ab-7159-42ac" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="dae6-e88c-cb03-2af1" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="dae6-e88c-cb03-2af1" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="14d8-3e68-bdc8-0759" name="Bound Ka’bandha" hidden="false" collective="false" import="false" targetId="aa91-7f0d-cade-cbc5" type="selectionEntry">
@@ -57,7 +57,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="e2a8-a51d-7a13-6abf" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="80fe-5484-f245-0f53" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="80fe-5484-f245-0f53" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="c3ed-182e-d418-8826" name="Bound Samus" hidden="false" collective="false" import="false" targetId="e6cf-4fa9-df0d-64c7" type="selectionEntry">
@@ -76,7 +76,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="7ba2-ef14-6b06-d89f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="25be-50e3-3ab1-63c1" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="25be-50e3-3ab1-63c1" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="a28d-da6c-bb4b-f24d" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -96,8 +96,8 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="ae68-95ec-1c12-999c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="c9df-1bec-305e-8cd8" name="New CategoryLink" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
-        <categoryLink id="04d2-fda4-3eb9-7774" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="c9df-1bec-305e-8cd8" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
+        <categoryLink id="04d2-fda4-3eb9-7774" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="2e8a-2d56-45e8-091c" name="Bound Daemons" hidden="false" collective="false" import="false" targetId="d601-e213-fa45-8ee8" type="selectionEntry">
@@ -113,7 +113,7 @@
         <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7b02-8d55-9779-bc67" type="max"/>
       </constraints>
       <categoryLinks>
-        <categoryLink id="3a46-adef-3012-3e57" name="New CategoryLink" hidden="false" targetId="e90d-e5a8-f42d-da84" primary="true"/>
+        <categoryLink id="3a46-adef-3012-3e57" name="Allegiance:" hidden="false" targetId="e90d-e5a8-f42d-da84" primary="true"/>
       </categoryLinks>
     </entryLink>
   </entryLinks>
@@ -280,7 +280,7 @@ The End and the Death – When fighting in a Challenge, successful Invulnerable 
       </selectionEntries>
       <entryLinks>
         <entryLink id="2047-6fc0-18b5-228d" name="Warlord" hidden="false" collective="false" import="true" targetId="0176-56a3-d590-b103" type="selectionEntry"/>
-        <entryLink id="b1a8-8a96-fd63-e0b6" name="Samus or Ka’bandha Warlord stuff" hidden="false" collective="false" import="true" targetId="092d-3716-36f8-8988" type="selectionEntry"/>
+        <entryLink id="b1a8-8a96-fd63-e0b6" name="Samus, Ka’bandha &amp; Cor&apos;bax Warlord stuff" hidden="false" collective="false" import="true" targetId="092d-3716-36f8-8988" type="selectionEntry"/>
         <entryLink import="true" name="Encroaching Ruin" hidden="false" type="selectionEntry" id="93e0-e2dc-96b5-d433" targetId="ca6c-e8cf-7bc1-eaa0">
           <constraints>
             <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="a0b4-3aa-ba0d-9ca3"/>
@@ -768,7 +768,7 @@ During a Reaction made in any Phase, a player may not choose to activate a model
   <selectionEntries>
     <selectionEntry type="upgrade" import="false" name="Ætheric Dominion (Whole Army)" hidden="false" id="93cd-66c2-89ba-8b2f">
       <categoryLinks>
-        <categoryLink targetId="5d31-e5d-67bd-1083" id="f4f0-d91d-946c-3ace" primary="true" name="Ruinstorm Ætheric Dominion (Whole Army)"/>
+        <categoryLink targetId="5d31-e5d-67bd-1083" id="f4f0-d91d-946c-3ace" primary="true" name="Ætheric Dominion (Whole Army)"/>
       </categoryLinks>
       <entryLinks>
         <entryLink import="true" name="The Ætheric Dominion (X)" hidden="false" type="selectionEntryGroup" id="1064-6518-7200-e98b" targetId="002f-0e40-9d49-2a22"/>

--- a/2022 - Daemons - Daemons of the Ruinstorm.cat
+++ b/2022 - Daemons - Daemons of the Ruinstorm.cat
@@ -16,111 +16,111 @@
         </modifier>
       </modifiers>
     </entryLink>
-    <entryLink import="false" name="01) Ruinstorm Daemon Sovereign" hidden="false" type="selectionEntry" id="61db-a83f-c0b6-90fd" targetId="2f3f-adc4-b19f-a5c7">
+    <entryLink import="false" name="Ruinstorm Daemon Sovereign" hidden="false" type="selectionEntry" id="61db-a83f-c0b6-90fd" targetId="2f3f-adc4-b19f-a5c7">
       <categoryLinks>
         <categoryLink targetId="36c3-e85e-97cc-c503" id="5bef-275-968-1f88" primary="false" name="Unit:"/>
         <categoryLink targetId="f823-8c1d-6a87-26a1" id="9b39-aee6-628-7679" primary="false" name="Compulsory HQ:"/>
         <categoryLink targetId="4f85-eb33-30c9-8f51" id="6903-a2c4-3819-1892" primary="true" name="HQ:"/>
       </categoryLinks>
     </entryLink>
-    <entryLink import="false" name="02) Ruinstorm Daemon Hierarch" hidden="false" type="selectionEntry" id="50a8-b11-67b1-26b5" targetId="ae8b-ee65-95b6-a8f9">
+    <entryLink import="false" name="Ruinstorm Daemon Hierarch" hidden="false" type="selectionEntry" id="50a8-b11-67b1-26b5" targetId="ae8b-ee65-95b6-a8f9">
       <categoryLinks>
         <categoryLink targetId="36c3-e85e-97cc-c503" id="6800-5472-898b-94d1" primary="false" name="Unit:"/>
         <categoryLink targetId="f823-8c1d-6a87-26a1" id="77be-912b-c5fb-b948" primary="false" name="Compulsory HQ:"/>
         <categoryLink targetId="4f85-eb33-30c9-8f51" id="d7d1-8d7c-5d78-bed1" primary="true" name="HQ:"/>
       </categoryLinks>
     </entryLink>
-    <entryLink import="false" name="03) Ruinstorm Daemon Harbinger" hidden="false" type="selectionEntry" id="aaad-9ba0-9f12-f55" targetId="5a2e-abe2-3044-3c1c">
+    <entryLink import="false" name="Ruinstorm Daemon Harbinger" hidden="false" type="selectionEntry" id="aaad-9ba0-9f12-f55" targetId="5a2e-abe2-3044-3c1c">
       <categoryLinks>
         <categoryLink targetId="36c3-e85e-97cc-c503" id="f277-8c54-15a0-5f68" primary="false" name="Unit:"/>
         <categoryLink targetId="f823-8c1d-6a87-26a1" id="8ac4-47e5-8e06-a2f" primary="false" name="Compulsory HQ:"/>
         <categoryLink targetId="4f85-eb33-30c9-8f51" id="3bfa-8d7e-75a9-1b55" primary="true" name="HQ:"/>
       </categoryLinks>
     </entryLink>
-    <entryLink import="false" name="04) Ruinstorm Daemon Brutes" hidden="false" type="selectionEntry" id="24b7-aabd-c772-ff9" targetId="2219-cb60-b52-a36c">
+    <entryLink import="false" name="Ruinstorm Daemon Brutes" hidden="false" type="selectionEntry" id="24b7-aabd-c772-ff9" targetId="2219-cb60-b52-a36c">
       <categoryLinks>
         <categoryLink targetId="36c3-e85e-97cc-c503" id="e447-148d-c915-ad03" primary="false" name="Unit:"/>
         <categoryLink targetId="bb1f-ae32-b587-c3e1" id="9413-d3f9-f69b-6129" primary="false" name="Compulsory Elite:"/>
         <categoryLink targetId="7aee-565f-b0ae-294e" id="f3ae-a32c-5970-ecc" primary="true" name="Elites:"/>
       </categoryLinks>
     </entryLink>
-    <entryLink import="false" name="05) Ruinstorm Daemon Beasts" hidden="false" type="selectionEntry" id="6c10-5ca2-fe18-f7b2" targetId="69ad-927-c71b-6b24">
+    <entryLink import="false" name="Ruinstorm Daemon Beasts" hidden="false" type="selectionEntry" id="6c10-5ca2-fe18-f7b2" targetId="69ad-927-c71b-6b24">
       <categoryLinks>
         <categoryLink targetId="36c3-e85e-97cc-c503" id="aa6e-9ff9-e76-7758" primary="false" name="Unit:"/>
         <categoryLink targetId="bb1f-ae32-b587-c3e1" id="bcb1-847b-a07a-4052" primary="false" name="Compulsory Elite:"/>
         <categoryLink targetId="7aee-565f-b0ae-294e" id="cda2-6ccb-5d6a-739a" primary="true" name="Elites:"/>
       </categoryLinks>
     </entryLink>
-    <entryLink import="false" name="06) Ruinstorm Lesser Daemons" hidden="false" type="selectionEntry" id="7a1e-4bc1-85cb-7569" targetId="157c-7592-a6b9-f96">
+    <entryLink import="false" name="Ruinstorm Lesser Daemons" hidden="false" type="selectionEntry" id="7a1e-4bc1-85cb-7569" targetId="157c-7592-a6b9-f96">
       <categoryLinks>
         <categoryLink targetId="36c3-e85e-97cc-c503" id="85fe-4c18-ede4-a0d7" primary="false" name="Unit:"/>
         <categoryLink targetId="9b5d-fac7-799b-d7e7" id="8307-4506-c34b-adbe" primary="true" name="Troops:"/>
         <categoryLink targetId="8f42-a824-fb5f-8fea" id="c3e1-270c-5235-177" primary="false" name="Compulsory Troops:"/>
       </categoryLinks>
     </entryLink>
-    <entryLink import="false" name="07) Ruinstorm Daemon Swarms" hidden="false" type="selectionEntry" id="d155-b3f4-5fca-6df2" targetId="bb35-e585-a226-28e">
+    <entryLink import="false" name="Ruinstorm Daemon Swarms" hidden="false" type="selectionEntry" id="d155-b3f4-5fca-6df2" targetId="bb35-e585-a226-28e">
       <categoryLinks>
         <categoryLink targetId="36c3-e85e-97cc-c503" id="f5a1-1368-93db-e3d2" primary="false" name="Unit:"/>
         <categoryLink targetId="9b5d-fac7-799b-d7e7" id="d41a-a3a0-91df-9626" primary="true" name="Troops:"/>
       </categoryLinks>
     </entryLink>
-    <entryLink import="false" name="08) Ruinstorm Daemon Cavalry" hidden="false" type="selectionEntry" id="47f6-44fe-d2ec-819e" targetId="b7b5-c59a-768c-276c">
+    <entryLink import="false" name="Ruinstorm Daemon Cavalry" hidden="false" type="selectionEntry" id="47f6-44fe-d2ec-819e" targetId="b7b5-c59a-768c-276c">
       <categoryLinks>
         <categoryLink targetId="36c3-e85e-97cc-c503" id="f1c9-ed9e-71f-8fe9" primary="false" name="Unit:"/>
         <categoryLink targetId="20ef-cd01-a8da-376e" id="fdaa-7d5c-1cc0-ae42" primary="true" name="Fast Attack:"/>
         <categoryLink targetId="3c75-d5f8-1ad4-24e5" id="f650-576a-51fe-77a3" primary="false" name="Compulsory Fast Attack:"/>
       </categoryLinks>
     </entryLink>
-    <entryLink import="false" name="09) Ruinstorm Daemon Harriers" hidden="false" type="selectionEntry" id="af04-d38a-aa6e-8d43" targetId="14c1-3063-c9b4-d99b">
+    <entryLink import="false" name="Ruinstorm Daemon Harriers" hidden="false" type="selectionEntry" id="af04-d38a-aa6e-8d43" targetId="14c1-3063-c9b4-d99b">
       <categoryLinks>
         <categoryLink targetId="36c3-e85e-97cc-c503" id="7ad1-ecbc-cf4d-7e90" primary="false" name="Unit:"/>
         <categoryLink targetId="20ef-cd01-a8da-376e" id="45b1-7cfa-5ef1-d973" primary="true" name="Fast Attack:"/>
         <categoryLink targetId="3c75-d5f8-1ad4-24e5" id="29ec-205a-4ab4-c76f" primary="false" name="Compulsory Fast Attack:"/>
       </categoryLinks>
     </entryLink>
-    <entryLink import="false" name="10) Greater Ruinstorm Daemon Beast" hidden="false" type="selectionEntry" id="271c-cc74-3c17-d759" targetId="41a0-6caa-af06-3684">
+    <entryLink import="false" name="Greater Ruinstorm Daemon Beast" hidden="false" type="selectionEntry" id="271c-cc74-3c17-d759" targetId="41a0-6caa-af06-3684">
       <categoryLinks>
         <categoryLink targetId="36c3-e85e-97cc-c503" id="1f63-b797-ecca-9698" primary="false" name="Unit:"/>
         <categoryLink targetId="7031-469a-1aeb-eab0" id="e6c-80f3-6dcc-9285" primary="true" name="Heavy Support:"/>
         <categoryLink targetId="030f-3801-4f54-e7f8" id="3c93-e4ed-a82b-172c" primary="false" name="Compulsory Heavy Support:"/>
       </categoryLinks>
     </entryLink>
-    <entryLink import="false" name="11) Ruinstorm Daemon Behemoth" hidden="false" type="selectionEntry" id="59ea-d83-a465-2697" targetId="240a-1822-9e4f-3080">
+    <entryLink import="false" name="Ruinstorm Daemon Behemoth" hidden="false" type="selectionEntry" id="59ea-d83-a465-2697" targetId="240a-1822-9e4f-3080">
       <categoryLinks>
         <categoryLink targetId="36c3-e85e-97cc-c503" id="4366-6f11-50bb-788b" primary="false" name="Unit:"/>
         <categoryLink targetId="7031-469a-1aeb-eab0" id="b906-2c88-de71-f891" primary="true" name="Heavy Support:"/>
         <categoryLink targetId="030f-3801-4f54-e7f8" id="8411-4fbb-1d6c-b7bf" primary="false" name="Compulsory Heavy Support:"/>
       </categoryLinks>
     </entryLink>
-    <entryLink import="false" name="12) Ruinstorm Arch-Daemon" hidden="false" type="selectionEntry" id="bde9-cbb2-1c62-da9a" targetId="1fbb-b82e-ae1e-5a12">
+    <entryLink import="false" name="Ruinstorm Arch-Daemon" hidden="false" type="selectionEntry" id="bde9-cbb2-1c62-da9a" targetId="1fbb-b82e-ae1e-5a12">
       <categoryLinks>
         <categoryLink targetId="36c3-e85e-97cc-c503" id="ac16-61f4-489b-9b43" primary="false" name="Unit:"/>
         <categoryLink targetId="c658-dc6b-727b-c488" id="b3f-ca75-5e86-c6fe" primary="true" name="Lords of War:"/>
         <categoryLink targetId="2eaf-32d6-9d1d-d906" id="2b18-2927-40b4-a00a" primary="false" name="LoW &amp; Primarchs (25% Limit)"/>
       </categoryLinks>
     </entryLink>
-    <entryLink import="false" name="13) Ka’bandha Unbound" hidden="false" type="selectionEntry" id="d606-d66-9d34-6fb4" targetId="baa5-baed-1a62-c820">
+    <entryLink import="false" name="Ka’bandha Unbound" hidden="false" type="selectionEntry" id="d606-d66-9d34-6fb4" targetId="baa5-baed-1a62-c820">
       <categoryLinks>
         <categoryLink targetId="36c3-e85e-97cc-c503" id="5a84-831c-e73f-7391" primary="false" name="Unit:"/>
         <categoryLink targetId="c658-dc6b-727b-c488" id="8b06-8469-b53d-66f0" primary="true" name="Lords of War:"/>
         <categoryLink targetId="2eaf-32d6-9d1d-d906" id="4ff1-219d-774a-e2e7" primary="false" name="LoW &amp; Primarchs (25% Limit)"/>
       </categoryLinks>
     </entryLink>
-    <entryLink import="false" name="14) Cor’bax Utterblight Unbound" hidden="false" type="selectionEntry" id="957e-2292-544d-8031" targetId="ef9d-3ad6-1f39-b84b">
+    <entryLink import="false" name="Cor’bax Utterblight Unbound" hidden="false" type="selectionEntry" id="957e-2292-544d-8031" targetId="ef9d-3ad6-1f39-b84b">
       <categoryLinks>
         <categoryLink targetId="36c3-e85e-97cc-c503" id="6452-7f07-bc29-5d6f" primary="false" name="Unit:"/>
         <categoryLink targetId="c658-dc6b-727b-c488" id="69a1-4379-610d-416c" primary="true" name="Lords of War:"/>
         <categoryLink targetId="2eaf-32d6-9d1d-d906" id="909c-dabc-d82d-7bf1" primary="false" name="LoW &amp; Primarchs (25% Limit)"/>
       </categoryLinks>
     </entryLink>
-    <entryLink import="false" name="15) Samus Unbound" hidden="false" type="selectionEntry" id="6f48-b881-40f3-5da" targetId="63f0-9b87-6482-87ee">
+    <entryLink import="false" name="Samus Unbound" hidden="false" type="selectionEntry" id="6f48-b881-40f3-5da" targetId="63f0-9b87-6482-87ee">
       <categoryLinks>
         <categoryLink targetId="36c3-e85e-97cc-c503" id="d89d-34dc-cb3d-7b9f" primary="false" name="Unit:"/>
         <categoryLink targetId="c658-dc6b-727b-c488" id="e313-85de-a363-2ca9" primary="true" name="Lords of War:"/>
         <categoryLink targetId="2eaf-32d6-9d1d-d906" id="3bd5-dd10-1738-7cb0" primary="false" name="LoW &amp; Primarchs (25% Limit)"/>
       </categoryLinks>
     </entryLink>
-    <entryLink import="true" name="Unknown" hidden="false" type="selectionEntry" id="9c45-3bab-77a7-1588" targetId="ce53-e40c-65b6-4d3a"/>
+    <entryLink import="true" name="Expeditionary Navigator" hidden="false" type="selectionEntry" id="9c45-3bab-77a7-1588" targetId="ce53-e40c-65b6-4d3a"/>
     <entryLink import="true" name="Davinite Lodge Priest" hidden="false" type="selectionEntry" id="430c-1c94-e60f-653" targetId="fe13-4a8f-b2af-1e40"/>
     <entryLink import="true" name="Cults Abominatio" hidden="false" type="selectionEntry" id="5b8b-6c4f-15ec-ba95" targetId="4a00-03d4-a850-884b"/>
   </entryLinks>
@@ -1810,7 +1810,7 @@ Lord of Decay – All units with the Daemon Unit Type and the Ætheric Dominion 
           </constraints>
         </entryLink>
         <entryLink id="499-6206-31d0-28be" name="Warlord" hidden="false" collective="false" import="true" targetId="0176-56a3-d590-b103" type="selectionEntry"/>
-        <entryLink id="7736-ebb9-a163-7071" name="Samus or Ka’bandha Warlord stuff" hidden="false" collective="false" import="true" targetId="092d-3716-36f8-8988" type="selectionEntry"/>
+        <entryLink id="7736-ebb9-a163-7071" name="Samus, Ka’bandha &amp; Cor&apos;bax Warlord stuff" hidden="false" collective="false" import="true" targetId="092d-3716-36f8-8988" type="selectionEntry"/>
         <entryLink import="true" name="Psychic Discipline: Biomancy" hidden="false" type="selectionEntry" id="20f1-f126-4e48-d658" targetId="861c-3744-c4ff-ef6c">
           <constraints>
             <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="92dd-2d59-fc39-50c7"/>
@@ -1969,7 +1969,7 @@ The End and the Death – When fighting in a Challenge, successful Invulnerable 
             <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="4724-5016-cba0-8b9b"/>
           </constraints>
         </entryLink>
-        <entryLink id="a3d8-6d09-8dcc-c572" name="Samus or Ka’bandha Warlord stuff" hidden="false" collective="false" import="true" targetId="092d-3716-36f8-8988" type="selectionEntry"/>
+        <entryLink id="a3d8-6d09-8dcc-c572" name="Samus, Ka’bandha &amp; Cor&apos;bax Warlord stuff" hidden="false" collective="false" import="true" targetId="092d-3716-36f8-8988" type="selectionEntry"/>
         <entryLink id="97a9-bc02-d06a-a63b" name="Warlord" hidden="false" collective="false" import="true" targetId="0176-56a3-d590-b103" type="selectionEntry"/>
       </entryLinks>
       <infoLinks>
@@ -2385,7 +2385,7 @@ Once all models in the selected units have moved onto the battlefield, the Warp 
   <selectionEntries>
     <selectionEntry type="upgrade" import="false" name="Ætheric Dominion (Whole Army)" hidden="false" id="f6d5-4f8d-7bcc-1405">
       <categoryLinks>
-        <categoryLink targetId="5d31-e5d-67bd-1083" id="1b05-8967-710b-6c83" primary="true" name="Ruinstorm Ætheric Dominion (Whole Army)"/>
+        <categoryLink targetId="5d31-e5d-67bd-1083" id="1b05-8967-710b-6c83" primary="true" name="Ætheric Dominion (Whole Army)"/>
       </categoryLinks>
       <entryLinks>
         <entryLink import="true" name="The Ætheric Dominion (X)" hidden="false" type="selectionEntryGroup" id="9508-a542-880a-8a31" targetId="002f-0e40-9d49-2a22"/>

--- a/2022 - Horus Heresy.gst
+++ b/2022 - Horus Heresy.gst
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<gameSystem xmlns="http://www.battlescribe.net/schema/gameSystemSchema" id="28d4-bd2e-4858-ece6" name="(HH V2) Horus Heresy (2022)" revision="99" battleScribeVersion="2.03" type="gameSystem">
+<gameSystem xmlns="http://www.battlescribe.net/schema/gameSystemSchema" id="28d4-bd2e-4858-ece6" name="Horus Heresy (2022)" revision="100" battleScribeVersion="2.03" type="gameSystem">
   <publications>
     <publication name="Github" hidden="false" id="e2a4-ac85-1bef-22f5" publisherUrl="https://github.com/BSData/horus-heresy" shortName="BSData/horus-heresy"/>
     <publication id="e77a-823a-da94-16b9" name="Warhammer: The Horus Heresy - Age of Darkness Rulebook" shortName="Main Rules" publicationDate="June 2022"/>

--- a/2022 - Horus Heresy.gst
+++ b/2022 - Horus Heresy.gst
@@ -1321,7 +1321,7 @@ Reactions:
         <categoryLink id="4240-0870-e7ec-839e" name="Rite of War:" hidden="false" targetId="d494-e450-d4aa-579a" primary="false"/>
         <categoryLink id="fd89-b215-5545-17c6" name="The Rewards Of Treachery" hidden="false" targetId="c5d2-69ee-8787-55d9" primary="false"/>
         <categoryLink id="86ea-14ab-791a-679c" name="Provenances of War" hidden="false" targetId="346a-fb59-a199-25c4" primary="false"/>
-        <categoryLink name="Ruinstorm Ætheric Dominion (Whole Army)" hidden="false" id="7ca6-11db-c5c6-4858" targetId="5d31-e5d-67bd-1083" type="category">
+        <categoryLink name="Ætheric Dominion (Whole Army)" hidden="false" id="7ca6-11db-c5c6-4858" targetId="5d31-e5d-67bd-1083" type="category">
           <modifiers>
             <modifier type="set" value="1" field="5cdb-d88d-5c88-7ff1">
               <conditionGroups>
@@ -2179,7 +2179,7 @@ Reactions:
         <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="756d-3f35-0c5a-7b48" type="max"/>
       </constraints>
       <categoryLinks>
-        <categoryLink id="da5a-91f1-3185-59ed" name="New CategoryLink" hidden="false" targetId="e90d-e5a8-f42d-da84" primary="true"/>
+        <categoryLink id="da5a-91f1-3185-59ed" name="Allegiance:" hidden="false" targetId="e90d-e5a8-f42d-da84" primary="true"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="2999-90f6-880e-d20f" name="Allegiance" hidden="false" collective="false" import="true">
@@ -2211,7 +2211,7 @@ Reactions:
         <constraint field="selections" scope="force" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e555-35cf-f840-e444" type="max"/>
       </constraints>
       <categoryLinks>
-        <categoryLink id="ec0a-62f9-971f-1f1e" name="New CategoryLink" hidden="false" targetId="e8ed-ca49-ad6d-5688" primary="true"/>
+        <categoryLink id="ec0a-62f9-971f-1f1e" name="Expanded Army Lists" hidden="false" targetId="e8ed-ca49-ad6d-5688" primary="true"/>
       </categoryLinks>
       <entryLinks>
         <entryLink id="3790-e8af-d3e2-0dec" name="Exemplary Option" hidden="false" collective="false" import="true" targetId="a149-55c5-23a1-9236" type="selectionEntryGroup"/>
@@ -2273,7 +2273,7 @@ THIS IS A TEMPORARY NOTIFICATION THAT WILL BE REMOVED IN A FEW MONTHS WHEN HOPEF
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="d7ec-95a3-173d-ca65" name="New CategoryLink" hidden="false" targetId="a24f-12d8-36c1-f477" primary="true"/>
+        <categoryLink id="d7ec-95a3-173d-ca65" name="Fortification:" hidden="false" targetId="a24f-12d8-36c1-f477" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="7488-dcd5-3230-57d7" name="Imperial Bunker" hidden="false" collective="false" import="true" targetId="5157-f309-77f9-1256" type="selectionEntry">
@@ -2305,7 +2305,7 @@ THIS IS A TEMPORARY NOTIFICATION THAT WILL BE REMOVED IN A FEW MONTHS WHEN HOPEF
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="38c2-9688-ede4-f626" name="New CategoryLink" hidden="false" targetId="a24f-12d8-36c1-f477" primary="true"/>
+        <categoryLink id="38c2-9688-ede4-f626" name="Fortification:" hidden="false" targetId="a24f-12d8-36c1-f477" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="427d-eb8e-dbbd-87a2" name="Defence Line" hidden="false" collective="false" import="true" targetId="ea91-0572-393c-e925" type="selectionEntry">
@@ -2337,12 +2337,12 @@ THIS IS A TEMPORARY NOTIFICATION THAT WILL BE REMOVED IN A FEW MONTHS WHEN HOPEF
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="86ff-083e-ce6d-8284" name="New CategoryLink" hidden="false" targetId="a24f-12d8-36c1-f477" primary="true"/>
+        <categoryLink id="86ff-083e-ce6d-8284" name="Fortification:" hidden="false" targetId="a24f-12d8-36c1-f477" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="ad63-7783-8500-e19f" name="Allied Detachment" hidden="false" collective="false" import="true" targetId="0fc8-91be-dcf4-1513" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="9fb6-1837-1414-95a7" name="New CategoryLink" hidden="false" targetId="d82b-1980-74f8-5dac" primary="true"/>
+        <categoryLink id="9fb6-1837-1414-95a7" name="Allied Detachment" hidden="false" targetId="d82b-1980-74f8-5dac" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="ffeb-34e6-ea59-170c" name="Firestorm Redoubt" hidden="false" collective="false" import="true" targetId="ad29-7efd-9c94-ac08" type="selectionEntry">
@@ -2375,7 +2375,7 @@ THIS IS A TEMPORARY NOTIFICATION THAT WILL BE REMOVED IN A FEW MONTHS WHEN HOPEF
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="247f-4a75-ac5d-c4f7" name="New CategoryLink" hidden="false" targetId="a24f-12d8-36c1-f477" primary="true"/>
+        <categoryLink id="247f-4a75-ac5d-c4f7" name="Fortification:" hidden="false" targetId="a24f-12d8-36c1-f477" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="c3fd-09fe-2ac7-2183" name="Vengeance Weapon Battery" hidden="false" collective="false" import="true" targetId="8e99-19e1-b84a-db0b" type="selectionEntry">
@@ -2408,7 +2408,7 @@ THIS IS A TEMPORARY NOTIFICATION THAT WILL BE REMOVED IN A FEW MONTHS WHEN HOPEF
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="7836-9c5f-7d2f-9e26" name="New CategoryLink" hidden="false" targetId="a24f-12d8-36c1-f477" primary="true"/>
+        <categoryLink id="7836-9c5f-7d2f-9e26" name="Fortification:" hidden="false" targetId="a24f-12d8-36c1-f477" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="f1d1-ca61-ae6b-4d33" name="Void Shield Generator" hidden="false" collective="false" import="true" targetId="fa45-1d74-9584-5bd5" type="selectionEntry">
@@ -2441,7 +2441,7 @@ THIS IS A TEMPORARY NOTIFICATION THAT WILL BE REMOVED IN A FEW MONTHS WHEN HOPEF
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="b9bf-59ce-321a-3bea" name="New CategoryLink" hidden="false" targetId="a24f-12d8-36c1-f477" primary="true"/>
+        <categoryLink id="b9bf-59ce-321a-3bea" name="Fortification:" hidden="false" targetId="a24f-12d8-36c1-f477" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="026e-1405-50cc-e19b" name="Skyshield Landing Pad" hidden="false" collective="false" import="true" targetId="a7fa-db40-52ee-b359" type="selectionEntry">
@@ -2474,7 +2474,7 @@ THIS IS A TEMPORARY NOTIFICATION THAT WILL BE REMOVED IN A FEW MONTHS WHEN HOPEF
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="5967-6a4c-46fd-c33e" name="New CategoryLink" hidden="false" targetId="a24f-12d8-36c1-f477" primary="true"/>
+        <categoryLink id="5967-6a4c-46fd-c33e" name="Fortification:" hidden="false" targetId="a24f-12d8-36c1-f477" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="dd67-c6ce-04e4-8dc2" name="Fortress Of Redemption" hidden="false" collective="false" import="true" targetId="6392-ce9d-29a7-1851" type="selectionEntry">
@@ -2507,7 +2507,7 @@ THIS IS A TEMPORARY NOTIFICATION THAT WILL BE REMOVED IN A FEW MONTHS WHEN HOPEF
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="b9eb-0b8e-0c45-463c" name="New CategoryLink" hidden="false" targetId="a24f-12d8-36c1-f477" primary="true"/>
+        <categoryLink id="b9eb-0b8e-0c45-463c" name="Fortification:" hidden="false" targetId="a24f-12d8-36c1-f477" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="d8a1-2527-d538-bdfb" name="Aquila Strongpoint" hidden="false" collective="false" import="true" targetId="e13d-9ef8-9b0d-bc22" type="selectionEntry">
@@ -2540,7 +2540,7 @@ THIS IS A TEMPORARY NOTIFICATION THAT WILL BE REMOVED IN A FEW MONTHS WHEN HOPEF
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="152d-1e4a-20aa-b580" name="New CategoryLink" hidden="false" targetId="a24f-12d8-36c1-f477" primary="true"/>
+        <categoryLink id="152d-1e4a-20aa-b580" name="Fortification:" hidden="false" targetId="a24f-12d8-36c1-f477" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="01dc-d34a-1988-3919" name="Primus Redoubt" hidden="false" collective="false" import="true" targetId="2d87-bde8-08d5-ae82" type="selectionEntry">
@@ -2573,7 +2573,7 @@ THIS IS A TEMPORARY NOTIFICATION THAT WILL BE REMOVED IN A FEW MONTHS WHEN HOPEF
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="d079-b62e-6190-edac" name="New CategoryLink" hidden="false" targetId="a24f-12d8-36c1-f477" primary="true"/>
+        <categoryLink id="d079-b62e-6190-edac" name="Fortification:" hidden="false" targetId="a24f-12d8-36c1-f477" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="91a3-bce0-aa49-e830" name="Hammerfall Bunker" hidden="false" collective="false" import="true" targetId="d5f5-a83b-ed8e-61c0" type="selectionEntry">
@@ -2606,7 +2606,7 @@ THIS IS A TEMPORARY NOTIFICATION THAT WILL BE REMOVED IN A FEW MONTHS WHEN HOPEF
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="eec3-bfaa-9984-36f1" name="New CategoryLink" hidden="false" targetId="a24f-12d8-36c1-f477" primary="true"/>
+        <categoryLink id="eec3-bfaa-9984-36f1" name="Fortification:" hidden="false" targetId="a24f-12d8-36c1-f477" primary="true"/>
       </categoryLinks>
     </entryLink>
   </entryLinks>
@@ -9210,7 +9210,7 @@ Hull Mounted (Rear) Mounted Twin-linked Heavy Bolter or Heavy Flamers</character
     <selectionEntry id="2449-dc45-3441-b471" name="Lasrifle" hidden="false" collective="true" import="true" type="upgrade">
       <infoLinks>
         <infoLink id="84c5-6839-17db-f251" name="Lasrifle (Blast Charger)" hidden="false" targetId="3eeb-f71b-46e1-f7d4" type="profile"/>
-        <infoLink id="f024-01ba-e7d4-c537" name="Lasrifle (Velley)" hidden="false" targetId="f755-3fa4-db2a-9540" type="profile"/>
+        <infoLink id="f024-01ba-e7d4-c537" name="Lasrifle (Volley)" hidden="false" targetId="f755-3fa4-db2a-9540" type="profile"/>
       </infoLinks>
       <costs>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
@@ -10272,7 +10272,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
       <infoLinks>
         <infoLink id="3380-3ab-8c69-61d8" name="Hammer of Wrath (X)" hidden="false" targetId="aec0-c3aa-1e4e-1779" type="rule"/>
         <infoLink id="72e1-d6ce-337d-fbee" name="Rending (X)" hidden="false" targetId="0ac9-fab7-aef3-de1d" type="rule"/>
-        <infoLink id="1804-acb9-a81b-1cd1" name="Psychic Focus (?? Where is this?)" hidden="false" targetId="bff3-3548-b2b8-72f1" type="rule"/>
+        <infoLink id="1804-acb9-a81b-1cd1" name="Psychic Focus" hidden="false" targetId="bff3-3548-b2b8-72f1" type="rule"/>
       </infoLinks>
       <costs>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>

--- a/2022 - Imperialis Militia.cat
+++ b/2022 - Imperialis Militia.cat
@@ -21,7 +21,7 @@
         <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5a85-cf9b-02ec-ab26" type="max"/>
       </constraints>
       <categoryLinks>
-        <categoryLink id="1603-2d05-0b77-78eb" name="New CategoryLink" hidden="false" targetId="346a-fb59-a199-25c4" primary="true"/>
+        <categoryLink id="1603-2d05-0b77-78eb" name="Provenances of War" hidden="false" targetId="346a-fb59-a199-25c4" primary="true"/>
       </categoryLinks>
       <entryLinks>
         <entryLink id="7789-b58c-91a7-68c9" name="Provenances of War" hidden="false" collective="false" import="true" targetId="7e02-b66b-55aa-1102" type="selectionEntryGroup">
@@ -53,13 +53,13 @@
         <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ab03-da8b-e39c-b99c" type="min"/>
       </constraints>
       <categoryLinks>
-        <categoryLink id="9a96-bf4b-af79-395a" name="New CategoryLink" hidden="false" targetId="e90d-e5a8-f42d-da84" primary="true"/>
+        <categoryLink id="9a96-bf4b-af79-395a" name="Allegiance:" hidden="false" targetId="e90d-e5a8-f42d-da84" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="83e5-d5f8-7d98-4c9d" name="01) IM - Force Commander (JNP)" hidden="false" collective="false" import="false" targetId="aa19-eda7-e81e-9868" type="selectionEntry">
+    <entryLink id="83e5-d5f8-7d98-4c9d" name="IM - Force Commander" hidden="false" collective="false" import="false" targetId="aa19-eda7-e81e-9868" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="edca-4045-c7b8-8722" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="2781-27ba-9156-0753" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="2781-27ba-9156-0753" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="3557-09ac-2957-8b34" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -77,10 +77,10 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="b6c4-fb0a-73cf-a7d1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="6731-195b-b6ef-3b16" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="6731-195b-b6ef-3b16" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="f98c-1bc5-80c1-1630" name="03) IM - Rogue Psyker (JNP)" hidden="true" collective="false" import="false" targetId="5fd6-8371-e5e5-7f0f" type="selectionEntry">
+    <entryLink id="f98c-1bc5-80c1-1630" name="IM - Rogue Psyker" hidden="true" collective="false" import="false" targetId="5fd6-8371-e5e5-7f0f" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditionGroups>
@@ -94,10 +94,10 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="e3cf-0e84-1b24-97ac" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="4371-0ca0-6365-bb11" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="4371-0ca0-6365-bb11" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="ec7c-fc7c-6fc7-5547" name="04) IM - Command Cadre (JNP)" hidden="false" collective="false" import="false" targetId="b179-24bb-a4b0-3eb4" type="selectionEntry">
+    <entryLink id="ec7c-fc7c-6fc7-5547" name="IM - Command Cadre" hidden="false" collective="false" import="false" targetId="b179-24bb-a4b0-3eb4" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditionGroups>
@@ -111,7 +111,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="8484-a434-488c-af80" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="7aa8-f1a5-1797-fa25" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="7aa8-f1a5-1797-fa25" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="8e6c-5309-5d14-3883" name="IM - Infantry Squad" hidden="false" collective="false" import="false" targetId="b4a8-0824-b604-3277" type="selectionEntry">
@@ -128,7 +128,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="58c7-eb2f-2323-59fb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="ac90-48b6-4c32-1a98" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="ac90-48b6-4c32-1a98" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="32d7-380a-3ef4-f929" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -146,11 +146,11 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="7d72-9867-6cae-52e3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="a38f-24e2-d77e-f758" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="a38f-24e2-d77e-f758" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="30cb-17ba-6fad-04bc" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="c96b-175c-3119-025f" name="07) IM - Grenadier Squad (JNP)" hidden="false" collective="false" import="false" targetId="c201-6fbc-a792-0509" type="selectionEntry">
+    <entryLink id="c96b-175c-3119-025f" name="IM - Grenadier Squad" hidden="false" collective="false" import="false" targetId="c201-6fbc-a792-0509" type="selectionEntry">
       <modifiers>
         <modifier type="add" field="category" value="8f42-a824-fb5f-8fea">
           <conditionGroups>
@@ -174,49 +174,49 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="e5bf-6973-dec6-b96f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="21e3-0a32-7c80-32f3" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="21e3-0a32-7c80-32f3" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="c6ce-6efe-316d-8a99" name="08) IM - Fire Support Squad" hidden="false" collective="false" import="false" targetId="3f92-41db-02f5-d0cd" type="selectionEntry">
+    <entryLink id="c6ce-6efe-316d-8a99" name="IM - Fire Support Squad" hidden="false" collective="false" import="false" targetId="3f92-41db-02f5-d0cd" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="5dcb-b81f-abb1-094c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="82f2-f006-84cb-bd20" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="82f2-f006-84cb-bd20" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="489d-ddd5-565d-659e" name="09) IM - Reconnaissance Squad" hidden="false" collective="false" import="false" targetId="6a90-6dc5-1e0b-9eaf" type="selectionEntry">
+    <entryLink id="489d-ddd5-565d-659e" name="IM - Reconnaissance Squad" hidden="false" collective="false" import="false" targetId="6a90-6dc5-1e0b-9eaf" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="43c4-e562-db15-2051" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="0915-da10-e519-d165" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="0915-da10-e519-d165" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="1c69-43b8-dd54-7cb0" name="10) IM - Medicae Detachment (JNP)" hidden="false" collective="false" import="false" targetId="64e6-42ff-959d-02a1" type="selectionEntry">
+    <entryLink id="1c69-43b8-dd54-7cb0" name="IM - Medicae Detachment" hidden="false" collective="false" import="false" targetId="64e6-42ff-959d-02a1" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="7eaa-e280-55f0-90e3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="9b60-9e5c-040b-76cd" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="9b60-9e5c-040b-76cd" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="0769-58d8-b5e6-2c8d" name="11) IM - Ogryn Brute Squad (JNP)" hidden="false" collective="false" import="false" targetId="e6d5-9f6a-b62b-c477" type="selectionEntry">
+    <entryLink id="0769-58d8-b5e6-2c8d" name="IM - Ogryn Brute Squad" hidden="false" collective="false" import="false" targetId="e6d5-9f6a-b62b-c477" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="7ab3-6772-b87b-a387" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="125f-a3a7-f2c3-1e96" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="125f-a3a7-f2c3-1e96" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="bd91-feb9-0a20-a55c" name="12) IM - Field Gun Battery (JNP)" hidden="false" collective="false" import="false" targetId="69d4-e221-a0cb-e428" type="selectionEntry">
+    <entryLink id="bd91-feb9-0a20-a55c" name="IM - Field Gun Battery" hidden="false" collective="false" import="false" targetId="69d4-e221-a0cb-e428" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="1ca9-75de-6be8-942e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="87c6-b510-1983-334f" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="87c6-b510-1983-334f" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="be47-b7f2-625b-94f8" name="IM - Arvus Transport" hidden="false" collective="false" import="false" targetId="6b4b-8295-b434-a7d4" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="aeea-a03d-1d1f-ca2f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="06d5-8cc9-cc1f-d4d3" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="06d5-8cc9-cc1f-d4d3" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="68fb-6589-6260-a6b6" name="IM - Cargo-8 Hauler Squadron" hidden="false" collective="false" import="false" targetId="866a-ed8e-0c2c-c030" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="c3d3-2cf6-60eb-0400" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="f110-465e-3402-d431" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="f110-465e-3402-d431" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="e911-ccb2-4ce3-01d6" name="IM - Cavalry Squad" hidden="false" collective="false" import="false" targetId="ffb1-4b4b-b88c-832c" type="selectionEntry">
@@ -238,37 +238,37 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="eabe-9585-3937-b220" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="ebb2-5ae2-5949-8018" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="ebb2-5ae2-5949-8018" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="4de9-1451-51a2-1627" name="IM - Beastmasters" hidden="false" collective="false" import="false" targetId="173c-2148-c3ce-9c5c" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="dde7-11fc-3a51-06c8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="6df1-a768-a117-6010" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="6df1-a768-a117-6010" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="40e4-5d89-29b2-b49f" name="17) IM - Sentinel Squadron (JNP)" hidden="false" collective="false" import="false" targetId="987d-3f99-2c52-3da4" type="selectionEntry">
+    <entryLink id="40e4-5d89-29b2-b49f" name="IM - Sentinel Squadron" hidden="false" collective="false" import="false" targetId="987d-3f99-2c52-3da4" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="80cf-d97b-424f-924b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="e79a-48cd-7065-3448" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="e79a-48cd-7065-3448" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="50bd-d720-acbd-a7ee" name="IM - Thunderbolt Fighter" hidden="false" collective="false" import="false" targetId="d7d4-da56-01e2-7b38" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="9ffb-8060-1013-9e47" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="20cb-9306-d6aa-6ff2" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="20cb-9306-d6aa-6ff2" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="b698-2fac-d94d-bf40" name="19) IM - Rapier Battery (JNP)" hidden="false" collective="false" import="false" targetId="fbb6-c597-3edb-1506" type="selectionEntry">
+    <entryLink id="b698-2fac-d94d-bf40" name="IM - Rapier Battery" hidden="false" collective="false" import="false" targetId="fbb6-c597-3edb-1506" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="e42c-6550-8a80-dc03" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="a6f3-de9f-f708-8eb8" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="a6f3-de9f-f708-8eb8" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="ce95-16aa-4152-83c5" name="20) IM - Malcador Heavy Tank (JNP)" hidden="false" collective="false" import="false" targetId="37f6-34e9-4938-0ff6" type="selectionEntry">
+    <entryLink id="ce95-16aa-4152-83c5" name="IM - Malcador Heavy Tank" hidden="false" collective="false" import="false" targetId="37f6-34e9-4938-0ff6" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="d462-6e61-33e2-64a8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="6eb0-60b6-0f8d-a18b" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="6eb0-60b6-0f8d-a18b" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="3acf-9101-eb88-9fb1" name="IM - Leman Russ" hidden="false" collective="false" import="false" targetId="4f35-c44e-4456-31f4" type="selectionEntry">
@@ -281,26 +281,26 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="134b-7000-189e-7c27" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="eeb4-50b0-6864-e5ad" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="eeb4-50b0-6864-e5ad" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
         <categoryLink id="af5d-d29f-0415-cd2f" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="cd09-4199-817a-53b3" name="22) IM - Heavy Ordnance Battery (JNP)" hidden="false" collective="false" import="false" targetId="413b-1304-f079-9875" type="selectionEntry">
+    <entryLink id="cd09-4199-817a-53b3" name="IM - Heavy Ordnance Battery" hidden="false" collective="false" import="false" targetId="413b-1304-f079-9875" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="3df5-775b-83aa-01ff" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="da7c-9810-7f78-390c" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="da7c-9810-7f78-390c" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="e090-6b04-112a-363a" name="23) IM - Gorgon Heavy Transporter (JNP)" hidden="false" collective="false" import="false" targetId="0651-5f5f-43cc-9ca1" type="selectionEntry">
+    <entryLink id="e090-6b04-112a-363a" name="IM - Gorgon Heavy Transporter" hidden="false" collective="false" import="false" targetId="0651-5f5f-43cc-9ca1" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="f2da-da6b-e65a-fd34" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="de34-8380-836e-7aac" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="de34-8380-836e-7aac" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="c2ed-5b56-c0b1-ddf5" name="24) IM - Baneblade Super-heavy Battle Tank (JNP)" hidden="false" collective="false" import="false" targetId="ecd4-2b5f-a98a-5093" type="selectionEntry">
+    <entryLink id="c2ed-5b56-c0b1-ddf5" name="IM - Baneblade Super-heavy Battle Tank" hidden="false" collective="false" import="false" targetId="ecd4-2b5f-a98a-5093" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="91a7-5fe4-ac91-3b29" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="b435-056f-aa48-f3a1" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="b435-056f-aa48-f3a1" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="eb78-29b8-e7bb-7295" name="IM - Cavalry Squad" hidden="true" collective="false" import="false" targetId="ffb1-4b4b-b88c-832c" type="selectionEntry">
@@ -320,12 +320,12 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="b6a2-8834-f2e1-2fa7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="6cf2-e356-d8c8-6bb2" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="6cf2-e356-d8c8-6bb2" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="530b-993b-87bf-956d" name="Clanfolk Cavalry (Troops)" hidden="false" targetId="d029-ac65-0ade-0c32" primary="false"/>
         <categoryLink id="c6b4-d14c-c268-8111" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="e2dc-87fa-2c76-eb60" name="11) IM - Ogryn Brute Squad (JNP)" hidden="true" collective="false" import="false" targetId="e6d5-9f6a-b62b-c477" type="selectionEntry">
+    <entryLink id="e2dc-87fa-2c76-eb60" name="IM - Ogryn Brute Squad" hidden="true" collective="false" import="false" targetId="e6d5-9f6a-b62b-c477" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditionGroups>
@@ -339,10 +339,10 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="c1c5-2d1b-7e6e-51ac" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="16ea-3da4-2540-9d42" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="16ea-3da4-2540-9d42" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="4017-636f-0edf-fc1f" name="07) IM - Grenadier Squad (JNP)" hidden="true" collective="false" import="false" targetId="c201-6fbc-a792-0509" type="selectionEntry">
+    <entryLink id="4017-636f-0edf-fc1f" name="IM - Grenadier Squad" hidden="true" collective="false" import="false" targetId="c201-6fbc-a792-0509" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditionGroups>
@@ -356,7 +356,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="971f-46bb-d237-781d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="b222-9213-415f-a15b" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="b222-9213-415f-a15b" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="3311-49ec-8f04-8706" name="IM - Leman Russ Squadron (Industrial Stronghold)" hidden="true" collective="false" import="false" targetId="a04d-8354-e71b-02f3" type="selectionEntry">
@@ -414,7 +414,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="8633-356d-5e28-fd23" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="8633-356d-5e28-fd23" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="db71-42c4-112c-df07" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="899d-2ceb-1f87-97c8" name="Rogue Psyker Daemons Restriction" hidden="false" targetId="58b3-196a-9732-2165" primary="false"/>
       </categoryLinks>
@@ -436,7 +436,7 @@
       <categoryLinks>
         <categoryLink id="daf1-201a-c6ab-c717" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="8c34-6c89-7a1b-c23a" name="Rogue Psyker Daemons Restriction" hidden="false" targetId="58b3-196a-9732-2165" primary="false"/>
-        <categoryLink id="942a-8275-8e14-f2d1" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="942a-8275-8e14-f2d1" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="3379-a60b-be1f-b920" name="Davinite Lodge Priest" hidden="true" collective="false" import="false" targetId="fe13-4a8f-b2af-1e40" type="selectionEntry">
@@ -457,7 +457,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="ad87-8131-9743-cc25" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="3a95-5d78-5c94-5f10" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="3a95-5d78-5c94-5f10" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="b91f-3e55-7081-b5bf" name="Expeditionary Navigator" hidden="true" collective="false" import="false" targetId="ce53-e40c-65b6-4d3a" type="selectionEntry">
@@ -477,7 +477,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="3bd8-5f18-0e78-159c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="f283-dff6-f484-a31e" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="f283-dff6-f484-a31e" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="2c1-1a87-bcc4-2c77" name="Nathaniel Garro" hidden="true" collective="false" import="false" targetId="0583-258d-f0a0-2170" type="selectionEntry">
@@ -500,7 +500,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="b328-f4db-ba3a-8fe2" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
+        <categoryLink id="b328-f4db-ba3a-8fe2" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
           <comment>template_id_0af1-d052-4bd7-aab6</comment>
         </categoryLink>
         <categoryLink id="bd16-4f90-7710-751a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -528,7 +528,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="2705-d06f-977f-bcfd" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
+        <categoryLink id="2705-d06f-977f-bcfd" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
           <comment>template_id_28e0-91e7-4ada-9fac</comment>
         </categoryLink>
         <categoryLink id="2b26-20db-3962-2ad8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1205,7 +1205,7 @@ Unless noted, the effects of any rules featured in the Provenance’s descriptio
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7264-5558-8905-18ad" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="a550-1780-2c45-b77f" name="04) IM - Command Cadre" hidden="false" collective="false" import="true" targetId="b179-24bb-a4b0-3eb4" type="selectionEntry"/>
+            <entryLink id="a550-1780-2c45-b77f" name="IM - Command Cadre" hidden="false" collective="false" import="true" targetId="b179-24bb-a4b0-3eb4" type="selectionEntry"/>
           </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
@@ -10120,7 +10120,7 @@ equal to the number of Militia Gunners in the unit when making a Shooting Attack
       </infoLinks>
       <categoryLinks>
         <categoryLink id="4918-c7ed-dc9c-9b19" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
-        <categoryLink id="c9e7-211b-aed2-e105" name="Transport" hidden="false" targetId="7b0a-a743-a8da-3a39" primary="false"/>
+        <categoryLink id="c9e7-211b-aed2-e105" name="Transport Sub-type:" hidden="false" targetId="7b0a-a743-a8da-3a39" primary="false"/>
         <categoryLink id="900b-8b06-0d05-270c" name="Third-line Unit Sub-type" hidden="false" targetId="cdaa-645b-fda7-8556" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
@@ -10250,7 +10250,7 @@ equal to the number of Militia Gunners in the unit when making a Shooting Attack
       </infoLinks>
       <categoryLinks>
         <categoryLink id="1ecd-2a6c-27b9-810f" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
-        <categoryLink id="d9cd-7fdd-c92e-72a0" name="Transport" hidden="false" targetId="7b0a-a743-a8da-3a39" primary="false"/>
+        <categoryLink id="d9cd-7fdd-c92e-72a0" name="Transport Sub-type:" hidden="false" targetId="7b0a-a743-a8da-3a39" primary="false"/>
         <categoryLink id="fbd3-e774-82ad-e0b6" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="7e5e-549a-a03f-7676" name="Third-line Unit Sub-type" hidden="false" targetId="cdaa-645b-fda7-8556" primary="false"/>
       </categoryLinks>
@@ -10333,7 +10333,7 @@ equal to the number of Militia Gunners in the unit when making a Shooting Attack
       <infoLinks>
         <infoLink id="7469-12ea-cba1-0625" name="Assault Vehicle" hidden="false" targetId="aa61-11f6-2bb5-7c0e" type="rule"/>
         <infoLink id="4125-edd1-8483-d061" name="Power of the Machine Spirit" hidden="false" targetId="5a93-13e0-809d-782a" type="rule"/>
-        <infoLink name="Unknown" hidden="false" type="profile" id="e6ef-ab28-c5aa-319e" targetId="2a46-a372-d986-d0eb">
+        <infoLink name="Land Raider Proteus Carrier" hidden="false" type="profile" id="e6ef-ab28-c5aa-319e" targetId="2a46-a372-d986-d0eb">
           <modifiers>
             <modifier type="set" value="3" field="51fb-b7d9-aa59-863d"/>
             <modifier type="set" value="Vehicle (Transport, Reinforced, Third-line)" field="e555-4aed-dfcc-c0b4"/>
@@ -10342,7 +10342,7 @@ equal to the number of Militia Gunners in the unit when making a Shooting Attack
       </infoLinks>
       <categoryLinks>
         <categoryLink id="8ee0-acf9-570d-0500" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
-        <categoryLink id="f3b5-bda5-3ce5-7572" name="Transport" hidden="false" targetId="7b0a-a743-a8da-3a39" primary="false"/>
+        <categoryLink id="f3b5-bda5-3ce5-7572" name="Transport Sub-type:" hidden="false" targetId="7b0a-a743-a8da-3a39" primary="false"/>
         <categoryLink id="436f-5f63-850c-4d1d" name="Reinforced Sub-type:" hidden="false" targetId="9b0d-738c-10e4-4ec1" primary="false"/>
         <categoryLink id="f647-1a00-45dc-f45a" name="Third-line Unit Sub-type" hidden="false" targetId="cdaa-645b-fda7-8556" primary="false"/>
       </categoryLinks>
@@ -11209,7 +11209,7 @@ When assigning additional models to units using the Among the Ranks and Militia 
   </sharedRules>
   <catalogueLinks>
     <catalogueLink id="5f24-4626-71c3-0511" name="Mech Library" targetId="3129-da35-55e0-642d" type="catalogue" importRootEntries="true"/>
-    <catalogueLink id="e048-9e5e-507c-5b11" name="LI - Assassins" targetId="4c88-1a81-7e53-0a67" type="catalogue" importRootEntries="true"/>
+    <catalogueLink id="e048-9e5e-507c-5b11" name="LI - Assassins and Agents" targetId="4c88-1a81-7e53-0a67" type="catalogue" importRootEntries="true"/>
     <catalogueLink id="e123-456e-507c-5t11" name="Daemons - Bound Daemons" targetId="e545-295b-4cd9-f235" type="catalogue" importRootEntries="true"/>
     <catalogueLink type="catalogue" name="Daemons - Daemons of the Ruinstorm" id="36bf-86e2-87b4-9336" targetId="ac63-5340-2e9e-1eb6"/>
     <catalogueLink type="catalogue" name="Mechanicum" id="a933-4626-1551-c187" targetId="c247-da79-1654-d39e"/>

--- a/2022 - LA - Alpha Legion.cat
+++ b/2022 - LA - Alpha Legion.cat
@@ -45,11 +45,11 @@
         <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="be13-bd28-eca0-a6e1" type="max"/>
       </constraints>
       <categoryLinks>
-        <categoryLink id="77e3-218b-41b9-3f82" name="New CategoryLink" hidden="false" targetId="c5d2-69ee-8787-55d9" primary="true"/>
+        <categoryLink id="77e3-218b-41b9-3f82" name="The Rewards Of Treachery" hidden="false" targetId="c5d2-69ee-8787-55d9" primary="true"/>
       </categoryLinks>
       <entryLinks>
-        <entryLink id="757d-56f6-93d3-9d1b" name="Rewards of Trechery Legion" hidden="false" collective="false" import="true" targetId="f8bc-5856-11c2-898f" type="selectionEntryGroup"/>
-        <entryLink id="8fc2-e051-033e-52a3" name="Rewards of Trechery Unit" hidden="false" collective="false" import="true" targetId="0004-ce27-39ed-b6a6" type="selectionEntryGroup"/>
+        <entryLink id="757d-56f6-93d3-9d1b" name="Rewards of Treachery Legion" hidden="false" collective="false" import="true" targetId="f8bc-5856-11c2-898f" type="selectionEntryGroup"/>
+        <entryLink id="8fc2-e051-033e-52a3" name="Rewards of Treachery Unit" hidden="false" collective="false" import="true" targetId="0004-ce27-39ed-b6a6" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
@@ -70,7 +70,7 @@
         <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a338-2298-5f62-d6d0" type="max"/>
       </constraints>
       <categoryLinks>
-        <categoryLink id="e87e-6482-7fb1-d401" name="New CategoryLink" hidden="false" targetId="e90d-e5a8-f42d-da84" primary="true"/>
+        <categoryLink id="e87e-6482-7fb1-d401" name="Allegiance:" hidden="false" targetId="e90d-e5a8-f42d-da84" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="ce80-6491-c668-2eb3" name="Crimson Paladins" hidden="true" collective="false" import="false" targetId="33fe-9683-bde5-95ca" type="selectionEntry">
@@ -92,7 +92,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="007a-4705-5f7a-695b" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="007a-4705-5f7a-695b" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="69ff-87ed-3c34-3742" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
         <categoryLink id="c597-72fd-c1c9-39ff" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
@@ -108,7 +108,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="3a48-ebd5-979a-ab0e" name="New CategoryLink" hidden="false" targetId="ad5f-31db-8bc7-5c46" primary="true"/>
+        <categoryLink id="3a48-ebd5-979a-ab0e" name="Primarch:" hidden="false" targetId="ad5f-31db-8bc7-5c46" primary="true"/>
         <categoryLink id="b56c-b87b-07a2-6437" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
       <entryLinks>
@@ -128,7 +128,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="dd12-09e4-7e98-1293" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="dd12-09e4-7e98-1293" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="3732-e871-9e0b-7235" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
         <categoryLink id="b2da-e306-a467-d325" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
@@ -144,7 +144,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="2c9a-c549-943f-5cd4" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="2c9a-c549-943f-5cd4" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="9b6f-0ee4-663a-93da" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -159,7 +159,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="8616-35c3-c887-a64c" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="8616-35c3-c887-a64c" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
         <categoryLink id="c995-fa87-2f17-b073" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -179,7 +179,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="46d2-e42c-5804-d2d4" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="46d2-e42c-5804-d2d4" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="1a05-3dc3-65de-89f6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -197,7 +197,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="c05e-35d3-2f58-ee87" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="c05e-35d3-2f58-ee87" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
         <categoryLink id="85bf-5c39-d77e-de7e" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
         <categoryLink id="0322-dc48-e060-7882" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
@@ -211,7 +211,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="a8ff-df82-9b34-d336" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="a8ff-df82-9b34-d336" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="2a5f-6671-1cd0-8824" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
         <categoryLink id="7f2a-7de5-1140-d4c1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
@@ -234,7 +234,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="04c0-2b59-6737-2841" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="04c0-2b59-6737-2841" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="4cb8-a680-b384-2e82" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
         <categoryLink id="209d-5586-1f70-fda7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
@@ -248,7 +248,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="b3ad-92e7-3dcd-b644" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="b3ad-92e7-3dcd-b644" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="ea34-926e-6a09-afe1" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
         <categoryLink id="ae94-21c7-e1d1-a2fc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
@@ -268,7 +268,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="46a9-0c8d-202d-f470" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
-        <categoryLink id="1cb0-db62-d7b8-96fb" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="1cb0-db62-d7b8-96fb" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
         <categoryLink id="4bac-0e00-a20e-b1bb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -290,7 +290,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="10d9-0cba-6158-32a9" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="10d9-0cba-6158-32a9" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="f31f-785e-2f52-2ebc" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
         <categoryLink id="ecd5-a8eb-ac46-efaa" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
@@ -314,7 +314,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="41da-54c7-c6c3-4991" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="41da-54c7-c6c3-4991" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="b730-a050-02af-16d5" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
         <categoryLink id="6522-92fe-75aa-77a4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
@@ -333,7 +333,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="b9f4-db55-fe6d-94b2" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="b9f4-db55-fe6d-94b2" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="2c47-5afd-2dc9-7b56" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
         <categoryLink id="3cca-372c-6f4e-a10e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
@@ -356,7 +356,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="16e5-e6f3-635f-6251" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="16e5-e6f3-635f-6251" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
         <categoryLink id="c1e3-bbfd-225e-5ab3" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
         <categoryLink id="60eb-e7a6-75c2-be95" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
@@ -409,7 +409,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="a77e-592b-fe68-b614" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="3e22-e8a9-32e5-c9ca" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="3e22-e8a9-32e5-c9ca" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="e8d2-9f63-b325-32c0" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -428,7 +428,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="731f-fd34-3855-df4a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="9f80-c46b-5b87-06fc" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="9f80-c46b-5b87-06fc" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
         <categoryLink id="7cad-b028-9cef-f092" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -446,7 +446,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="6c1e-4c9e-e3bd-1ed1" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="6c1e-4c9e-e3bd-1ed1" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="85c5-b06d-1d39-aad0" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
         <categoryLink id="b485-56bf-6221-dd06" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
@@ -460,7 +460,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="bae3-e5c1-dfc6-dc12" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="bae3-e5c1-dfc6-dc12" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="274f-7764-d62a-c30a" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
         <categoryLink id="7001-3855-b64e-05b4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
@@ -483,7 +483,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="08d9-f6ed-b8dd-e10c" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="08d9-f6ed-b8dd-e10c" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
         <categoryLink id="a4fa-28fa-2625-6b6e" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
         <categoryLink id="94ac-87ca-a047-7f37" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
@@ -506,7 +506,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="e9fb-2b4f-655a-82db" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="e9fb-2b4f-655a-82db" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="90cd-cd1d-07cb-c23b" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
         <categoryLink id="4e70-99fb-415a-a938" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
@@ -529,7 +529,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="ae0e-4cf9-c6f7-c1a2" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="ae0e-4cf9-c6f7-c1a2" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="a82b-8ee2-5f4e-826f" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
         <categoryLink id="1461-85ec-945e-5e31" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
@@ -552,7 +552,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="475a-4d51-e6b1-b353" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="475a-4d51-e6b1-b353" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="9758-f439-2d9f-f6c0" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
         <categoryLink id="443f-534b-ca5c-39ec" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
@@ -575,7 +575,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="8d21-c340-4539-6209" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="8d21-c340-4539-6209" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
         <categoryLink id="8daf-d124-9b5c-e0c1" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
         <categoryLink id="c6fd-e694-7395-20f2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
@@ -594,7 +594,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="f056-f0c1-ad40-6834" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="f056-f0c1-ad40-6834" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="54f4-39a6-c4fc-c33e" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
         <categoryLink id="fe1a-584c-173e-87f3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
@@ -618,7 +618,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="6eb4-905f-5c57-cf57" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="6eb4-905f-5c57-cf57" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
         <categoryLink id="68dc-de7f-8ab8-838d" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
         <categoryLink id="3166-a82f-5b57-1c5e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
@@ -632,7 +632,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="c435-91dd-cb19-23ed" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="c435-91dd-cb19-23ed" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="cdf9-f163-9e6d-1243" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
         <categoryLink id="4ee3-79a9-4706-6791" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
@@ -646,7 +646,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="1f0a-5ac7-30de-45e8" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="1f0a-5ac7-30de-45e8" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="ae02-dcb6-4b6e-f03e" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
         <categoryLink id="127b-1f7c-f850-d939" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
@@ -660,7 +660,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="a09d-624d-b66c-4f59" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="a09d-624d-b66c-4f59" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="1175-0a3e-b135-13f0" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
         <categoryLink id="aebc-435f-a0b7-79c3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
@@ -674,7 +674,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="57a2-7099-cbed-ecc4" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="57a2-7099-cbed-ecc4" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="d02b-01a8-c88c-266f" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
         <categoryLink id="aa49-0b17-af19-2871" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
@@ -688,7 +688,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="97b1-3f08-d172-8a15" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="97b1-3f08-d172-8a15" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
         <categoryLink id="90c2-8531-b18d-b9b9" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
         <categoryLink id="a1a6-0507-e958-2599" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
@@ -702,7 +702,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="0d35-e913-d462-7066" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="0d35-e913-d462-7066" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="6267-16c3-3f0c-d3ce" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
         <categoryLink id="af87-08f0-109f-d6c5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
@@ -721,7 +721,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="95ea-2552-bc04-8f45" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="95ea-2552-bc04-8f45" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="8610-0a32-a51b-1666" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
         <categoryLink id="e8ef-534c-a9ca-b1e6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
@@ -744,7 +744,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="5fe0-ce32-6415-3d27" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="5fe0-ce32-6415-3d27" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="b2d4-8fb2-d07a-d9d1" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
         <categoryLink id="2b5a-3212-0e2c-4b35" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
@@ -758,7 +758,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="fe9d-d416-66cc-3840" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="fe9d-d416-66cc-3840" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="5bbd-91c1-a792-d250" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
         <categoryLink id="5dcd-cef6-8861-fba9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
@@ -781,7 +781,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="ab26-ddb6-3918-328e" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="ab26-ddb6-3918-328e" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="6b1d-a72a-6eae-d530" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
         <categoryLink id="ad6f-009a-e3fd-03f3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
@@ -805,7 +805,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="aa05-6f88-816e-bfda" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="aa05-6f88-816e-bfda" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="387c-5bef-8480-79fa" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
         <categoryLink id="e42f-2919-31ba-66ed" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
@@ -828,7 +828,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="a321-0fd1-53f5-1756" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="a321-0fd1-53f5-1756" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="75fd-7486-ed31-b419" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
         <categoryLink id="d328-4b4c-55b5-63bf" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
@@ -847,7 +847,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="e5a7-c6bf-98d1-b1f7" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="e5a7-c6bf-98d1-b1f7" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="5f5b-f5e8-7f86-eb96" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
         <categoryLink id="441b-6620-46c3-d0b1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
@@ -861,7 +861,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="6400-720a-7c91-b8c6" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="6400-720a-7c91-b8c6" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="dcf6-53ba-4274-e748" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
         <categoryLink id="6da8-2162-e41c-9dbb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
@@ -884,7 +884,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="13ca-19e6-fa4c-59a3" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="13ca-19e6-fa4c-59a3" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="226f-9aa6-780b-aac9" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
         <categoryLink id="98c7-72db-c50a-e9e5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
@@ -908,7 +908,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="6792-3273-84df-2c16" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="6792-3273-84df-2c16" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="ae24-f3cc-26f6-f8ed" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
         <categoryLink id="c36d-5646-132d-cfde" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
         <categoryLink id="38a8-7fe8-d5cb-a542" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
@@ -934,7 +934,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="dc7c-154a-28ef-62cc" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
-        <categoryLink id="9e6c-a4a4-973d-f93f" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="9e6c-a4a4-973d-f93f" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="90e3-ff3c-3b76-d42c" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
         <categoryLink id="26c4-7af8-ab43-8177" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
@@ -954,7 +954,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="8fc2-00bd-c7a6-0cca" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
-        <categoryLink id="c1c1-f2a0-d7a8-8a2f" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="c1c1-f2a0-d7a8-8a2f" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="73b5-a699-f247-c096" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -972,7 +972,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="8cce-74a0-825f-76b2" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="8cce-74a0-825f-76b2" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
         <categoryLink id="fcea-6b0f-9886-453f" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
         <categoryLink id="0f28-156d-4624-4fb8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
@@ -986,7 +986,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="10b6-efe8-eb05-1122" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="10b6-efe8-eb05-1122" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="8493-2d60-abcf-0341" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
         <categoryLink id="b10b-27e3-45a1-93c1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
@@ -1000,7 +1000,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="43b6-e5db-d065-4c3d" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="43b6-e5db-d065-4c3d" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="3e9e-aa2d-e31b-82b4" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
         <categoryLink id="985b-042a-6c7f-3d8b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
@@ -1023,7 +1023,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="e9db-b17f-ef90-49c9" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="e9db-b17f-ef90-49c9" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="9881-969b-bd71-6e33" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
         <categoryLink id="b75b-ced4-7c8c-82ee" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
@@ -1047,7 +1047,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="4b53-0b13-f50e-bd04" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="4b53-0b13-f50e-bd04" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="4e61-2ef8-09c5-342f" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
         <categoryLink id="6ef7-3e18-5801-0c99" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
@@ -1070,7 +1070,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="6081-3aef-69a9-0723" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="6081-3aef-69a9-0723" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="46a6-2a49-b309-965a" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
         <categoryLink id="6a44-ef13-acf2-cef6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
@@ -1089,7 +1089,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="10ca-0f92-db85-de6f" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="10ca-0f92-db85-de6f" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
         <categoryLink id="4582-1241-6135-f55c" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
         <categoryLink id="3be9-a405-a78b-a1d3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
@@ -1108,7 +1108,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="8576-3c18-b764-3bf9" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="8576-3c18-b764-3bf9" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="b291-e267-0c5b-6b07" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
         <categoryLink id="ecf9-b782-cdec-0f89" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
@@ -1131,7 +1131,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="b90f-7fe3-220d-b301" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="b90f-7fe3-220d-b301" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="2601-513b-bf12-ee56" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
         <categoryLink id="3d0a-44a8-dd1c-1167" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
@@ -1155,7 +1155,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="2abe-d220-2c83-214a" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="2abe-d220-2c83-214a" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="8957-dd47-1e4a-f19e" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
         <categoryLink id="101d-e6ef-d933-ef24" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
@@ -1171,7 +1171,7 @@
       <categoryLinks>
         <categoryLink id="99d9-1f22-45d6-01e2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="2d51-411b-c502-acaf" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
-        <categoryLink id="375c-755b-17a9-1232" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="375c-755b-17a9-1232" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="336e-3223-67ce-912c" name="Kyzagan Assault Speeder Squadron" hidden="true" collective="false" import="false" targetId="e37e-09ea-50c6-2daa" type="selectionEntry">
@@ -1193,7 +1193,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="3e18-b878-223f-289e" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="3e18-b878-223f-289e" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
         <categoryLink id="1538-9081-32fa-c24b" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
         <categoryLink id="6de1-d44e-3b0c-d4b5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
@@ -1212,7 +1212,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="806e-73fd-00f3-b1ca" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="806e-73fd-00f3-b1ca" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="55ad-798d-1f21-7563" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
         <categoryLink id="1c7f-0bda-93a9-fd09" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
@@ -1231,7 +1231,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="89aa-08cc-1ad3-9073" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="89aa-08cc-1ad3-9073" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
         <categoryLink id="6cef-29a8-2dba-b29a" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
         <categoryLink id="c6fd-0435-662e-908d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
@@ -1254,7 +1254,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="b1a0-b911-73a6-3f52" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="b1a0-b911-73a6-3f52" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="399f-5ed8-9211-f7be" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
         <categoryLink id="9503-23d5-fc66-cea2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
@@ -1273,7 +1273,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="581b-17a1-da13-5fea" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="581b-17a1-da13-5fea" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="7f2e-7d15-717b-90a6" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
         <categoryLink id="99e6-38c3-c771-151d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
@@ -1292,7 +1292,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="6af3-1969-4705-0fb1" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="6af3-1969-4705-0fb1" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="91af-e352-f10a-b59a" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
         <categoryLink id="c519-c47d-546b-3000" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
@@ -1306,7 +1306,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="d168-2562-e83e-8e9b" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="d168-2562-e83e-8e9b" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="2eb1-2e57-dbbc-957b" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
         <categoryLink id="ce2b-fc21-8058-7388" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
@@ -1329,7 +1329,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="bab1-bf37-f813-87b0" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="bab1-bf37-f813-87b0" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="7d89-c6b5-084b-5ed7" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
         <categoryLink id="dc77-206a-860a-db65" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
@@ -1348,7 +1348,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="6601-3a00-9ee4-d330" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="6601-3a00-9ee4-d330" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="822c-7e6e-04bd-e562" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
         <categoryLink id="ca87-f80f-b302-cabb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
@@ -1362,7 +1362,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="87af-6bfa-d646-4441" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="87af-6bfa-d646-4441" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="b0ef-c961-5f21-627a" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
         <categoryLink id="7618-a59b-753f-2ff8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
@@ -1373,7 +1373,7 @@
         <categoryLink id="dd65-9d73-41ca-96bf" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_c6d4-581f-4746-bec3</comment>
         </categoryLink>
-        <categoryLink id="8f07-256b-48db-a923" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
+        <categoryLink id="8f07-256b-48db-a923" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
           <comment>template_id_2489-ee2a-45dd-b384</comment>
         </categoryLink>
       </categoryLinks>
@@ -1410,7 +1410,7 @@
         <categoryLink id="39d8-6f42-493f-9da2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_8378-ede4-476d-b657</comment>
         </categoryLink>
-        <categoryLink id="5226-92f8-4d38-a3c3" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="5226-92f8-4d38-a3c3" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_d64f-ad19-426c-adf7</comment>
         </categoryLink>
       </categoryLinks>
@@ -1443,7 +1443,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="291c-80cd-49a8-863a" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="291c-80cd-49a8-863a" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_ac26-e639-4d53-9b8b</comment>
         </categoryLink>
         <categoryLink id="b18c-5d6f-47d1-bb41" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1490,7 +1490,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="ff4b-8e71-4a9e-97f1" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="ff4b-8e71-4a9e-97f1" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_3a22-caae-4eea-9bc5</comment>
         </categoryLink>
         <categoryLink id="17ce-4ee3-4f48-aaad" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1565,7 +1565,7 @@
         <categoryLink id="8caa-ec08-4828-aa35" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_bd6a-0cda-4e0f-80ae</comment>
         </categoryLink>
-        <categoryLink id="dff6-3290-43b6-b790" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
+        <categoryLink id="dff6-3290-43b6-b790" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
           <comment>template_id_ae75-7cca-4701-9d56</comment>
         </categoryLink>
         <categoryLink id="de92-9ae1-4978-9ea2" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false">
@@ -1609,7 +1609,7 @@
         <categoryLink id="2c25-22f0-4770-9195" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false">
           <comment>template_id_f51c-73d7-4f29-be1c</comment>
         </categoryLink>
-        <categoryLink id="ee00-8be7-41bd-ab32" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
+        <categoryLink id="ee00-8be7-41bd-ab32" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
           <comment>template_id_257d-78c0-4bab-ba65</comment>
         </categoryLink>
       </categoryLinks>
@@ -1664,7 +1664,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="7004-0a0e-41de-8931" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="7004-0a0e-41de-8931" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_f1c8-27fd-4f98-8527</comment>
         </categoryLink>
         <categoryLink id="056a-4c0d-47ef-a90a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1700,7 +1700,7 @@
         <categoryLink id="88a0-8557-4f48-9e1c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_dd44-e0a8-42a8-bdcc</comment>
         </categoryLink>
-        <categoryLink id="bf38-2dd3-44c2-88ef" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
+        <categoryLink id="bf38-2dd3-44c2-88ef" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
           <comment>template_id_c5b0-f9ae-468d-924a</comment>
         </categoryLink>
       </categoryLinks>
@@ -1734,7 +1734,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="f0dd-4ac2-439b-a2b2" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
+        <categoryLink id="f0dd-4ac2-439b-a2b2" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
           <comment>template_id_f926-27fd-4a92-97a1</comment>
         </categoryLink>
         <categoryLink id="76d0-2ece-4b5c-b8fa" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1811,7 +1811,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="30b0-c2c3-4700-9569" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="30b0-c2c3-4700-9569" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_361e-fb90-4b0e-ac3d</comment>
         </categoryLink>
         <categoryLink id="b7dd-57c3-40ed-96b0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1837,7 +1837,7 @@
         <categoryLink id="7955-d9c4-46ac-a748" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_473b-e812-4158-9416</comment>
         </categoryLink>
-        <categoryLink id="e9dc-2281-454b-8dbb" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
+        <categoryLink id="e9dc-2281-454b-8dbb" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
           <comment>template_id_00a2-63ff-4698-a35b</comment>
         </categoryLink>
       </categoryLinks>
@@ -1868,7 +1868,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="bf0c-eb03-43bb-af46" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="bf0c-eb03-43bb-af46" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_2a08-4432-42ad-bfdb</comment>
         </categoryLink>
         <categoryLink id="13ae-1f22-40f7-b5ed" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1908,7 +1908,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="cfbb-8b59-4e55-9d8e" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="cfbb-8b59-4e55-9d8e" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_f4c0-4396-4f39-a34f</comment>
         </categoryLink>
         <categoryLink id="5173-1b2c-4066-8847" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1948,7 +1948,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="6a95-de6b-4210-8792" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="6a95-de6b-4210-8792" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_caf6-5548-4b89-8102</comment>
         </categoryLink>
         <categoryLink id="7534-c598-4943-82d3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2022,7 +2022,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="6cc6-e627-4a99-a3b0" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="6cc6-e627-4a99-a3b0" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_d53e-113f-4a40-a3d5</comment>
         </categoryLink>
         <categoryLink id="a6a8-47c0-43c2-972c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2050,7 +2050,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="e410-1ff4-4aac-aa9d" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="e410-1ff4-4aac-aa9d" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_e6f7-a6ca-4825-bfc5</comment>
         </categoryLink>
         <categoryLink id="72fd-ea7d-4dde-a973" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2090,7 +2090,7 @@
         <categoryLink id="62ae-24eb-48a3-befe" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_cefb-cfd7-4dc8-99c4</comment>
         </categoryLink>
-        <categoryLink id="90fe-68d3-4553-a7ea" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="90fe-68d3-4553-a7ea" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_a9fd-9d16-4a5e-855c</comment>
         </categoryLink>
       </categoryLinks>
@@ -2121,7 +2121,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="98eb-4153-4ff5-ba4d" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="98eb-4153-4ff5-ba4d" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_a56d-347b-4b09-a918</comment>
         </categoryLink>
         <categoryLink id="f6a2-7107-48bf-87b4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2161,7 +2161,7 @@
         <categoryLink id="aef1-7c82-4b16-884e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_9441-d79b-4720-9667</comment>
         </categoryLink>
-        <categoryLink id="30bf-fcc6-4f9d-bd44" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="30bf-fcc6-4f9d-bd44" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_7d7e-32d3-4692-b401</comment>
         </categoryLink>
       </categoryLinks>
@@ -2235,7 +2235,7 @@
         <categoryLink id="e814-7ce4-4679-86e9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_bc67-ce1f-4004-aeb7</comment>
         </categoryLink>
-        <categoryLink id="e715-f122-4594-ba5d" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="e715-f122-4594-ba5d" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_9a45-9699-4475-aeef</comment>
         </categoryLink>
       </categoryLinks>
@@ -2343,7 +2343,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="8738-db14-4b13-a2c5" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="8738-db14-4b13-a2c5" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_4d7c-201f-4c99-b89a</comment>
         </categoryLink>
         <categoryLink id="4ee1-4f38-4640-b617" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2366,7 +2366,7 @@
         <categoryLink id="6cf8-ab23-4976-91e6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_6140-2404-46f9-bd42</comment>
         </categoryLink>
-        <categoryLink id="4798-3935-4057-a29e" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
+        <categoryLink id="4798-3935-4057-a29e" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
           <comment>template_id_1c86-fad8-46ec-a0b0</comment>
         </categoryLink>
       </categoryLinks>
@@ -2419,7 +2419,7 @@
         <categoryLink id="e6fc-6a0f-4825-9f9f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_4272-9b9d-4c59-95f0</comment>
         </categoryLink>
-        <categoryLink id="11f7-444e-4ba8-8527" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="11f7-444e-4ba8-8527" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_d85b-1ae7-40d5-9341</comment>
         </categoryLink>
       </categoryLinks>
@@ -2448,7 +2448,7 @@
         <categoryLink id="0991-5236-4969-99ae" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_ff9f-01cb-41b9-800e</comment>
         </categoryLink>
-        <categoryLink id="a4da-54f1-4849-a4fa" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="a4da-54f1-4849-a4fa" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_1315-6051-4a46-b070</comment>
         </categoryLink>
       </categoryLinks>
@@ -2465,7 +2465,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="7b2f-09ab-4029-b9d7" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
+        <categoryLink id="7b2f-09ab-4029-b9d7" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
           <comment>template_id_b084-df23-4f99-812f</comment>
         </categoryLink>
         <categoryLink id="581e-8eaf-4990-8109" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false">
@@ -2615,7 +2615,7 @@
         <categoryLink id="7e49-1f15-47ec-bb24" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_75a7-dc06-445b-b2dc</comment>
         </categoryLink>
-        <categoryLink id="d6b0-768f-4711-8f68" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="d6b0-768f-4711-8f68" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_e21a-c03b-4885-ac46</comment>
         </categoryLink>
       </categoryLinks>
@@ -2640,7 +2640,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="8ac5-b487-4889-8504" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
+        <categoryLink id="8ac5-b487-4889-8504" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
           <comment>template_id_f55b-7555-444b-beee</comment>
         </categoryLink>
         <categoryLink id="9cfe-69e0-46eb-b1bf" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2668,7 +2668,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="4dc5-b1be-4e81-a759" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="4dc5-b1be-4e81-a759" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_79fa-3370-4ae0-9e12</comment>
         </categoryLink>
         <categoryLink id="a674-e8d0-41ac-9ba8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2701,7 +2701,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="93b3-d3b3-4e5c-bfb4" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="93b3-d3b3-4e5c-bfb4" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_8d82-3279-4481-84bb</comment>
         </categoryLink>
         <categoryLink id="8ef1-19ac-44c2-abcd" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2741,7 +2741,7 @@
         <categoryLink id="1489-21a2-4d07-bd0e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_7010-be56-4709-b058</comment>
         </categoryLink>
-        <categoryLink id="4f8a-f4d5-4f7e-b114" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="4f8a-f4d5-4f7e-b114" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_7379-a740-47ba-a054</comment>
         </categoryLink>
       </categoryLinks>
@@ -2766,7 +2766,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="a71a-bed7-4494-844c" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="a71a-bed7-4494-844c" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_944f-7420-4982-8ea9</comment>
         </categoryLink>
         <categoryLink id="a50c-6437-4f7c-86c4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2826,7 +2826,7 @@
         <categoryLink id="6b5b-3f75-4d08-b2aa" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_c6ff-0977-4c92-bb28</comment>
         </categoryLink>
-        <categoryLink id="14ed-e797-4583-ba9e" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="14ed-e797-4583-ba9e" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_f555-7d39-458f-84c9</comment>
         </categoryLink>
       </categoryLinks>
@@ -2863,7 +2863,7 @@
         <categoryLink id="c6c3-7560-453e-8f6f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_39e5-eda5-45d1-a643</comment>
         </categoryLink>
-        <categoryLink id="68dc-bfac-4a4a-88ba" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="68dc-bfac-4a4a-88ba" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_6416-21bb-4df4-9de8</comment>
         </categoryLink>
       </categoryLinks>
@@ -2900,7 +2900,7 @@
         <categoryLink id="c4a0-7b0c-4952-99a7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_5528-2dac-4be5-900c</comment>
         </categoryLink>
-        <categoryLink id="4cb8-2645-4b9b-bd4e" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="4cb8-2645-4b9b-bd4e" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_dc8f-d888-4585-991d</comment>
         </categoryLink>
       </categoryLinks>
@@ -2937,7 +2937,7 @@
         <categoryLink id="aa4c-e3b2-4c67-83a7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_899e-b052-4d5b-8c18</comment>
         </categoryLink>
-        <categoryLink id="dffe-6b16-4e1f-939a" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="dffe-6b16-4e1f-939a" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_f5e9-cff6-41d2-a016</comment>
         </categoryLink>
       </categoryLinks>
@@ -2974,7 +2974,7 @@
         <categoryLink id="cf6c-e7ea-414f-a98e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_09cd-2176-40af-bba6</comment>
         </categoryLink>
-        <categoryLink id="3a38-d6e8-4301-9675" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="3a38-d6e8-4301-9675" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_05e6-7c63-4a35-9ba0</comment>
         </categoryLink>
       </categoryLinks>
@@ -3003,7 +3003,7 @@
         <categoryLink id="d029-44b7-45af-99df" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_0dfa-4004-4751-8022</comment>
         </categoryLink>
-        <categoryLink id="70fb-763f-4c6b-878a" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="70fb-763f-4c6b-878a" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_a669-0f5d-4fd3-811b</comment>
         </categoryLink>
       </categoryLinks>
@@ -3037,7 +3037,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="5d9a-0b03-4847-a322" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="5d9a-0b03-4847-a322" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_4f60-472b-45a9-ab9e</comment>
         </categoryLink>
         <categoryLink id="3b14-a126-4512-8db7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -3071,7 +3071,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="6aa2-28ce-4637-b897" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="6aa2-28ce-4637-b897" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_2008-f1c4-4285-a14f</comment>
         </categoryLink>
         <categoryLink id="280a-430d-4f29-8b1a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -3110,7 +3110,7 @@
         <categoryLink id="bd87-7eb9-44cb-bbfd" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_9189-836c-475d-a52e</comment>
         </categoryLink>
-        <categoryLink id="31e3-9699-4212-9052" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="31e3-9699-4212-9052" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_e1fa-b7d8-47b0-a88a</comment>
         </categoryLink>
         <categoryLink id="28b2-f834-4f65-84fa" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false">
@@ -3133,7 +3133,7 @@
         <categoryLink id="7fce-6dc4-44f8-a830" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_b1d5-fd75-4f17-bbf4</comment>
         </categoryLink>
-        <categoryLink id="edfc-a1ad-4598-b5d5" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="edfc-a1ad-4598-b5d5" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_f221-bf81-4045-849b</comment>
         </categoryLink>
       </categoryLinks>
@@ -3144,7 +3144,7 @@
         <categoryLink id="c92f-0ac2-4469-b637" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_51af-a137-4a1c-97a4</comment>
         </categoryLink>
-        <categoryLink id="b78e-d286-4c5c-8468" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
+        <categoryLink id="b78e-d286-4c5c-8468" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
           <comment>template_id_ec1f-c326-40a8-9d1f</comment>
         </categoryLink>
       </categoryLinks>
@@ -3189,7 +3189,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="7ffb-aa68-4a39-9e23" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
+        <categoryLink id="7ffb-aa68-4a39-9e23" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
           <comment>template_id_ac1c-b3bf-4011-918a</comment>
         </categoryLink>
         <categoryLink id="d45e-df6b-4cd9-830e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -3225,7 +3225,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="54a2-be22-4670-a709" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="54a2-be22-4670-a709" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_7d4f-547c-43ed-a520</comment>
         </categoryLink>
         <categoryLink id="60de-22e0-4f83-9151" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -3265,7 +3265,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="869f-d28c-4320-b5ac" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="869f-d28c-4320-b5ac" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_e22a-c5f8-4825-a45f</comment>
         </categoryLink>
         <categoryLink id="b00b-2e9b-4244-bbfc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -3291,7 +3291,7 @@
         <categoryLink id="f27c-d454-447b-99d8" name="Compulsory Elite:" hidden="false" targetId="bb1f-ae32-b587-c3e1" primary="false">
           <comment>template_id_7d5a-62e7-43ee-b79b</comment>
         </categoryLink>
-        <categoryLink id="6940-944b-49d2-b4e8" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
+        <categoryLink id="6940-944b-49d2-b4e8" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
           <comment>template_id_4986-9157-49f2-b670</comment>
         </categoryLink>
       </categoryLinks>
@@ -3328,7 +3328,7 @@
         <categoryLink id="2b78-a63c-4ce1-99b4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_1b86-0977-4a8b-adac</comment>
         </categoryLink>
-        <categoryLink id="299b-90f0-4b8b-97db" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="299b-90f0-4b8b-97db" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_b449-403a-4e42-9239</comment>
         </categoryLink>
       </categoryLinks>
@@ -3362,12 +3362,12 @@
         <categoryLink id="cad3-b602-4a23-982b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_4f71-446f-4cff-afda</comment>
         </categoryLink>
-        <categoryLink id="8c30-97d8-4256-bbd8" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="8c30-97d8-4256-bbd8" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_3f44-8647-43a4-ac22</comment>
         </categoryLink>
       </categoryLinks>
     </entryLink>
-    <entryLink id="8481-56ed-57c9-49bb" name="Avenger Strike Fighter" hidden="true" collective="false" import="false" targetId="b25c-e85c-1c29-9e05" type="selectionEntry">
+    <entryLink id="8481-56ed-57c9-49bb" name="Legion Avenger Strike Fighter" hidden="true" collective="false" import="false" targetId="b25c-e85c-1c29-9e05" type="selectionEntry">
       <comment>template_id_1064-175d-4616-9c71</comment>
       <modifiers>
         <modifier type="set" field="hidden" value="false">
@@ -3396,7 +3396,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="d18a-b406-423f-8896" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="d18a-b406-423f-8896" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_a009-a597-4b51-b228</comment>
         </categoryLink>
         <categoryLink id="fff6-fe0e-424f-ae57" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -3436,7 +3436,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="674e-e8a9-4f35-8fca" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="674e-e8a9-4f35-8fca" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_c165-3906-463a-9c73</comment>
         </categoryLink>
         <categoryLink id="d245-4fe9-4949-9dc2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -3473,7 +3473,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="99e0-f1a4-408e-b33d" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="99e0-f1a4-408e-b33d" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_251a-df5b-4bfd-ad63</comment>
         </categoryLink>
         <categoryLink id="7838-5c39-4a76-bc76" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -3517,7 +3517,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="e835-9b85-4453-b0f4" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
+        <categoryLink id="e835-9b85-4453-b0f4" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
           <comment>template_id_67c2-df43-44fc-92d1</comment>
         </categoryLink>
         <categoryLink id="ddf1-701b-41d2-a4b2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -3557,7 +3557,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="c255-88c9-4314-9911" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="c255-88c9-4314-9911" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_f65b-8958-49b3-92a5</comment>
         </categoryLink>
         <categoryLink id="1def-511a-439e-9447" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -3597,7 +3597,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="0b4a-48da-4242-988e" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="0b4a-48da-4242-988e" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_c6a8-22a8-4d41-b969</comment>
         </categoryLink>
         <categoryLink id="3f35-61ca-45f1-a80c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -3640,7 +3640,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="bbf9-de75-4e7c-8a7b" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="bbf9-de75-4e7c-8a7b" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_3610-c975-4d55-bdfe</comment>
         </categoryLink>
         <categoryLink id="7b1b-95bc-4a67-a6c0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -3683,7 +3683,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="29d8-4893-4769-8f26" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="29d8-4893-4769-8f26" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_f81d-9435-4f11-99c1</comment>
         </categoryLink>
         <categoryLink id="a8f0-3f36-4a58-830a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -3726,7 +3726,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="cd8e-d681-413e-8d04" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="cd8e-d681-413e-8d04" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_b24f-3ae0-4cbb-b016</comment>
         </categoryLink>
         <categoryLink id="5365-9e60-417d-bcbb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -3766,7 +3766,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="ab1e-5821-460f-87b1" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="ab1e-5821-460f-87b1" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_c77f-0819-473b-a8a2</comment>
         </categoryLink>
         <categoryLink id="a202-7bd7-48f9-858a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -3806,7 +3806,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="b26b-fa98-4b3f-997c" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="b26b-fa98-4b3f-997c" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_0397-c837-4fea-a527</comment>
         </categoryLink>
         <categoryLink id="6fbe-0a96-4e78-b359" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -3849,7 +3849,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="5ea9-1909-4746-b2ea" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="5ea9-1909-4746-b2ea" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_c1cf-cea4-4278-8f27</comment>
         </categoryLink>
         <categoryLink id="54e5-6d49-4ade-8f8f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -3892,7 +3892,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="5605-d1e3-4f4e-afc9" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="5605-d1e3-4f4e-afc9" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_0c16-6841-42b2-b02d</comment>
         </categoryLink>
         <categoryLink id="e802-d9d8-411f-be0e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -3935,7 +3935,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="6e6b-e874-4f68-9e92" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="6e6b-e874-4f68-9e92" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_3632-0b5d-4622-ae33</comment>
         </categoryLink>
         <categoryLink id="4160-1fc4-4ec5-ad56" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -3978,7 +3978,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="31fa-c2be-4b3a-8d1b" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="31fa-c2be-4b3a-8d1b" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_5ad5-8701-42cd-b2b6</comment>
         </categoryLink>
         <categoryLink id="1de7-8105-44a3-bda1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -4018,7 +4018,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="f837-6db8-4fae-9fca" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="f837-6db8-4fae-9fca" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_4e52-ad1b-48d4-8eed</comment>
         </categoryLink>
         <categoryLink id="4557-2293-442f-a99b" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false">
@@ -4047,7 +4047,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="7fc4-0309-47eb-b285" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
+        <categoryLink id="7fc4-0309-47eb-b285" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
           <comment>template_id_0af1-d052-4bd7-aab6</comment>
         </categoryLink>
         <categoryLink id="310a-c51f-4f4c-9928" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -4084,7 +4084,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="5089-2257-4ee6-8f60" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="5089-2257-4ee6-8f60" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_b822-3417-4613-be37</comment>
         </categoryLink>
         <categoryLink id="bcb9-2aa0-4819-b54e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -4153,7 +4153,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="5b25-6068-44a2-ba92" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="5b25-6068-44a2-ba92" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_f203-bc26-421f-b79e</comment>
         </categoryLink>
         <categoryLink id="d472-dbb0-417a-bbe0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -4194,7 +4194,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="777c-a916-40a0-8ca7" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="777c-a916-40a0-8ca7" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_fce3-801c-49c8-85d4</comment>
         </categoryLink>
         <categoryLink id="46ce-a6ee-4757-8c88" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -4231,7 +4231,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="49b8-177a-478f-bb9c" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="49b8-177a-478f-bb9c" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_5a04-9847-4c91-a49a</comment>
         </categoryLink>
         <categoryLink id="d58e-a7f9-4e9d-8b5b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -4260,7 +4260,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="ac91-ff61-4c5b-9d17" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
+        <categoryLink id="ac91-ff61-4c5b-9d17" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
           <comment>template_id_28e0-91e7-4ada-9fac</comment>
         </categoryLink>
         <categoryLink id="dc1e-4f94-460b-ad9b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -4324,7 +4324,7 @@
         <categoryLink id="f350-1bcc-441e-94c6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_b6b1-886e-4194-8bcd</comment>
         </categoryLink>
-        <categoryLink id="35b2-f26b-443a-bee5" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="35b2-f26b-443a-bee5" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_51b5-f9c1-4587-8fc7</comment>
         </categoryLink>
       </categoryLinks>
@@ -4343,7 +4343,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="b5c7-eef2-083e-e476" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="b5c7-eef2-083e-e476" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="36a5-9aa2-c707-37c4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="6e85-f36f-314a-039b" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
       </categoryLinks>
@@ -4369,7 +4369,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="9100-0528-4fb3-498f" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="9100-0528-4fb3-498f" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="d60c-df86-9cb1-55cd" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
         <categoryLink id="92d0-76a4-36ac-6286" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
@@ -4388,7 +4388,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="3178-b0d7-a0fa-b4cc" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="3178-b0d7-a0fa-b4cc" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="b16c-d76c-4ffc-2668" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="e9b8-6460-2e0d-75cf" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
       </categoryLinks>
@@ -4426,7 +4426,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="dc16-16d0-4890-a8e8" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="dc16-16d0-4890-a8e8" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="4b1e-3f1f-49cb-8343" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -4449,7 +4449,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="32cb-7077-4d54-9f38" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="2c35-def7-4c44-9b02" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="2c35-def7-4c44-9b02" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="0c9a-d272-491c-a4a0" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -4471,7 +4471,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="5b41-a9f0-4801-9dff" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="5b41-a9f0-4801-9dff" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="d64e-e976-4668-bb95" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
         <categoryLink id="17a6-f363-4094-9a7c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
@@ -4496,7 +4496,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="fe4f-c8f2-470f-901c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="f3f0-973b-4a45-ac41" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="f3f0-973b-4a45-ac41" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="24d0-b77c-4b1e-a8ba" name="Sky-Hunter Squadron" hidden="true" collective="false" import="false" targetId="6263-c696-2f2e-c105" type="selectionEntry">
@@ -4519,7 +4519,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="63ff-0a92-42ab-ae8c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="204c-7b0f-4fb9-b1b3" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="204c-7b0f-4fb9-b1b3" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="85e6-cb31-427c-a040" name="Line Sub-type:" hidden="false" targetId="6399-5c65-7833-1025" primary="false"/>
         <categoryLink id="2ddb-e541-8186-a9d2" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
       </categoryLinks>
@@ -4544,7 +4544,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="68dd-fc0f-4fde-8adc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="74ca-dd4f-46be-8be7" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="74ca-dd4f-46be-8be7" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="6531-ccb1-08b0-1263" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -4635,7 +4635,7 @@
       <categoryLinks>
         <categoryLink id="0d5b-be56-47af-a22e" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="2e59-1043-4719-96c4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="52fa-8c3c-49d4-a321" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="52fa-8c3c-49d4-a321" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="4285-56d5-4db0-b7af" name="Termite Assault Drill" hidden="true" collective="false" import="false" targetId="cb30-307a-f0d7-3b13" type="selectionEntry">
@@ -4659,7 +4659,7 @@
       <categoryLinks>
         <categoryLink id="1fef-4409-4fab-93fc" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="ca2d-245e-48b4-a1cf" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="6692-6e39-44f0-ad8e" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="6692-6e39-44f0-ad8e" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="a16d-4209-40a9-b75d" name="Venerable Ancient Contemptor Dreadnought" hidden="true" collective="false" import="false" targetId="dad1-0807-e254-d498" type="selectionEntry">
@@ -4676,7 +4676,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="9261-acb5-4230-8d89" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="1a5d-cbc8-418f-91a3" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="1a5d-cbc8-418f-91a3" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="c0cb-406f-4b46-9d8d" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
       </categoryLinks>
       <entryLinks>
@@ -4699,7 +4699,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="c0b2-dd90-46c1-a2a9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="9a94-76fb-4a89-ad5d" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="9a94-76fb-4a89-ad5d" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="a04c-2259-4cc3-e856" name="Deathstorm Drop Pod Squadron" hidden="false" collective="false" import="false" targetId="af13-fb4e-b792-61a3" type="selectionEntry">
@@ -4733,7 +4733,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="d616-b69b-d533-3c41" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="d616-b69b-d533-3c41" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
         <categoryLink id="856d-d4a4-cf3e-0c04" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -4747,7 +4747,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="6855-23e2-15b7-8391" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="ea20-d476-e91d-5f33" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="ea20-d476-e91d-5f33" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="01e1-f246-169f-057b" name="Domitar Battle-Automata Maniple" hidden="true" collective="false" import="false" targetId="1a1b-fa35-a6a2-ca78" type="selectionEntry">
@@ -4760,7 +4760,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="b332-99a7-7d2c-59c2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="43f8-c11c-adf8-9f16" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="43f8-c11c-adf8-9f16" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="6829-7b62-78e2-0740" name="Castellax Battle-Automata Maniple" hidden="true" collective="false" import="false" targetId="537f-846d-90e3-2526" type="selectionEntry">
@@ -4773,7 +4773,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="ccd5-2095-d26e-cc26" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="a24f-81a3-a67f-7d9e" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="a24f-81a3-a67f-7d9e" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="cfe3-874c-01db-9e29" name="Thanatar Siege-automata Maniple" hidden="true" collective="false" import="false" targetId="2903-fef6-e839-368b" type="selectionEntry">
@@ -4790,7 +4790,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="af72-3dd9-ab6a-6160" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="7a3f-293f-ba33-4abb" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="7a3f-293f-ba33-4abb" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="9854-87c7-8154-bc87" name="Inner Circle Knights Cenobium" hidden="true" collective="false" import="false" targetId="9946-61c0-3656-36dd" type="selectionEntry">
@@ -4808,7 +4808,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="3e2a-23ae-e695-fe44" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="8d82-ffb7-78ea-a738" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="8d82-ffb7-78ea-a738" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="d9a2-fab8-fc39-519c" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
         <categoryLink id="029c-d948-ebee-92cf" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
       </categoryLinks>
@@ -4831,7 +4831,7 @@
         <categoryLink id="08d9-7458-36d1-acb8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="51f2-3067-7f13-01d0" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
         <categoryLink id="f15b-7db5-2d7e-3f80" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
-        <categoryLink id="f96d-4a86-c8e9-1e07" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="f96d-4a86-c8e9-1e07" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="2c19-a7f8-32f2-e417" name="Crimson Paladins" hidden="true" collective="false" import="false" targetId="33fe-9683-bde5-95ca" type="selectionEntry">
@@ -4872,7 +4872,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="b998-8d46-edcc-9d40" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="4c15-48b6-2aea-97b0" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="4c15-48b6-2aea-97b0" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="e87d-750d-86df-48ac" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -4895,7 +4895,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="0632-42c5-8fe0-b831" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="fdf3-aa59-c103-8aee" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="fdf3-aa59-c103-8aee" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="d3a9-508f-dad6-245b" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
         <categoryLink id="9f03-849f-9a34-cdc0" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
       </categoryLinks>
@@ -4939,7 +4939,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="89a0-d63e-1704-a361" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="cf79-ea38-4ce8-4326" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="cf79-ea38-4ce8-4326" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="b107-9d15-016a-d275" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
         <categoryLink id="3b8e-008b-785f-2eca" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
       </categoryLinks>
@@ -4982,7 +4982,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="b217-605f-cdc9-3261" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="0a8f-2b63-3053-9c0f" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="0a8f-2b63-3053-9c0f" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="558d-7ef0-ffd2-1195" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
         <categoryLink id="3606-ab0e-6106-c6e4" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
       </categoryLinks>
@@ -5003,7 +5003,7 @@
       <categoryLinks>
         <categoryLink id="9ae9-93c8-5a9f-6729" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
         <categoryLink id="eae7-7a27-2c1b-2b8e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="f0c3-7f9b-ee5e-112f" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="f0c3-7f9b-ee5e-112f" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="1d4a-5fb3-d145-b874" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -5023,7 +5023,7 @@
       <categoryLinks>
         <categoryLink id="93df-22ad-b57b-eb33" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
         <categoryLink id="2ac5-c29b-4ed7-d0e4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="8298-378b-2d74-1b16" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="8298-378b-2d74-1b16" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="3eae-6f57-8ad3-1a41" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -5046,7 +5046,7 @@
       <categoryLinks>
         <categoryLink id="eca6-16fd-c40b-9d2a" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
         <categoryLink id="9c42-852c-8a35-e087" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="07bf-f9f7-0ae4-eef0" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="07bf-f9f7-0ae4-eef0" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="7c8b-5edf-3437-3fae" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -5068,7 +5068,7 @@
       <categoryLinks>
         <categoryLink id="40b8-0153-aed3-a46f" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
         <categoryLink id="9d5b-e6fa-20bc-3633" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="ea25-c00c-c903-323d" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="ea25-c00c-c903-323d" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="e976-5b92-923e-109f" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -5091,7 +5091,7 @@
       <categoryLinks>
         <categoryLink id="073d-85bf-5671-655e" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
         <categoryLink id="83b6-ebef-2a51-7e4e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="2458-d10e-33ca-8a0a" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="2458-d10e-33ca-8a0a" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="92aa-3145-3e7c-46b1" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -5113,7 +5113,7 @@
       <categoryLinks>
         <categoryLink id="7a2b-c127-97e6-515e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="0508-7155-7284-7b78" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
-        <categoryLink id="4438-2d5f-d813-d11e" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="4438-2d5f-d813-d11e" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="fcd6-ef0f-ec7f-c22d" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -5135,7 +5135,7 @@
       <categoryLinks>
         <categoryLink id="017e-0179-47a7-56f4" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
         <categoryLink id="39c3-05db-50d1-4ab3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="45d8-21af-6a42-98cf" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="45d8-21af-6a42-98cf" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="5966-2d25-fcfb-00ed" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -5156,7 +5156,7 @@
         <categoryLink id="16a4-d2be-0dbe-09fc" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
         <categoryLink id="a051-95bc-7cd3-dec4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="57f9-8cc0-32be-baa9" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
-        <categoryLink id="567b-6c06-037c-a0dc" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="567b-6c06-037c-a0dc" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="b96f-2ff8-d337-ce66" name="Varagyr Wolf Guard Terminator Squad" hidden="true" collective="false" import="false" targetId="9359-61a5-fcdb-c28e" type="selectionEntry">
@@ -5177,7 +5177,7 @@
       <categoryLinks>
         <categoryLink id="24b9-f70e-6b34-3d46" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
         <categoryLink id="6415-7c44-93f0-2a34" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="fafa-5803-08bd-1055" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="fafa-5803-08bd-1055" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="6210-8c16-4ae7-510e" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -5210,7 +5210,7 @@
         <constraint field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4318-84ce-47b1-996c" type="max"/>
       </constraints>
       <categoryLinks>
-        <categoryLink id="3ae0-c6b8-a50d-24a2" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="3ae0-c6b8-a50d-24a2" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="8e1d-d418-f25e-1d1e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -5248,7 +5248,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="b6e4-b9f5-ef4a-b558" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="b6e4-b9f5-ef4a-b558" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="816e-2176-c80a-6337" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="9e56-9be2-382e-5dfb" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
       </categoryLinks>
@@ -5269,7 +5269,7 @@
       <categoryLinks>
         <categoryLink id="40f7-1e8c-2b99-d33a" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
         <categoryLink id="5aba-721a-3b1c-ee1d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="3ff8-466b-c639-5034" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="3ff8-466b-c639-5034" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="d9c1-45ba-695f-e214" name="Effrit Disruption Cadre" hidden="true" collective="false" import="false" targetId="7fd1-9b0d-9d9e-680b" type="selectionEntry">
@@ -5293,7 +5293,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="0f1f-a2ef-7494-86e8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="1b95-6302-333e-c29e" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="1b95-6302-333e-c29e" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="f99e-4939-0d4c-3ae0" name="Procurators" hidden="true" collective="false" import="false" targetId="9cca-47d5-0779-79a2" type="selectionEntry">
@@ -5311,7 +5311,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="d460-af5c-954a-864b" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="d460-af5c-954a-864b" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="15c9-8757-af41-85d7" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
         <categoryLink id="98fb-d1de-a136-00e3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
@@ -5335,7 +5335,7 @@
         <categoryLink id="be74-516a-5478-36cc" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
         <categoryLink id="3b02-b28d-694d-929e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="70e3-112a-d554-d29f" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
-        <categoryLink id="a8bb-f884-2117-0766" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="a8bb-f884-2117-0766" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="b4bc-ef74-bd2c-2c73" name="Headhunter Kill Team" hidden="true" collective="false" import="false" targetId="70e6-ace3-8feb-1ddc" type="selectionEntry">
@@ -5355,7 +5355,7 @@
       <categoryLinks>
         <categoryLink id="4775-bc95-b737-f396" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="7dbc-7305-d2e8-e6a8" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
-        <categoryLink id="81e6-ef94-ef5f-864d" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="81e6-ef94-ef5f-864d" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
       </categoryLinks>
     </entryLink>
   </entryLinks>
@@ -5383,7 +5383,7 @@
       </infoLinks>
       <categoryLinks>
         <categoryLink id="86bf-d7af-033d-7bc5" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="38f4-15f0-cef1-6eed" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+        <categoryLink id="38f4-15f0-cef1-6eed" name="Heavy Sub-type:" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
         <categoryLink id="d9d8-ed91-7e24-1a00" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="9c8d-bff7-f814-f674" name="Line Sub-type:" hidden="false" targetId="6399-5c65-7833-1025" primary="false"/>
       </categoryLinks>
@@ -8186,7 +8186,7 @@ A weapon with this special rule may not be used to make Shooting Attacks as part
     </selectionEntryGroup>
   </sharedSelectionEntryGroups>
   <catalogueLinks>
-    <catalogueLink id="2f60-18fb-e6ed-8574" name="(HH V2) Legions Astartes" targetId="6393-649c-7213-a327" type="catalogue" importRootEntries="true"/>
+    <catalogueLink id="2f60-18fb-e6ed-8574" name="Legions Astartes" targetId="6393-649c-7213-a327" type="catalogue" importRootEntries="true"/>
     <catalogueLink id="22ab-29e1-22f3-7cff" name="LA -   I: Dark Angels" targetId="ee5e-198e-1b19-4b9f" type="catalogue" importRootEntries="true"/>
     <catalogueLink id="a164-9b86-cdff-a77e" name="LA -   III: Emperor&apos;s Children" targetId="72ba-61c2-37ad-c785" type="catalogue" importRootEntries="true"/>
     <catalogueLink id="f3da-bf4c-5557-55ca" name="LA -   IV: Iron Warriors" targetId="2ee4-57ed-db44-8a63" type="catalogue" importRootEntries="true"/>

--- a/2022 - LA - Blood Angels.cat
+++ b/2022 - LA - Blood Angels.cat
@@ -4,7 +4,7 @@
     <entryLink id="1900-3f09-f47b-bed2" name="Praetor" hidden="false" collective="false" import="false" targetId="03be-5d55-d05a-771d" type="selectionEntry">
       <comment>template_id_5798-3fc7-4d4c-ad41</comment>
       <categoryLinks>
-        <categoryLink id="573a-6577-4196-be29" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
+        <categoryLink id="573a-6577-4196-be29" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
           <comment>template_id_b084-df23-4f99-812f</comment>
         </categoryLink>
         <categoryLink id="dd35-efeb-4f2e-ab57" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false">
@@ -32,7 +32,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="9ebe-3513-9ab7-69db" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="9ebe-3513-9ab7-69db" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="3357-5e6d-c437-5295" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
         <categoryLink id="8eb8-b5f6-a13e-e6a7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
@@ -50,7 +50,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="f0c3-dea6-a3b3-8814" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="f0c3-dea6-a3b3-8814" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
         <categoryLink id="94a0-f009-d095-0a13" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -72,13 +72,13 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="b2fb-57e6-76d1-b70e" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="b2fb-57e6-76d1-b70e" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="99ad-3f89-2b00-ceea" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="f425-f617-0a7a-ce2b" name="Dawnbreaker Cohort" hidden="false" collective="false" import="false" targetId="3c67-35da-d64a-f22b" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="2138-4038-c520-9323" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="2138-4038-c520-9323" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="06d6-2550-bdf0-d9fd" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -91,7 +91,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="66b1-54b1-9b38-8d89" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="66b1-54b1-9b38-8d89" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="805e-3ba0-5df2-fb4d" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
         <categoryLink id="4cf4-9b23-0677-86f5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
@@ -110,7 +110,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="fc0b-2d5b-6e2b-a661" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="fc0b-2d5b-6e2b-a661" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="18df-f052-5edd-948c" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
         <categoryLink id="50a0-d65b-9aed-4040" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
@@ -129,7 +129,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="9dac-939c-1711-76ba" name="New CategoryLink" hidden="false" targetId="ad5f-31db-8bc7-5c46" primary="true"/>
+        <categoryLink id="9dac-939c-1711-76ba" name="Primarch:" hidden="false" targetId="ad5f-31db-8bc7-5c46" primary="true"/>
         <categoryLink id="b565-cac7-63e5-fb44" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
       <entryLinks>
@@ -147,7 +147,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="bd40-3a9c-fc64-acc2" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="bd40-3a9c-fc64-acc2" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="f2df-62ef-c931-765a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -164,7 +164,7 @@
         <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="003d-a734-8fef-78ec" type="min"/>
       </constraints>
       <categoryLinks>
-        <categoryLink id="e29c-aaca-175b-3061" name="New CategoryLink" hidden="false" targetId="e90d-e5a8-f42d-da84" primary="true"/>
+        <categoryLink id="e29c-aaca-175b-3061" name="Allegiance:" hidden="false" targetId="e90d-e5a8-f42d-da84" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="b4bc-0590-372e-0c49" name="Apothecarion Detachment" hidden="false" collective="false" import="false" targetId="81df-ffd4-a32b-b4a1" type="selectionEntry">
@@ -173,7 +173,7 @@
         <categoryLink id="a715-36c7-49a3-a257" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_c6d4-581f-4746-bec3</comment>
         </categoryLink>
-        <categoryLink id="7e6f-5790-4d44-9d5b" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
+        <categoryLink id="7e6f-5790-4d44-9d5b" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
           <comment>template_id_2489-ee2a-45dd-b384</comment>
         </categoryLink>
       </categoryLinks>
@@ -203,7 +203,7 @@
         <categoryLink id="0ab2-f388-466a-9026" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_8378-ede4-476d-b657</comment>
         </categoryLink>
-        <categoryLink id="32c7-f22f-4460-b94c" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="32c7-f22f-4460-b94c" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_d64f-ad19-426c-adf7</comment>
         </categoryLink>
       </categoryLinks>
@@ -229,7 +229,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="beae-7f9e-4bf4-9d94" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="beae-7f9e-4bf4-9d94" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_ac26-e639-4d53-9b8b</comment>
         </categoryLink>
         <categoryLink id="afe8-cb28-4bd8-a296" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -269,7 +269,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="ec79-bc73-4272-b272" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="ec79-bc73-4272-b272" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_3a22-caae-4eea-9bc5</comment>
         </categoryLink>
         <categoryLink id="5a6c-a4d1-4a5a-abfe" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -328,7 +328,7 @@
         <categoryLink id="016b-757d-49d9-8e7c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_bd6a-0cda-4e0f-80ae</comment>
         </categoryLink>
-        <categoryLink id="e674-c8cf-4709-8d63" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
+        <categoryLink id="e674-c8cf-4709-8d63" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
           <comment>template_id_ae75-7cca-4701-9d56</comment>
         </categoryLink>
         <categoryLink id="3d88-ff13-4c03-a6b9" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false">
@@ -363,7 +363,7 @@
         <categoryLink id="982c-2909-40e4-b9fe" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false">
           <comment>template_id_f51c-73d7-4f29-be1c</comment>
         </categoryLink>
-        <categoryLink id="2bc1-4d39-44a1-99f5" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
+        <categoryLink id="2bc1-4d39-44a1-99f5" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
           <comment>template_id_257d-78c0-4bab-ba65</comment>
         </categoryLink>
       </categoryLinks>
@@ -411,7 +411,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="8e16-0988-4c10-a8c1" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="8e16-0988-4c10-a8c1" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_f1c8-27fd-4f98-8527</comment>
         </categoryLink>
         <categoryLink id="3e05-7678-4937-924f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -440,7 +440,7 @@
         <categoryLink id="895c-3d6c-44f8-b5a5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_dd44-e0a8-42a8-bdcc</comment>
         </categoryLink>
-        <categoryLink id="86ea-d295-4247-ac82" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
+        <categoryLink id="86ea-d295-4247-ac82" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
           <comment>template_id_c5b0-f9ae-468d-924a</comment>
         </categoryLink>
       </categoryLinks>
@@ -467,7 +467,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="0b2c-a157-44de-ada8" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
+        <categoryLink id="0b2c-a157-44de-ada8" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
           <comment>template_id_f926-27fd-4a92-97a1</comment>
         </categoryLink>
         <categoryLink id="4bd1-50e0-4e1d-9875" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -530,7 +530,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="e0bd-98d3-4439-8016" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="e0bd-98d3-4439-8016" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_361e-fb90-4b0e-ac3d</comment>
         </categoryLink>
         <categoryLink id="195b-bd76-484f-9858" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -547,7 +547,7 @@
         <categoryLink id="577d-dbb8-48fa-81b9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_473b-e812-4158-9416</comment>
         </categoryLink>
-        <categoryLink id="83c8-94b3-40bb-8fba" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
+        <categoryLink id="83c8-94b3-40bb-8fba" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
           <comment>template_id_00a2-63ff-4698-a35b</comment>
         </categoryLink>
       </categoryLinks>
@@ -571,7 +571,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="c982-77af-4a45-a8e5" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="c982-77af-4a45-a8e5" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_2a08-4432-42ad-bfdb</comment>
         </categoryLink>
         <categoryLink id="f2fe-52c0-434b-9a94" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -604,7 +604,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="12a7-517f-47f9-937b" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="12a7-517f-47f9-937b" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_f4c0-4396-4f39-a34f</comment>
         </categoryLink>
         <categoryLink id="b4d1-ed2b-4e61-a2e9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -637,7 +637,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="6cb1-8e62-4434-90b8" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="6cb1-8e62-4434-90b8" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_caf6-5548-4b89-8102</comment>
         </categoryLink>
         <categoryLink id="409c-d4de-4d5f-8b7b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -697,7 +697,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="feba-7303-4c83-a249" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="feba-7303-4c83-a249" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_d53e-113f-4a40-a3d5</comment>
         </categoryLink>
         <categoryLink id="b10d-3577-4130-a02d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -718,7 +718,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="1e20-6fe1-49d5-bd0b" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="1e20-6fe1-49d5-bd0b" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_e6f7-a6ca-4825-bfc5</comment>
         </categoryLink>
         <categoryLink id="d9b6-8a33-48c2-9179" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -751,7 +751,7 @@
         <categoryLink id="2621-c9a2-42b6-a4d0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_cefb-cfd7-4dc8-99c4</comment>
         </categoryLink>
-        <categoryLink id="bde1-773c-4b9c-a4b0" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="bde1-773c-4b9c-a4b0" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_a9fd-9d16-4a5e-855c</comment>
         </categoryLink>
       </categoryLinks>
@@ -775,7 +775,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="f185-1a6a-465e-b04f" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="f185-1a6a-465e-b04f" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_a56d-347b-4b09-a918</comment>
         </categoryLink>
         <categoryLink id="6db0-aadb-4beb-859d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -808,7 +808,7 @@
         <categoryLink id="9d47-6d25-4c98-9b51" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_9441-d79b-4720-9667</comment>
         </categoryLink>
-        <categoryLink id="8e49-7f34-4cdd-9859" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="8e49-7f34-4cdd-9859" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_7d7e-32d3-4692-b401</comment>
         </categoryLink>
       </categoryLinks>
@@ -868,7 +868,7 @@
         <categoryLink id="378b-5c5c-42a2-89ca" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_bc67-ce1f-4004-aeb7</comment>
         </categoryLink>
-        <categoryLink id="9b63-a6b7-4900-8e4f" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="9b63-a6b7-4900-8e4f" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_9a45-9699-4475-aeef</comment>
         </categoryLink>
       </categoryLinks>
@@ -962,7 +962,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="7738-3ea9-4a1e-bc04" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="7738-3ea9-4a1e-bc04" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_4d7c-201f-4c99-b89a</comment>
         </categoryLink>
         <categoryLink id="6c80-9fbe-4c30-957f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -976,7 +976,7 @@
         <categoryLink id="733f-4aaa-4a0a-a74b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_6140-2404-46f9-bd42</comment>
         </categoryLink>
-        <categoryLink id="c98d-d84c-48de-92f5" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
+        <categoryLink id="c98d-d84c-48de-92f5" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
           <comment>template_id_1c86-fad8-46ec-a0b0</comment>
         </categoryLink>
       </categoryLinks>
@@ -1007,7 +1007,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="cd2a-7f81-43c8-adc6" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
+        <categoryLink id="cd2a-7f81-43c8-adc6" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
           <comment>template_id_dc16-16d0-4890-a8e8</comment>
         </categoryLink>
         <categoryLink id="0567-9e1d-4e40-b478" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1032,7 +1032,7 @@
         <categoryLink id="dcfb-f685-4079-8fdd" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_ff9f-01cb-41b9-800e</comment>
         </categoryLink>
-        <categoryLink id="2ef2-ed4d-493b-8e5c" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="2ef2-ed4d-493b-8e5c" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_1315-6051-4a46-b070</comment>
         </categoryLink>
       </categoryLinks>
@@ -1112,7 +1112,7 @@
         <categoryLink id="15b8-a7f7-4fde-b1c0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_32cb-7077-4d54-9f38</comment>
         </categoryLink>
-        <categoryLink id="c990-a89f-4c4e-8ae3" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="c990-a89f-4c4e-8ae3" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_2c35-def7-4c44-9b02</comment>
         </categoryLink>
         <categoryLink id="ab74-1b9b-4775-82cc" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false">
@@ -1137,7 +1137,7 @@
         <categoryLink id="e552-6fd2-42b7-bdc8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_75a7-dc06-445b-b2dc</comment>
         </categoryLink>
-        <categoryLink id="724a-bc27-4293-8b9a" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="724a-bc27-4293-8b9a" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_e21a-c03b-4885-ac46</comment>
         </categoryLink>
       </categoryLinks>
@@ -1155,7 +1155,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="911e-0d22-4de1-b2de" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
+        <categoryLink id="911e-0d22-4de1-b2de" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
           <comment>template_id_f55b-7555-444b-beee</comment>
         </categoryLink>
         <categoryLink id="e863-0913-45e8-8bab" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1176,7 +1176,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="309e-0eea-4c29-9e32" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="309e-0eea-4c29-9e32" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_79fa-3370-4ae0-9e12</comment>
         </categoryLink>
         <categoryLink id="c7d0-3275-4bbc-bd58" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1202,7 +1202,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="73dc-01fb-4e6e-a5ab" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="73dc-01fb-4e6e-a5ab" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_8d82-3279-4481-84bb</comment>
         </categoryLink>
         <categoryLink id="e76e-74a9-4907-b49b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1235,7 +1235,7 @@
         <categoryLink id="7f27-b4d1-4b94-bce2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_7010-be56-4709-b058</comment>
         </categoryLink>
-        <categoryLink id="29e1-e7e9-4de6-9a11" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="29e1-e7e9-4de6-9a11" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_7379-a740-47ba-a054</comment>
         </categoryLink>
       </categoryLinks>
@@ -1253,7 +1253,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="c18d-92e0-461f-88bc" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="c18d-92e0-461f-88bc" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_944f-7420-4982-8ea9</comment>
         </categoryLink>
         <categoryLink id="5d9a-ffef-4cf4-9596" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1297,7 +1297,7 @@
         <categoryLink id="416f-50a3-4c87-8515" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_c6ff-0977-4c92-bb28</comment>
         </categoryLink>
-        <categoryLink id="c2e7-827b-46d4-885d" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="c2e7-827b-46d4-885d" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_f555-7d39-458f-84c9</comment>
         </categoryLink>
       </categoryLinks>
@@ -1327,7 +1327,7 @@
         <categoryLink id="bfe9-ea0a-42cf-ad8e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_39e5-eda5-45d1-a643</comment>
         </categoryLink>
-        <categoryLink id="b012-f513-4135-9bf5" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="b012-f513-4135-9bf5" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_6416-21bb-4df4-9de8</comment>
         </categoryLink>
       </categoryLinks>
@@ -1357,7 +1357,7 @@
         <categoryLink id="9d77-2f64-48b0-b4ca" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_5528-2dac-4be5-900c</comment>
         </categoryLink>
-        <categoryLink id="94da-63b9-4579-bdcc" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="94da-63b9-4579-bdcc" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_dc8f-d888-4585-991d</comment>
         </categoryLink>
       </categoryLinks>
@@ -1387,7 +1387,7 @@
         <categoryLink id="958e-ec83-48d4-a38b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_899e-b052-4d5b-8c18</comment>
         </categoryLink>
-        <categoryLink id="4bc9-02a4-411b-8a79" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="4bc9-02a4-411b-8a79" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_f5e9-cff6-41d2-a016</comment>
         </categoryLink>
       </categoryLinks>
@@ -1417,7 +1417,7 @@
         <categoryLink id="c54b-a4f8-446f-b28a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_09cd-2176-40af-bba6</comment>
         </categoryLink>
-        <categoryLink id="c2d0-1866-4d40-bdfb" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="c2d0-1866-4d40-bdfb" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_05e6-7c63-4a35-9ba0</comment>
         </categoryLink>
       </categoryLinks>
@@ -1439,7 +1439,7 @@
         <categoryLink id="60cf-af72-4e32-a9cb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_0dfa-4004-4751-8022</comment>
         </categoryLink>
-        <categoryLink id="3be0-7480-4511-acae" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="3be0-7480-4511-acae" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_a669-0f5d-4fd3-811b</comment>
         </categoryLink>
       </categoryLinks>
@@ -1466,7 +1466,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="96fa-05bb-4a89-ba4b" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="96fa-05bb-4a89-ba4b" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_4f60-472b-45a9-ab9e</comment>
         </categoryLink>
         <categoryLink id="fb16-4044-4619-9d69" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1519,7 +1519,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="079d-ad7a-4ae5-8d3d" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="079d-ad7a-4ae5-8d3d" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_2008-f1c4-4285-a14f</comment>
         </categoryLink>
         <categoryLink id="d036-0a5b-483e-9b91" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1551,7 +1551,7 @@
         <categoryLink id="6b9b-9550-4676-805a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_9189-836c-475d-a52e</comment>
         </categoryLink>
-        <categoryLink id="9aa1-4755-4717-b052" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="9aa1-4755-4717-b052" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_e1fa-b7d8-47b0-a88a</comment>
         </categoryLink>
         <categoryLink id="f2b2-2d4f-4c2b-b497" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false">
@@ -1565,7 +1565,7 @@
         <categoryLink id="f1dc-4c2e-4e6b-9d35" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_b1d5-fd75-4f17-bbf4</comment>
         </categoryLink>
-        <categoryLink id="c59d-9ef6-44e7-8ead" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="c59d-9ef6-44e7-8ead" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_f221-bf81-4045-849b</comment>
         </categoryLink>
       </categoryLinks>
@@ -1576,7 +1576,7 @@
         <categoryLink id="78cc-704b-4faf-b864" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_51af-a137-4a1c-97a4</comment>
         </categoryLink>
-        <categoryLink id="e26c-7a4f-4cf9-a13b" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
+        <categoryLink id="e26c-7a4f-4cf9-a13b" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
           <comment>template_id_ec1f-c326-40a8-9d1f</comment>
         </categoryLink>
       </categoryLinks>
@@ -1605,7 +1605,7 @@
     <entryLink id="0853-5abf-3a9a-70d8" name="Terminator Tartaros Squad" hidden="false" collective="false" import="false" targetId="1a8e-0ded-a4dc-2b4e" type="selectionEntry">
       <comment>template_id_0848-4e03-417a-b224</comment>
       <categoryLinks>
-        <categoryLink id="09f0-cf41-4504-87a8" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
+        <categoryLink id="09f0-cf41-4504-87a8" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
           <comment>template_id_ac1c-b3bf-4011-918a</comment>
         </categoryLink>
         <categoryLink id="5d7a-9083-4717-b7d4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1635,7 +1635,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="0942-1e5d-486e-88d5" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="0942-1e5d-486e-88d5" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_7d4f-547c-43ed-a520</comment>
         </categoryLink>
         <categoryLink id="ee08-2c10-4192-acf6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1668,7 +1668,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="9091-500f-4547-a8b9" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="9091-500f-4547-a8b9" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_e22a-c5f8-4825-a45f</comment>
         </categoryLink>
         <categoryLink id="9a92-dc4a-4424-822a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1685,7 +1685,7 @@
         <categoryLink id="9c20-a9a2-4bab-ab8a" name="Compulsory Elite:" hidden="false" targetId="bb1f-ae32-b587-c3e1" primary="false">
           <comment>template_id_7d5a-62e7-43ee-b79b</comment>
         </categoryLink>
-        <categoryLink id="3d03-97d3-4bb6-8202" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
+        <categoryLink id="3d03-97d3-4bb6-8202" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
           <comment>template_id_4986-9157-49f2-b670</comment>
         </categoryLink>
       </categoryLinks>
@@ -1715,7 +1715,7 @@
         <categoryLink id="ed8f-285b-4279-9541" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_1b86-0977-4a8b-adac</comment>
         </categoryLink>
-        <categoryLink id="6461-1235-41e4-9576" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="6461-1235-41e4-9576" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_b449-403a-4e42-9239</comment>
         </categoryLink>
       </categoryLinks>
@@ -1742,12 +1742,12 @@
         <categoryLink id="b7cb-1e5c-4453-b1ad" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_4f71-446f-4cff-afda</comment>
         </categoryLink>
-        <categoryLink id="93c8-c4b9-41e6-b819" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="93c8-c4b9-41e6-b819" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_3f44-8647-43a4-ac22</comment>
         </categoryLink>
       </categoryLinks>
     </entryLink>
-    <entryLink id="8dd6-67d7-980c-1196" name="Avenger Strike Fighter" hidden="true" collective="false" import="false" targetId="b25c-e85c-1c29-9e05" type="selectionEntry">
+    <entryLink id="8dd6-67d7-980c-1196" name="Legion Avenger Strike Fighter" hidden="true" collective="false" import="false" targetId="b25c-e85c-1c29-9e05" type="selectionEntry">
       <comment>template_id_1064-175d-4616-9c71</comment>
       <modifiers>
         <modifier type="set" field="hidden" value="false">
@@ -1769,7 +1769,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="dce0-d263-4b91-9832" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="dce0-d263-4b91-9832" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_a009-a597-4b51-b228</comment>
         </categoryLink>
         <categoryLink id="fe5e-0f9a-43e3-95fd" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1802,7 +1802,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="9f71-7a96-4398-aa4a" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="9f71-7a96-4398-aa4a" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_c165-3906-463a-9c73</comment>
         </categoryLink>
         <categoryLink id="8d78-f591-4f47-b399" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1832,7 +1832,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="ffeb-fd83-4d0a-b7a6" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="ffeb-fd83-4d0a-b7a6" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_251a-df5b-4bfd-ad63</comment>
         </categoryLink>
         <categoryLink id="2cae-cdca-494d-9c85" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1869,7 +1869,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="680f-169a-4195-b8fe" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
+        <categoryLink id="680f-169a-4195-b8fe" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
           <comment>template_id_67c2-df43-44fc-92d1</comment>
         </categoryLink>
         <categoryLink id="9955-2473-4288-acbf" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1902,7 +1902,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="e2d6-6e95-471a-8853" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="e2d6-6e95-471a-8853" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_f65b-8958-49b3-92a5</comment>
         </categoryLink>
         <categoryLink id="e961-2a31-4f84-a4c5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1935,7 +1935,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="057c-fb99-4b31-87b8" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="057c-fb99-4b31-87b8" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_c6a8-22a8-4d41-b969</comment>
         </categoryLink>
         <categoryLink id="42cc-3552-46b6-afcf" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1971,7 +1971,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="4971-aeef-45e8-a7fa" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="4971-aeef-45e8-a7fa" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_3610-c975-4d55-bdfe</comment>
         </categoryLink>
         <categoryLink id="e0e1-5b97-4a12-9d2a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2007,7 +2007,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="94cf-1507-4f79-983f" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="94cf-1507-4f79-983f" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_f81d-9435-4f11-99c1</comment>
         </categoryLink>
         <categoryLink id="9d47-6fc0-4ecf-8ce2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2043,7 +2043,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="8bb4-15e3-41dd-a661" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="8bb4-15e3-41dd-a661" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_b24f-3ae0-4cbb-b016</comment>
         </categoryLink>
         <categoryLink id="4542-fec2-4601-ac1e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2076,7 +2076,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="7d71-2428-40b4-b1fd" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="7d71-2428-40b4-b1fd" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_c77f-0819-473b-a8a2</comment>
         </categoryLink>
         <categoryLink id="d995-b3fb-4051-b253" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2109,7 +2109,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="0b4c-2d90-4379-bbcc" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="0b4c-2d90-4379-bbcc" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_0397-c837-4fea-a527</comment>
         </categoryLink>
         <categoryLink id="77b8-9a65-47be-8ee3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2145,7 +2145,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="2a32-7e36-464f-bb49" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="2a32-7e36-464f-bb49" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_c1cf-cea4-4278-8f27</comment>
         </categoryLink>
         <categoryLink id="8d2b-8a8a-4093-9c3c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2181,7 +2181,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="9e2d-cd1b-417e-b40b" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="9e2d-cd1b-417e-b40b" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_0c16-6841-42b2-b02d</comment>
         </categoryLink>
         <categoryLink id="93e8-de2a-4f55-96dc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2217,7 +2217,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="afae-ce2e-4037-a02c" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="afae-ce2e-4037-a02c" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_3632-0b5d-4622-ae33</comment>
         </categoryLink>
         <categoryLink id="b057-fb11-4897-b334" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2253,7 +2253,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="dc1c-c75d-42eb-a441" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="dc1c-c75d-42eb-a441" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_5ad5-8701-42cd-b2b6</comment>
         </categoryLink>
         <categoryLink id="4359-9587-413f-9028" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2286,7 +2286,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="72bd-c94b-46f1-b075" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="72bd-c94b-46f1-b075" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_4e52-ad1b-48d4-8eed</comment>
         </categoryLink>
         <categoryLink id="633a-0dae-4047-b6a1" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false">
@@ -2315,7 +2315,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="5cb2-8404-4b48-9f3c" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
+        <categoryLink id="5cb2-8404-4b48-9f3c" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
           <comment>template_id_0af1-d052-4bd7-aab6</comment>
         </categoryLink>
         <categoryLink id="1f54-6454-45a0-96e1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2345,7 +2345,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="05cb-1b0d-41c6-8119" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="05cb-1b0d-41c6-8119" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_b822-3417-4613-be37</comment>
         </categoryLink>
         <categoryLink id="06df-2ad4-45bd-a5d0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2374,7 +2374,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="5ab5-d329-4fd9-a0cc" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="5ab5-d329-4fd9-a0cc" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_f203-bc26-421f-b79e</comment>
         </categoryLink>
         <categoryLink id="3816-caf2-4f78-97f6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2408,7 +2408,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="dd6d-a814-4bd9-9902" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="dd6d-a814-4bd9-9902" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_fce3-801c-49c8-85d4</comment>
         </categoryLink>
         <categoryLink id="079c-649d-4dfd-94f6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2438,7 +2438,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="471e-2d49-4ad0-b701" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="471e-2d49-4ad0-b701" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_5a04-9847-4c91-a49a</comment>
         </categoryLink>
         <categoryLink id="bbaf-5055-4a74-8f3e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2467,7 +2467,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="f747-c7d7-47ea-abcf" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
+        <categoryLink id="f747-c7d7-47ea-abcf" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
           <comment>template_id_28e0-91e7-4ada-9fac</comment>
         </categoryLink>
         <categoryLink id="f3a1-e19e-4b1a-8500" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2524,7 +2524,7 @@
         <categoryLink id="7843-b6f7-4e2b-8c89" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_b6b1-886e-4194-8bcd</comment>
         </categoryLink>
-        <categoryLink id="6ecb-1481-4707-9e2b" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="6ecb-1481-4707-9e2b" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_51b5-f9c1-4587-8fc7</comment>
         </categoryLink>
       </categoryLinks>
@@ -2547,7 +2547,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="5f66-bd79-4034-a466" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
+        <categoryLink id="5f66-bd79-4034-a466" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
           <comment>template_id_5b41-a9f0-4801-9dff</comment>
         </categoryLink>
         <categoryLink id="b1f8-481a-412b-974b" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false">
@@ -2609,7 +2609,7 @@
         <categoryLink id="ae83-4bc5-49ca-9756" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_fe4f-c8f2-470f-901c</comment>
         </categoryLink>
-        <categoryLink id="5553-0519-40c1-95d8" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
+        <categoryLink id="5553-0519-40c1-95d8" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
           <comment>template_id_f3f0-973b-4a45-ac41</comment>
         </categoryLink>
       </categoryLinks>
@@ -2636,7 +2636,7 @@
         <categoryLink id="8d2b-5023-44d7-b8ec" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_63ff-0a92-42ab-ae8c</comment>
         </categoryLink>
-        <categoryLink id="b43f-eff3-4984-aaae" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="b43f-eff3-4984-aaae" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_204c-7b0f-4fb9-b1b3</comment>
         </categoryLink>
         <categoryLink id="0dee-430e-458e-a030" name="Line Sub-type:" hidden="false" targetId="6399-5c65-7833-1025" primary="false">
@@ -2667,7 +2667,7 @@
         <categoryLink id="39f5-2ddc-4a5a-8308" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_68dd-fc0f-4fde-8adc</comment>
         </categoryLink>
-        <categoryLink id="249e-844f-4b48-885e" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="249e-844f-4b48-885e" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_74ca-dd4f-46be-8be7</comment>
         </categoryLink>
         <categoryLink id="4050-1f05-7633-743c" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
@@ -2714,7 +2714,7 @@
         <categoryLink id="81cf-89a0-4ccd-9d0c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_4272-9b9d-4c59-95f0</comment>
         </categoryLink>
-        <categoryLink id="1ef1-268f-4740-9c9a" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="1ef1-268f-4740-9c9a" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_d85b-1ae7-40d5-9341</comment>
         </categoryLink>
       </categoryLinks>
@@ -2841,7 +2841,7 @@
         <categoryLink id="f25a-864e-417d-89ae" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_2e59-1043-4719-96c4</comment>
         </categoryLink>
-        <categoryLink id="3ce8-ef09-4dc8-b7ce" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="3ce8-ef09-4dc8-b7ce" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_52fa-8c3c-49d4-a321</comment>
         </categoryLink>
       </categoryLinks>
@@ -2871,7 +2871,7 @@
         <categoryLink id="c763-f8c8-4a02-bcd1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_ca2d-245e-48b4-a1cf</comment>
         </categoryLink>
-        <categoryLink id="1cb3-dd6b-41a6-abaf" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="1cb3-dd6b-41a6-abaf" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_6692-6e39-44f0-ad8e</comment>
         </categoryLink>
       </categoryLinks>
@@ -2892,7 +2892,7 @@
         <categoryLink id="7b12-1775-4e92-955a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_9261-acb5-4230-8d89</comment>
         </categoryLink>
-        <categoryLink id="2277-e9fa-48be-878b" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
+        <categoryLink id="2277-e9fa-48be-878b" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
           <comment>template_id_1a5d-cbc8-418f-91a3</comment>
         </categoryLink>
         <categoryLink id="b8f1-31dd-49a7-b4d0" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false">
@@ -2921,7 +2921,7 @@
         <categoryLink id="2ee9-bddc-4fe3-88e1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_c0b2-dd90-46c1-a2a9</comment>
         </categoryLink>
-        <categoryLink id="8f1e-11b7-4102-b7a9" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="8f1e-11b7-4102-b7a9" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_9a94-76fb-4a89-ad5d</comment>
         </categoryLink>
       </categoryLinks>
@@ -2950,7 +2950,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="f34a-107c-8e08-01b0" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="f34a-107c-8e08-01b0" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
         <categoryLink id="8f81-e192-1c20-fd52" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -2964,7 +2964,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="6da3-d006-9266-590c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="0937-b3f0-818c-0c3e" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="0937-b3f0-818c-0c3e" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="c09e-827f-d817-afc2" name="Vorax Battle-automata Maniple" hidden="true" collective="false" import="false" targetId="f144-1079-11ff-019d" type="selectionEntry">
@@ -2977,7 +2977,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="53af-8bff-c228-0069" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="2eba-3688-c3b2-0994" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="2eba-3688-c3b2-0994" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="2d95-8f42-7cf3-3553" name="Thanatar Siege-automata Maniple" hidden="true" collective="false" import="false" targetId="2903-fef6-e839-368b" type="selectionEntry">
@@ -2994,7 +2994,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="859b-5586-ec5c-1dc7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="b69e-0c3a-c6ea-ef85" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="b69e-0c3a-c6ea-ef85" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="f650-22fa-50f8-4c07" name="Domitar Battle-Automata Maniple" hidden="true" collective="false" import="false" targetId="1a1b-fa35-a6a2-ca78" type="selectionEntry">
@@ -3007,7 +3007,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="8e9c-5750-4a31-31a3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="21eb-d9d4-7190-17f7" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="21eb-d9d4-7190-17f7" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="1c6e-a6f2-6440-8128" name="Thallax Cohort" hidden="true" collective="false" import="false" targetId="25c8-3e0f-e22d-a7eb" type="selectionEntry">
@@ -3032,7 +3032,7 @@
         <constraint field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="458a-4ee0-d9c4-3ec9" type="max"/>
       </constraints>
       <categoryLinks>
-        <categoryLink id="a445-b5bd-ae4c-cc03" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="a445-b5bd-ae4c-cc03" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="4672-2965-0e73-1d20" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -3046,7 +3046,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="efb0-ff66-c864-3af3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="b24f-9fff-a577-46c8" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="b24f-9fff-a577-46c8" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
       </categoryLinks>
     </entryLink>
   </entryLinks>
@@ -3471,7 +3471,7 @@ Sanguinius may still Run on a turn when his wings have been activated. When maki
       </infoLinks>
       <categoryLinks>
         <categoryLink id="21ac-518e-b688-7692" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="5bf7-7060-f4e9-3862" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+        <categoryLink id="5bf7-7060-f4e9-3862" name="Heavy Sub-type:" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
         <categoryLink id="38d1-09b6-7e6d-9833" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
       </categoryLinks>
       <selectionEntries>
@@ -3499,7 +3499,7 @@ Sanguinius may still Run on a turn when his wings have been activated. When maki
           </profiles>
           <categoryLinks>
             <categoryLink id="f69b-2b54-8d15-5c73" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
-            <categoryLink id="c012-908d-abb8-1f88" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+            <categoryLink id="c012-908d-abb8-1f88" name="Heavy Sub-type:" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
             <categoryLink id="310b-bcb8-52f5-55e7" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
@@ -4840,7 +4840,7 @@ A unit selected in this manner is considered a &apos;Retinue Squad? The Retinue 
       <categoryLinks>
         <categoryLink id="54b5-51ed-7e8b-f3fb" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="42e7-a248-5756-01f9" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="feb6-58bf-657f-310e" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+        <categoryLink id="feb6-58bf-657f-310e" name="Heavy Sub-type:" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
         <categoryLink id="7bd8-4f22-3143-1abc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
       <selectionEntries>
@@ -4867,7 +4867,7 @@ A unit selected in this manner is considered a &apos;Retinue Squad? The Retinue 
             </profile>
           </profiles>
           <categoryLinks>
-            <categoryLink id="c36e-bb39-8df0-74e2" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+            <categoryLink id="c36e-bb39-8df0-74e2" name="Heavy Sub-type:" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
             <categoryLink id="b4d7-4ed5-a971-32a5" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
             <categoryLink id="191b-abdd-c10c-0657" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
             <categoryLink id="3f8c-7a78-380b-d895" name="Jump Infantry:" hidden="false" targetId="eee8-3c7c-2762-e33e" primary="false"/>
@@ -5983,6 +5983,6 @@ Whenever a Warlord with this Trait is on the winning side of a combat in which t
     </selectionEntryGroup>
   </sharedSelectionEntryGroups>
   <catalogueLinks>
-    <catalogueLink id="9a4b-b42e-d077-a3c7" name="(HH V2) Legions Astartes" targetId="6393-649c-7213-a327" type="catalogue" importRootEntries="true"/>
+    <catalogueLink id="9a4b-b42e-d077-a3c7" name="Legions Astartes" targetId="6393-649c-7213-a327" type="catalogue" importRootEntries="true"/>
   </catalogueLinks>
 </catalogue>

--- a/2022 - LA - Dark Angels.cat
+++ b/2022 - LA - Dark Angels.cat
@@ -3,7 +3,7 @@
   <entryLinks>
     <entryLink id="7653-8041-8d1c-c872" name="Dreadwing Interemptor Squad" hidden="false" collective="false" import="false" targetId="3008-e8ed-9e97-71c9" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="b375-4d79-dba1-0791" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="b375-4d79-dba1-0791" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="73f2-8df7-0fa9-dd37" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -17,7 +17,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="a4a2-0795-10b3-814b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="7b72-0a2d-ea5f-e088" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="7b72-0a2d-ea5f-e088" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="e12a-8c05-d094-5857" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -40,7 +40,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="55c1-d230-9b2a-bc6c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="abcd-0d59-34c8-6814" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="abcd-0d59-34c8-6814" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="c177-60f6-4324-8398" name="Inner Circle Knights Cenobium" hidden="false" collective="false" import="false" targetId="9946-61c0-3656-36dd" type="selectionEntry">
@@ -52,7 +52,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="694a-cf77-3824-c33c" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="694a-cf77-3824-c33c" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="f12a-bca3-dacd-dafe" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -74,7 +74,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="96bb-7267-db95-12f9" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="96bb-7267-db95-12f9" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="bc8b-eb32-5fdd-202b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -88,7 +88,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="9d97-2b3e-e904-a1c9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="ab33-7225-f48a-340c" name="New CategoryLink" hidden="false" targetId="ad5f-31db-8bc7-5c46" primary="true"/>
+        <categoryLink id="ab33-7225-f48a-340c" name="Primarch:" hidden="false" targetId="ad5f-31db-8bc7-5c46" primary="true"/>
       </categoryLinks>
       <entryLinks>
         <entryLink id="f6a1-76fb-9dff-b12b" name="Retinue" hidden="false" collective="false" import="true" targetId="66e9-e8f8-5eb6-1cf6" type="selectionEntryGroup"/>
@@ -109,7 +109,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="e67b-8c05-a2d9-646e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="65f5-a164-400b-1ccb" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="65f5-a164-400b-1ccb" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="c8ff-1043-75af-8a7d" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -128,7 +128,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="8bf4-9640-3056-cb98" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="f522-bc46-1dcc-5c12" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="f522-bc46-1dcc-5c12" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="dbda-9f35-26f3-f2bf" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -148,7 +148,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="bebe-9b3c-7ba0-ed35" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="75ff-379c-b33c-2438" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="75ff-379c-b33c-2438" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="7e2b-77a4-fe27-c674" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -162,7 +162,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="6790-aaee-430e-8b31" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="dd86-2ee5-56d6-27c7" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="dd86-2ee5-56d6-27c7" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="cf27-5a4c-7672-62b9" name="I: Dark Angels" hidden="false" collective="false" import="false" targetId="b2b4-2198-0b90-dd9f" type="selectionEntry">
@@ -178,14 +178,14 @@
         <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e692-8686-cae7-1ec4" type="max"/>
       </constraints>
       <categoryLinks>
-        <categoryLink id="94dd-b497-2933-d015" name="New CategoryLink" hidden="false" targetId="e90d-e5a8-f42d-da84" primary="true"/>
+        <categoryLink id="94dd-b497-2933-d015" name="Allegiance:" hidden="false" targetId="e90d-e5a8-f42d-da84" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="4964-7bcf-88a5-5cfd" name="Apothecarion Detachment" hidden="false" collective="false" import="false" targetId="81df-ffd4-a32b-b4a1" type="selectionEntry">
       <comment>template_id_c2bc-2985-468b-b512</comment>
       <categoryLinks>
         <categoryLink id="84d1-5fce-4399-c5fb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="a94a-f1d7-8d56-330a" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="a94a-f1d7-8d56-330a" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="091b-b797-9197-956e" name="Arquitor Squadron" hidden="false" collective="false" import="false" targetId="9e46-a480-c382-c49c" type="selectionEntry">
@@ -211,7 +211,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="76c5-9477-a767-459c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="fc0c-f41f-e0bc-ee06" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="fc0c-f41f-e0bc-ee06" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="db79-8bda-3f20-3087" name="Assault Squad" hidden="false" collective="false" import="false" targetId="a8e9-70e1-b8bc-8ee2" type="selectionEntry">
@@ -237,7 +237,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="58f4-5efb-796b-85bd" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="58f4-5efb-796b-85bd" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="e451-4053-070a-8c83" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="f1fa-fed8-1461-7cfc" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
       </categoryLinks>
@@ -294,7 +294,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="4dc9-6765-9e9d-cec2" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="4dc9-6765-9e9d-cec2" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="3cab-3815-a10e-ef74" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="911f-0dfb-085a-2b17" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
       </categoryLinks>
@@ -339,7 +339,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="89a9-3e97-50f9-7766" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="89a9-3e97-50f9-7766" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="f47c-3b19-a492-cc7f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -375,7 +375,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="def8-7fb8-af1a-732a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="3b52-8600-5632-0bb4" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="3b52-8600-5632-0bb4" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="624d-ec13-ebfe-252d" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
       </categoryLinks>
       <entryLinks>
@@ -389,7 +389,7 @@
             </modifier>
           </modifiers>
         </entryLink>
-        <entryLink id="1583-3791-ad3f-415e" name="Hexagrammaton Choice" hidden="false" collective="false" import="true" targetId="61a2-7005-1e6c-c08e" type="selectionEntryGroup"/>
+        <entryLink id="1583-3791-ad3f-415e" name="Hexagrammaton Choice:" hidden="false" collective="false" import="true" targetId="61a2-7005-1e6c-c08e" type="selectionEntryGroup"/>
       </entryLinks>
     </entryLink>
     <entryLink id="9ab3-c31b-6807-621d" name="Centurion, Tartaros" hidden="false" collective="false" import="false" targetId="f806-8a4e-d0d6-beaa" type="selectionEntry">
@@ -397,7 +397,7 @@
       <categoryLinks>
         <categoryLink id="2631-13ac-b8ba-207a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="1a78-52af-91e9-5b42" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
-        <categoryLink id="7540-5928-b79d-7f97" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="7540-5928-b79d-7f97" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
       </categoryLinks>
       <entryLinks>
         <entryLink id="0186-e75a-8589-28e8" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="bb85-3277-2090-6576" type="selectionEntryGroup"/>
@@ -410,7 +410,7 @@
             </modifier>
           </modifiers>
         </entryLink>
-        <entryLink id="fdc2-9684-389e-91af" name="Hexagrammaton Choice" hidden="false" collective="false" import="true" targetId="61a2-7005-1e6c-c08e" type="selectionEntryGroup"/>
+        <entryLink id="fdc2-9684-389e-91af" name="Hexagrammaton Choice:" hidden="false" collective="false" import="true" targetId="61a2-7005-1e6c-c08e" type="selectionEntryGroup"/>
       </entryLinks>
     </entryLink>
     <entryLink id="749e-547a-3413-fc89" name="Cerberus Squadron" hidden="false" collective="false" import="false" targetId="137a-e079-34cd-8161" type="selectionEntry">
@@ -438,7 +438,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="098d-b390-5331-2b62" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="098d-b390-5331-2b62" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
         <categoryLink id="8899-78cc-8e41-0087" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -461,7 +461,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="800e-9f53-d647-877e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="75f6-0592-4625-5c55" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="75f6-0592-4625-5c55" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="2cac-8ef5-3ff1-aa7f" name="Damocles Command Rhino" hidden="false" collective="false" import="false" targetId="e337-8239-5e92-7f5f" type="selectionEntry">
@@ -486,7 +486,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="a979-6641-5f2b-8cfc" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="a979-6641-5f2b-8cfc" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="e162-0d4b-7615-902f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -540,7 +540,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="9e92-b0e9-a0ad-fab5" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="9e92-b0e9-a0ad-fab5" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="8080-1ad9-81bd-ae25" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="73c0-3b11-5105-6f71" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
       </categoryLinks>
@@ -573,7 +573,7 @@
       <comment>template_id_7a36-d995-434a-a787</comment>
       <categoryLinks>
         <categoryLink id="ff51-2669-d709-63cd" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="d632-08b3-3613-4628" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="d632-08b3-3613-4628" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="8626-0b82-87d7-ea4c" name="Dreadclaw Drop Pod" hidden="false" collective="false" import="false" targetId="bbe8-818d-3068-d79c" type="selectionEntry">
@@ -595,7 +595,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="2b26-3803-a23a-87d0" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="2b26-3803-a23a-87d0" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
         <categoryLink id="5442-09cb-6083-fc96" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -624,7 +624,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="4e04-baff-3d25-4703" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="4e04-baff-3d25-4703" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
         <categoryLink id="b2f0-3641-09a8-fa69" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -653,7 +653,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="3950-15b1-cc51-437d" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="3950-15b1-cc51-437d" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
         <categoryLink id="e6c6-43e5-6c90-5f0b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -705,7 +705,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="d081-da98-04e1-afc0" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="d081-da98-04e1-afc0" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
         <categoryLink id="cf0c-1f34-8c79-4d59" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -719,7 +719,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="64b0-377d-20a2-58b9" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="64b0-377d-20a2-58b9" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
         <categoryLink id="af07-bbe7-79bf-52e8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -743,7 +743,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="2aba-51fb-832d-2026" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="90b3-43e1-7947-1f0c" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="90b3-43e1-7947-1f0c" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="5cf5-7d89-c838-8431" name="Kharybdis Assault Claw" hidden="false" collective="false" import="false" targetId="f64a-90b7-19c8-182a" type="selectionEntry">
@@ -765,7 +765,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="6611-5705-4666-a738" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="6611-5705-4666-a738" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
         <categoryLink id="fbce-6c82-7cd7-e67b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -792,7 +792,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="d7f1-5d19-62e2-b5cd" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="2ab5-0cec-e3a9-1a18" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="2ab5-0cec-e3a9-1a18" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="46f6-60cc-1fca-2b78" name="Land Raider Proteus Carrier Squadron" hidden="false" collective="false" import="false" targetId="b6cd-dd1a-6b2c-41d6" type="selectionEntry">
@@ -844,7 +844,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="0099-221c-c756-3e82" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="22cf-8806-d2b2-9c27" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="22cf-8806-d2b2-9c27" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="2c86-cb97-d947-538b" name="Land Raider Spartan" hidden="false" collective="false" import="false" targetId="bac1-f30e-2c04-d27d" type="selectionEntry">
@@ -925,7 +925,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="0240-a7e6-50a5-8f7d" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="0240-a7e6-50a5-8f7d" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
         <categoryLink id="108b-aacd-baf5-6594" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -933,7 +933,7 @@
       <comment>template_id_1e13-9ff6-4335-8fbd</comment>
       <categoryLinks>
         <categoryLink id="5d6e-c680-110b-d492" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="5e65-8493-e3ff-adae" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="5e65-8493-e3ff-adae" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="0155-a66b-1896-2dbe" name="Nullificator Squad" hidden="true" collective="false" import="false" targetId="954d-cf8e-eefd-27a6" type="selectionEntry">
@@ -955,7 +955,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="22d7-29b0-4997-641c" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="22d7-29b0-4997-641c" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="8375-d31d-346a-acdc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -974,7 +974,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="eb1c-7483-c217-720e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="7523-ee60-859f-c063" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="7523-ee60-859f-c063" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="7de7-fdfa-c41d-45f3" name="Praetor" hidden="false" collective="false" import="false" targetId="03be-5d55-d05a-771d" type="selectionEntry">
@@ -994,7 +994,7 @@
         </infoLink>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="fb23-8b6b-0611-ed86" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="fb23-8b6b-0611-ed86" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="eb5d-715f-63b5-af5e" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
         <categoryLink id="5c7e-a83d-2108-1c5e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
@@ -1075,7 +1075,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="8228-23b5-f8e6-08e9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="9f62-9dde-27c7-bc6b" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="9f62-9dde-27c7-bc6b" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="c199-e101-141a-c98c" name="Rapier Battery" hidden="false" collective="false" import="false" targetId="23e4-c64b-65b4-c8a5" type="selectionEntry">
@@ -1088,7 +1088,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="26da-c3f4-a2fd-85cd" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="26da-c3f4-a2fd-85cd" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="e029-2f3c-8004-ab6e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -1102,7 +1102,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="de2f-8629-3e21-aeb3" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="de2f-8629-3e21-aeb3" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="83ba-817e-185c-f8c3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -1124,7 +1124,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="9d75-84ba-2462-3c99" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="9d75-84ba-2462-3c99" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
         <categoryLink id="9030-8c26-50ae-09fa" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -1151,7 +1151,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="3148-e641-e109-5e3d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="dcd3-2fb1-6ea2-5107" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="dcd3-2fb1-6ea2-5107" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="9f04-cc5c-38b2-5ccc" name="Scout Squad" hidden="false" collective="false" import="false" targetId="9b10-b657-a65a-9d60" type="selectionEntry">
@@ -1164,7 +1164,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="7ca0-ebf9-5e1c-c640" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="7ca0-ebf9-5e1c-c640" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="175c-468c-28f4-11d6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -1198,7 +1198,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="4793-7c03-b46b-35e5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="073a-b2be-7f22-2783" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="073a-b2be-7f22-2783" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="20d7-4161-0067-f4da" name="Sicaran Omega Squadron" hidden="false" collective="false" import="false" targetId="c88b-fe44-34a3-97e1" type="selectionEntry">
@@ -1224,7 +1224,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="f7fd-029d-98de-8d09" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="4b7f-6969-0c0d-dab1" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="4b7f-6969-0c0d-dab1" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="0251-2bc9-75a8-0d24" name="Sicaran Punisher Squadron" hidden="false" collective="false" import="false" targetId="13d9-b56a-6194-d521" type="selectionEntry">
@@ -1250,7 +1250,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="0d36-d572-7fb5-7730" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="c99b-62ff-a283-d448" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="c99b-62ff-a283-d448" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="a616-1e39-f3d8-5b3c" name="Sicaran Squadron" hidden="false" collective="false" import="false" targetId="706a-9532-f06d-00ed" type="selectionEntry">
@@ -1276,7 +1276,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="e4c8-a63c-9b21-d3c2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="0243-9ea0-53a6-8c37" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="0243-9ea0-53a6-8c37" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="1371-2c69-e70d-9290" name="Sicaran Venator Squadron" hidden="false" collective="false" import="false" targetId="1345-e0db-2fcb-dcc8" type="selectionEntry">
@@ -1302,7 +1302,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="2b8f-9a19-92ac-377c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="3f40-8771-9f37-de2a" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="3f40-8771-9f37-de2a" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="6753-fb6d-0fd5-23e8" name="Sky-Hunter Squadron" hidden="false" collective="false" import="false" targetId="6263-c696-2f2e-c105" type="selectionEntry">
@@ -1321,7 +1321,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="26fd-1ac6-6495-5711" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="6f3c-e8e0-e87c-f983" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="6f3c-e8e0-e87c-f983" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="bce7-861c-99b7-cb2f" name="Sokar Stormbird" hidden="false" collective="false" import="false" targetId="f403-630f-71ae-5a7d" type="selectionEntry">
@@ -1346,7 +1346,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="db9b-9ea5-b949-851d" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="db9b-9ea5-b949-851d" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
         <categoryLink id="3b6d-2eb9-4ecc-17ba" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -1391,7 +1391,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="c9f3-ba68-aba9-9632" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="c9f3-ba68-aba9-9632" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
         <categoryLink id="f362-c81c-0949-cd49" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -1419,7 +1419,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="33ce-33a3-824e-7449" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="fbe0-87e9-18d3-d36e" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="fbe0-87e9-18d3-d36e" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="5880-c8f6-27ae-b438" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
       </categoryLinks>
       <entryLinks>
@@ -1451,7 +1451,7 @@
       <comment>template_id_7333-e181-4a55-8831</comment>
       <categoryLinks>
         <categoryLink id="b3d9-83c2-da09-fdcb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="6992-7d8d-606c-8b27" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="6992-7d8d-606c-8b27" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
       </categoryLinks>
       <entryLinks>
         <entryLink id="e98d-b4c7-90e4-7a2c" name="Infiltrate (The Serpent&apos;s Bane)" hidden="false" collective="false" import="true" targetId="3fd3-ae87-f006-a71a" type="selectionEntry">
@@ -1469,7 +1469,7 @@
       <comment>template_id_d202-8e38-4b5e-96a8</comment>
       <categoryLinks>
         <categoryLink id="2450-c5a8-e488-d7cc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="6c3e-2dfa-c609-d082" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="6c3e-2dfa-c609-d082" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="e130-7c8b-6cf9-29c5" name="Terminator Cataphractii Squad" hidden="false" collective="false" import="false" targetId="d91a-a3c7-d7be-4293" type="selectionEntry">
@@ -1509,7 +1509,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="203c-456b-22b5-c12f" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="203c-456b-22b5-c12f" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="2f3b-bb86-38b1-732b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
       <entryLinks>
@@ -1527,7 +1527,7 @@
     <entryLink id="1431-cf29-f3a6-9a24" name="Terminator Tartaros Squad" hidden="false" collective="false" import="false" targetId="1a8e-0ded-a4dc-2b4e" type="selectionEntry">
       <comment>template_id_0848-4e03-417a-b224</comment>
       <categoryLinks>
-        <categoryLink id="b955-1f0b-01c0-2e69" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="b955-1f0b-01c0-2e69" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="29d6-efb7-4f96-7083" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -1553,7 +1553,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="a6fe-90d6-4d99-f75b" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="a6fe-90d6-4d99-f75b" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
         <categoryLink id="2ee3-ef14-7158-09e2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -1582,7 +1582,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="7c4f-41f5-015f-9d08" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="7c4f-41f5-015f-9d08" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
         <categoryLink id="b574-8088-0962-d845" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -1591,7 +1591,7 @@
       <categoryLinks>
         <categoryLink id="d710-bd41-02c7-c3e5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="e92d-d512-e86f-b0b0" name="Compulsory Elite:" hidden="false" targetId="bb1f-ae32-b587-c3e1" primary="false"/>
-        <categoryLink id="91a1-3807-f49f-6f7a" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="91a1-3807-f49f-6f7a" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="37a7-9999-cf46-e386" name="Vindicator Squadron" hidden="false" collective="false" import="false" targetId="9245-0776-6747-adb8" type="selectionEntry">
@@ -1611,7 +1611,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="f76e-d3f4-27e5-6d16" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="06b1-de01-6413-6ba0" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="06b1-de01-6413-6ba0" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="bdce-5cd5-1072-2020" name="Xiphon Interceptor" hidden="false" collective="false" import="false" targetId="596b-5478-e079-59ab" type="selectionEntry">
@@ -1634,7 +1634,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="9d37-ebcf-d90f-b433" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="a8e5-a7dd-01fc-e2e6" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="a8e5-a7dd-01fc-e2e6" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="5f4f-a0b7-1ea3-a1cf" name="Seeker Squad" hidden="true" collective="false" import="false" targetId="58e6-f9cc-4c46-e258" type="selectionEntry">
@@ -1653,7 +1653,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="d8ac-ff1f-014d-5042" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="9382-ceeb-671a-8173" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="9382-ceeb-671a-8173" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="7ad7-3420-c909-489a" name="Land Raider Achilles Squadron" hidden="true" collective="false" import="false" targetId="4996-8971-603f-e2a2" type="selectionEntry">
@@ -1681,7 +1681,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="2bc7-9954-5dfb-fb60" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="2bc7-9954-5dfb-fb60" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
         <categoryLink id="e1bf-3b3d-4d2c-9711" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -1710,11 +1710,11 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="3a9a-8244-f733-d979" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="3a9a-8244-f733-d979" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
         <categoryLink id="de90-f2ca-f8cf-22db" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="d60d-2615-fce1-c010" name="Avenger Strike Fighter" hidden="true" collective="false" import="false" targetId="b25c-e85c-1c29-9e05" type="selectionEntry">
+    <entryLink id="d60d-2615-fce1-c010" name="Legion Avenger Strike Fighter" hidden="true" collective="false" import="false" targetId="b25c-e85c-1c29-9e05" type="selectionEntry">
       <comment>template_id_1064-175d-4616-9c71</comment>
       <modifiers>
         <modifier type="set" field="hidden" value="false">
@@ -1736,7 +1736,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="8af2-16a7-ff44-6632" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="8af2-16a7-ff44-6632" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
         <categoryLink id="ec1d-f9a8-b945-3b21" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -1765,7 +1765,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="a886-c2b1-62fc-d2bf" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="a886-c2b1-62fc-d2bf" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
         <categoryLink id="05eb-169d-0787-ab1e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -1791,7 +1791,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="e068-e3b6-7097-6c68" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="e068-e3b6-7097-6c68" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
         <categoryLink id="7b75-a363-34e2-7fee" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -1819,7 +1819,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="aed7-b59f-6039-2e8a" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="aed7-b59f-6039-2e8a" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
         <categoryLink id="06c6-14f2-d465-9516" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -1851,7 +1851,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="b55b-d7c5-6b07-585d" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="b55b-d7c5-6b07-585d" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
         <categoryLink id="3bc4-08e6-f571-5ce4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -1883,7 +1883,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="5dca-6147-c8d9-0b55" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="5dca-6147-c8d9-0b55" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
         <categoryLink id="5f05-858f-5f35-292d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -1915,7 +1915,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="e89b-c855-2e05-8bbf" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="e89b-c855-2e05-8bbf" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
         <categoryLink id="66e1-e02a-d031-26c3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -1944,7 +1944,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="49d8-f3e8-d400-7b41" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="49d8-f3e8-d400-7b41" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
         <categoryLink id="bbe6-fc48-3bf0-a37e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -1973,7 +1973,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="2010-69f6-3360-23b4" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="2010-69f6-3360-23b4" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
         <categoryLink id="25de-c95b-03f4-4efe" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -2005,7 +2005,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="8789-a461-22e1-918d" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="8789-a461-22e1-918d" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
         <categoryLink id="0089-32a6-2136-2e75" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -2037,7 +2037,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="2a9c-8044-ff4b-7593" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="2a9c-8044-ff4b-7593" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
         <categoryLink id="3346-69f2-f841-acdf" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -2069,7 +2069,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="da35-6498-31ee-2e2e" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="da35-6498-31ee-2e2e" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
         <categoryLink id="a18e-317a-24ad-00d1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -2101,7 +2101,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="1f8d-f244-e904-cfa3" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="1f8d-f244-e904-cfa3" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
         <categoryLink id="9339-ccbb-5846-7ff9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -2127,7 +2127,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="6bd8-a5bb-9033-14b3" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="6bd8-a5bb-9033-14b3" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
         <categoryLink id="2c67-04f1-5aaa-ef7b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -2146,7 +2146,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="26d8-e61b-f351-9461" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="26d8-e61b-f351-9461" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="b92e-1644-4a92-c664" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -2165,7 +2165,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="a26e-92f2-2eee-95ec" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="a26e-92f2-2eee-95ec" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="8af2-ab51-a6e5-2272" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -2190,7 +2190,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="e42c-b09e-78f2-a854" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="e42c-b09e-78f2-a854" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
         <categoryLink id="53c5-1af1-7f34-60a9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -2216,7 +2216,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="98dc-2b29-4617-a8b1" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="98dc-2b29-4617-a8b1" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
         <categoryLink id="9005-8ba4-cf9d-e3c2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -2403,7 +2403,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="d7ce-7417-0aea-1e6a" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="d7ce-7417-0aea-1e6a" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="fa60-ad41-6354-7894" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="471b-c1b9-0d0d-8420" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
       </categoryLinks>
@@ -2505,7 +2505,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="348d-ed8c-2a2c-170b" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="348d-ed8c-2a2c-170b" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="d226-8c29-dd7f-d2d7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
       <entryLinks>
@@ -2539,7 +2539,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="2baa-9922-8bca-6ac0" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="2baa-9922-8bca-6ac0" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="3667-ec70-9854-6fe1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="b017-cdc5-3585-d37e" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
       </categoryLinks>
@@ -2575,7 +2575,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="beb7-738e-0985-73fc" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="beb7-738e-0985-73fc" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="4fcd-d122-c685-5be7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="d818-df9b-fce6-3bfd" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
       </categoryLinks>
@@ -2615,7 +2615,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="c2d1-1f28-900c-a078" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="246b-51e3-8f63-d7f1" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="246b-51e3-8f63-d7f1" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="d3c1-105c-4f60-bb44" name="Legion Medusa Squadron" hidden="true" collective="false" import="false" targetId="24c8-5f6a-d48a-27b7" type="selectionEntry">
@@ -2643,7 +2643,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="4e52-ad1b-48d4-8eed" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="4e52-ad1b-48d4-8eed" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
         <categoryLink id="6979-1ed3-4f1f-a025" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -2665,7 +2665,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="5b41-a9f0-4801-9dff" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="5b41-a9f0-4801-9dff" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="d64e-e976-4668-bb95" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
         <categoryLink id="17a6-f363-4094-9a7c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
@@ -2689,7 +2689,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="fe4f-c8f2-470f-901c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="f3f0-973b-4a45-ac41" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="f3f0-973b-4a45-ac41" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="5840-93eb-4a89-afc5" name="Proteus Land Speeder Squadron" hidden="true" collective="false" import="false" targetId="a736-43ca-ed95-a08f" type="selectionEntry">
@@ -2712,7 +2712,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="68dd-fc0f-4fde-8adc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="74ca-dd4f-46be-8be7" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="74ca-dd4f-46be-8be7" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="f3fd-0906-c981-5ecd" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -2737,7 +2737,7 @@
       <categoryLinks>
         <categoryLink id="0d5b-be56-47af-a22e" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="2e59-1043-4719-96c4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="52fa-8c3c-49d4-a321" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="52fa-8c3c-49d4-a321" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="4309-20eb-4d21-963c" name="Termite Assault Drill" hidden="true" collective="false" import="false" targetId="cb30-307a-f0d7-3b13" type="selectionEntry">
@@ -2761,7 +2761,7 @@
       <categoryLinks>
         <categoryLink id="1fef-4409-4fab-93fc" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="ca2d-245e-48b4-a1cf" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="6692-6e39-44f0-ad8e" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="6692-6e39-44f0-ad8e" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="0a91-29b9-4d86-b4cf" name="Venerable Ancient Contemptor Dreadnought" hidden="true" collective="false" import="false" targetId="dad1-0807-e254-d498" type="selectionEntry">
@@ -2778,7 +2778,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="9261-acb5-4230-8d89" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="1a5d-cbc8-418f-91a3" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="1a5d-cbc8-418f-91a3" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="c0cb-406f-4b46-9d8d" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
       </categoryLinks>
       <entryLinks>
@@ -2799,7 +2799,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="c0b2-dd90-46c1-a2a9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="9a94-76fb-4a89-ad5d" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="9a94-76fb-4a89-ad5d" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="a669-d7c7-489e-fa3b" name="Vorax Battle-automata Maniple" hidden="true" collective="false" import="false" targetId="f144-1079-11ff-019d" type="selectionEntry">
@@ -2812,7 +2812,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="c13f-d13c-67bd-ae89" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="22ab-24e1-9661-4347" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="22ab-24e1-9661-4347" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="cb1a-216f-5ece-6cf6" name="Thanatar Siege-automata Maniple" hidden="true" collective="false" import="false" targetId="2903-fef6-e839-368b" type="selectionEntry">
@@ -2829,7 +2829,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="833e-cf06-7cb2-0f1f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="8c07-9215-b922-7f94" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="8c07-9215-b922-7f94" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="d061-2118-71dc-5349" name="Domitar Battle-Automata Maniple" hidden="true" collective="false" import="false" targetId="1a1b-fa35-a6a2-ca78" type="selectionEntry">
@@ -2842,7 +2842,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="530e-ed1f-559f-17c9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="6013-201f-933a-8504" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="6013-201f-933a-8504" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="4fde-e09f-5f80-b860" name="Castellax Battle-Automata Maniple" hidden="true" collective="false" import="false" targetId="537f-846d-90e3-2526" type="selectionEntry">
@@ -2855,7 +2855,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="d210-16e4-28f5-eb5a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="59ba-1670-3c15-9a82" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="59ba-1670-3c15-9a82" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="1bac-e129-01c2-9326" name="Inner Circle Knights Cenobium" hidden="true" collective="false" import="false" targetId="9946-61c0-3656-36dd" type="selectionEntry">
@@ -2872,7 +2872,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="360c-3772-4e8c-4fa3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="f0bc-21ae-5974-1fe0" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="f0bc-21ae-5974-1fe0" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="2cf0-f52c-9277-6c58" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -2891,7 +2891,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="43f3-4b6d-d004-156c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="2cb7-c8b6-8f01-be76" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="2cb7-c8b6-8f01-be76" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="2257-85a9-0fc6-c142" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -2917,7 +2917,7 @@
         <constraint field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4661-134f-9e06-e8ac" type="max"/>
       </constraints>
       <categoryLinks>
-        <categoryLink id="45fb-e4f8-ad23-06cc" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="45fb-e4f8-ad23-06cc" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="8411-1862-5232-cf37" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -3479,7 +3479,7 @@
       </infoLinks>
       <categoryLinks>
         <categoryLink id="6efd-8f1a-fc43-564f" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="41dc-2f36-d265-13b9" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+        <categoryLink id="41dc-2f36-d265-13b9" name="Heavy Sub-type:" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
         <categoryLink id="4a74-0b7b-e4f1-ac5d" name="Cybertheurgist" hidden="false" targetId="57a1-ae47-ff1b-36e4" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
@@ -3686,7 +3686,7 @@
           </constraints>
         </entryLink>
         <entryLink id="42cc-cf88-b137-d2de" name="Animatus Excindor (Cybertheurgic Weapon)" hidden="false" collective="false" import="true" targetId="caa2-99d2-b7a0-21b7" type="selectionEntry"/>
-        <entryLink id="a7b4-ef3e-9d9e-eae0" name="Shackled Artificia" hidden="false" collective="false" import="true" targetId="26ab-ceec-f2da-8bfb" type="selectionEntry"/>
+        <entryLink id="a7b4-ef3e-9d9e-eae0" name="Shackled Artificia - Unit Type" hidden="false" collective="false" import="true" targetId="26ab-ceec-f2da-8bfb" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="350"/>
@@ -4159,7 +4159,7 @@ Selenite Shard-bolt Pistol</description>
       </constraints>
       <categoryLinks>
         <categoryLink id="02a1-f083-b1fa-673a" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="ef49-f8a7-3bda-0fba" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+        <categoryLink id="ef49-f8a7-3bda-0fba" name="Heavy Sub-type:" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
         <categoryLink id="2dec-96ad-9237-42f0" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="21de-4e57-9f08-b389" name="Terminators:" hidden="false" targetId="bab3-f50d-3e5f-2f78" primary="false"/>
       </categoryLinks>
@@ -4325,7 +4325,7 @@ special rule.</description>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="359e-1590-1dcc-33d3" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="c379-1039-7f09-252d" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+        <categoryLink id="c379-1039-7f09-252d" name="Heavy Sub-type:" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
         <categoryLink id="94ed-ef24-43f7-ea1e" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
       </categoryLinks>
       <selectionEntries>
@@ -4656,7 +4656,7 @@ special rule.</description>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="5ae3-be22-48b5-7f36" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="9a31-0a49-48f9-57ca" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+        <categoryLink id="9a31-0a49-48f9-57ca" name="Heavy Sub-type:" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
         <categoryLink id="ca24-0dcb-67f2-0a38" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
       </categoryLinks>
       <selectionEntries>
@@ -5113,7 +5113,7 @@ special rule.</description>
         <categoryLink id="2601-e1ee-e7fc-4791" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="ee1c-afee-f2c8-3259" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="2687-f1d9-6b82-5dc4" name="Terminators:" hidden="false" targetId="bab3-f50d-3e5f-2f78" primary="false"/>
-        <categoryLink id="ffb0-fffb-d657-d8f2" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+        <categoryLink id="ffb0-fffb-d657-d8f2" name="Heavy Sub-type:" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="3f28-07ff-77b7-bd25" name="Regalia of the Shattered Sceptre" hidden="false" collective="false" import="true" type="upgrade">
@@ -5701,7 +5701,7 @@ special rule.</description>
         <categoryLink id="e21c-04da-da7e-bb0e" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="d44a-5429-5007-3517" name="Terminators:" hidden="false" targetId="bab3-f50d-3e5f-2f78" primary="false"/>
         <categoryLink id="4c36-2523-addd-8242" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="d90b-68bb-e362-fd4d" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+        <categoryLink id="d90b-68bb-e362-fd4d" name="Heavy Sub-type:" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="4f8a-d905-51a0-aa44" name="Deathwing Cataphractii Oathbearer" publicationId="d0df-7166-5cd3-89fd" page="48" hidden="false" collective="false" import="true" type="model">
@@ -6390,7 +6390,7 @@ Legion and Legiones Astartes (Dark Angels) special rules is referred to as the r
             </modifier>
           </modifiers>
         </entryLink>
-        <entryLink id="60e2-167c-bb6e-450f" name="Command Squad (Placeholder Points)" hidden="false" collective="false" import="true" targetId="0aca-632d-1642-8af9" type="selectionEntry"/>
+        <entryLink id="60e2-167c-bb6e-450f" name="Command Squad" hidden="false" collective="false" import="true" targetId="0aca-632d-1642-8af9" type="selectionEntry"/>
         <entryLink id="68f3-363d-e7a5-17d0" name="Command Squad, Tartaros" hidden="false" collective="false" import="true" targetId="58d0-a0fd-d20b-cb1b" type="selectionEntry"/>
         <entryLink id="0982-69a0-7e63-8f73" name="Command Squad, Cataphractii" hidden="false" collective="false" import="true" targetId="1b17-dcd6-0153-3efe" type="selectionEntry">
           <modifiers>
@@ -6514,6 +6514,6 @@ This additional Reaction may on be made as long as the Warlord has not been remo
     </profile>
   </sharedProfiles>
   <catalogueLinks>
-    <catalogueLink id="2f60-18fb-e6ed-8574" name="(HH V2) Legions Astartes" targetId="6393-649c-7213-a327" type="catalogue" importRootEntries="true"/>
+    <catalogueLink id="2f60-18fb-e6ed-8574" name="Legions Astartes" targetId="6393-649c-7213-a327" type="catalogue" importRootEntries="true"/>
   </catalogueLinks>
 </catalogue>

--- a/2022 - LA - Death Guard.cat
+++ b/2022 - LA - Death Guard.cat
@@ -10,7 +10,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="44be-4e1f-6984-02f2" name="New CategoryLink" hidden="false" targetId="ad5f-31db-8bc7-5c46" primary="true"/>
+        <categoryLink id="44be-4e1f-6984-02f2" name="Primarch:" hidden="false" targetId="ad5f-31db-8bc7-5c46" primary="true"/>
         <categoryLink id="edd2-1a56-37a4-4b58" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
       <entryLinks>
@@ -38,7 +38,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="004e-da45-354f-882d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="0fd1-c287-ea0a-743e" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="0fd1-c287-ea0a-743e" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="763f-933b-5168-70a4" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -51,7 +51,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="d8e2-0a1e-ab02-3e0b" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="d8e2-0a1e-ab02-3e0b" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="a4a4-7b67-e98d-27bd" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -87,7 +87,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="7cec-7e9a-41cf-e2cb" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="7cec-7e9a-41cf-e2cb" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="84cb-a551-d3fd-4401" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="8bc4-d33a-bea2-a8f0" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
       </categoryLinks>
@@ -111,7 +111,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="6535-1408-9914-1567" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="6535-1408-9914-1567" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="952c-b3c9-50e1-b074" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="bd34-12ec-2df1-8239" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
       </categoryLinks>
@@ -129,7 +129,7 @@
         <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a15e-901a-3e4f-8f42" type="max"/>
       </constraints>
       <categoryLinks>
-        <categoryLink id="1e82-64bc-993b-72e3" name="New CategoryLink" hidden="false" targetId="e90d-e5a8-f42d-da84" primary="true"/>
+        <categoryLink id="1e82-64bc-993b-72e3" name="Allegiance:" hidden="false" targetId="e90d-e5a8-f42d-da84" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="f353-7810-9fd4-e0f2" name="Apothecarion Detachment" hidden="false" collective="false" import="false" targetId="81df-ffd4-a32b-b4a1" type="selectionEntry">
@@ -138,7 +138,7 @@
         <categoryLink id="46b6-d928-42c7-8a07" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_c6d4-581f-4746-bec3</comment>
         </categoryLink>
-        <categoryLink id="b26d-c902-427b-834e" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
+        <categoryLink id="b26d-c902-427b-834e" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
           <comment>template_id_2489-ee2a-45dd-b384</comment>
         </categoryLink>
       </categoryLinks>
@@ -168,7 +168,7 @@
         <categoryLink id="5efa-646d-48cb-b8a1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_8378-ede4-476d-b657</comment>
         </categoryLink>
-        <categoryLink id="5f04-9b94-4cc4-a6ae" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="5f04-9b94-4cc4-a6ae" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_d64f-ad19-426c-adf7</comment>
         </categoryLink>
       </categoryLinks>
@@ -194,7 +194,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="f733-1a6f-4dc0-827a" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="f733-1a6f-4dc0-827a" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_ac26-e639-4d53-9b8b</comment>
         </categoryLink>
         <categoryLink id="28f0-7c49-49b0-ada1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -205,7 +205,7 @@
         </categoryLink>
       </categoryLinks>
     </entryLink>
-    <entryLink id="a631-793e-4efd-16e7" name="Avenger Strike Fighter" hidden="true" collective="false" import="false" targetId="b25c-e85c-1c29-9e05" type="selectionEntry">
+    <entryLink id="a631-793e-4efd-16e7" name="Legion Avenger Strike Fighter" hidden="true" collective="false" import="false" targetId="b25c-e85c-1c29-9e05" type="selectionEntry">
       <comment>template_id_1064-175d-4616-9c71</comment>
       <modifiers>
         <modifier type="set" field="hidden" value="false">
@@ -227,7 +227,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="c3ee-8129-42df-9a8d" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="c3ee-8129-42df-9a8d" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_a009-a597-4b51-b228</comment>
         </categoryLink>
         <categoryLink id="6807-b5e5-45a3-a224" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -260,7 +260,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="cb52-c11b-4bb6-ba2b" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="cb52-c11b-4bb6-ba2b" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_c165-3906-463a-9c73</comment>
         </categoryLink>
         <categoryLink id="7094-e5b5-465f-b1ea" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -297,7 +297,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="3d3c-79e0-4df6-8929" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="3d3c-79e0-4df6-8929" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_3a22-caae-4eea-9bc5</comment>
         </categoryLink>
         <categoryLink id="0cfd-0928-4022-b814" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -330,7 +330,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="8385-ea9e-4d88-abf3" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="8385-ea9e-4d88-abf3" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_251a-df5b-4bfd-ad63</comment>
         </categoryLink>
         <categoryLink id="a2c8-84fe-480b-8a8b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -367,7 +367,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="0924-60ad-4e5e-9be1" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
+        <categoryLink id="0924-60ad-4e5e-9be1" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
           <comment>template_id_67c2-df43-44fc-92d1</comment>
         </categoryLink>
         <categoryLink id="08a3-7000-4804-a4f1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -423,7 +423,7 @@
         <categoryLink id="de0d-e76f-474d-aab2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_bd6a-0cda-4e0f-80ae</comment>
         </categoryLink>
-        <categoryLink id="df44-7b07-4b98-9bb9" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
+        <categoryLink id="df44-7b07-4b98-9bb9" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
           <comment>template_id_ae75-7cca-4701-9d56</comment>
         </categoryLink>
         <categoryLink id="7d0d-c0ca-4ed1-90ab" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false">
@@ -458,7 +458,7 @@
         <categoryLink id="7507-76ab-4735-a305" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false">
           <comment>template_id_f51c-73d7-4f29-be1c</comment>
         </categoryLink>
-        <categoryLink id="6902-34e5-47c8-959d" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
+        <categoryLink id="6902-34e5-47c8-959d" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
           <comment>template_id_257d-78c0-4bab-ba65</comment>
         </categoryLink>
       </categoryLinks>
@@ -506,7 +506,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="bd09-1025-4f06-85e8" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="bd09-1025-4f06-85e8" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_f1c8-27fd-4f98-8527</comment>
         </categoryLink>
         <categoryLink id="a612-c826-40aa-aeea" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -535,7 +535,7 @@
         <categoryLink id="5974-e109-4641-b6bc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_dd44-e0a8-42a8-bdcc</comment>
         </categoryLink>
-        <categoryLink id="e5d9-e459-4301-b639" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
+        <categoryLink id="e5d9-e459-4301-b639" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
           <comment>template_id_c5b0-f9ae-468d-924a</comment>
         </categoryLink>
       </categoryLinks>
@@ -562,7 +562,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="f104-6054-49b7-afd3" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
+        <categoryLink id="f104-6054-49b7-afd3" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
           <comment>template_id_f926-27fd-4a92-97a1</comment>
         </categoryLink>
         <categoryLink id="8e59-0f70-4a33-9615" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -594,7 +594,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="c888-75ff-1ced-e0fa" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="c888-75ff-1ced-e0fa" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
         <categoryLink id="ad57-d4e3-1730-d0e7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -653,7 +653,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="2e28-b3d4-4664-8080" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="2e28-b3d4-4664-8080" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_361e-fb90-4b0e-ac3d</comment>
         </categoryLink>
         <categoryLink id="00ad-90c4-4628-9129" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -670,7 +670,7 @@
         <categoryLink id="8185-8a16-4725-b5aa" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_473b-e812-4158-9416</comment>
         </categoryLink>
-        <categoryLink id="61b7-8b45-4430-87c1" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
+        <categoryLink id="61b7-8b45-4430-87c1" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
           <comment>template_id_00a2-63ff-4698-a35b</comment>
         </categoryLink>
       </categoryLinks>
@@ -694,7 +694,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="9de5-0da9-4f87-b25e" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="9de5-0da9-4f87-b25e" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_2a08-4432-42ad-bfdb</comment>
         </categoryLink>
         <categoryLink id="05fa-97d6-4592-90e1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -727,7 +727,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="df93-4faf-4c0a-a0b6" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="df93-4faf-4c0a-a0b6" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_f4c0-4396-4f39-a34f</comment>
         </categoryLink>
         <categoryLink id="cf44-f0d1-4410-917d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -760,7 +760,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="84b3-11d1-4102-963b" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="84b3-11d1-4102-963b" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_caf6-5548-4b89-8102</comment>
         </categoryLink>
         <categoryLink id="a91c-d4bd-49ce-a7de" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -820,7 +820,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="2b8d-d168-462a-b97f" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="2b8d-d168-462a-b97f" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_d53e-113f-4a40-a3d5</comment>
         </categoryLink>
         <categoryLink id="03dd-220d-4bfc-a032" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -841,7 +841,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="b1db-24e6-44b8-bef1" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="b1db-24e6-44b8-bef1" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_e6f7-a6ca-4825-bfc5</comment>
         </categoryLink>
         <categoryLink id="38ed-5caa-41f7-b089" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -874,7 +874,7 @@
         <categoryLink id="5072-6f29-403e-8d58" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_cefb-cfd7-4dc8-99c4</comment>
         </categoryLink>
-        <categoryLink id="5fbb-9dfc-48de-9db9" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="5fbb-9dfc-48de-9db9" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_a9fd-9d16-4a5e-855c</comment>
         </categoryLink>
       </categoryLinks>
@@ -898,7 +898,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="ffa4-dd0f-435f-a02e" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="ffa4-dd0f-435f-a02e" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_a56d-347b-4b09-a918</comment>
         </categoryLink>
         <categoryLink id="2f3e-ccb6-47ad-be57" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -931,7 +931,7 @@
         <categoryLink id="a78d-9ec9-4736-b598" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_9441-d79b-4720-9667</comment>
         </categoryLink>
-        <categoryLink id="a47a-6dd7-420b-8e38" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="a47a-6dd7-420b-8e38" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_7d7e-32d3-4692-b401</comment>
         </categoryLink>
       </categoryLinks>
@@ -961,7 +961,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="905a-411e-4f36-a1b6" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="905a-411e-4f36-a1b6" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_f65b-8958-49b3-92a5</comment>
         </categoryLink>
         <categoryLink id="b4f3-26f9-4dee-afbf" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -994,7 +994,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="2834-0439-44c1-a6e2" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="2834-0439-44c1-a6e2" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_c6a8-22a8-4d41-b969</comment>
         </categoryLink>
         <categoryLink id="fd73-4941-4646-99e8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1057,7 +1057,7 @@
         <categoryLink id="d517-2af4-4fd0-86d1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_bc67-ce1f-4004-aeb7</comment>
         </categoryLink>
-        <categoryLink id="03bb-f9fb-40cd-8fb6" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="03bb-f9fb-40cd-8fb6" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_9a45-9699-4475-aeef</comment>
         </categoryLink>
       </categoryLinks>
@@ -1120,7 +1120,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="0d9e-2334-4a7a-9591" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="0d9e-2334-4a7a-9591" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_3610-c975-4d55-bdfe</comment>
         </categoryLink>
         <categoryLink id="675a-335b-43dc-b590" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1156,7 +1156,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="ea9a-b188-435c-93e0" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="ea9a-b188-435c-93e0" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_f81d-9435-4f11-99c1</comment>
         </categoryLink>
         <categoryLink id="0c43-adee-4b29-99c4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1192,7 +1192,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="9bd4-5c39-401e-8d79" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="9bd4-5c39-401e-8d79" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_b24f-3ae0-4cbb-b016</comment>
         </categoryLink>
         <categoryLink id="507d-2175-483a-892a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1225,7 +1225,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="852a-56ed-4ea1-819f" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="852a-56ed-4ea1-819f" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_c77f-0819-473b-a8a2</comment>
         </categoryLink>
         <categoryLink id="3743-e821-47e9-b98d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1258,7 +1258,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="6483-faea-483b-8239" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="6483-faea-483b-8239" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_0397-c837-4fea-a527</comment>
         </categoryLink>
         <categoryLink id="ba72-0d70-4ef2-9b4e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1294,7 +1294,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="818b-4694-4948-898b" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="818b-4694-4948-898b" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_c1cf-cea4-4278-8f27</comment>
         </categoryLink>
         <categoryLink id="3304-7478-4088-873b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1330,7 +1330,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="04b4-c493-4d15-aca8" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="04b4-c493-4d15-aca8" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_0c16-6841-42b2-b02d</comment>
         </categoryLink>
         <categoryLink id="57e1-c0be-444b-b88a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1366,7 +1366,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="e036-eadf-47a4-902c" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="e036-eadf-47a4-902c" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_3632-0b5d-4622-ae33</comment>
         </categoryLink>
         <categoryLink id="9551-b11e-4dd6-a233" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1402,7 +1402,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="f6b0-d166-4a6a-86c7" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="f6b0-d166-4a6a-86c7" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_5ad5-8701-42cd-b2b6</comment>
         </categoryLink>
         <categoryLink id="2ad9-3225-4ed8-8854" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1469,7 +1469,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="b165-c8b8-47b8-be0f" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="b165-c8b8-47b8-be0f" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_4d7c-201f-4c99-b89a</comment>
         </categoryLink>
         <categoryLink id="331f-1193-4fe8-961e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1502,7 +1502,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="1b64-4b12-4e73-b8db" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="1b64-4b12-4e73-b8db" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_4e52-ad1b-48d4-8eed</comment>
         </categoryLink>
         <categoryLink id="aaf8-a762-4e0c-8dc4" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false">
@@ -1516,7 +1516,7 @@
         <categoryLink id="f7d9-258b-484f-b8d0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_6140-2404-46f9-bd42</comment>
         </categoryLink>
-        <categoryLink id="4460-1f6c-47ff-a393" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
+        <categoryLink id="4460-1f6c-47ff-a393" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
           <comment>template_id_1c86-fad8-46ec-a0b0</comment>
         </categoryLink>
       </categoryLinks>
@@ -1562,7 +1562,7 @@
         <categoryLink id="25c9-24cb-422d-beab" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_4272-9b9d-4c59-95f0</comment>
         </categoryLink>
-        <categoryLink id="b61d-c7c5-40a3-b97d" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="b61d-c7c5-40a3-b97d" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_d85b-1ae7-40d5-9341</comment>
         </categoryLink>
       </categoryLinks>
@@ -1588,7 +1588,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="3d8a-95ce-4eef-a40f" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
+        <categoryLink id="3d8a-95ce-4eef-a40f" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
           <comment>template_id_0af1-d052-4bd7-aab6</comment>
         </categoryLink>
         <categoryLink id="a788-fd60-458e-8322" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1613,7 +1613,7 @@
         <categoryLink id="1b39-81de-4719-ab2b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_ff9f-01cb-41b9-800e</comment>
         </categoryLink>
-        <categoryLink id="4fe3-ac45-409a-b4ff" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="4fe3-ac45-409a-b4ff" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_1315-6051-4a46-b070</comment>
         </categoryLink>
       </categoryLinks>
@@ -1621,7 +1621,7 @@
     <entryLink id="0fac-cfce-3ed8-0bda" name="Praetor" hidden="false" collective="false" import="false" targetId="03be-5d55-d05a-771d" type="selectionEntry">
       <comment>template_id_5798-3fc7-4d4c-ad41</comment>
       <categoryLinks>
-        <categoryLink id="a004-475c-417b-bc39" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
+        <categoryLink id="a004-475c-417b-bc39" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
           <comment>template_id_b084-df23-4f99-812f</comment>
         </categoryLink>
         <categoryLink id="d48e-553b-4eef-8120" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false">
@@ -1746,7 +1746,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="a64a-38ee-41c1-afea" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="a64a-38ee-41c1-afea" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_b822-3417-4613-be37</comment>
         </categoryLink>
         <categoryLink id="a35e-75d0-4f5a-84ac" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1771,7 +1771,7 @@
         <categoryLink id="dd6b-09eb-441a-8509" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_75a7-dc06-445b-b2dc</comment>
         </categoryLink>
-        <categoryLink id="2b8e-3d9b-42f1-95ef" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="2b8e-3d9b-42f1-95ef" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_e21a-c03b-4885-ac46</comment>
         </categoryLink>
       </categoryLinks>
@@ -1789,7 +1789,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="2b3d-ba26-45c4-b64a" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
+        <categoryLink id="2b3d-ba26-45c4-b64a" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
           <comment>template_id_f55b-7555-444b-beee</comment>
         </categoryLink>
         <categoryLink id="ae40-88ba-4359-b6e0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1810,7 +1810,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="0640-14ee-48de-98f5" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="0640-14ee-48de-98f5" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_79fa-3370-4ae0-9e12</comment>
         </categoryLink>
         <categoryLink id="2cdd-cc84-4f55-b795" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1836,7 +1836,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="6794-0f2a-4ffb-ac55" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="6794-0f2a-4ffb-ac55" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_8d82-3279-4481-84bb</comment>
         </categoryLink>
         <categoryLink id="ca45-e8f1-4d80-9fdb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1869,7 +1869,7 @@
         <categoryLink id="6bd5-77bd-4d48-a4b4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_7010-be56-4709-b058</comment>
         </categoryLink>
-        <categoryLink id="eecf-f85a-47c4-82ea" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="eecf-f85a-47c4-82ea" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_7379-a740-47ba-a054</comment>
         </categoryLink>
       </categoryLinks>
@@ -1887,7 +1887,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="4521-e07b-4a95-94f7" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="4521-e07b-4a95-94f7" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_944f-7420-4982-8ea9</comment>
         </categoryLink>
         <categoryLink id="6818-1549-4d10-80fe" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1931,7 +1931,7 @@
         <categoryLink id="8188-729a-42b3-8f1a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_c6ff-0977-4c92-bb28</comment>
         </categoryLink>
-        <categoryLink id="0d9c-3be4-4996-8717" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="0d9c-3be4-4996-8717" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_f555-7d39-458f-84c9</comment>
         </categoryLink>
       </categoryLinks>
@@ -1961,7 +1961,7 @@
         <categoryLink id="5377-9ea5-4082-b355" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_39e5-eda5-45d1-a643</comment>
         </categoryLink>
-        <categoryLink id="c779-2731-4673-872a" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="c779-2731-4673-872a" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_6416-21bb-4df4-9de8</comment>
         </categoryLink>
       </categoryLinks>
@@ -1991,7 +1991,7 @@
         <categoryLink id="38ff-e429-4607-a40e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_5528-2dac-4be5-900c</comment>
         </categoryLink>
-        <categoryLink id="67ea-5c5d-46f5-9ac0" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="67ea-5c5d-46f5-9ac0" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_dc8f-d888-4585-991d</comment>
         </categoryLink>
       </categoryLinks>
@@ -2021,7 +2021,7 @@
         <categoryLink id="8e89-4e0b-4a2a-9c32" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_899e-b052-4d5b-8c18</comment>
         </categoryLink>
-        <categoryLink id="cde1-b7b7-407e-9266" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="cde1-b7b7-407e-9266" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_f5e9-cff6-41d2-a016</comment>
         </categoryLink>
       </categoryLinks>
@@ -2051,7 +2051,7 @@
         <categoryLink id="96bf-c342-44dd-b255" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_09cd-2176-40af-bba6</comment>
         </categoryLink>
-        <categoryLink id="0bf9-bd36-4c2e-b15f" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="0bf9-bd36-4c2e-b15f" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_05e6-7c63-4a35-9ba0</comment>
         </categoryLink>
       </categoryLinks>
@@ -2073,7 +2073,7 @@
         <categoryLink id="2695-d088-457c-813d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_0dfa-4004-4751-8022</comment>
         </categoryLink>
-        <categoryLink id="4820-4785-49c3-a885" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="4820-4785-49c3-a885" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_a669-0f5d-4fd3-811b</comment>
         </categoryLink>
       </categoryLinks>
@@ -2100,7 +2100,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="d5f0-53ce-47e3-bf16" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="d5f0-53ce-47e3-bf16" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_4f60-472b-45a9-ab9e</comment>
         </categoryLink>
         <categoryLink id="2e43-304b-4f5f-b582" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2153,7 +2153,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="c56e-2345-4ba3-bd2b" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="c56e-2345-4ba3-bd2b" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_2008-f1c4-4285-a14f</comment>
         </categoryLink>
         <categoryLink id="fe22-62c6-4c43-be1f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2185,7 +2185,7 @@
         <categoryLink id="6b53-b81e-4b74-b93c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_9189-836c-475d-a52e</comment>
         </categoryLink>
-        <categoryLink id="426b-bffd-4189-b09e" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="426b-bffd-4189-b09e" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_e1fa-b7d8-47b0-a88a</comment>
         </categoryLink>
         <categoryLink id="aa21-79e3-4716-8e19" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false">
@@ -2199,7 +2199,7 @@
         <categoryLink id="40d6-ca4e-4a61-b01a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_b1d5-fd75-4f17-bbf4</comment>
         </categoryLink>
-        <categoryLink id="9392-8a53-4659-86bc" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="9392-8a53-4659-86bc" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_f221-bf81-4045-849b</comment>
         </categoryLink>
       </categoryLinks>
@@ -2225,7 +2225,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="2b9d-b4cc-4f14-b3fc" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="2b9d-b4cc-4f14-b3fc" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_f203-bc26-421f-b79e</comment>
         </categoryLink>
         <categoryLink id="cae8-a86b-433c-9333" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2239,7 +2239,7 @@
         <categoryLink id="ac1b-2192-4a06-b831" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_51af-a137-4a1c-97a4</comment>
         </categoryLink>
-        <categoryLink id="e374-97a8-4bca-b72b" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
+        <categoryLink id="e374-97a8-4bca-b72b" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
           <comment>template_id_ec1f-c326-40a8-9d1f</comment>
         </categoryLink>
       </categoryLinks>
@@ -2291,7 +2291,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="f779-b2b2-41ca-9796" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="f779-b2b2-41ca-9796" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_fce3-801c-49c8-85d4</comment>
         </categoryLink>
         <categoryLink id="5162-3b45-451a-9e78" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2302,7 +2302,7 @@
     <entryLink id="83ae-538e-57d9-ce01" name="Terminator Tartaros Squad" hidden="false" collective="false" import="false" targetId="1a8e-0ded-a4dc-2b4e" type="selectionEntry">
       <comment>template_id_0848-4e03-417a-b224</comment>
       <categoryLinks>
-        <categoryLink id="233b-a0bf-4f84-9f9c" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
+        <categoryLink id="233b-a0bf-4f84-9f9c" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
           <comment>template_id_ac1c-b3bf-4011-918a</comment>
         </categoryLink>
         <categoryLink id="7855-2f84-4e78-b724" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2332,7 +2332,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="7a9a-6f08-4d18-b9f9" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="7a9a-6f08-4d18-b9f9" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_5a04-9847-4c91-a49a</comment>
         </categoryLink>
         <categoryLink id="63c5-a5f1-478e-9ad0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2362,7 +2362,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="cfb6-cb0c-4987-a18d" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="cfb6-cb0c-4987-a18d" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_7d4f-547c-43ed-a520</comment>
         </categoryLink>
         <categoryLink id="6bb6-7a3f-47d0-ac20" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2391,7 +2391,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="3cf0-353f-459b-9bbd" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
+        <categoryLink id="3cf0-353f-459b-9bbd" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
           <comment>template_id_28e0-91e7-4ada-9fac</comment>
         </categoryLink>
         <categoryLink id="84de-f66c-477e-91b9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2424,7 +2424,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="88a5-d0e3-41d8-a088" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="88a5-d0e3-41d8-a088" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_e22a-c5f8-4825-a45f</comment>
         </categoryLink>
         <categoryLink id="9590-0364-4da1-850f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2441,7 +2441,7 @@
         <categoryLink id="7ff2-7fdf-401b-914e" name="Compulsory Elite:" hidden="false" targetId="bb1f-ae32-b587-c3e1" primary="false">
           <comment>template_id_7d5a-62e7-43ee-b79b</comment>
         </categoryLink>
-        <categoryLink id="01af-6f73-48ee-8e70" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
+        <categoryLink id="01af-6f73-48ee-8e70" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
           <comment>template_id_4986-9157-49f2-b670</comment>
         </categoryLink>
       </categoryLinks>
@@ -2471,7 +2471,7 @@
         <categoryLink id="b3f4-5765-4650-8865" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_1b86-0977-4a8b-adac</comment>
         </categoryLink>
-        <categoryLink id="f8e0-af16-4725-89e2" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="f8e0-af16-4725-89e2" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_b449-403a-4e42-9239</comment>
         </categoryLink>
       </categoryLinks>
@@ -2531,7 +2531,7 @@
         <categoryLink id="f664-1acd-4d89-b3bb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_4f71-446f-4cff-afda</comment>
         </categoryLink>
-        <categoryLink id="55ec-b4db-4c6a-9a8a" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="55ec-b4db-4c6a-9a8a" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_3f44-8647-43a4-ac22</comment>
         </categoryLink>
       </categoryLinks>
@@ -2558,7 +2558,7 @@
         <categoryLink id="22ac-2a06-4b14-80e9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_b6b1-886e-4194-8bcd</comment>
         </categoryLink>
-        <categoryLink id="bc56-8ed2-4040-9d2e" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="bc56-8ed2-4040-9d2e" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_51b5-f9c1-4587-8fc7</comment>
         </categoryLink>
       </categoryLinks>
@@ -2589,7 +2589,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="dc16-16d0-4890-a8e8" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="dc16-16d0-4890-a8e8" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="4b1e-3f1f-49cb-8343" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -2612,7 +2612,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="32cb-7077-4d54-9f38" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="2c35-def7-4c44-9b02" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="2c35-def7-4c44-9b02" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="0c9a-d272-491c-a4a0" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -2634,7 +2634,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="5b41-a9f0-4801-9dff" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="5b41-a9f0-4801-9dff" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="d64e-e976-4668-bb95" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
         <categoryLink id="17a6-f363-4094-9a7c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
@@ -2658,7 +2658,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="fe4f-c8f2-470f-901c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="f3f0-973b-4a45-ac41" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="f3f0-973b-4a45-ac41" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="a1f4-33fb-480b-a02d" name="Sky-Hunter Squadron" hidden="true" collective="false" import="false" targetId="6263-c696-2f2e-c105" type="selectionEntry">
@@ -2681,7 +2681,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="63ff-0a92-42ab-ae8c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="204c-7b0f-4fb9-b1b3" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="204c-7b0f-4fb9-b1b3" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="85e6-cb31-427c-a040" name="Line Sub-type:" hidden="false" targetId="6399-5c65-7833-1025" primary="false"/>
         <categoryLink id="0281-8957-1b18-1e6c" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
       </categoryLinks>
@@ -2706,7 +2706,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="68dd-fc0f-4fde-8adc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="74ca-dd4f-46be-8be7" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="74ca-dd4f-46be-8be7" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="fd5b-c567-bd28-2753" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -2807,7 +2807,7 @@
       <categoryLinks>
         <categoryLink id="0d5b-be56-47af-a22e" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="2e59-1043-4719-96c4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="52fa-8c3c-49d4-a321" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="52fa-8c3c-49d4-a321" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="d580-e36e-43c9-86bb" name="Termite Assault Drill" hidden="true" collective="false" import="false" targetId="cb30-307a-f0d7-3b13" type="selectionEntry">
@@ -2831,7 +2831,7 @@
       <categoryLinks>
         <categoryLink id="1fef-4409-4fab-93fc" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="ca2d-245e-48b4-a1cf" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="6692-6e39-44f0-ad8e" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="6692-6e39-44f0-ad8e" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="ff49-3945-43fb-8762" name="Venerable Ancient Contemptor Dreadnought" hidden="true" collective="false" import="false" targetId="dad1-0807-e254-d498" type="selectionEntry">
@@ -2848,7 +2848,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="9261-acb5-4230-8d89" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="1a5d-cbc8-418f-91a3" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="1a5d-cbc8-418f-91a3" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="c0cb-406f-4b46-9d8d" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
       </categoryLinks>
       <entryLinks>
@@ -2871,7 +2871,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="c0b2-dd90-46c1-a2a9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="9a94-76fb-4a89-ad5d" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="9a94-76fb-4a89-ad5d" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="520a-16ef-765b-0c7c" name="Castellax Battle-Automata Maniple" hidden="true" collective="false" import="false" targetId="537f-846d-90e3-2526" type="selectionEntry">
@@ -2884,7 +2884,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="4cad-8236-ecb4-c699" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="aa70-1161-8b6b-0ad2" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="aa70-1161-8b6b-0ad2" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="a5fe-03f9-6da6-f12e" name="Domitar Battle-Automata Maniple" hidden="true" collective="false" import="false" targetId="1a1b-fa35-a6a2-ca78" type="selectionEntry">
@@ -2897,7 +2897,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="e990-96fe-1ff2-3049" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="4186-2b93-7783-5ae3" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="4186-2b93-7783-5ae3" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="84f6-4f9f-3438-3dd5" name="Thanatar Siege-automata Maniple" hidden="true" collective="false" import="false" targetId="2903-fef6-e839-368b" type="selectionEntry">
@@ -2914,7 +2914,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="42ac-46b8-2624-63c4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="09bb-b199-6163-e7ae" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="09bb-b199-6163-e7ae" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="7d86-f4ec-f01d-fac4" name="Vorax Battle-automata Maniple" hidden="true" collective="false" import="false" targetId="f144-1079-11ff-019d" type="selectionEntry">
@@ -2927,7 +2927,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="58e2-d046-07fd-48e5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="1258-612f-3f75-322b" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="1258-612f-3f75-322b" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="e0ba-94e5-40ba-18cb" name="Deathshroud Terminator Squad" hidden="true" collective="false" import="false" targetId="7669-a6c0-7f86-e641" type="selectionEntry">
@@ -2948,7 +2948,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="baec-86df-8f5a-a9ef" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="0c5c-52d7-ab57-d3a7" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="0c5c-52d7-ab57-d3a7" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="70f9-3d17-01e1-bacb" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -2974,7 +2974,7 @@
         <constraint field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4bf4-7e9a-5eb5-b06f" type="max"/>
       </constraints>
       <categoryLinks>
-        <categoryLink id="a5c8-4462-8eaf-066d" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="a5c8-4462-8eaf-066d" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="09f2-2f60-0ef0-8d53" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -2996,7 +2996,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="c876-68e5-5812-a06c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="7361-2367-91dc-1b00" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="7361-2367-91dc-1b00" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="3398-c844-442a-f561" name="Heavy Support Squad" hidden="true" collective="false" import="false" targetId="bac9-5389-e2e7-0b1f" type="selectionEntry">
@@ -3027,7 +3027,7 @@
         <categoryLink id="def1-b261-8261-02fc" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="33f7-f2cd-2c9b-34cb" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="8177-1aab-8a85-3acc" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
-        <categoryLink id="2f7a-f3e1-0ebe-7f53" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+        <categoryLink id="2f7a-f3e1-0ebe-7f53" name="Heavy Sub-type:" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
         <categoryLink id="043c-bb03-e878-0086" name="Psyker:" hidden="false" targetId="6e0c-29ba-a445-8321" primary="false"/>
         <categoryLink id="8ef4-70d2-ba35-70b9" name="Terminators:" hidden="false" targetId="bab3-f50d-3e5f-2f78" primary="false"/>
       </categoryLinks>
@@ -3141,7 +3141,7 @@
                   <infoLinks>
                     <infoLink id="0bf0-66bd-f147-6697" name="Fleshbane" hidden="false" targetId="40cd-9505-253c-e76f" type="rule"/>
                     <infoLink id="db05-e595-8bd5-e117" name="Pinning" hidden="false" targetId="1c96-205c-59a0-3cf2" type="rule"/>
-                    <infoLink id="239c-affa-db28-97a9" name="Psychic Focus (?? Where is this?)" hidden="false" targetId="bff3-3548-b2b8-72f1" type="rule"/>
+                    <infoLink id="239c-affa-db28-97a9" name="Psychic Focus" hidden="false" targetId="bff3-3548-b2b8-72f1" type="rule"/>
                   </infoLinks>
                   <costs>
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
@@ -3235,7 +3235,7 @@
       </constraints>
       <categoryLinks>
         <categoryLink id="b149-05d4-2f7b-a3bd" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="713f-55c6-1fc9-4fca" name="LoW &amp; Primarchs" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false"/>
+        <categoryLink id="713f-55c6-1fc9-4fca" name="LoW &amp; Primarchs (25% Limit)" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="4106-fc7b-3756-ae9a" name="Mortarion" hidden="false" collective="false" import="true" type="model">
@@ -3423,7 +3423,7 @@ If this option is used then Mortarion is removed from the battlefield, leaving a
       </infoLinks>
       <categoryLinks>
         <categoryLink id="8781-fa3a-a2f2-bfea" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="dfa4-63db-3a8e-a198" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+        <categoryLink id="dfa4-63db-3a8e-a198" name="Heavy Sub-type:" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
         <categoryLink id="4ee0-168f-36f7-496d" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
       </categoryLinks>
       <selectionEntries>
@@ -3864,7 +3864,7 @@ If this option is used then Mortarion is removed from the battlefield, leaving a
         <infoLink id="05c4-1c08-0950-b643" name="Shrouded in Death" hidden="false" targetId="2a8e-65b7-11c5-f84a" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="ca31-c0b0-1723-d85a" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+        <categoryLink id="ca31-c0b0-1723-d85a" name="Heavy Sub-type:" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
         <categoryLink id="4b86-b5c5-f3e9-3f35" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="0fe4-702f-0f7f-805c" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="51c7-b78d-5c3b-7ebd" name="Terminators:" hidden="false" targetId="bab3-f50d-3e5f-2f78" primary="false"/>
@@ -4213,7 +4213,7 @@ If this option is used then Mortarion is removed from the battlefield, leaving a
       <categoryLinks>
         <categoryLink id="09dd-97f2-3578-0b77" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="c14e-e1ca-7d1e-8ba9" name="Psyker:" hidden="false" targetId="6e0c-29ba-a445-8321" primary="false"/>
-        <categoryLink id="3ab9-09ca-d35c-7778" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+        <categoryLink id="3ab9-09ca-d35c-7778" name="Heavy Sub-type:" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="82e1-3fe4-d8a1-63c5" name="The Revenant&apos;s Aegis" hidden="false" collective="false" import="true" type="upgrade">
@@ -4376,7 +4376,7 @@ If this option is used then Mortarion is removed from the battlefield, leaving a
       </infoLinks>
       <categoryLinks>
         <categoryLink id="58d0-40f3-bf65-136f" name="Siege Breaker:" hidden="false" targetId="8247-54dc-9194-948f" primary="false"/>
-        <categoryLink id="076e-8fde-df99-a46e" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+        <categoryLink id="076e-8fde-df99-a46e" name="Heavy Sub-type:" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
         <categoryLink id="9919-bd28-8a44-115d" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
       </categoryLinks>
       <selectionEntries>
@@ -4725,7 +4725,7 @@ If this option is used then Mortarion is removed from the battlefield, leaving a
             </modifier>
           </modifiers>
         </entryLink>
-        <entryLink id="fb88-e88e-d8d2-180f" name="Tartaros Command Squad (Placeholder Points)" hidden="false" collective="false" import="true" targetId="58d0-a0fd-d20b-cb1b" type="selectionEntry"/>
+        <entryLink id="fb88-e88e-d8d2-180f" name="Command Squad, Tartaros" hidden="false" collective="false" import="true" targetId="58d0-a0fd-d20b-cb1b" type="selectionEntry"/>
         <entryLink id="e962-2f46-9618-fa58" name="Command Squad" hidden="false" collective="false" import="true" targetId="0aca-632d-1642-8af9" type="selectionEntry"/>
         <entryLink id="c083-d710-edfa-5fc2" name="Deathshroud Terminator Squad" hidden="false" collective="false" import="true" targetId="7669-a6c0-7f86-e641" type="selectionEntry"/>
       </entryLinks>
@@ -4832,6 +4832,6 @@ Any enemy unit with at least one model within 12&quot; of a Warlord with this Tr
     </rule>
   </sharedRules>
   <catalogueLinks>
-    <catalogueLink id="2f60-18fb-e6ed-8574" name="(HH V2) Legions Astartes" targetId="6393-649c-7213-a327" type="catalogue" importRootEntries="true"/>
+    <catalogueLink id="2f60-18fb-e6ed-8574" name="Legions Astartes" targetId="6393-649c-7213-a327" type="catalogue" importRootEntries="true"/>
   </catalogueLinks>
 </catalogue>

--- a/2022 - LA - Emperor's Children.cat
+++ b/2022 - LA - Emperor's Children.cat
@@ -10,7 +10,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="8198-4bd3-2445-7a2b" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="8198-4bd3-2445-7a2b" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="9304-b442-49fe-fa71" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
         <categoryLink id="1574-a84f-21ef-30ad" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
@@ -24,7 +24,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="ae2e-66fe-3c38-c0c2" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="ae2e-66fe-3c38-c0c2" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="c295-161b-a153-5e23" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
         <categoryLink id="c818-c8fe-e1d4-843d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
@@ -43,7 +43,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="d1b1-8747-b31c-93ba" name="New CategoryLink" hidden="false" targetId="ad5f-31db-8bc7-5c46" primary="true"/>
+        <categoryLink id="d1b1-8747-b31c-93ba" name="Primarch:" hidden="false" targetId="ad5f-31db-8bc7-5c46" primary="true"/>
         <categoryLink id="d25a-accf-b6de-facb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
       <entryLinks>
@@ -70,7 +70,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="76ab-3f7a-43b7-7b98" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="76ab-3f7a-43b7-7b98" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
         <categoryLink id="89c1-4a2a-ad42-8b4b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -83,20 +83,20 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="d7b4-0c11-69c4-0790" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="d7b4-0c11-69c4-0790" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="dafb-5fbd-1def-b788" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
         <categoryLink id="92b5-0c2e-6efd-c525" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="b704-91be-c88e-763e" name="Palatine Blade Squad" hidden="false" collective="false" import="false" targetId="71ab-ba48-0083-8e4c" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="8bd4-b59d-9966-f4a9" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="8bd4-b59d-9966-f4a9" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="1e32-b5d5-15b6-759c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="d901-03b2-b27a-d793" name="Phoenix Terminator Squad" hidden="false" collective="false" import="false" targetId="5b08-65c1-cc45-1b91" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="0f06-08b1-9de3-dac5" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="0f06-08b1-9de3-dac5" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="1823-c289-362f-ce97" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
       <infoLinks>
@@ -121,7 +121,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="f813-02a8-90f1-a6fe" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="f813-02a8-90f1-a6fe" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="3a40-1d8f-dc1d-d52b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -139,7 +139,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="2a6f-aeba-536a-ffb8" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="2a6f-aeba-536a-ffb8" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
         <categoryLink id="806c-e31c-d83d-3c70" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -149,7 +149,7 @@
         <categoryLink id="7dab-58e7-4980-b89b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_c6d4-581f-4746-bec3</comment>
         </categoryLink>
-        <categoryLink id="6acc-0dc6-4995-bbb1" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
+        <categoryLink id="6acc-0dc6-4995-bbb1" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
           <comment>template_id_2489-ee2a-45dd-b384</comment>
         </categoryLink>
       </categoryLinks>
@@ -179,7 +179,7 @@
         <categoryLink id="a57c-a26d-46f4-b597" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_8378-ede4-476d-b657</comment>
         </categoryLink>
-        <categoryLink id="4672-121b-44c3-b0ac" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="4672-121b-44c3-b0ac" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_d64f-ad19-426c-adf7</comment>
         </categoryLink>
       </categoryLinks>
@@ -205,7 +205,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="f7bf-22b0-427d-bcd0" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="f7bf-22b0-427d-bcd0" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_ac26-e639-4d53-9b8b</comment>
         </categoryLink>
         <categoryLink id="6b8f-306f-4a23-8ed0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -216,7 +216,7 @@
         </categoryLink>
       </categoryLinks>
     </entryLink>
-    <entryLink id="5665-bf93-acdc-1f4c" name="Avenger Strike Fighter" hidden="true" collective="false" import="false" targetId="b25c-e85c-1c29-9e05" type="selectionEntry">
+    <entryLink id="5665-bf93-acdc-1f4c" name="Legion Avenger Strike Fighter" hidden="true" collective="false" import="false" targetId="b25c-e85c-1c29-9e05" type="selectionEntry">
       <comment>template_id_1064-175d-4616-9c71</comment>
       <modifiers>
         <modifier type="set" field="hidden" value="false">
@@ -238,7 +238,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="15a9-ed79-4cb6-863c" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="15a9-ed79-4cb6-863c" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_a009-a597-4b51-b228</comment>
         </categoryLink>
         <categoryLink id="7334-9c6c-4bfc-bbdc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -271,7 +271,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="6f6c-cae3-43bc-ba12" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="6f6c-cae3-43bc-ba12" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_c165-3906-463a-9c73</comment>
         </categoryLink>
         <categoryLink id="1b58-be6a-4c76-9321" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -308,7 +308,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="b388-a51e-4b48-b8b5" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="b388-a51e-4b48-b8b5" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_3a22-caae-4eea-9bc5</comment>
         </categoryLink>
         <categoryLink id="b9e4-1b17-441b-bcb7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -341,7 +341,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="e6f5-b8b2-4e13-bdb7" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="e6f5-b8b2-4e13-bdb7" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_251a-df5b-4bfd-ad63</comment>
         </categoryLink>
         <categoryLink id="be77-eee8-465e-b9b7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -378,7 +378,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="497a-ef76-422e-8b70" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
+        <categoryLink id="497a-ef76-422e-8b70" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
           <comment>template_id_67c2-df43-44fc-92d1</comment>
         </categoryLink>
         <categoryLink id="f4fc-f1f6-4a48-9538" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -434,7 +434,7 @@
         <categoryLink id="f1b2-f13e-4773-9693" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_bd6a-0cda-4e0f-80ae</comment>
         </categoryLink>
-        <categoryLink id="647e-d098-404f-99e0" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
+        <categoryLink id="647e-d098-404f-99e0" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
           <comment>template_id_ae75-7cca-4701-9d56</comment>
         </categoryLink>
         <categoryLink id="e0af-0b61-4a3e-bd4c" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false">
@@ -469,7 +469,7 @@
         <categoryLink id="0fea-0015-494c-96ee" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false">
           <comment>template_id_f51c-73d7-4f29-be1c</comment>
         </categoryLink>
-        <categoryLink id="9027-ddc1-4d66-8902" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
+        <categoryLink id="9027-ddc1-4d66-8902" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
           <comment>template_id_257d-78c0-4bab-ba65</comment>
         </categoryLink>
       </categoryLinks>
@@ -517,7 +517,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="fd55-e5b9-492f-8f91" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="fd55-e5b9-492f-8f91" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_f1c8-27fd-4f98-8527</comment>
         </categoryLink>
         <categoryLink id="e148-4310-47b0-b49b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -546,7 +546,7 @@
         <categoryLink id="64f4-cb2e-490a-aceb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_dd44-e0a8-42a8-bdcc</comment>
         </categoryLink>
-        <categoryLink id="9353-de16-405a-a1e6" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
+        <categoryLink id="9353-de16-405a-a1e6" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
           <comment>template_id_c5b0-f9ae-468d-924a</comment>
         </categoryLink>
       </categoryLinks>
@@ -573,7 +573,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="50e5-38d1-440a-80d7" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
+        <categoryLink id="50e5-38d1-440a-80d7" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
           <comment>template_id_f926-27fd-4a92-97a1</comment>
         </categoryLink>
         <categoryLink id="63d7-7c31-4be0-b35b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -605,7 +605,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="b421-52fe-eae9-c778" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="b421-52fe-eae9-c778" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
         <categoryLink id="6d11-28dd-b5d0-ffb0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -664,7 +664,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="f753-33fe-441f-b3ba" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="f753-33fe-441f-b3ba" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_361e-fb90-4b0e-ac3d</comment>
         </categoryLink>
         <categoryLink id="b020-96d3-44ea-adf5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -681,7 +681,7 @@
         <categoryLink id="d2e5-d918-45f8-8546" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_473b-e812-4158-9416</comment>
         </categoryLink>
-        <categoryLink id="aa9a-09ae-45ad-8aa2" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
+        <categoryLink id="aa9a-09ae-45ad-8aa2" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
           <comment>template_id_00a2-63ff-4698-a35b</comment>
         </categoryLink>
       </categoryLinks>
@@ -705,7 +705,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="3b2d-7bc2-4c3e-85c7" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="3b2d-7bc2-4c3e-85c7" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_2a08-4432-42ad-bfdb</comment>
         </categoryLink>
         <categoryLink id="2370-ecab-4dea-bf9c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -738,7 +738,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="31b1-0d93-4c07-a659" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="31b1-0d93-4c07-a659" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_f4c0-4396-4f39-a34f</comment>
         </categoryLink>
         <categoryLink id="3b5f-22ba-4a1f-b070" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -771,7 +771,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="d748-2ffd-4baa-981c" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="d748-2ffd-4baa-981c" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_caf6-5548-4b89-8102</comment>
         </categoryLink>
         <categoryLink id="952b-d5b2-4208-8600" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -819,7 +819,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="d69b-1a33-4fbb-9abf" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="d69b-1a33-4fbb-9abf" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_e6f7-a6ca-4825-bfc5</comment>
         </categoryLink>
         <categoryLink id="3307-ef10-42b2-8dac" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -852,7 +852,7 @@
         <categoryLink id="1ae1-1dba-41bb-ad56" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_cefb-cfd7-4dc8-99c4</comment>
         </categoryLink>
-        <categoryLink id="1b2e-1a4e-4a74-a265" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="1b2e-1a4e-4a74-a265" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_a9fd-9d16-4a5e-855c</comment>
         </categoryLink>
       </categoryLinks>
@@ -876,7 +876,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="6c81-342d-49f5-9bda" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="6c81-342d-49f5-9bda" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_a56d-347b-4b09-a918</comment>
         </categoryLink>
         <categoryLink id="be94-2d0e-4efc-9ab1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -909,7 +909,7 @@
         <categoryLink id="a96a-0c0f-453e-bf98" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_9441-d79b-4720-9667</comment>
         </categoryLink>
-        <categoryLink id="0c29-d985-4e08-bc86" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="0c29-d985-4e08-bc86" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_7d7e-32d3-4692-b401</comment>
         </categoryLink>
       </categoryLinks>
@@ -939,7 +939,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="9bdc-bfc8-49f3-8482" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="9bdc-bfc8-49f3-8482" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_f65b-8958-49b3-92a5</comment>
         </categoryLink>
         <categoryLink id="be99-5768-433b-bf2b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -972,7 +972,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="d5c3-7134-438b-9d23" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="d5c3-7134-438b-9d23" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_c6a8-22a8-4d41-b969</comment>
         </categoryLink>
         <categoryLink id="37da-f5d9-421f-8056" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1035,7 +1035,7 @@
         <categoryLink id="36ba-8d9f-44da-9224" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_bc67-ce1f-4004-aeb7</comment>
         </categoryLink>
-        <categoryLink id="7703-f41c-4c29-beb7" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="7703-f41c-4c29-beb7" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_9a45-9699-4475-aeef</comment>
         </categoryLink>
       </categoryLinks>
@@ -1098,7 +1098,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="dea0-5d32-4cdd-8fcd" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="dea0-5d32-4cdd-8fcd" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_3610-c975-4d55-bdfe</comment>
         </categoryLink>
         <categoryLink id="c084-f252-4245-8686" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1134,7 +1134,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="1594-0ccb-43e6-a0ea" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="1594-0ccb-43e6-a0ea" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_f81d-9435-4f11-99c1</comment>
         </categoryLink>
         <categoryLink id="923e-a209-4617-9c41" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1170,7 +1170,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="6bb0-90ba-4237-be04" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="6bb0-90ba-4237-be04" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_b24f-3ae0-4cbb-b016</comment>
         </categoryLink>
         <categoryLink id="08e2-3af5-4784-ad0c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1203,7 +1203,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="1b1d-ae25-4ab2-aaf7" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="1b1d-ae25-4ab2-aaf7" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_c77f-0819-473b-a8a2</comment>
         </categoryLink>
         <categoryLink id="55f5-ff59-4f11-9fcc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1236,7 +1236,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="06e6-7a72-4868-ae2a" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="06e6-7a72-4868-ae2a" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_0397-c837-4fea-a527</comment>
         </categoryLink>
         <categoryLink id="7cca-b682-4c6f-a701" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1272,7 +1272,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="41d5-b878-4f1a-8755" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="41d5-b878-4f1a-8755" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_c1cf-cea4-4278-8f27</comment>
         </categoryLink>
         <categoryLink id="ba3f-a258-46d6-8f0a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1308,7 +1308,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="b511-c07e-47ec-bb28" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="b511-c07e-47ec-bb28" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_0c16-6841-42b2-b02d</comment>
         </categoryLink>
         <categoryLink id="048c-8fe1-4e30-947e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1344,7 +1344,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="a89b-f377-4a3c-b5e3" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="a89b-f377-4a3c-b5e3" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_3632-0b5d-4622-ae33</comment>
         </categoryLink>
         <categoryLink id="9fdb-dd82-4897-8507" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1380,7 +1380,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="02c9-4761-4b98-a4cd" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="02c9-4761-4b98-a4cd" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_5ad5-8701-42cd-b2b6</comment>
         </categoryLink>
         <categoryLink id="5767-9d0e-4815-85fc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1447,7 +1447,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="968a-6e1f-4aec-a4d8" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="968a-6e1f-4aec-a4d8" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_4d7c-201f-4c99-b89a</comment>
         </categoryLink>
         <categoryLink id="57e7-71c7-4d10-86ad" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1480,7 +1480,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="3fbf-91e2-4620-a44c" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="3fbf-91e2-4620-a44c" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_4e52-ad1b-48d4-8eed</comment>
         </categoryLink>
         <categoryLink id="94f9-a70f-43df-bb67" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false">
@@ -1494,7 +1494,7 @@
         <categoryLink id="0993-0623-4fcf-aa21" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_6140-2404-46f9-bd42</comment>
         </categoryLink>
-        <categoryLink id="c249-cd83-4389-a409" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
+        <categoryLink id="c249-cd83-4389-a409" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
           <comment>template_id_1c86-fad8-46ec-a0b0</comment>
         </categoryLink>
       </categoryLinks>
@@ -1520,7 +1520,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="13e8-7122-4221-b315" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
+        <categoryLink id="13e8-7122-4221-b315" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
           <comment>template_id_0af1-d052-4bd7-aab6</comment>
         </categoryLink>
         <categoryLink id="7e7d-1007-47e6-95f1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1569,7 +1569,7 @@
         <categoryLink id="3cc4-870e-4655-9d2d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_4272-9b9d-4c59-95f0</comment>
         </categoryLink>
-        <categoryLink id="bde3-0e8e-4d78-8ef8" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="bde3-0e8e-4d78-8ef8" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_d85b-1ae7-40d5-9341</comment>
         </categoryLink>
       </categoryLinks>
@@ -1591,7 +1591,7 @@
         <categoryLink id="0098-9f2d-47ee-afd3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_ff9f-01cb-41b9-800e</comment>
         </categoryLink>
-        <categoryLink id="462a-6786-46c1-bb17" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="462a-6786-46c1-bb17" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_1315-6051-4a46-b070</comment>
         </categoryLink>
       </categoryLinks>
@@ -1599,7 +1599,7 @@
     <entryLink id="3524-ef12-bdd1-19c0" name="Praetor" hidden="false" collective="false" import="false" targetId="03be-5d55-d05a-771d" type="selectionEntry">
       <comment>template_id_5798-3fc7-4d4c-ad41</comment>
       <categoryLinks>
-        <categoryLink id="1d7d-9bc2-47a1-a654" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
+        <categoryLink id="1d7d-9bc2-47a1-a654" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
           <comment>template_id_b084-df23-4f99-812f</comment>
         </categoryLink>
         <categoryLink id="fddb-52bd-4823-a24c" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false">
@@ -1743,7 +1743,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="cf8d-5f5a-44cf-9ee7" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="cf8d-5f5a-44cf-9ee7" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_b822-3417-4613-be37</comment>
         </categoryLink>
         <categoryLink id="0142-e23c-47c9-9549" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1769,7 +1769,7 @@
         <categoryLink id="d352-2095-4201-90ad" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_75a7-dc06-445b-b2dc</comment>
         </categoryLink>
-        <categoryLink id="e58b-b2dc-456c-93fd" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="e58b-b2dc-456c-93fd" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_e21a-c03b-4885-ac46</comment>
         </categoryLink>
       </categoryLinks>
@@ -1787,7 +1787,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="8a14-97b4-42a6-89b7" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
+        <categoryLink id="8a14-97b4-42a6-89b7" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
           <comment>template_id_f55b-7555-444b-beee</comment>
         </categoryLink>
         <categoryLink id="b87f-5474-4902-baea" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1808,7 +1808,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="3cc6-466a-470d-b6b3" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="3cc6-466a-470d-b6b3" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_79fa-3370-4ae0-9e12</comment>
         </categoryLink>
         <categoryLink id="214a-b294-4985-9231" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1834,7 +1834,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="985b-5024-423a-b3ba" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="985b-5024-423a-b3ba" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_8d82-3279-4481-84bb</comment>
         </categoryLink>
         <categoryLink id="e9c7-23cd-43d6-9339" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1867,7 +1867,7 @@
         <categoryLink id="b922-036a-43bc-b014" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_7010-be56-4709-b058</comment>
         </categoryLink>
-        <categoryLink id="8f51-ece7-4f66-b2bf" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="8f51-ece7-4f66-b2bf" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_7379-a740-47ba-a054</comment>
         </categoryLink>
       </categoryLinks>
@@ -1885,7 +1885,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="164d-e57f-4355-9bce" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="164d-e57f-4355-9bce" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_944f-7420-4982-8ea9</comment>
         </categoryLink>
         <categoryLink id="0318-cead-4713-ad15" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1929,7 +1929,7 @@
         <categoryLink id="ccd9-e335-40e9-8a0b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_c6ff-0977-4c92-bb28</comment>
         </categoryLink>
-        <categoryLink id="fb8b-3788-4a73-a328" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="fb8b-3788-4a73-a328" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_f555-7d39-458f-84c9</comment>
         </categoryLink>
       </categoryLinks>
@@ -1959,7 +1959,7 @@
         <categoryLink id="2d26-1ea9-4f1f-8a8b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_39e5-eda5-45d1-a643</comment>
         </categoryLink>
-        <categoryLink id="9bf8-77a2-4d25-8d3a" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="9bf8-77a2-4d25-8d3a" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_6416-21bb-4df4-9de8</comment>
         </categoryLink>
       </categoryLinks>
@@ -1989,7 +1989,7 @@
         <categoryLink id="e1ca-3b7b-40db-bb16" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_5528-2dac-4be5-900c</comment>
         </categoryLink>
-        <categoryLink id="a2b4-6ff6-4813-afb7" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="a2b4-6ff6-4813-afb7" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_dc8f-d888-4585-991d</comment>
         </categoryLink>
       </categoryLinks>
@@ -2019,7 +2019,7 @@
         <categoryLink id="d87e-874f-4f4d-8f4b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_899e-b052-4d5b-8c18</comment>
         </categoryLink>
-        <categoryLink id="4a3a-5434-435a-829f" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="4a3a-5434-435a-829f" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_f5e9-cff6-41d2-a016</comment>
         </categoryLink>
       </categoryLinks>
@@ -2049,7 +2049,7 @@
         <categoryLink id="233e-c2c7-4f39-a0a1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_09cd-2176-40af-bba6</comment>
         </categoryLink>
-        <categoryLink id="b3b7-dca8-45d3-af56" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="b3b7-dca8-45d3-af56" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_05e6-7c63-4a35-9ba0</comment>
         </categoryLink>
       </categoryLinks>
@@ -2073,7 +2073,7 @@
         <categoryLink id="1f3a-8276-49e7-956b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_0dfa-4004-4751-8022</comment>
         </categoryLink>
-        <categoryLink id="0f3a-764d-429c-9ab3" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="0f3a-764d-429c-9ab3" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_a669-0f5d-4fd3-811b</comment>
         </categoryLink>
       </categoryLinks>
@@ -2100,7 +2100,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="fb36-4123-4113-a476" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="fb36-4123-4113-a476" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_4f60-472b-45a9-ab9e</comment>
         </categoryLink>
         <categoryLink id="7787-c869-479e-bc35" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2153,7 +2153,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="907a-922d-4390-ac2e" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="907a-922d-4390-ac2e" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_2008-f1c4-4285-a14f</comment>
         </categoryLink>
         <categoryLink id="4a1d-1568-4472-a4cf" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2185,7 +2185,7 @@
         <categoryLink id="b2f0-5ef0-431b-8fd1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_9189-836c-475d-a52e</comment>
         </categoryLink>
-        <categoryLink id="3d86-713b-455b-95e0" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="3d86-713b-455b-95e0" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_e1fa-b7d8-47b0-a88a</comment>
         </categoryLink>
         <categoryLink id="b09b-5538-4245-bc72" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false">
@@ -2199,7 +2199,7 @@
         <categoryLink id="4a1a-042b-4489-8f1c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_b1d5-fd75-4f17-bbf4</comment>
         </categoryLink>
-        <categoryLink id="d33a-f6e1-46a7-93a0" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="d33a-f6e1-46a7-93a0" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_f221-bf81-4045-849b</comment>
         </categoryLink>
       </categoryLinks>
@@ -2236,7 +2236,7 @@
         <constraint field="selections" scope="parent" value="-1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5803-2455-197a-5ae7" type="max"/>
       </constraints>
       <categoryLinks>
-        <categoryLink id="2c6e-4f02-4d86-a16d" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="2c6e-4f02-4d86-a16d" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_f203-bc26-421f-b79e</comment>
         </categoryLink>
         <categoryLink id="a269-e6d1-4837-93cb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2250,7 +2250,7 @@
         <categoryLink id="21cb-5c96-413a-bd4e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_51af-a137-4a1c-97a4</comment>
         </categoryLink>
-        <categoryLink id="49ac-acf3-4e78-a1ce" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
+        <categoryLink id="49ac-acf3-4e78-a1ce" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
           <comment>template_id_ec1f-c326-40a8-9d1f</comment>
         </categoryLink>
       </categoryLinks>
@@ -2302,7 +2302,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="7dd8-d485-4732-a9e6" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="7dd8-d485-4732-a9e6" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_fce3-801c-49c8-85d4</comment>
         </categoryLink>
         <categoryLink id="7957-dfb2-4a11-9799" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2313,7 +2313,7 @@
     <entryLink id="1a8f-9850-89eb-d7ad" name="Terminator Tartaros Squad" hidden="false" collective="false" import="false" targetId="1a8e-0ded-a4dc-2b4e" type="selectionEntry">
       <comment>template_id_0848-4e03-417a-b224</comment>
       <categoryLinks>
-        <categoryLink id="3806-ddf2-4d4d-843e" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
+        <categoryLink id="3806-ddf2-4d4d-843e" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
           <comment>template_id_ac1c-b3bf-4011-918a</comment>
         </categoryLink>
         <categoryLink id="a4b7-7402-4624-8383" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2343,7 +2343,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="3677-2167-4bc2-8eb8" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="3677-2167-4bc2-8eb8" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_5a04-9847-4c91-a49a</comment>
         </categoryLink>
         <categoryLink id="255f-d4eb-4a4d-a673" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2373,7 +2373,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="22f1-5faa-4bc1-a32b" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="22f1-5faa-4bc1-a32b" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_7d4f-547c-43ed-a520</comment>
         </categoryLink>
         <categoryLink id="8571-12b0-4a8c-bd32" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2402,7 +2402,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="27d4-ad63-4f46-866b" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
+        <categoryLink id="27d4-ad63-4f46-866b" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
           <comment>template_id_28e0-91e7-4ada-9fac</comment>
         </categoryLink>
         <categoryLink id="ffab-1f3f-4133-bd72" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2435,7 +2435,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="548e-c8b6-4c2a-a2ad" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="548e-c8b6-4c2a-a2ad" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_e22a-c5f8-4825-a45f</comment>
         </categoryLink>
         <categoryLink id="7bb0-69d8-4021-8c1b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2452,7 +2452,7 @@
         <categoryLink id="a4b4-ef72-49c5-9728" name="Compulsory Elite:" hidden="false" targetId="bb1f-ae32-b587-c3e1" primary="false">
           <comment>template_id_7d5a-62e7-43ee-b79b</comment>
         </categoryLink>
-        <categoryLink id="8d83-a3f7-4348-8756" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
+        <categoryLink id="8d83-a3f7-4348-8756" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
           <comment>template_id_4986-9157-49f2-b670</comment>
         </categoryLink>
       </categoryLinks>
@@ -2482,7 +2482,7 @@
         <categoryLink id="8b62-3e98-48ce-aed7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_1b86-0977-4a8b-adac</comment>
         </categoryLink>
-        <categoryLink id="1993-aa80-411d-80de" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="1993-aa80-411d-80de" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_b449-403a-4e42-9239</comment>
         </categoryLink>
       </categoryLinks>
@@ -2542,7 +2542,7 @@
         <categoryLink id="e277-2875-4830-b55e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_4f71-446f-4cff-afda</comment>
         </categoryLink>
-        <categoryLink id="403d-07a6-4621-8a21" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="403d-07a6-4621-8a21" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_3f44-8647-43a4-ac22</comment>
         </categoryLink>
       </categoryLinks>
@@ -2563,7 +2563,7 @@
         <categoryLink id="eaf3-e9b0-4e2f-8704" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_b6b1-886e-4194-8bcd</comment>
         </categoryLink>
-        <categoryLink id="d578-6cb2-43a3-92c5" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="d578-6cb2-43a3-92c5" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_51b5-f9c1-4587-8fc7</comment>
         </categoryLink>
       </categoryLinks>
@@ -2581,7 +2581,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="bb1b-2c62-f62f-a62b" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="bb1b-2c62-f62f-a62b" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="d6f0-6dea-78dc-5e07" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -2610,7 +2610,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="d53e-113f-4a40-a3d5" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="d53e-113f-4a40-a3d5" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
         <categoryLink id="1939-76b5-4279-9f8c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -2640,7 +2640,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="dc16-16d0-4890-a8e8" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="dc16-16d0-4890-a8e8" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="4b1e-3f1f-49cb-8343" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -2663,7 +2663,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="32cb-7077-4d54-9f38" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="2c35-def7-4c44-9b02" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="2c35-def7-4c44-9b02" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="0c9a-d272-491c-a4a0" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -2685,7 +2685,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="5b41-a9f0-4801-9dff" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="5b41-a9f0-4801-9dff" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="d64e-e976-4668-bb95" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
         <categoryLink id="17a6-f363-4094-9a7c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
@@ -2709,7 +2709,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="fe4f-c8f2-470f-901c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="f3f0-973b-4a45-ac41" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="f3f0-973b-4a45-ac41" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="3edc-ede4-4324-962c" name="Sky-Hunter Squadron" hidden="true" collective="false" import="false" targetId="6263-c696-2f2e-c105" type="selectionEntry">
@@ -2732,7 +2732,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="63ff-0a92-42ab-ae8c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="204c-7b0f-4fb9-b1b3" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="204c-7b0f-4fb9-b1b3" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="85e6-cb31-427c-a040" name="Line Sub-type:" hidden="false" targetId="6399-5c65-7833-1025" primary="false"/>
         <categoryLink id="eb1a-028b-3e62-994a" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
       </categoryLinks>
@@ -2757,7 +2757,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="68dd-fc0f-4fde-8adc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="74ca-dd4f-46be-8be7" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="74ca-dd4f-46be-8be7" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="af41-c6ba-6146-d0c8" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -2848,7 +2848,7 @@
       <categoryLinks>
         <categoryLink id="0d5b-be56-47af-a22e" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="2e59-1043-4719-96c4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="52fa-8c3c-49d4-a321" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="52fa-8c3c-49d4-a321" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="35a3-9ce1-4896-94f0" name="Termite Assault Drill" hidden="true" collective="false" import="false" targetId="cb30-307a-f0d7-3b13" type="selectionEntry">
@@ -2872,7 +2872,7 @@
       <categoryLinks>
         <categoryLink id="1fef-4409-4fab-93fc" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="ca2d-245e-48b4-a1cf" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="6692-6e39-44f0-ad8e" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="6692-6e39-44f0-ad8e" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="d5b8-dd69-4537-abc2" name="Venerable Ancient Contemptor Dreadnought" hidden="true" collective="false" import="false" targetId="dad1-0807-e254-d498" type="selectionEntry">
@@ -2889,7 +2889,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="9261-acb5-4230-8d89" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="1a5d-cbc8-418f-91a3" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="1a5d-cbc8-418f-91a3" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="c0cb-406f-4b46-9d8d" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
       </categoryLinks>
       <entryLinks>
@@ -2912,7 +2912,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="c0b2-dd90-46c1-a2a9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="9a94-76fb-4a89-ad5d" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="9a94-76fb-4a89-ad5d" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="26b3-ba8f-b7dc-a237" name="Vorax Battle-automata Maniple" hidden="true" collective="false" import="false" targetId="f144-1079-11ff-019d" type="selectionEntry">
@@ -2925,7 +2925,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="4e65-620a-ef51-1569" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="1c4e-cbe5-f297-290b" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="1c4e-cbe5-f297-290b" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="d71d-439e-5732-5d1a" name="Thanatar Siege-automata Maniple" hidden="true" collective="false" import="false" targetId="2903-fef6-e839-368b" type="selectionEntry">
@@ -2942,7 +2942,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="dcd6-993c-a15a-a720" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="e191-f8bc-399b-d0b0" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="e191-f8bc-399b-d0b0" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="b13f-77a1-1ac7-2ff1" name="Domitar Battle-Automata Maniple" hidden="true" collective="false" import="false" targetId="1a1b-fa35-a6a2-ca78" type="selectionEntry">
@@ -2955,7 +2955,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="de12-d5a2-34bf-85d3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="a267-2a67-4c5e-c691" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="a267-2a67-4c5e-c691" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="1511-b73a-9364-40cd" name="Castellax Battle-Automata Maniple" hidden="true" collective="false" import="false" targetId="537f-846d-90e3-2526" type="selectionEntry">
@@ -2968,7 +2968,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="9016-2f16-eef8-2652" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="77d9-8381-5c63-537d" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="77d9-8381-5c63-537d" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="b0c8-a5b1-cdc8-7045" name="Phoenix Terminator Squad" hidden="true" collective="false" import="false" targetId="5b08-65c1-cc45-1b91" type="selectionEntry">
@@ -2989,7 +2989,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="c09f-90c6-fc06-a3d4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="058c-fcf4-9dad-9cbd" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="058c-fcf4-9dad-9cbd" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="4f4b-d1c3-457d-5c30" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
       </categoryLinks>
       <infoLinks>
@@ -3022,7 +3022,7 @@
         <constraint field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="5836-337b-19b1-cbcc" type="max"/>
       </constraints>
       <categoryLinks>
-        <categoryLink id="edf9-a156-d18b-fd24" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="edf9-a156-d18b-fd24" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="d66e-24c7-45e8-fb1a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -3089,7 +3089,7 @@
       </constraints>
       <categoryLinks>
         <categoryLink id="f617-3901-e330-116d" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="0144-fa04-5a73-9890" name="LoW &amp; Primarchs" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false"/>
+        <categoryLink id="0144-fa04-5a73-9890" name="LoW &amp; Primarchs (25% Limit)" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="7350-db6b-c492-06cf" name="Firebrand" hidden="false" collective="false" import="true" type="upgrade">
@@ -3671,7 +3671,7 @@ A unit with this special rule gains +1 to the score used to calculate the winner
         <infoLink id="fef3-5508-cd08-3c42" name="Legiones Hereticus (Emperor’s Children)" hidden="false" targetId="b9e-b2ef-86e-e52d" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="4ad3-2a6e-3de4-93f5" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+        <categoryLink id="4ad3-2a6e-3de4-93f5" name="Heavy Sub-type:" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
         <categoryLink id="d713-71c8-57c2-e819" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="a519-1c43-8810-6c3b" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
       </categoryLinks>
@@ -4711,7 +4711,7 @@ then he gains +1 to his Attacks Characteristic.</description>
         <infoLink id="67f2-7c26-f16e-8c6" name="Legiones Hereticus (Emperor’s Children)" hidden="false" targetId="b9e-b2ef-86e-e52d" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="9ffc-7328-547c-da5c" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+        <categoryLink id="9ffc-7328-547c-da5c" name="Heavy Sub-type:" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
         <categoryLink id="3590-8673-cb28-8ec9" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="4c73-6800-a149-a8a9" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
       </categoryLinks>
@@ -6246,7 +6246,7 @@ A Warlord with this Trait and all models in a unit the Warlord has joined that h
     </selectionEntryGroup>
   </sharedSelectionEntryGroups>
   <catalogueLinks>
-    <catalogueLink id="2f60-18fb-e6ed-8574" name="(HH V2) Legions Astartes" targetId="6393-649c-7213-a327" type="catalogue" importRootEntries="true"/>
+    <catalogueLink id="2f60-18fb-e6ed-8574" name="Legions Astartes" targetId="6393-649c-7213-a327" type="catalogue" importRootEntries="true"/>
   </catalogueLinks>
   <selectionEntries>
     <selectionEntry type="upgrade" import="false" name="Legions Astartes or Hereticus" hidden="false" id="d744-9ab9-93ab-ce79">

--- a/2022 - LA - Imperial Fists.cat
+++ b/2022 - LA - Imperial Fists.cat
@@ -19,7 +19,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="ee0f-2bd2-436f-ec16" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="ee0f-2bd2-436f-ec16" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="2c32-d871-9f89-6b91" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="8d13-d219-2715-ad2a" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
       </categoryLinks>
@@ -45,7 +45,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="74f0-6109-ed78-2945" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="74f0-6109-ed78-2945" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="d3ba-a5cd-59f7-f99a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="e598-efd8-ee80-b4c1" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
       </categoryLinks>
@@ -93,7 +93,7 @@
       </infoLinks>
       <categoryLinks>
         <categoryLink id="5d82-2938-d6b0-d460" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="0a15-f02d-76e8-3f43" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="0a15-f02d-76e8-3f43" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="eb84-0ca9-ee5b-9d94" name="Sigismund" hidden="false" collective="false" import="false" targetId="f323-a02c-fa4e-b1ef" type="selectionEntry">
@@ -105,7 +105,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="3ef3-f102-3e71-37b5" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="3ef3-f102-3e71-37b5" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="c59c-4b7b-a872-41e7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="f613-1e6d-5e72-52bb" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
       </categoryLinks>
@@ -131,7 +131,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="b5a2-d4b6-25b7-29df" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="b5a2-d4b6-25b7-29df" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="796e-07e7-3709-4854" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -144,7 +144,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="47a6-fca8-5f4d-405a" name="New CategoryLink" hidden="false" targetId="ad5f-31db-8bc7-5c46" primary="true"/>
+        <categoryLink id="47a6-fca8-5f4d-405a" name="Primarch:" hidden="false" targetId="ad5f-31db-8bc7-5c46" primary="true"/>
         <categoryLink id="e638-6d16-32ac-73f5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
       <entryLinks>
@@ -171,7 +171,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="16af-a65b-280b-08c7" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="16af-a65b-280b-08c7" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="cb46-df5a-b5d3-a80b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -198,7 +198,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="beb5-b21a-55d0-1402" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="beb5-b21a-55d0-1402" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
         <categoryLink id="03eb-1039-9034-ac08" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -215,7 +215,7 @@
         <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0e48-8604-9f0e-d8c0" type="max"/>
       </constraints>
       <categoryLinks>
-        <categoryLink id="9994-ceb4-762d-8d57" name="New CategoryLink" hidden="false" targetId="e90d-e5a8-f42d-da84" primary="true"/>
+        <categoryLink id="9994-ceb4-762d-8d57" name="Allegiance:" hidden="false" targetId="e90d-e5a8-f42d-da84" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="9586-4b82-f199-8c7c" name="Apothecarion Detachment" hidden="false" collective="false" import="false" targetId="81df-ffd4-a32b-b4a1" type="selectionEntry">
@@ -240,7 +240,7 @@
         <categoryLink id="d3f0-cb9d-4c8e-9469" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_c6d4-581f-4746-bec3</comment>
         </categoryLink>
-        <categoryLink id="c68f-1df1-4084-ad7e" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
+        <categoryLink id="c68f-1df1-4084-ad7e" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
           <comment>template_id_2489-ee2a-45dd-b384</comment>
         </categoryLink>
       </categoryLinks>
@@ -278,7 +278,7 @@
         <categoryLink id="4cab-5ce5-4225-b7fa" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_8378-ede4-476d-b657</comment>
         </categoryLink>
-        <categoryLink id="6e8b-ecc5-4ce2-add4" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="6e8b-ecc5-4ce2-add4" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_d64f-ad19-426c-adf7</comment>
         </categoryLink>
       </categoryLinks>
@@ -307,7 +307,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="15cf-00fb-4b4c-a4e9" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="15cf-00fb-4b4c-a4e9" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_ac26-e639-4d53-9b8b</comment>
         </categoryLink>
         <categoryLink id="46e5-40ff-47a1-be46" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -318,7 +318,7 @@
         </categoryLink>
       </categoryLinks>
     </entryLink>
-    <entryLink id="9fc4-d7aa-eeb0-0a56" name="Avenger Strike Fighter" hidden="true" collective="false" import="false" targetId="b25c-e85c-1c29-9e05" type="selectionEntry">
+    <entryLink id="9fc4-d7aa-eeb0-0a56" name="Legion Avenger Strike Fighter" hidden="true" collective="false" import="false" targetId="b25c-e85c-1c29-9e05" type="selectionEntry">
       <comment>template_id_1064-175d-4616-9c71</comment>
       <modifiers>
         <modifier type="set" field="hidden" value="false">
@@ -354,7 +354,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="ffdb-4282-40c8-83d7" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="ffdb-4282-40c8-83d7" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_a009-a597-4b51-b228</comment>
         </categoryLink>
         <categoryLink id="c386-b366-4f72-9623" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -395,7 +395,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="3604-c11e-4414-867b" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="3604-c11e-4414-867b" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_c165-3906-463a-9c73</comment>
         </categoryLink>
         <categoryLink id="bcf6-2cdf-4323-8306" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -435,7 +435,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="bf6e-1cdb-4409-a50e" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="bf6e-1cdb-4409-a50e" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_3a22-caae-4eea-9bc5</comment>
         </categoryLink>
         <categoryLink id="a0f2-3814-4bf4-9ee2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -468,7 +468,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="c2dd-1bff-46bc-b48f" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="c2dd-1bff-46bc-b48f" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_251a-df5b-4bfd-ad63</comment>
         </categoryLink>
         <categoryLink id="f5be-a57a-4f5b-aed1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -519,7 +519,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="af81-64d7-4d46-8868" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
+        <categoryLink id="af81-64d7-4d46-8868" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
           <comment>template_id_67c2-df43-44fc-92d1</comment>
         </categoryLink>
         <categoryLink id="9a52-0a67-4363-933d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -575,7 +575,7 @@
         <categoryLink id="71f2-1921-49f2-9a43" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_bd6a-0cda-4e0f-80ae</comment>
         </categoryLink>
-        <categoryLink id="4657-9be9-4ab2-804d" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
+        <categoryLink id="4657-9be9-4ab2-804d" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
           <comment>template_id_ae75-7cca-4701-9d56</comment>
         </categoryLink>
         <categoryLink id="7ca9-7333-460d-ae89" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false">
@@ -610,7 +610,7 @@
         <categoryLink id="7247-1037-41d1-9fff" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false">
           <comment>template_id_f51c-73d7-4f29-be1c</comment>
         </categoryLink>
-        <categoryLink id="28e4-09a3-41fc-b85e" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
+        <categoryLink id="28e4-09a3-41fc-b85e" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
           <comment>template_id_257d-78c0-4bab-ba65</comment>
         </categoryLink>
       </categoryLinks>
@@ -658,7 +658,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="8822-0d15-462c-aff4" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="8822-0d15-462c-aff4" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_f1c8-27fd-4f98-8527</comment>
         </categoryLink>
         <categoryLink id="ac8f-1e05-4ff4-8738" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -701,7 +701,7 @@
         <categoryLink id="cfd9-f24f-421c-be2f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_dd44-e0a8-42a8-bdcc</comment>
         </categoryLink>
-        <categoryLink id="2cc5-1efd-4a9d-a19f" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
+        <categoryLink id="2cc5-1efd-4a9d-a19f" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
           <comment>template_id_c5b0-f9ae-468d-924a</comment>
         </categoryLink>
       </categoryLinks>
@@ -736,7 +736,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="faa1-5455-4c28-9c87" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
+        <categoryLink id="faa1-5455-4c28-9c87" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
           <comment>template_id_f926-27fd-4a92-97a1</comment>
         </categoryLink>
         <categoryLink id="2731-9e48-40fb-b32f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -768,7 +768,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="0443-96ce-bcb4-0051" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="0443-96ce-bcb4-0051" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
         <categoryLink id="6489-c04e-5c52-779e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -830,7 +830,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="3fd4-8208-4615-9b90" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="3fd4-8208-4615-9b90" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_361e-fb90-4b0e-ac3d</comment>
         </categoryLink>
         <categoryLink id="7156-fd7d-4a2c-833f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -863,7 +863,7 @@
         <categoryLink id="8db6-6588-4d5d-bace" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_473b-e812-4158-9416</comment>
         </categoryLink>
-        <categoryLink id="9a7f-d63d-43a7-9667" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
+        <categoryLink id="9a7f-d63d-43a7-9667" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
           <comment>template_id_00a2-63ff-4698-a35b</comment>
         </categoryLink>
       </categoryLinks>
@@ -901,7 +901,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="7cba-9999-4b44-b796" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="7cba-9999-4b44-b796" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_2a08-4432-42ad-bfdb</comment>
         </categoryLink>
         <categoryLink id="56c1-61a3-44c0-b363" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -942,7 +942,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="bd6c-63c4-42f4-a9d5" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="bd6c-63c4-42f4-a9d5" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_f4c0-4396-4f39-a34f</comment>
         </categoryLink>
         <categoryLink id="e85e-8b1f-4cbf-bcf1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -983,7 +983,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="118a-1582-46ba-9b34" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="118a-1582-46ba-9b34" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_caf6-5548-4b89-8102</comment>
         </categoryLink>
         <categoryLink id="d18e-94ee-4588-b975" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1051,7 +1051,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="2c78-1607-49cc-9d34" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="2c78-1607-49cc-9d34" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_d53e-113f-4a40-a3d5</comment>
         </categoryLink>
         <categoryLink id="52f5-995e-4bb1-ad12" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1072,7 +1072,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="115e-8282-4a91-ac40" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="115e-8282-4a91-ac40" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_e6f7-a6ca-4825-bfc5</comment>
         </categoryLink>
         <categoryLink id="32e2-fc40-40dc-acdb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1119,7 +1119,7 @@
         <categoryLink id="7219-11d9-4bb1-b496" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_cefb-cfd7-4dc8-99c4</comment>
         </categoryLink>
-        <categoryLink id="4dcc-9f39-48ba-b49d" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="4dcc-9f39-48ba-b49d" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_a9fd-9d16-4a5e-855c</comment>
         </categoryLink>
       </categoryLinks>
@@ -1143,7 +1143,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="2714-6823-42c1-b7ef" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="2714-6823-42c1-b7ef" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_a56d-347b-4b09-a918</comment>
         </categoryLink>
         <categoryLink id="8486-76ad-42a9-b86f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1184,7 +1184,7 @@
         <categoryLink id="1d21-49a1-476c-b1e6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_9441-d79b-4720-9667</comment>
         </categoryLink>
-        <categoryLink id="cff9-fac2-4e13-8da3" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="cff9-fac2-4e13-8da3" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_7d7e-32d3-4692-b401</comment>
         </categoryLink>
       </categoryLinks>
@@ -1222,7 +1222,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="efb5-0e81-4e99-b0ce" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="efb5-0e81-4e99-b0ce" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_f65b-8958-49b3-92a5</comment>
         </categoryLink>
         <categoryLink id="6b51-55dd-4027-b339" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1263,7 +1263,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="6aa9-25df-4591-8b12" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="6aa9-25df-4591-8b12" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_c6a8-22a8-4d41-b969</comment>
         </categoryLink>
         <categoryLink id="1032-6393-4c43-a4c0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1342,7 +1342,7 @@
         <categoryLink id="1c87-7072-489d-a0e2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_bc67-ce1f-4004-aeb7</comment>
         </categoryLink>
-        <categoryLink id="2311-66b8-40e9-a5e4" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="2311-66b8-40e9-a5e4" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_9a45-9699-4475-aeef</comment>
         </categoryLink>
       </categoryLinks>
@@ -1421,7 +1421,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="3948-2fee-4005-a3fa" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="3948-2fee-4005-a3fa" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_3610-c975-4d55-bdfe</comment>
         </categoryLink>
         <categoryLink id="b320-7acf-4b48-8b5e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1465,7 +1465,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="438e-8823-4e7d-b2c5" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="438e-8823-4e7d-b2c5" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_f81d-9435-4f11-99c1</comment>
         </categoryLink>
         <categoryLink id="0a5b-203b-4d18-8d87" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1509,7 +1509,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="b341-096b-44a3-9aa1" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="b341-096b-44a3-9aa1" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_b24f-3ae0-4cbb-b016</comment>
         </categoryLink>
         <categoryLink id="4e82-d681-4227-8060" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1550,7 +1550,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="847e-b454-4aa3-b86a" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="847e-b454-4aa3-b86a" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_c77f-0819-473b-a8a2</comment>
         </categoryLink>
         <categoryLink id="e8c3-b480-40ca-b10f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1591,7 +1591,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="d99d-45fc-48d4-9648" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="d99d-45fc-48d4-9648" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_0397-c837-4fea-a527</comment>
         </categoryLink>
         <categoryLink id="82a2-7c36-46dd-b65e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1635,7 +1635,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="9264-e03b-46ea-a2d9" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="9264-e03b-46ea-a2d9" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_c1cf-cea4-4278-8f27</comment>
         </categoryLink>
         <categoryLink id="ca15-145f-4fe7-aac5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1679,7 +1679,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="ad95-f8cd-4d0a-93d1" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="ad95-f8cd-4d0a-93d1" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_0c16-6841-42b2-b02d</comment>
         </categoryLink>
         <categoryLink id="23c8-d3d1-4065-8817" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1723,7 +1723,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="a32d-8c05-4205-ae58" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="a32d-8c05-4205-ae58" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_3632-0b5d-4622-ae33</comment>
         </categoryLink>
         <categoryLink id="9f43-8675-4e4e-8451" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1767,7 +1767,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="6284-bd05-45e6-9123" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="6284-bd05-45e6-9123" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_5ad5-8701-42cd-b2b6</comment>
         </categoryLink>
         <categoryLink id="3fb2-e9af-48fb-bed0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1842,7 +1842,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="cebc-a6ee-44ec-b023" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="cebc-a6ee-44ec-b023" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_4d7c-201f-4c99-b89a</comment>
         </categoryLink>
         <categoryLink id="38f6-dca4-46b3-8949" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1883,7 +1883,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="35b2-7abe-410c-87c1" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="35b2-7abe-410c-87c1" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_4e52-ad1b-48d4-8eed</comment>
         </categoryLink>
         <categoryLink id="277c-3bff-4990-91b6" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false">
@@ -1913,7 +1913,7 @@
         <categoryLink id="f204-1c09-4da2-9685" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_6140-2404-46f9-bd42</comment>
         </categoryLink>
-        <categoryLink id="e032-55b7-48f8-b05b" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
+        <categoryLink id="e032-55b7-48f8-b05b" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
           <comment>template_id_1c86-fad8-46ec-a0b0</comment>
         </categoryLink>
       </categoryLinks>
@@ -1939,7 +1939,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="c05c-47cc-403f-a25e" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
+        <categoryLink id="c05c-47cc-403f-a25e" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
           <comment>template_id_0af1-d052-4bd7-aab6</comment>
         </categoryLink>
         <categoryLink id="831d-5b82-4068-bc99" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1988,7 +1988,7 @@
         <categoryLink id="4f1d-b07d-4d04-8eab" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_4272-9b9d-4c59-95f0</comment>
         </categoryLink>
-        <categoryLink id="7f66-32f3-44a7-8cc0" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="7f66-32f3-44a7-8cc0" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_d85b-1ae7-40d5-9341</comment>
         </categoryLink>
       </categoryLinks>
@@ -2024,7 +2024,7 @@
         <categoryLink id="116b-18fb-485d-ad6d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_ff9f-01cb-41b9-800e</comment>
         </categoryLink>
-        <categoryLink id="a275-bd36-4404-9768" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="a275-bd36-4404-9768" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_1315-6051-4a46-b070</comment>
         </categoryLink>
       </categoryLinks>
@@ -2032,7 +2032,7 @@
     <entryLink id="66e7-ee64-2389-9645" name="Praetor" hidden="false" collective="false" import="false" targetId="03be-5d55-d05a-771d" type="selectionEntry">
       <comment>template_id_5798-3fc7-4d4c-ad41</comment>
       <categoryLinks>
-        <categoryLink id="2b33-a9a8-49eb-8237" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
+        <categoryLink id="2b33-a9a8-49eb-8237" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
           <comment>template_id_b084-df23-4f99-812f</comment>
         </categoryLink>
         <categoryLink id="db02-cb9d-4bb0-8bec" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false">
@@ -2179,7 +2179,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="fe46-d1f9-44f3-a423" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="fe46-d1f9-44f3-a423" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_b822-3417-4613-be37</comment>
         </categoryLink>
         <categoryLink id="68c1-d0dc-4352-81f3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2218,7 +2218,7 @@
         <categoryLink id="68ae-1d35-4996-82c6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_75a7-dc06-445b-b2dc</comment>
         </categoryLink>
-        <categoryLink id="e39a-18f6-4664-98a1" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="e39a-18f6-4664-98a1" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_e21a-c03b-4885-ac46</comment>
         </categoryLink>
       </categoryLinks>
@@ -2250,7 +2250,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="feae-09be-4a36-be3a" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
+        <categoryLink id="feae-09be-4a36-be3a" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
           <comment>template_id_f55b-7555-444b-beee</comment>
         </categoryLink>
         <categoryLink id="05ca-a4f0-44cd-aa7f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2271,7 +2271,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="c618-9c76-4138-ba0d" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="c618-9c76-4138-ba0d" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_79fa-3370-4ae0-9e12</comment>
         </categoryLink>
         <categoryLink id="8798-f85c-477c-a818" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2314,7 +2314,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="5e56-8d23-488f-9b96" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="5e56-8d23-488f-9b96" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_8d82-3279-4481-84bb</comment>
         </categoryLink>
         <categoryLink id="8e16-69fd-4d5d-82f2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2355,7 +2355,7 @@
         <categoryLink id="440a-f7ed-46af-9890" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_7010-be56-4709-b058</comment>
         </categoryLink>
-        <categoryLink id="a2d2-f033-4707-b3fb" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="a2d2-f033-4707-b3fb" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_7379-a740-47ba-a054</comment>
         </categoryLink>
       </categoryLinks>
@@ -2373,7 +2373,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="fd9b-be65-4c2f-be62" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="fd9b-be65-4c2f-be62" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_944f-7420-4982-8ea9</comment>
         </categoryLink>
         <categoryLink id="ccef-e1bc-4e35-9c2d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2441,7 +2441,7 @@
         <categoryLink id="974c-da5a-4284-9b31" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_c6ff-0977-4c92-bb28</comment>
         </categoryLink>
-        <categoryLink id="45af-f788-4cbd-9a7e" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="45af-f788-4cbd-9a7e" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_f555-7d39-458f-84c9</comment>
         </categoryLink>
       </categoryLinks>
@@ -2479,7 +2479,7 @@
         <categoryLink id="c8a6-807a-4a38-9c08" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_39e5-eda5-45d1-a643</comment>
         </categoryLink>
-        <categoryLink id="3e6a-9e8e-48ad-afd1" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="3e6a-9e8e-48ad-afd1" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_6416-21bb-4df4-9de8</comment>
         </categoryLink>
       </categoryLinks>
@@ -2517,7 +2517,7 @@
         <categoryLink id="201a-6246-4511-bd31" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_5528-2dac-4be5-900c</comment>
         </categoryLink>
-        <categoryLink id="c04e-06c6-49bf-9b41" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="c04e-06c6-49bf-9b41" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_dc8f-d888-4585-991d</comment>
         </categoryLink>
       </categoryLinks>
@@ -2555,7 +2555,7 @@
         <categoryLink id="cd3a-b00b-4c54-8436" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_899e-b052-4d5b-8c18</comment>
         </categoryLink>
-        <categoryLink id="73bf-c31b-4c39-9957" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="73bf-c31b-4c39-9957" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_f5e9-cff6-41d2-a016</comment>
         </categoryLink>
       </categoryLinks>
@@ -2593,7 +2593,7 @@
         <categoryLink id="2f51-de85-4639-bff2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_09cd-2176-40af-bba6</comment>
         </categoryLink>
-        <categoryLink id="cb12-1ee6-49f4-af3d" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="cb12-1ee6-49f4-af3d" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_05e6-7c63-4a35-9ba0</comment>
         </categoryLink>
       </categoryLinks>
@@ -2631,7 +2631,7 @@
         <categoryLink id="a91e-dfdc-494a-92f7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_0dfa-4004-4751-8022</comment>
         </categoryLink>
-        <categoryLink id="e265-d334-4355-96e0" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="e265-d334-4355-96e0" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_a669-0f5d-4fd3-811b</comment>
         </categoryLink>
       </categoryLinks>
@@ -2658,7 +2658,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="864d-1e85-4ccb-9d54" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="864d-1e85-4ccb-9d54" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_4f60-472b-45a9-ab9e</comment>
         </categoryLink>
         <categoryLink id="1d1e-c958-4d22-8d77" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2739,7 +2739,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="469b-edc2-4cf1-8278" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="469b-edc2-4cf1-8278" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_2008-f1c4-4285-a14f</comment>
         </categoryLink>
         <categoryLink id="a5c3-1823-4c9a-8dcf" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2774,7 +2774,7 @@
         <categoryLink id="d83d-1d4f-4be4-9d89" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_9189-836c-475d-a52e</comment>
         </categoryLink>
-        <categoryLink id="a994-cfc8-4333-b98c" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="a994-cfc8-4333-b98c" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_e1fa-b7d8-47b0-a88a</comment>
         </categoryLink>
         <categoryLink id="254e-e7e4-4cac-bd13" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false">
@@ -2788,7 +2788,7 @@
         <categoryLink id="0fae-fa6e-46a3-90de" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_b1d5-fd75-4f17-bbf4</comment>
         </categoryLink>
-        <categoryLink id="a882-55f8-423b-81e1" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="a882-55f8-423b-81e1" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_f221-bf81-4045-849b</comment>
         </categoryLink>
       </categoryLinks>
@@ -2828,7 +2828,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="3d0e-4174-428d-bcab" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="3d0e-4174-428d-bcab" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_f203-bc26-421f-b79e</comment>
         </categoryLink>
         <categoryLink id="384f-83a1-4c68-a5fe" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2858,7 +2858,7 @@
         <categoryLink id="a145-37a5-42df-9dbb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_51af-a137-4a1c-97a4</comment>
         </categoryLink>
-        <categoryLink id="8fdc-d13c-4799-b063" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
+        <categoryLink id="8fdc-d13c-4799-b063" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
           <comment>template_id_ec1f-c326-40a8-9d1f</comment>
         </categoryLink>
       </categoryLinks>
@@ -2924,7 +2924,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="b3c5-9816-4d6b-ad66" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="b3c5-9816-4d6b-ad66" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_fce3-801c-49c8-85d4</comment>
         </categoryLink>
         <categoryLink id="c6e4-c714-486e-9444" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2935,7 +2935,7 @@
     <entryLink id="0cb9-d47f-f2d7-bfb9" name="Terminator Tartaros Squad" hidden="false" collective="false" import="false" targetId="1a8e-0ded-a4dc-2b4e" type="selectionEntry">
       <comment>template_id_0848-4e03-417a-b224</comment>
       <categoryLinks>
-        <categoryLink id="8ccd-8bdc-49ce-a92f" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
+        <categoryLink id="8ccd-8bdc-49ce-a92f" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
           <comment>template_id_ac1c-b3bf-4011-918a</comment>
         </categoryLink>
         <categoryLink id="6d3f-606d-4aee-89d6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2979,7 +2979,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="9c9e-fe48-4e0f-9564" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="9c9e-fe48-4e0f-9564" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_5a04-9847-4c91-a49a</comment>
         </categoryLink>
         <categoryLink id="04d1-0d44-490f-b30f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -3009,7 +3009,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="e81d-262a-49a7-80af" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="e81d-262a-49a7-80af" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_7d4f-547c-43ed-a520</comment>
         </categoryLink>
         <categoryLink id="201e-47b6-4c26-8874" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -3038,7 +3038,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="2528-cf50-43e3-9136" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
+        <categoryLink id="2528-cf50-43e3-9136" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
           <comment>template_id_28e0-91e7-4ada-9fac</comment>
         </categoryLink>
         <categoryLink id="f4f5-9c09-4885-891c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -3079,7 +3079,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="b2e0-b87b-447e-bfd5" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="b2e0-b87b-447e-bfd5" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_e22a-c5f8-4825-a45f</comment>
         </categoryLink>
         <categoryLink id="18cf-3981-430f-b5f6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -3112,7 +3112,7 @@
         <categoryLink id="fbe4-915c-4e11-af61" name="Compulsory Elite:" hidden="false" targetId="bb1f-ae32-b587-c3e1" primary="false">
           <comment>template_id_7d5a-62e7-43ee-b79b</comment>
         </categoryLink>
-        <categoryLink id="c127-9d97-4023-85e1" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
+        <categoryLink id="c127-9d97-4023-85e1" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
           <comment>template_id_4986-9157-49f2-b670</comment>
         </categoryLink>
       </categoryLinks>
@@ -3142,7 +3142,7 @@
         <categoryLink id="ac24-0350-42cd-ba0b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_1b86-0977-4a8b-adac</comment>
         </categoryLink>
-        <categoryLink id="6350-053d-429d-aed0" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="6350-053d-429d-aed0" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_b449-403a-4e42-9239</comment>
         </categoryLink>
       </categoryLinks>
@@ -3224,7 +3224,7 @@
         <categoryLink id="3153-9bb7-4242-beb6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_4f71-446f-4cff-afda</comment>
         </categoryLink>
-        <categoryLink id="f50c-a911-496a-93d2" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="f50c-a911-496a-93d2" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_3f44-8647-43a4-ac22</comment>
         </categoryLink>
       </categoryLinks>
@@ -3245,7 +3245,7 @@
         <categoryLink id="39a1-51e2-4764-a688" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_b6b1-886e-4194-8bcd</comment>
         </categoryLink>
-        <categoryLink id="8213-afb5-44c8-8f36" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="8213-afb5-44c8-8f36" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_51b5-f9c1-4587-8fc7</comment>
         </categoryLink>
       </categoryLinks>
@@ -3290,7 +3290,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="dc16-16d0-4890-a8e8" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="dc16-16d0-4890-a8e8" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="4b1e-3f1f-49cb-8343" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -3313,7 +3313,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="32cb-7077-4d54-9f38" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="2c35-def7-4c44-9b02" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="2c35-def7-4c44-9b02" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="0c9a-d272-491c-a4a0" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -3335,7 +3335,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="5b41-a9f0-4801-9dff" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="5b41-a9f0-4801-9dff" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="d64e-e976-4668-bb95" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
         <categoryLink id="17a6-f363-4094-9a7c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
@@ -3359,7 +3359,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="fe4f-c8f2-470f-901c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="f3f0-973b-4a45-ac41" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="f3f0-973b-4a45-ac41" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="5c30-161a-40da-9db5" name="Sky-Hunter Squadron" hidden="true" collective="false" import="false" targetId="6263-c696-2f2e-c105" type="selectionEntry">
@@ -3382,7 +3382,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="63ff-0a92-42ab-ae8c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="204c-7b0f-4fb9-b1b3" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="204c-7b0f-4fb9-b1b3" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="85e6-cb31-427c-a040" name="Line Sub-type:" hidden="false" targetId="6399-5c65-7833-1025" primary="false"/>
         <categoryLink id="3d10-19eb-5585-7c96" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
       </categoryLinks>
@@ -3407,7 +3407,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="68dd-fc0f-4fde-8adc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="74ca-dd4f-46be-8be7" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="74ca-dd4f-46be-8be7" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="d86e-6559-dad7-3f1b" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -3498,7 +3498,7 @@
       <categoryLinks>
         <categoryLink id="0d5b-be56-47af-a22e" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="2e59-1043-4719-96c4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="52fa-8c3c-49d4-a321" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="52fa-8c3c-49d4-a321" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="9b87-d3cb-4851-829a" name="Termite Assault Drill" hidden="true" collective="false" import="false" targetId="cb30-307a-f0d7-3b13" type="selectionEntry">
@@ -3522,7 +3522,7 @@
       <categoryLinks>
         <categoryLink id="1fef-4409-4fab-93fc" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="ca2d-245e-48b4-a1cf" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="6692-6e39-44f0-ad8e" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="6692-6e39-44f0-ad8e" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="5190-2c0b-4bf4-9679" name="Venerable Ancient Contemptor Dreadnought" hidden="true" collective="false" import="false" targetId="dad1-0807-e254-d498" type="selectionEntry">
@@ -3539,7 +3539,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="9261-acb5-4230-8d89" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="1a5d-cbc8-418f-91a3" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="1a5d-cbc8-418f-91a3" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="c0cb-406f-4b46-9d8d" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
       </categoryLinks>
       <entryLinks>
@@ -3562,7 +3562,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="c0b2-dd90-46c1-a2a9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="9a94-76fb-4a89-ad5d" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="9a94-76fb-4a89-ad5d" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="0153-8ebd-7037-4772" name="Castellax Battle-Automata Maniple" hidden="true" collective="false" import="false" targetId="537f-846d-90e3-2526" type="selectionEntry">
@@ -3575,7 +3575,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="3a8f-0038-542a-4ad4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="98f2-bd58-abce-b2ca" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="98f2-bd58-abce-b2ca" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="29ab-25dd-bd10-2e1d" name="Domitar Battle-Automata Maniple" hidden="true" collective="false" import="false" targetId="1a1b-fa35-a6a2-ca78" type="selectionEntry">
@@ -3588,7 +3588,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="c529-9492-f51d-1bdb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="ce77-de2b-a58a-45d8" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="ce77-de2b-a58a-45d8" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="fe2e-ce63-6b2f-9bd1" name="Thanatar Siege-automata Maniple" hidden="true" collective="false" import="false" targetId="2903-fef6-e839-368b" type="selectionEntry">
@@ -3605,7 +3605,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="e464-da97-8e63-b24e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="1cd8-6f2f-b0a5-04ae" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="1cd8-6f2f-b0a5-04ae" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="f8a8-ece6-0f6f-304f" name="Vorax Battle-automata Maniple" hidden="true" collective="false" import="false" targetId="f144-1079-11ff-019d" type="selectionEntry">
@@ -3618,7 +3618,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="34d8-ce2f-6cea-ab60" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="bbc5-9a24-45bc-7d13" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="bbc5-9a24-45bc-7d13" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="849e-fefd-a2a2-421d" name="Templar Brethren" hidden="true" collective="false" import="false" targetId="6f69-665c-3199-77aa" type="selectionEntry">
@@ -3663,7 +3663,7 @@
       </infoLinks>
       <categoryLinks>
         <categoryLink id="6595-ae1c-71f8-decd" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="e0c1-8341-e322-1cc2" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="e0c1-8341-e322-1cc2" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="b128-642a-d8c3-97fe" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -3703,7 +3703,7 @@
         <constraint field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0a22-9cfa-1c7a-c0cb" type="max"/>
       </constraints>
       <categoryLinks>
-        <categoryLink id="1f17-523a-8dec-a55a" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="1f17-523a-8dec-a55a" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="655d-74eb-71bd-3f90" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -3743,7 +3743,7 @@
       </infoLinks>
       <categoryLinks>
         <categoryLink id="8a45-41a9-f691-a18c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="1a63-5cf5-060b-fefe" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="1a63-5cf5-060b-fefe" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="2705-9abc-5949-8227" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -3765,7 +3765,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="b383-ec37-312b-b219" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="b383-ec37-312b-b219" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="482d-2875-6358-9d40" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
         <categoryLink id="e310-fe75-4896-117f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
@@ -3795,7 +3795,7 @@
         <infoLink id="bac0-f49c-0b38-29bc" name="Legiones Astartes (Imperial Fists)" hidden="false" targetId="e876-4f8f-a30f-8b22" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="fdda-3efe-5d7d-bf3e" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+        <categoryLink id="fdda-3efe-5d7d-bf3e" name="Heavy Sub-type:" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
         <categoryLink id="37c5-26ea-8f6f-cc83" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="b742-fcda-a7e3-3a0e" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
       </categoryLinks>
@@ -4434,7 +4434,7 @@
       <categoryLinks>
         <categoryLink id="93db-ffc9-0558-73e6" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="e823-f428-97c9-b5d7" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="7668-e167-087e-ec1a" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+        <categoryLink id="7668-e167-087e-ec1a" name="Heavy Sub-type:" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
       </categoryLinks>
       <entryLinks>
         <entryLink id="02b9-034a-2569-5151" name="Warlord" hidden="false" collective="false" import="true" targetId="0176-56a3-d590-b103" type="selectionEntry">
@@ -4554,7 +4554,7 @@
       <categoryLinks>
         <categoryLink id="7d2a-1492-8056-3083" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="f860-72fd-d93c-1290" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="1715-31a2-3ed9-4522" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+        <categoryLink id="1715-31a2-3ed9-4522" name="Heavy Sub-type:" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="5353-20d5-7bd9-9db1" name="The Headsman and The Hunter" hidden="false" collective="false" import="true" type="upgrade">
@@ -5252,7 +5252,7 @@ Both weapons are counted as ‘Power’ weapons for those rules that affect such
         <infoLink id="1b54-dd41-0d20-8ea4" name="Deep Strike" hidden="false" targetId="f1e1-986f-c783-ca9e" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="9c2c-a3a7-f173-2fd3" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+        <categoryLink id="9c2c-a3a7-f173-2fd3" name="Heavy Sub-type:" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
         <categoryLink id="1611-1fbf-b28d-082b" name="Terminators:" hidden="false" targetId="bab3-f50d-3e5f-2f78" primary="false"/>
         <categoryLink id="7d8a-f02e-04ca-e7e6" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="c04e-d6da-5531-7c3a" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
@@ -5825,7 +5825,7 @@ Butcher of Larissan – If, at the start of any player turn, the opposing player
         <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="644e-3b1e-aafd-25e2" type="max"/>
       </constraints>
       <entryLinks>
-        <entryLink id="c8e0-4021-0f8b-e9b9" name="Tartaros Command Squad" hidden="false" collective="false" import="true" targetId="58d0-a0fd-d20b-cb1b" type="selectionEntry"/>
+        <entryLink id="c8e0-4021-0f8b-e9b9" name="Command Squad, Tartaros" hidden="false" collective="false" import="true" targetId="58d0-a0fd-d20b-cb1b" type="selectionEntry"/>
         <entryLink id="9db7-8776-0292-d1f5" name="Huscarl Squad" hidden="true" collective="false" import="true" targetId="4420-5ce0-beb7-cb5e" type="selectionEntry">
           <modifiers>
             <modifier type="set" field="hidden" value="false">
@@ -5986,6 +5986,6 @@ While locked in combat with an enemy unit that includes the enemy Warlord, or an
     </selectionEntryGroup>
   </sharedSelectionEntryGroups>
   <catalogueLinks>
-    <catalogueLink id="2f60-18fb-e6ed-8574" name="(HH V2) Legions Astartes" targetId="6393-649c-7213-a327" type="catalogue" importRootEntries="true"/>
+    <catalogueLink id="2f60-18fb-e6ed-8574" name="Legions Astartes" targetId="6393-649c-7213-a327" type="catalogue" importRootEntries="true"/>
   </catalogueLinks>
 </catalogue>

--- a/2022 - LA - Iron Hands.cat
+++ b/2022 - LA - Iron Hands.cat
@@ -14,7 +14,7 @@
         <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="da6a-761c-e00e-569b" type="max"/>
       </constraints>
       <categoryLinks>
-        <categoryLink id="8e8d-01b9-6875-ad9c" name="New CategoryLink" hidden="false" targetId="e90d-e5a8-f42d-da84" primary="true"/>
+        <categoryLink id="8e8d-01b9-6875-ad9c" name="Allegiance:" hidden="false" targetId="e90d-e5a8-f42d-da84" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="2fdc-7a7e-ae85-ad77" name="Iron Father Autek Mor" hidden="true" collective="false" import="false" targetId="0283-efdd-6ee3-6741" type="selectionEntry">
@@ -55,7 +55,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="4352-3cd4-e3da-54fa" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="4352-3cd4-e3da-54fa" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="5628-344a-7f03-95bf" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink targetId="f823-8c1d-6a87-26a1" id="e8c0-d953-4c54-def4" primary="false" name="Compulsory HQ:"/>
       </categoryLinks>
@@ -69,7 +69,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="028c-19b9-ccdf-9229" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="028c-19b9-ccdf-9229" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="3f2e-25c7-b685-51db" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -82,7 +82,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="26b1-401b-c49d-a163" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="26b1-401b-c49d-a163" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="0ac3-4093-1c72-a6c2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -107,7 +107,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="84ec-691d-8d75-7998" name="New CategoryLink" hidden="false" targetId="ad5f-31db-8bc7-5c46" primary="true"/>
+        <categoryLink id="84ec-691d-8d75-7998" name="Primarch:" hidden="false" targetId="ad5f-31db-8bc7-5c46" primary="true"/>
         <categoryLink id="4198-15b1-372c-89c8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
       <entryLinks>
@@ -122,7 +122,7 @@
         <categoryLink id="7683-f549-4aeb-b17c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_c6d4-581f-4746-bec3</comment>
         </categoryLink>
-        <categoryLink id="2f77-ab82-48bc-a7d0" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
+        <categoryLink id="2f77-ab82-48bc-a7d0" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
           <comment>template_id_2489-ee2a-45dd-b384</comment>
         </categoryLink>
       </categoryLinks>
@@ -152,7 +152,7 @@
         <categoryLink id="1a12-e8a5-43d5-88dc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_8378-ede4-476d-b657</comment>
         </categoryLink>
-        <categoryLink id="d616-aa3d-454d-803b" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="d616-aa3d-454d-803b" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_d64f-ad19-426c-adf7</comment>
         </categoryLink>
       </categoryLinks>
@@ -178,7 +178,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="4162-b432-4130-9b44" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="4162-b432-4130-9b44" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_ac26-e639-4d53-9b8b</comment>
         </categoryLink>
         <categoryLink id="ab6d-5dbc-49fa-b1f5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -189,7 +189,7 @@
         </categoryLink>
       </categoryLinks>
     </entryLink>
-    <entryLink id="1f59-14e1-1648-5cb4" name="Avenger Strike Fighter" hidden="true" collective="false" import="false" targetId="b25c-e85c-1c29-9e05" type="selectionEntry">
+    <entryLink id="1f59-14e1-1648-5cb4" name="Legion Avenger Strike Fighter" hidden="true" collective="false" import="false" targetId="b25c-e85c-1c29-9e05" type="selectionEntry">
       <comment>template_id_1064-175d-4616-9c71</comment>
       <modifiers>
         <modifier type="set" field="hidden" value="false">
@@ -211,7 +211,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="04a5-ffb0-41c1-9186" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="04a5-ffb0-41c1-9186" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_a009-a597-4b51-b228</comment>
         </categoryLink>
         <categoryLink id="3a90-828e-43ef-bd4b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -244,7 +244,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="2000-ff0e-44b4-8bb8" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="2000-ff0e-44b4-8bb8" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_c165-3906-463a-9c73</comment>
         </categoryLink>
         <categoryLink id="bba5-9f9e-4d9f-98eb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -281,7 +281,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="b577-1e77-448b-8832" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="b577-1e77-448b-8832" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_3a22-caae-4eea-9bc5</comment>
         </categoryLink>
         <categoryLink id="d77e-ada5-4dd8-bfd1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -314,7 +314,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="fce5-bf28-4be8-ae84" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="fce5-bf28-4be8-ae84" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_251a-df5b-4bfd-ad63</comment>
         </categoryLink>
         <categoryLink id="2ec3-8c30-49da-ab05" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -351,7 +351,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="19f3-10a3-4301-9213" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
+        <categoryLink id="19f3-10a3-4301-9213" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
           <comment>template_id_67c2-df43-44fc-92d1</comment>
         </categoryLink>
         <categoryLink id="002a-3d5d-46cb-966a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -407,7 +407,7 @@
         <categoryLink id="363d-de50-4343-80b9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_bd6a-0cda-4e0f-80ae</comment>
         </categoryLink>
-        <categoryLink id="88c6-86da-4163-b575" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
+        <categoryLink id="88c6-86da-4163-b575" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
           <comment>template_id_ae75-7cca-4701-9d56</comment>
         </categoryLink>
         <categoryLink id="eab6-c4fa-4cb3-a4f9" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false">
@@ -442,7 +442,7 @@
         <categoryLink id="da1c-db14-4133-beda" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false">
           <comment>template_id_f51c-73d7-4f29-be1c</comment>
         </categoryLink>
-        <categoryLink id="3ebe-6583-4dc6-9da4" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
+        <categoryLink id="3ebe-6583-4dc6-9da4" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
           <comment>template_id_257d-78c0-4bab-ba65</comment>
         </categoryLink>
       </categoryLinks>
@@ -490,7 +490,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="673f-a311-4439-9ad3" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="673f-a311-4439-9ad3" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_f1c8-27fd-4f98-8527</comment>
         </categoryLink>
         <categoryLink id="2ced-12a5-4348-b66f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -519,7 +519,7 @@
         <categoryLink id="7274-faea-4f90-9304" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_dd44-e0a8-42a8-bdcc</comment>
         </categoryLink>
-        <categoryLink id="ece3-76a8-4e23-be5e" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
+        <categoryLink id="ece3-76a8-4e23-be5e" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
           <comment>template_id_c5b0-f9ae-468d-924a</comment>
         </categoryLink>
       </categoryLinks>
@@ -546,7 +546,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="c0bd-d1d4-4c20-b957" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
+        <categoryLink id="c0bd-d1d4-4c20-b957" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
           <comment>template_id_f926-27fd-4a92-97a1</comment>
         </categoryLink>
         <categoryLink id="68ee-f6a6-4d8e-9644" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -578,7 +578,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="1477-4a3f-d2b5-c7bf" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="1477-4a3f-d2b5-c7bf" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
         <categoryLink id="09b3-c5f5-37b7-512a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -637,7 +637,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="f5b4-a847-40bd-9fcc" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="f5b4-a847-40bd-9fcc" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_361e-fb90-4b0e-ac3d</comment>
         </categoryLink>
         <categoryLink id="0cc1-e21c-4567-a7d5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -654,7 +654,7 @@
         <categoryLink id="a1bd-ae00-4214-a9b9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_473b-e812-4158-9416</comment>
         </categoryLink>
-        <categoryLink id="3a63-f533-43f1-a628" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
+        <categoryLink id="3a63-f533-43f1-a628" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
           <comment>template_id_00a2-63ff-4698-a35b</comment>
         </categoryLink>
       </categoryLinks>
@@ -678,7 +678,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="ca0e-d305-425e-91d6" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="ca0e-d305-425e-91d6" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_2a08-4432-42ad-bfdb</comment>
         </categoryLink>
         <categoryLink id="2349-394d-44c8-80d8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -711,7 +711,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="31ff-2ccc-4e58-ab5c" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="31ff-2ccc-4e58-ab5c" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_f4c0-4396-4f39-a34f</comment>
         </categoryLink>
         <categoryLink id="98b5-26aa-482e-a84f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -744,7 +744,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="2304-3950-4554-bd93" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="2304-3950-4554-bd93" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_caf6-5548-4b89-8102</comment>
         </categoryLink>
         <categoryLink id="5197-c018-4fe8-968c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -804,7 +804,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="95cf-b65f-4d0c-911d" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="95cf-b65f-4d0c-911d" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_d53e-113f-4a40-a3d5</comment>
         </categoryLink>
         <categoryLink id="013f-17e2-468b-9899" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -825,7 +825,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="7925-3317-4a88-8efa" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="7925-3317-4a88-8efa" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_e6f7-a6ca-4825-bfc5</comment>
         </categoryLink>
         <categoryLink id="c3b6-38ef-49a5-8127" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -858,7 +858,7 @@
         <categoryLink id="2727-19fc-4baf-a661" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_cefb-cfd7-4dc8-99c4</comment>
         </categoryLink>
-        <categoryLink id="6f64-4eb8-45d3-b8b4" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="6f64-4eb8-45d3-b8b4" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_a9fd-9d16-4a5e-855c</comment>
         </categoryLink>
       </categoryLinks>
@@ -882,7 +882,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="cc3c-4262-4895-a8bf" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="cc3c-4262-4895-a8bf" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_a56d-347b-4b09-a918</comment>
         </categoryLink>
         <categoryLink id="1425-c955-4f44-836b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -915,7 +915,7 @@
         <categoryLink id="c8e2-f86c-4958-bdd5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_9441-d79b-4720-9667</comment>
         </categoryLink>
-        <categoryLink id="ff75-dddb-4920-bb1c" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="ff75-dddb-4920-bb1c" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_7d7e-32d3-4692-b401</comment>
         </categoryLink>
       </categoryLinks>
@@ -945,7 +945,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="191e-94f2-4152-b3ed" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="191e-94f2-4152-b3ed" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_f65b-8958-49b3-92a5</comment>
         </categoryLink>
         <categoryLink id="6a7f-8950-467d-871b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -978,7 +978,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="24ad-6999-414b-a114" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="24ad-6999-414b-a114" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_c6a8-22a8-4d41-b969</comment>
         </categoryLink>
         <categoryLink id="a8dc-1b96-4ecc-8b7d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1041,7 +1041,7 @@
         <categoryLink id="8191-db70-4c73-a399" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_bc67-ce1f-4004-aeb7</comment>
         </categoryLink>
-        <categoryLink id="c66d-2e7e-436d-855f" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="c66d-2e7e-436d-855f" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_9a45-9699-4475-aeef</comment>
         </categoryLink>
       </categoryLinks>
@@ -1104,7 +1104,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="ac20-c01d-45b7-aa1a" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="ac20-c01d-45b7-aa1a" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_3610-c975-4d55-bdfe</comment>
         </categoryLink>
         <categoryLink id="460e-ce32-4b4c-87f7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1140,7 +1140,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="f2fd-c8e9-4f28-9dff" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="f2fd-c8e9-4f28-9dff" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_f81d-9435-4f11-99c1</comment>
         </categoryLink>
         <categoryLink id="787b-fa03-4c22-bee3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1176,7 +1176,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="e69a-17f8-4243-9edb" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="e69a-17f8-4243-9edb" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_b24f-3ae0-4cbb-b016</comment>
         </categoryLink>
         <categoryLink id="fc46-c775-4230-86bf" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1209,7 +1209,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="0fb2-8945-4a73-8c90" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="0fb2-8945-4a73-8c90" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_c77f-0819-473b-a8a2</comment>
         </categoryLink>
         <categoryLink id="be53-0ab7-470e-b19e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1242,7 +1242,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="3427-23dc-41b3-85ed" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="3427-23dc-41b3-85ed" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_0397-c837-4fea-a527</comment>
         </categoryLink>
         <categoryLink id="1762-7500-4d8c-a753" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1278,7 +1278,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="9e14-eb32-463e-abd8" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="9e14-eb32-463e-abd8" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_c1cf-cea4-4278-8f27</comment>
         </categoryLink>
         <categoryLink id="4b27-42a6-4c8e-8289" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1314,7 +1314,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="8e74-d116-41b0-986d" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="8e74-d116-41b0-986d" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_0c16-6841-42b2-b02d</comment>
         </categoryLink>
         <categoryLink id="2619-d62f-42bf-939e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1350,7 +1350,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="1d0a-a03a-4378-ac2a" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="1d0a-a03a-4378-ac2a" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_3632-0b5d-4622-ae33</comment>
         </categoryLink>
         <categoryLink id="e270-3fa9-4a07-aab7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1386,7 +1386,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="f100-2cf0-4736-a1ca" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="f100-2cf0-4736-a1ca" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_5ad5-8701-42cd-b2b6</comment>
         </categoryLink>
         <categoryLink id="dd35-c0d7-4e7d-ae89" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1453,7 +1453,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="0240-0ea7-4985-a213" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="0240-0ea7-4985-a213" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_4d7c-201f-4c99-b89a</comment>
         </categoryLink>
         <categoryLink id="2a47-b4bb-440e-bd51" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1486,7 +1486,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="2054-ee06-42b4-b03b" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="2054-ee06-42b4-b03b" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_4e52-ad1b-48d4-8eed</comment>
         </categoryLink>
         <categoryLink id="0257-3836-4167-bd31" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false">
@@ -1500,7 +1500,7 @@
         <categoryLink id="cb96-b6fe-42d8-aedd" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_6140-2404-46f9-bd42</comment>
         </categoryLink>
-        <categoryLink id="17e6-3fb7-4a2d-8de2" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
+        <categoryLink id="17e6-3fb7-4a2d-8de2" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
           <comment>template_id_1c86-fad8-46ec-a0b0</comment>
         </categoryLink>
       </categoryLinks>
@@ -1526,7 +1526,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="9422-e630-4369-8a9c" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
+        <categoryLink id="9422-e630-4369-8a9c" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
           <comment>template_id_0af1-d052-4bd7-aab6</comment>
         </categoryLink>
         <categoryLink id="4f39-1490-4048-a9b4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1575,7 +1575,7 @@
         <categoryLink id="0ae3-249b-4f8a-8543" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_4272-9b9d-4c59-95f0</comment>
         </categoryLink>
-        <categoryLink id="8eb5-8bad-4be2-9c51" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="8eb5-8bad-4be2-9c51" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_d85b-1ae7-40d5-9341</comment>
         </categoryLink>
       </categoryLinks>
@@ -1597,7 +1597,7 @@
         <categoryLink id="d536-8dce-45b0-9ecf" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_ff9f-01cb-41b9-800e</comment>
         </categoryLink>
-        <categoryLink id="0c87-9ec2-465c-b4bf" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="0c87-9ec2-465c-b4bf" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_1315-6051-4a46-b070</comment>
         </categoryLink>
       </categoryLinks>
@@ -1605,7 +1605,7 @@
     <entryLink id="7d73-b111-0aff-e0d8" name="Praetor" hidden="false" collective="false" import="false" targetId="03be-5d55-d05a-771d" type="selectionEntry">
       <comment>template_id_5798-3fc7-4d4c-ad41</comment>
       <categoryLinks>
-        <categoryLink id="1a55-5638-44a7-b62d" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
+        <categoryLink id="1a55-5638-44a7-b62d" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
           <comment>template_id_b084-df23-4f99-812f</comment>
         </categoryLink>
         <categoryLink id="957d-a4cf-4b6c-a314" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false">
@@ -1730,7 +1730,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="dfa7-370f-4495-b71e" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="dfa7-370f-4495-b71e" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_b822-3417-4613-be37</comment>
         </categoryLink>
         <categoryLink id="1133-e98f-414e-ae55" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1756,7 +1756,7 @@
         <categoryLink id="c393-8e6c-4361-8223" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_75a7-dc06-445b-b2dc</comment>
         </categoryLink>
-        <categoryLink id="045b-ec81-4078-a0dd" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="045b-ec81-4078-a0dd" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_e21a-c03b-4885-ac46</comment>
         </categoryLink>
       </categoryLinks>
@@ -1774,7 +1774,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="a351-1bd0-4f6e-bcdb" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
+        <categoryLink id="a351-1bd0-4f6e-bcdb" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
           <comment>template_id_f55b-7555-444b-beee</comment>
         </categoryLink>
         <categoryLink id="2a09-cc6f-4efb-b641" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1795,7 +1795,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="9e37-3e4e-432b-8b17" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="9e37-3e4e-432b-8b17" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_79fa-3370-4ae0-9e12</comment>
         </categoryLink>
         <categoryLink id="9193-ba0c-4129-9095" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1821,7 +1821,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="4031-11fd-4b63-ae09" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="4031-11fd-4b63-ae09" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_8d82-3279-4481-84bb</comment>
         </categoryLink>
         <categoryLink id="345d-8033-4d35-9951" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1854,7 +1854,7 @@
         <categoryLink id="1d34-17cb-4d42-8e66" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_7010-be56-4709-b058</comment>
         </categoryLink>
-        <categoryLink id="cabc-b92c-4e55-9b2b" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="cabc-b92c-4e55-9b2b" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_7379-a740-47ba-a054</comment>
         </categoryLink>
       </categoryLinks>
@@ -1872,7 +1872,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="074f-1376-44f5-9f80" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="074f-1376-44f5-9f80" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_944f-7420-4982-8ea9</comment>
         </categoryLink>
         <categoryLink id="c7bb-9159-48c4-b85c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1916,7 +1916,7 @@
         <categoryLink id="1d5f-4d33-4a11-b560" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_c6ff-0977-4c92-bb28</comment>
         </categoryLink>
-        <categoryLink id="b1a5-8060-4987-b508" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="b1a5-8060-4987-b508" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_f555-7d39-458f-84c9</comment>
         </categoryLink>
       </categoryLinks>
@@ -1946,7 +1946,7 @@
         <categoryLink id="3f99-f0cc-4aeb-8668" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_39e5-eda5-45d1-a643</comment>
         </categoryLink>
-        <categoryLink id="ec43-c362-4142-8889" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="ec43-c362-4142-8889" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_6416-21bb-4df4-9de8</comment>
         </categoryLink>
       </categoryLinks>
@@ -1976,7 +1976,7 @@
         <categoryLink id="e635-ab9d-4d7f-828e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_5528-2dac-4be5-900c</comment>
         </categoryLink>
-        <categoryLink id="c899-390e-47e9-af93" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="c899-390e-47e9-af93" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_dc8f-d888-4585-991d</comment>
         </categoryLink>
       </categoryLinks>
@@ -2006,7 +2006,7 @@
         <categoryLink id="263b-340a-4aff-b94c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_899e-b052-4d5b-8c18</comment>
         </categoryLink>
-        <categoryLink id="0550-d4b2-4249-a943" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="0550-d4b2-4249-a943" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_f5e9-cff6-41d2-a016</comment>
         </categoryLink>
       </categoryLinks>
@@ -2036,7 +2036,7 @@
         <categoryLink id="6e93-7a9b-42d1-bed1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_09cd-2176-40af-bba6</comment>
         </categoryLink>
-        <categoryLink id="5905-e9b2-474f-87b7" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="5905-e9b2-474f-87b7" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_05e6-7c63-4a35-9ba0</comment>
         </categoryLink>
       </categoryLinks>
@@ -2060,7 +2060,7 @@
         <categoryLink id="f27b-7b17-48aa-91b3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_0dfa-4004-4751-8022</comment>
         </categoryLink>
-        <categoryLink id="296e-f599-4b87-9ab8" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="296e-f599-4b87-9ab8" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_a669-0f5d-4fd3-811b</comment>
         </categoryLink>
       </categoryLinks>
@@ -2087,7 +2087,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="5534-2628-41ba-a472" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="5534-2628-41ba-a472" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_4f60-472b-45a9-ab9e</comment>
         </categoryLink>
         <categoryLink id="89c7-8dc9-45b3-9c81" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2140,7 +2140,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="ed72-97fe-4893-88e7" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="ed72-97fe-4893-88e7" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_2008-f1c4-4285-a14f</comment>
         </categoryLink>
         <categoryLink id="f579-f446-4298-84b9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2172,7 +2172,7 @@
         <categoryLink id="6581-1578-4996-984c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_9189-836c-475d-a52e</comment>
         </categoryLink>
-        <categoryLink id="ba8a-99a8-4551-aaa8" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="ba8a-99a8-4551-aaa8" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_e1fa-b7d8-47b0-a88a</comment>
         </categoryLink>
         <categoryLink id="e4e1-fd8a-47d1-a193" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false">
@@ -2186,7 +2186,7 @@
         <categoryLink id="78ea-d942-460f-ae3e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_b1d5-fd75-4f17-bbf4</comment>
         </categoryLink>
-        <categoryLink id="a00a-d987-43e1-93b9" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="a00a-d987-43e1-93b9" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_f221-bf81-4045-849b</comment>
         </categoryLink>
       </categoryLinks>
@@ -2212,7 +2212,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="cab0-268a-4cc3-86c8" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="cab0-268a-4cc3-86c8" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_f203-bc26-421f-b79e</comment>
         </categoryLink>
         <categoryLink id="b66e-bba9-40a9-b44a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2226,7 +2226,7 @@
         <categoryLink id="9f25-e473-4ae5-b0df" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_51af-a137-4a1c-97a4</comment>
         </categoryLink>
-        <categoryLink id="a19c-4128-49ae-beda" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
+        <categoryLink id="a19c-4128-49ae-beda" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
           <comment>template_id_ec1f-c326-40a8-9d1f</comment>
         </categoryLink>
       </categoryLinks>
@@ -2278,7 +2278,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="f2ba-b747-4d1b-a869" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="f2ba-b747-4d1b-a869" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_fce3-801c-49c8-85d4</comment>
         </categoryLink>
         <categoryLink id="07a9-9284-46f4-a69b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2289,7 +2289,7 @@
     <entryLink id="4882-f7c6-bb2a-1149" name="Terminator Tartaros Squad" hidden="false" collective="false" import="false" targetId="1a8e-0ded-a4dc-2b4e" type="selectionEntry">
       <comment>template_id_0848-4e03-417a-b224</comment>
       <categoryLinks>
-        <categoryLink id="2497-341f-437b-9d8b" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
+        <categoryLink id="2497-341f-437b-9d8b" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
           <comment>template_id_ac1c-b3bf-4011-918a</comment>
         </categoryLink>
         <categoryLink id="6d11-eded-4529-b8a5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2319,7 +2319,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="cab8-641e-4542-8146" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="cab8-641e-4542-8146" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_5a04-9847-4c91-a49a</comment>
         </categoryLink>
         <categoryLink id="59df-3334-4981-9b2a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2349,7 +2349,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="4a23-5020-4bca-af53" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="4a23-5020-4bca-af53" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_7d4f-547c-43ed-a520</comment>
         </categoryLink>
         <categoryLink id="987a-8cc7-4528-85cd" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2378,7 +2378,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="0d93-17f2-4ba3-a1f8" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
+        <categoryLink id="0d93-17f2-4ba3-a1f8" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
           <comment>template_id_28e0-91e7-4ada-9fac</comment>
         </categoryLink>
         <categoryLink id="eaf1-7c54-4def-8f33" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2411,7 +2411,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="18a3-bb12-4734-8442" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="18a3-bb12-4734-8442" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_e22a-c5f8-4825-a45f</comment>
         </categoryLink>
         <categoryLink id="cf33-2617-4d81-8699" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2428,7 +2428,7 @@
         <categoryLink id="e1d1-f500-419d-beef" name="Compulsory Elite:" hidden="false" targetId="bb1f-ae32-b587-c3e1" primary="false">
           <comment>template_id_7d5a-62e7-43ee-b79b</comment>
         </categoryLink>
-        <categoryLink id="f84d-74fd-4d11-9a56" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
+        <categoryLink id="f84d-74fd-4d11-9a56" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
           <comment>template_id_4986-9157-49f2-b670</comment>
         </categoryLink>
       </categoryLinks>
@@ -2458,7 +2458,7 @@
         <categoryLink id="2385-0bf3-446b-9124" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_1b86-0977-4a8b-adac</comment>
         </categoryLink>
-        <categoryLink id="1ad8-d351-40e1-b55c" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="1ad8-d351-40e1-b55c" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_b449-403a-4e42-9239</comment>
         </categoryLink>
       </categoryLinks>
@@ -2518,7 +2518,7 @@
         <categoryLink id="4c4f-780f-49bf-8537" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_4f71-446f-4cff-afda</comment>
         </categoryLink>
-        <categoryLink id="71ce-85f9-4bcb-8916" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="71ce-85f9-4bcb-8916" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_3f44-8647-43a4-ac22</comment>
         </categoryLink>
       </categoryLinks>
@@ -2539,7 +2539,7 @@
         <categoryLink id="80ba-9c98-4038-bd18" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_b6b1-886e-4194-8bcd</comment>
         </categoryLink>
-        <categoryLink id="dca9-a2b9-47c6-8647" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="dca9-a2b9-47c6-8647" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_51b5-f9c1-4587-8fc7</comment>
         </categoryLink>
       </categoryLinks>
@@ -2570,7 +2570,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="dc16-16d0-4890-a8e8" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="dc16-16d0-4890-a8e8" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="4b1e-3f1f-49cb-8343" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -2593,7 +2593,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="32cb-7077-4d54-9f38" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="2c35-def7-4c44-9b02" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="2c35-def7-4c44-9b02" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="0c9a-d272-491c-a4a0" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -2615,7 +2615,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="5b41-a9f0-4801-9dff" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="5b41-a9f0-4801-9dff" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="d64e-e976-4668-bb95" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
         <categoryLink id="17a6-f363-4094-9a7c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
@@ -2639,7 +2639,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="fe4f-c8f2-470f-901c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="f3f0-973b-4a45-ac41" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="f3f0-973b-4a45-ac41" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="9791-2c90-4894-97b2" name="Sky-Hunter Squadron" hidden="true" collective="false" import="false" targetId="6263-c696-2f2e-c105" type="selectionEntry">
@@ -2662,7 +2662,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="63ff-0a92-42ab-ae8c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="204c-7b0f-4fb9-b1b3" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="204c-7b0f-4fb9-b1b3" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="85e6-cb31-427c-a040" name="Line Sub-type:" hidden="false" targetId="6399-5c65-7833-1025" primary="false"/>
         <categoryLink id="7e11-9f14-3960-d32c" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
       </categoryLinks>
@@ -2687,7 +2687,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="68dd-fc0f-4fde-8adc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="74ca-dd4f-46be-8be7" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="74ca-dd4f-46be-8be7" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="0c8d-64dc-c6cd-742b" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -2778,7 +2778,7 @@
       <categoryLinks>
         <categoryLink id="0d5b-be56-47af-a22e" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="2e59-1043-4719-96c4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="52fa-8c3c-49d4-a321" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="52fa-8c3c-49d4-a321" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="c900-4b3a-4f5a-84e9" name="Termite Assault Drill" hidden="true" collective="false" import="false" targetId="cb30-307a-f0d7-3b13" type="selectionEntry">
@@ -2802,7 +2802,7 @@
       <categoryLinks>
         <categoryLink id="1fef-4409-4fab-93fc" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="ca2d-245e-48b4-a1cf" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="6692-6e39-44f0-ad8e" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="6692-6e39-44f0-ad8e" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="ac1b-9510-4209-8ea6" name="Venerable Ancient Contemptor Dreadnought" hidden="true" collective="false" import="false" targetId="dad1-0807-e254-d498" type="selectionEntry">
@@ -2819,7 +2819,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="9261-acb5-4230-8d89" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="1a5d-cbc8-418f-91a3" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="1a5d-cbc8-418f-91a3" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="c0cb-406f-4b46-9d8d" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
       </categoryLinks>
       <entryLinks>
@@ -2842,7 +2842,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="c0b2-dd90-46c1-a2a9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="9a94-76fb-4a89-ad5d" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="9a94-76fb-4a89-ad5d" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="db67-3e5a-0ee9-ed74" name="Gorgon Terminator Squad" hidden="true" collective="false" import="false" targetId="ea50-6315-7a52-f560" type="selectionEntry">
@@ -2869,7 +2869,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="48d8-72a1-c662-e1c1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="a1f2-c1dc-308c-5b11" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="a1f2-c1dc-308c-5b11" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="0bcd-8cc6-acd5-ded9" name="Thanatar Siege-automata Maniple" hidden="true" collective="false" import="false" targetId="2903-fef6-e839-368b" type="selectionEntry">
@@ -2886,7 +2886,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="dc3a-51ab-4186-80db" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="7dc7-c3f0-8ed9-f013" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="7dc7-c3f0-8ed9-f013" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="e548-fe26-790b-63c1" name="Domitar Battle-Automata Maniple" hidden="true" collective="false" import="false" targetId="1a1b-fa35-a6a2-ca78" type="selectionEntry">
@@ -2899,7 +2899,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="bcf4-63dd-94c7-a7fe" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="1117-670d-b683-08a4" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="1117-670d-b683-08a4" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="b7fb-f377-515e-bd19" name="Castellax Battle-Automata Maniple" hidden="true" collective="false" import="false" targetId="537f-846d-90e3-2526" type="selectionEntry">
@@ -2912,7 +2912,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="5ead-1dae-3374-cc0a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="c10a-45e6-6111-3911" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="c10a-45e6-6111-3911" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="1fd4-ed34-9e7c-23fc" name="Thallax Cohort" hidden="true" collective="false" import="false" targetId="25c8-3e0f-e22d-a7eb" type="selectionEntry">
@@ -2937,7 +2937,7 @@
         <constraint field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="572b-a220-0cce-7793" type="max"/>
       </constraints>
       <categoryLinks>
-        <categoryLink id="abaf-c5f8-0fac-6441" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="abaf-c5f8-0fac-6441" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="bc42-ae8a-eac1-d143" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -2952,7 +2952,7 @@
       <categoryLinks>
         <categoryLink id="d344-03de-8f50-c08d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="ab40-f905-6161-4440" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
-        <categoryLink id="b76f-f82b-7dc1-8a34" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="b76f-f82b-7dc1-8a34" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="b57b-698b-f6ad-836d" name="Line Sub-type:" hidden="false" targetId="6399-5c65-7833-1025" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -2966,7 +2966,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="061f-18e1-b87b-96e4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="0561-e8fb-fd49-3876" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="0561-e8fb-fd49-3876" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="f274-e9b2-ca0d-11ea" name="Morlock Terminator Squad" hidden="true" collective="false" import="false" targetId="af91-5d08-88ee-80d1" type="selectionEntry">
@@ -3015,7 +3015,7 @@
         <infoLink id="db91-3a2e-46b5-3998" name="Stubborn" hidden="false" targetId="7989-1f2c-a43d-82ae" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="9593-8dda-915e-8ef4" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+        <categoryLink id="9593-8dda-915e-8ef4" name="Heavy Sub-type:" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
         <categoryLink id="0de3-d934-b836-a40c" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="5df3-9231-c29a-5bf6" name="Terminators:" hidden="false" targetId="bab3-f50d-3e5f-2f78" primary="false"/>
         <categoryLink id="9bfa-f05f-d04f-e983" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
@@ -3424,7 +3424,7 @@
       </infoLinks>
       <categoryLinks>
         <categoryLink id="922a-9c91-509f-36fd" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="b0a0-c02f-f97d-8b78" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+        <categoryLink id="b0a0-c02f-f97d-8b78" name="Heavy Sub-type:" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
         <categoryLink id="221e-a4f5-b097-1747" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
       </categoryLinks>
       <selectionEntries>
@@ -3458,7 +3458,7 @@
             </profile>
           </profiles>
           <categoryLinks>
-            <categoryLink id="ce14-5b51-ca57-a479" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+            <categoryLink id="ce14-5b51-ca57-a479" name="Heavy Sub-type:" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
             <categoryLink id="3981-f592-d5f7-9f94" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
             <categoryLink id="ecc9-de7f-c8ba-d75a" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
           </categoryLinks>
@@ -3766,7 +3766,7 @@
                 </profile>
               </profiles>
               <categoryLinks>
-                <categoryLink id="49a1-da73-5b34-36d5" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+                <categoryLink id="49a1-da73-5b34-36d5" name="Heavy Sub-type:" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
                 <categoryLink id="8046-11c0-741f-8507" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
               </categoryLinks>
               <selectionEntryGroups>
@@ -3916,7 +3916,7 @@
       </constraints>
       <categoryLinks>
         <categoryLink id="9014-262a-9067-0e59" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="d7ac-8652-d9dd-8de6" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+        <categoryLink id="d7ac-8652-d9dd-8de6" name="Heavy Sub-type:" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
         <categoryLink id="4ea5-44d6-046c-15da" name="LoW &amp; Primarchs (25% Limit)" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false"/>
       </categoryLinks>
       <selectionEntries>
@@ -4882,7 +4882,7 @@ A Warlord with this Trait, and all models in any unit he joins, gain the Fear (1
             </modifier>
           </modifiers>
         </entryLink>
-        <entryLink id="9f8a-3c65-6a66-e294" name="Tartaros Command Squad (Placeholder Points)" hidden="false" collective="false" import="true" targetId="58d0-a0fd-d20b-cb1b" type="selectionEntry"/>
+        <entryLink id="9f8a-3c65-6a66-e294" name="Command Squad, Tartaros" hidden="false" collective="false" import="true" targetId="58d0-a0fd-d20b-cb1b" type="selectionEntry"/>
         <entryLink id="92a3-5f51-0863-b6f8" name="Command Squad" hidden="false" collective="false" import="true" targetId="0aca-632d-1642-8af9" type="selectionEntry"/>
         <entryLink id="ace0-174d-aa38-0054" name="Morlock Terminator Squad" hidden="false" collective="false" import="true" targetId="af91-5d08-88ee-80d1" type="selectionEntry">
           <modifiers>
@@ -4909,6 +4909,6 @@ A Warlord with this Trait, and all models in any unit he joins, gain the Fear (1
     </selectionEntryGroup>
   </sharedSelectionEntryGroups>
   <catalogueLinks>
-    <catalogueLink id="2f60-18fb-e6ed-8574" name="(HH V2) Legions Astartes" targetId="6393-649c-7213-a327" type="catalogue" importRootEntries="true"/>
+    <catalogueLink id="2f60-18fb-e6ed-8574" name="Legions Astartes" targetId="6393-649c-7213-a327" type="catalogue" importRootEntries="true"/>
   </catalogueLinks>
 </catalogue>

--- a/2022 - LA - Iron Warriors.cat
+++ b/2022 - LA - Iron Warriors.cat
@@ -17,7 +17,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="daf2-90f2-060e-054f" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="daf2-90f2-060e-054f" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="a63e-60c5-2db0-676a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="684c-a721-6593-9e2a" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
       </categoryLinks>
@@ -31,7 +31,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="4fe3-7aed-a86d-e3a9" name="New CategoryLink" hidden="false" targetId="ad5f-31db-8bc7-5c46" primary="true"/>
+        <categoryLink id="4fe3-7aed-a86d-e3a9" name="Primarch:" hidden="false" targetId="ad5f-31db-8bc7-5c46" primary="true"/>
         <categoryLink id="23ea-8f2f-28bd-c663" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
       <entryLinks>
@@ -58,7 +58,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="1e67-0fa0-e2ff-ea41" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="1e67-0fa0-e2ff-ea41" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
         <categoryLink id="e64e-f755-b7d9-b016" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -72,7 +72,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="9203-b759-34d2-9552" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="eb77-1b03-c09f-6681" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="eb77-1b03-c09f-6681" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="6d85-0a41-fc02-2844" name="Tyrant Siege Terminator Squad" hidden="false" collective="false" import="false" targetId="795a-5698-a1bc-6ec6" type="selectionEntry">
@@ -85,7 +85,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="002f-dc9a-b983-d44c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="7da6-dade-1275-d75a" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="7da6-dade-1275-d75a" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="ef25-725f-b90b-46fa" name="The Tormentor" hidden="true" collective="false" import="false" targetId="ec77-b9e7-904a-f49b" type="selectionEntry">
@@ -104,7 +104,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="23c5-64f4-07e9-0ac0" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="23c5-64f4-07e9-0ac0" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
         <categoryLink id="c205-4746-3526-3bb2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -124,7 +124,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="3cb3-e3bb-c0cf-9678" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="3cb3-e3bb-c0cf-9678" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="df59-0d00-2be6-f275" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="fbaf-2b4b-5a38-6925" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
       </categoryLinks>
@@ -138,7 +138,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="a813-57fa-9782-da6f" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="a813-57fa-9782-da6f" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="621a-4766-c501-14df" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="f5c8-d1da-2871-3ba5" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
       </categoryLinks>
@@ -152,7 +152,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="019f-1e63-3d79-80c1" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="019f-1e63-3d79-80c1" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="9a0e-d1d8-e80c-7561" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -169,7 +169,7 @@
         <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c1a8-3243-43ed-49a9" type="max"/>
       </constraints>
       <categoryLinks>
-        <categoryLink id="4a17-436d-d77f-9962" name="New CategoryLink" hidden="false" targetId="e90d-e5a8-f42d-da84" primary="true"/>
+        <categoryLink id="4a17-436d-d77f-9962" name="Allegiance:" hidden="false" targetId="e90d-e5a8-f42d-da84" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="66d0-dab6-1aa9-95e1" name="Apothecarion Detachment" hidden="false" collective="false" import="false" targetId="81df-ffd4-a32b-b4a1" type="selectionEntry">
@@ -178,7 +178,7 @@
         <categoryLink id="3480-0120-402f-9064" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_c6d4-581f-4746-bec3</comment>
         </categoryLink>
-        <categoryLink id="f044-1ca9-4bac-955d" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
+        <categoryLink id="f044-1ca9-4bac-955d" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
           <comment>template_id_2489-ee2a-45dd-b384</comment>
         </categoryLink>
       </categoryLinks>
@@ -208,7 +208,7 @@
         <categoryLink id="e27d-220f-4a03-b6c3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_8378-ede4-476d-b657</comment>
         </categoryLink>
-        <categoryLink id="1d60-3fa4-4195-ab02" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="1d60-3fa4-4195-ab02" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_d64f-ad19-426c-adf7</comment>
         </categoryLink>
       </categoryLinks>
@@ -234,7 +234,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="c590-d302-4ddc-a356" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="c590-d302-4ddc-a356" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_ac26-e639-4d53-9b8b</comment>
         </categoryLink>
         <categoryLink id="69bf-4ea2-40b0-96ff" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -245,7 +245,7 @@
         </categoryLink>
       </categoryLinks>
     </entryLink>
-    <entryLink id="0f30-a6a9-c5b0-8ff0" name="Avenger Strike Fighter" hidden="true" collective="false" import="false" targetId="b25c-e85c-1c29-9e05" type="selectionEntry">
+    <entryLink id="0f30-a6a9-c5b0-8ff0" name="Legion Avenger Strike Fighter" hidden="true" collective="false" import="false" targetId="b25c-e85c-1c29-9e05" type="selectionEntry">
       <comment>template_id_1064-175d-4616-9c71</comment>
       <modifiers>
         <modifier type="set" field="hidden" value="false">
@@ -267,7 +267,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="095a-8309-442d-8b8c" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="095a-8309-442d-8b8c" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_a009-a597-4b51-b228</comment>
         </categoryLink>
         <categoryLink id="926d-32ad-4163-9ea0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -300,7 +300,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="60e0-2033-46ad-a797" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="60e0-2033-46ad-a797" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_c165-3906-463a-9c73</comment>
         </categoryLink>
         <categoryLink id="4266-0626-4e8b-95ba" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -337,7 +337,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="3e62-cb74-4bd2-8b75" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="3e62-cb74-4bd2-8b75" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_3a22-caae-4eea-9bc5</comment>
         </categoryLink>
         <categoryLink id="cfc1-e3b1-4a06-80d1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -370,7 +370,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="9981-361e-47a2-bc0a" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="9981-361e-47a2-bc0a" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_251a-df5b-4bfd-ad63</comment>
         </categoryLink>
         <categoryLink id="90e4-0887-4f22-afe2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -407,7 +407,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="0ab3-6996-4738-8d35" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
+        <categoryLink id="0ab3-6996-4738-8d35" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
           <comment>template_id_67c2-df43-44fc-92d1</comment>
         </categoryLink>
         <categoryLink id="fc8b-e387-4c9a-8c08" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -463,7 +463,7 @@
         <categoryLink id="eae0-c0a1-425f-9b02" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_bd6a-0cda-4e0f-80ae</comment>
         </categoryLink>
-        <categoryLink id="79c3-75c3-4738-8098" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
+        <categoryLink id="79c3-75c3-4738-8098" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
           <comment>template_id_ae75-7cca-4701-9d56</comment>
         </categoryLink>
         <categoryLink id="7edf-55b9-42de-9706" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false">
@@ -498,7 +498,7 @@
         <categoryLink id="b5bb-04dd-4aec-be5c" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false">
           <comment>template_id_f51c-73d7-4f29-be1c</comment>
         </categoryLink>
-        <categoryLink id="713b-44e8-4d73-90eb" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
+        <categoryLink id="713b-44e8-4d73-90eb" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
           <comment>template_id_257d-78c0-4bab-ba65</comment>
         </categoryLink>
       </categoryLinks>
@@ -546,7 +546,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="3467-53f0-4e43-9090" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="3467-53f0-4e43-9090" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_f1c8-27fd-4f98-8527</comment>
         </categoryLink>
         <categoryLink id="7c50-c4ef-4e75-b303" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -575,7 +575,7 @@
         <categoryLink id="e2be-bc6c-444c-bf15" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_dd44-e0a8-42a8-bdcc</comment>
         </categoryLink>
-        <categoryLink id="a0f8-b3c6-4e4d-935a" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
+        <categoryLink id="a0f8-b3c6-4e4d-935a" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
           <comment>template_id_c5b0-f9ae-468d-924a</comment>
         </categoryLink>
       </categoryLinks>
@@ -602,7 +602,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="9e4f-5266-41cf-895a" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
+        <categoryLink id="9e4f-5266-41cf-895a" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
           <comment>template_id_f926-27fd-4a92-97a1</comment>
         </categoryLink>
         <categoryLink id="572f-2424-4ccf-9aa7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -634,7 +634,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="fdca-882c-907a-656f" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="fdca-882c-907a-656f" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
         <categoryLink id="6e97-1320-d8bc-d928" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -693,7 +693,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="db93-1605-4605-94c3" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="db93-1605-4605-94c3" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_361e-fb90-4b0e-ac3d</comment>
         </categoryLink>
         <categoryLink id="a077-017c-4442-bb3c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -710,7 +710,7 @@
         <categoryLink id="cda1-d0d1-482b-b163" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_473b-e812-4158-9416</comment>
         </categoryLink>
-        <categoryLink id="07c1-4272-4338-ab97" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
+        <categoryLink id="07c1-4272-4338-ab97" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
           <comment>template_id_00a2-63ff-4698-a35b</comment>
         </categoryLink>
       </categoryLinks>
@@ -734,7 +734,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="fa03-9332-441f-9e4a" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="fa03-9332-441f-9e4a" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_2a08-4432-42ad-bfdb</comment>
         </categoryLink>
         <categoryLink id="b1a7-093e-402b-9275" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -767,7 +767,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="0571-ed70-4eb3-aaf3" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="0571-ed70-4eb3-aaf3" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_f4c0-4396-4f39-a34f</comment>
         </categoryLink>
         <categoryLink id="b42b-3442-4b95-9349" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -800,7 +800,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="4604-bd74-40fe-8fc4" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="4604-bd74-40fe-8fc4" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_caf6-5548-4b89-8102</comment>
         </categoryLink>
         <categoryLink id="ea56-d83a-4964-9e2b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -860,7 +860,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="3df7-f550-4eb3-800b" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="3df7-f550-4eb3-800b" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_d53e-113f-4a40-a3d5</comment>
         </categoryLink>
         <categoryLink id="b4d4-0a58-4785-806d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -881,7 +881,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="4ac2-2897-4488-9042" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="4ac2-2897-4488-9042" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_e6f7-a6ca-4825-bfc5</comment>
         </categoryLink>
         <categoryLink id="de7a-dc1e-4bfc-9baf" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -916,7 +916,7 @@
         <categoryLink id="6062-9708-4eec-8d5f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_cefb-cfd7-4dc8-99c4</comment>
         </categoryLink>
-        <categoryLink id="7bee-6aaf-45fc-b477" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="7bee-6aaf-45fc-b477" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_a9fd-9d16-4a5e-855c</comment>
         </categoryLink>
       </categoryLinks>
@@ -940,7 +940,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="b830-00ab-4d14-8e44" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="b830-00ab-4d14-8e44" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_a56d-347b-4b09-a918</comment>
         </categoryLink>
         <categoryLink id="9e07-0767-407b-ae7d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -973,7 +973,7 @@
         <categoryLink id="15fb-12b2-492f-bd8f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_9441-d79b-4720-9667</comment>
         </categoryLink>
-        <categoryLink id="9a61-6617-42a1-88b8" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="9a61-6617-42a1-88b8" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_7d7e-32d3-4692-b401</comment>
         </categoryLink>
       </categoryLinks>
@@ -1003,7 +1003,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="5014-85c3-4fa7-916b" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="5014-85c3-4fa7-916b" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_f65b-8958-49b3-92a5</comment>
         </categoryLink>
         <categoryLink id="c486-7244-4be5-9aa2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1036,7 +1036,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="10b1-0b6d-4941-bbca" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="10b1-0b6d-4941-bbca" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_c6a8-22a8-4d41-b969</comment>
         </categoryLink>
         <categoryLink id="3bb1-ddca-4b32-8f85" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1099,7 +1099,7 @@
         <categoryLink id="f770-c09a-405e-b5dc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_bc67-ce1f-4004-aeb7</comment>
         </categoryLink>
-        <categoryLink id="4961-05b3-48f1-bc97" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="4961-05b3-48f1-bc97" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_9a45-9699-4475-aeef</comment>
         </categoryLink>
       </categoryLinks>
@@ -1162,7 +1162,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="93c1-d700-4d63-87cb" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="93c1-d700-4d63-87cb" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_3610-c975-4d55-bdfe</comment>
         </categoryLink>
         <categoryLink id="cd76-3b14-4d48-8ffd" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1198,7 +1198,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="5efa-76e0-4d3c-aa3a" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="5efa-76e0-4d3c-aa3a" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_f81d-9435-4f11-99c1</comment>
         </categoryLink>
         <categoryLink id="aaf7-f995-4dc5-a20e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1234,7 +1234,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="e02c-2902-46ba-9918" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="e02c-2902-46ba-9918" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_b24f-3ae0-4cbb-b016</comment>
         </categoryLink>
         <categoryLink id="fb4d-63b5-4869-977c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1267,7 +1267,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="44c7-94e9-40ff-bad6" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="44c7-94e9-40ff-bad6" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_c77f-0819-473b-a8a2</comment>
         </categoryLink>
         <categoryLink id="501d-ed09-4cca-b4dd" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1300,7 +1300,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="e778-1bd4-4ddf-ac4f" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="e778-1bd4-4ddf-ac4f" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_0397-c837-4fea-a527</comment>
         </categoryLink>
         <categoryLink id="b5a9-305e-4af8-baa1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1336,7 +1336,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="84ef-e73b-4cf3-9fc2" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="84ef-e73b-4cf3-9fc2" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_c1cf-cea4-4278-8f27</comment>
         </categoryLink>
         <categoryLink id="b553-6ad0-4f54-bb30" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1372,7 +1372,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="5921-a8a9-4cdd-ac5f" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="5921-a8a9-4cdd-ac5f" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_0c16-6841-42b2-b02d</comment>
         </categoryLink>
         <categoryLink id="99d0-fc77-464c-9b2e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1408,7 +1408,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="a709-44cd-4e7e-b92a" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="a709-44cd-4e7e-b92a" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_3632-0b5d-4622-ae33</comment>
         </categoryLink>
         <categoryLink id="4ffc-9835-4f7e-9298" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1444,7 +1444,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="e1b8-dcaf-425c-8ca6" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="e1b8-dcaf-425c-8ca6" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_5ad5-8701-42cd-b2b6</comment>
         </categoryLink>
         <categoryLink id="51cc-c71a-4db5-8db5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1511,7 +1511,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="2dcd-ad62-4b7f-93e4" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="2dcd-ad62-4b7f-93e4" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_4d7c-201f-4c99-b89a</comment>
         </categoryLink>
         <categoryLink id="8ad9-deca-4ef2-9e81" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1544,7 +1544,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="002d-47e7-49c0-b051" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="002d-47e7-49c0-b051" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_4e52-ad1b-48d4-8eed</comment>
         </categoryLink>
         <categoryLink id="5011-e3b9-42ee-a1a7" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false">
@@ -1558,7 +1558,7 @@
         <categoryLink id="e4c6-90d6-4495-ae83" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_6140-2404-46f9-bd42</comment>
         </categoryLink>
-        <categoryLink id="b949-5c73-48c2-bb96" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
+        <categoryLink id="b949-5c73-48c2-bb96" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
           <comment>template_id_1c86-fad8-46ec-a0b0</comment>
         </categoryLink>
       </categoryLinks>
@@ -1584,7 +1584,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="eb43-c6b7-4479-9fc3" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
+        <categoryLink id="eb43-c6b7-4479-9fc3" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
           <comment>template_id_0af1-d052-4bd7-aab6</comment>
         </categoryLink>
         <categoryLink id="ee23-807c-494d-9cff" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1618,7 +1618,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="efd8-6a9a-4f0c-936a" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
+        <categoryLink id="efd8-6a9a-4f0c-936a" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
           <comment>template_id_dc16-16d0-4890-a8e8</comment>
         </categoryLink>
         <categoryLink id="789d-debc-4333-bd74" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1643,7 +1643,7 @@
         <categoryLink id="2d71-dc2a-458f-a666" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_ff9f-01cb-41b9-800e</comment>
         </categoryLink>
-        <categoryLink id="3a0e-18e0-4bec-b172" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="3a0e-18e0-4bec-b172" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_1315-6051-4a46-b070</comment>
         </categoryLink>
       </categoryLinks>
@@ -1651,7 +1651,7 @@
     <entryLink id="4c07-c42c-76d5-bdb0" name="Praetor" hidden="false" collective="false" import="false" targetId="03be-5d55-d05a-771d" type="selectionEntry">
       <comment>template_id_5798-3fc7-4d4c-ad41</comment>
       <categoryLinks>
-        <categoryLink id="e4f1-f59e-4617-9c5e" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
+        <categoryLink id="e4f1-f59e-4617-9c5e" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
           <comment>template_id_b084-df23-4f99-812f</comment>
         </categoryLink>
         <categoryLink id="c650-574f-4363-8723" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false">
@@ -1776,7 +1776,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="a115-098d-48d0-9547" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="a115-098d-48d0-9547" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_b822-3417-4613-be37</comment>
         </categoryLink>
         <categoryLink id="65f7-fece-4a9e-8f2b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1803,7 +1803,7 @@
         <categoryLink id="67c0-4a2a-4ae7-b919" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_75a7-dc06-445b-b2dc</comment>
         </categoryLink>
-        <categoryLink id="9fb8-7ee6-4fe7-b8bc" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="9fb8-7ee6-4fe7-b8bc" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_e21a-c03b-4885-ac46</comment>
         </categoryLink>
       </categoryLinks>
@@ -1821,7 +1821,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="6052-2220-443e-b908" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
+        <categoryLink id="6052-2220-443e-b908" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
           <comment>template_id_f55b-7555-444b-beee</comment>
         </categoryLink>
         <categoryLink id="fc43-ee5f-47c5-8171" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1842,7 +1842,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="deee-9b5c-48e8-b35a" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="deee-9b5c-48e8-b35a" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_79fa-3370-4ae0-9e12</comment>
         </categoryLink>
         <categoryLink id="a39c-61e6-4112-85b1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1868,7 +1868,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="7ab4-4796-41a0-afa6" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="7ab4-4796-41a0-afa6" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_8d82-3279-4481-84bb</comment>
         </categoryLink>
         <categoryLink id="ab27-f555-4e2e-af2b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1901,7 +1901,7 @@
         <categoryLink id="0509-9c44-4352-867e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_7010-be56-4709-b058</comment>
         </categoryLink>
-        <categoryLink id="0c08-cb52-48d6-927a" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="0c08-cb52-48d6-927a" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_7379-a740-47ba-a054</comment>
         </categoryLink>
       </categoryLinks>
@@ -1919,7 +1919,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="d4aa-4d4e-45d4-a6ad" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="d4aa-4d4e-45d4-a6ad" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_944f-7420-4982-8ea9</comment>
         </categoryLink>
         <categoryLink id="12dc-27ef-472b-a6b5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1963,7 +1963,7 @@
         <categoryLink id="8ec4-6f33-4e7b-bafe" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_c6ff-0977-4c92-bb28</comment>
         </categoryLink>
-        <categoryLink id="a059-b004-45a1-b9b6" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="a059-b004-45a1-b9b6" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_f555-7d39-458f-84c9</comment>
         </categoryLink>
       </categoryLinks>
@@ -1993,7 +1993,7 @@
         <categoryLink id="5a20-79d9-45ac-b724" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_39e5-eda5-45d1-a643</comment>
         </categoryLink>
-        <categoryLink id="7051-3fbf-4dae-ab11" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="7051-3fbf-4dae-ab11" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_6416-21bb-4df4-9de8</comment>
         </categoryLink>
       </categoryLinks>
@@ -2023,7 +2023,7 @@
         <categoryLink id="1465-07c9-4bb3-a0dc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_5528-2dac-4be5-900c</comment>
         </categoryLink>
-        <categoryLink id="8567-bb82-4ce5-af08" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="8567-bb82-4ce5-af08" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_dc8f-d888-4585-991d</comment>
         </categoryLink>
       </categoryLinks>
@@ -2053,7 +2053,7 @@
         <categoryLink id="8278-2b32-4cd3-b76d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_899e-b052-4d5b-8c18</comment>
         </categoryLink>
-        <categoryLink id="3c6c-f53a-4b59-b030" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="3c6c-f53a-4b59-b030" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_f5e9-cff6-41d2-a016</comment>
         </categoryLink>
       </categoryLinks>
@@ -2083,7 +2083,7 @@
         <categoryLink id="2fbf-e65a-4230-b5b0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_09cd-2176-40af-bba6</comment>
         </categoryLink>
-        <categoryLink id="c9ab-452c-4793-a7c6" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="c9ab-452c-4793-a7c6" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_05e6-7c63-4a35-9ba0</comment>
         </categoryLink>
       </categoryLinks>
@@ -2107,7 +2107,7 @@
         <categoryLink id="cb99-5a42-4ec5-bdec" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_0dfa-4004-4751-8022</comment>
         </categoryLink>
-        <categoryLink id="247b-436e-4331-a7e1" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="247b-436e-4331-a7e1" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_a669-0f5d-4fd3-811b</comment>
         </categoryLink>
       </categoryLinks>
@@ -2134,7 +2134,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="ac57-cabc-4112-bc71" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="ac57-cabc-4112-bc71" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_4f60-472b-45a9-ab9e</comment>
         </categoryLink>
         <categoryLink id="22e4-b1ad-46bd-a271" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2187,7 +2187,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="9116-ad5f-42b5-8124" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="9116-ad5f-42b5-8124" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_2008-f1c4-4285-a14f</comment>
         </categoryLink>
         <categoryLink id="ccb8-0fa6-4dab-b5d5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2219,7 +2219,7 @@
         <categoryLink id="e3a9-9416-46e1-8cee" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_9189-836c-475d-a52e</comment>
         </categoryLink>
-        <categoryLink id="7174-7327-41b8-97bd" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="7174-7327-41b8-97bd" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_e1fa-b7d8-47b0-a88a</comment>
         </categoryLink>
         <categoryLink id="9903-bddc-4348-8073" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false">
@@ -2233,7 +2233,7 @@
         <categoryLink id="2506-cdf8-4b49-9f51" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_b1d5-fd75-4f17-bbf4</comment>
         </categoryLink>
-        <categoryLink id="780d-be84-4521-b066" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="780d-be84-4521-b066" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_f221-bf81-4045-849b</comment>
         </categoryLink>
       </categoryLinks>
@@ -2259,7 +2259,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="2b3e-1f42-44f3-94ef" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="2b3e-1f42-44f3-94ef" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_f203-bc26-421f-b79e</comment>
         </categoryLink>
         <categoryLink id="6531-5f68-44fa-ad7d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2273,7 +2273,7 @@
         <categoryLink id="cedb-bfd6-4c53-a3af" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_51af-a137-4a1c-97a4</comment>
         </categoryLink>
-        <categoryLink id="4373-3192-4a77-b7a1" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
+        <categoryLink id="4373-3192-4a77-b7a1" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
           <comment>template_id_ec1f-c326-40a8-9d1f</comment>
         </categoryLink>
       </categoryLinks>
@@ -2325,7 +2325,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="3d93-e293-4654-9baa" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="3d93-e293-4654-9baa" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_fce3-801c-49c8-85d4</comment>
         </categoryLink>
         <categoryLink id="73cd-eb56-45bc-ac55" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2336,7 +2336,7 @@
     <entryLink id="3e5f-dbb7-33ac-dca8" name="Terminator Tartaros Squad" hidden="false" collective="false" import="false" targetId="1a8e-0ded-a4dc-2b4e" type="selectionEntry">
       <comment>template_id_0848-4e03-417a-b224</comment>
       <categoryLinks>
-        <categoryLink id="4620-23a4-48a7-9966" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
+        <categoryLink id="4620-23a4-48a7-9966" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
           <comment>template_id_ac1c-b3bf-4011-918a</comment>
         </categoryLink>
         <categoryLink id="9c6e-80a7-4997-b0ab" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2366,7 +2366,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="dacd-5aab-4251-8b95" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="dacd-5aab-4251-8b95" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_5a04-9847-4c91-a49a</comment>
         </categoryLink>
         <categoryLink id="278b-c775-4921-aa54" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2396,7 +2396,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="0eb5-e3fe-4a63-9131" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="0eb5-e3fe-4a63-9131" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_7d4f-547c-43ed-a520</comment>
         </categoryLink>
         <categoryLink id="69dd-d097-4bf2-a77d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2425,7 +2425,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="f3a6-be2c-4df2-b32b" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
+        <categoryLink id="f3a6-be2c-4df2-b32b" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
           <comment>template_id_28e0-91e7-4ada-9fac</comment>
         </categoryLink>
         <categoryLink id="6d69-67b3-4cb0-9074" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2458,7 +2458,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="118b-3199-492f-9fe8" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="118b-3199-492f-9fe8" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_e22a-c5f8-4825-a45f</comment>
         </categoryLink>
         <categoryLink id="5a6f-0328-4253-aee4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2475,7 +2475,7 @@
         <categoryLink id="08bf-7ff5-4aa9-b1c0" name="Compulsory Elite:" hidden="false" targetId="bb1f-ae32-b587-c3e1" primary="false">
           <comment>template_id_7d5a-62e7-43ee-b79b</comment>
         </categoryLink>
-        <categoryLink id="589b-0222-4b85-9039" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
+        <categoryLink id="589b-0222-4b85-9039" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
           <comment>template_id_4986-9157-49f2-b670</comment>
         </categoryLink>
       </categoryLinks>
@@ -2505,7 +2505,7 @@
         <categoryLink id="d54a-47f1-4dd2-917e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_1b86-0977-4a8b-adac</comment>
         </categoryLink>
-        <categoryLink id="5a91-7e82-4a50-95ce" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="5a91-7e82-4a50-95ce" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_b449-403a-4e42-9239</comment>
         </categoryLink>
       </categoryLinks>
@@ -2565,7 +2565,7 @@
         <categoryLink id="680a-b41e-448e-b91d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_4f71-446f-4cff-afda</comment>
         </categoryLink>
-        <categoryLink id="abca-f93d-4d99-8376" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="abca-f93d-4d99-8376" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_3f44-8647-43a4-ac22</comment>
         </categoryLink>
       </categoryLinks>
@@ -2586,7 +2586,7 @@
         <categoryLink id="4f29-096b-4233-bf17" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_b6b1-886e-4194-8bcd</comment>
         </categoryLink>
-        <categoryLink id="21a8-298c-40fa-ab30" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="21a8-298c-40fa-ab30" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_51b5-f9c1-4587-8fc7</comment>
         </categoryLink>
       </categoryLinks>
@@ -2632,7 +2632,7 @@
         <categoryLink id="2cd2-b1d1-4b79-9868" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_4272-9b9d-4c59-95f0</comment>
         </categoryLink>
-        <categoryLink id="248a-a756-409e-b072" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="248a-a756-409e-b072" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_d85b-1ae7-40d5-9341</comment>
         </categoryLink>
       </categoryLinks>
@@ -2656,7 +2656,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="32cb-7077-4d54-9f38" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="2c35-def7-4c44-9b02" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="2c35-def7-4c44-9b02" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="0c9a-d272-491c-a4a0" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -2678,7 +2678,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="5b41-a9f0-4801-9dff" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="5b41-a9f0-4801-9dff" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="d64e-e976-4668-bb95" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
         <categoryLink id="17a6-f363-4094-9a7c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
@@ -2702,7 +2702,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="fe4f-c8f2-470f-901c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="f3f0-973b-4a45-ac41" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="f3f0-973b-4a45-ac41" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="ec30-7009-4a87-85fe" name="Sky-Hunter Squadron" hidden="true" collective="false" import="false" targetId="6263-c696-2f2e-c105" type="selectionEntry">
@@ -2725,7 +2725,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="63ff-0a92-42ab-ae8c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="204c-7b0f-4fb9-b1b3" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="204c-7b0f-4fb9-b1b3" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="85e6-cb31-427c-a040" name="Line Sub-type:" hidden="false" targetId="6399-5c65-7833-1025" primary="false"/>
         <categoryLink id="0a88-bbe3-e9f2-050a" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
       </categoryLinks>
@@ -2750,7 +2750,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="68dd-fc0f-4fde-8adc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="74ca-dd4f-46be-8be7" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="74ca-dd4f-46be-8be7" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="5ea3-4940-8768-ef05" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -2841,7 +2841,7 @@
       <categoryLinks>
         <categoryLink id="0d5b-be56-47af-a22e" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="2e59-1043-4719-96c4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="52fa-8c3c-49d4-a321" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="52fa-8c3c-49d4-a321" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="e283-89de-4e42-9c85" name="Termite Assault Drill" hidden="true" collective="false" import="false" targetId="cb30-307a-f0d7-3b13" type="selectionEntry">
@@ -2865,7 +2865,7 @@
       <categoryLinks>
         <categoryLink id="1fef-4409-4fab-93fc" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="ca2d-245e-48b4-a1cf" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="6692-6e39-44f0-ad8e" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="6692-6e39-44f0-ad8e" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="4b38-23fb-45b2-aaf8" name="Venerable Ancient Contemptor Dreadnought" hidden="true" collective="false" import="false" targetId="dad1-0807-e254-d498" type="selectionEntry">
@@ -2882,7 +2882,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="9261-acb5-4230-8d89" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="1a5d-cbc8-418f-91a3" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="1a5d-cbc8-418f-91a3" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="c0cb-406f-4b46-9d8d" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
       </categoryLinks>
       <entryLinks>
@@ -2905,7 +2905,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="c0b2-dd90-46c1-a2a9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="9a94-76fb-4a89-ad5d" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="9a94-76fb-4a89-ad5d" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="7a80-d674-1ed3-0a9b" name="Castellax Battle-Automata Maniple" hidden="true" collective="false" import="false" targetId="537f-846d-90e3-2526" type="selectionEntry">
@@ -2918,7 +2918,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="1017-62c2-789a-dda4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="e1a2-4c51-21d8-00f9" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="e1a2-4c51-21d8-00f9" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="d659-1db6-2bb2-c071" name="Domitar Battle-Automata Maniple" hidden="true" collective="false" import="false" targetId="1a1b-fa35-a6a2-ca78" type="selectionEntry">
@@ -2931,7 +2931,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="9f0c-c5a4-6d0c-643c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="a839-23d1-8ace-cc40" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="a839-23d1-8ace-cc40" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="4fbc-5385-d633-d1cc" name="Thanatar Siege-automata Maniple" hidden="true" collective="false" import="false" targetId="2903-fef6-e839-368b" type="selectionEntry">
@@ -2948,7 +2948,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="c7d1-12c2-319f-3dee" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="2ce7-e2c8-2ff5-c0df" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="2ce7-e2c8-2ff5-c0df" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="a076-cc11-421a-6173" name="Vorax Battle-automata Maniple" hidden="true" collective="false" import="false" targetId="f144-1079-11ff-019d" type="selectionEntry">
@@ -2961,7 +2961,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="5406-a7b2-2f43-16d2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="63d4-6fff-0854-732a" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="63d4-6fff-0854-732a" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="fad2-a9d9-c782-54bc" name="Dominator Cohort" hidden="true" collective="false" import="false" targetId="1bfa-2413-beb9-5f32" type="selectionEntry">
@@ -2981,7 +2981,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="8b06-7981-d422-3982" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="2f27-c83b-f935-c686" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="2f27-c83b-f935-c686" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="14b8-379a-2d2f-2054" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -3007,7 +3007,7 @@
         <constraint field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a1df-1d6a-179e-d811" type="max"/>
       </constraints>
       <categoryLinks>
-        <categoryLink id="216b-edfd-4c11-f5a7" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="216b-edfd-4c11-f5a7" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="14bd-50f9-5189-a219" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -3032,7 +3032,7 @@
         <categoryLink id="07e8-1ce7-9bbe-6def" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_8378-ede4-476d-b657</comment>
         </categoryLink>
-        <categoryLink id="1d53-f359-bf3c-be70" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="1d53-f359-bf3c-be70" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
       </categoryLinks>
     </entryLink>
   </entryLinks>
@@ -3061,7 +3061,7 @@
       </infoLinks>
       <categoryLinks>
         <categoryLink id="ee56-4096-c582-710a" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="99a3-f200-6427-bcfb" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+        <categoryLink id="99a3-f200-6427-bcfb" name="Heavy Sub-type:" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
         <categoryLink id="3f0c-0709-e9a4-dafd" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
       </categoryLinks>
       <selectionEntries>
@@ -3195,7 +3195,7 @@
       </constraints>
       <categoryLinks>
         <categoryLink id="2cb8-f4af-7359-ee4e" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="9de2-18e7-2489-6f6a" name="LoW &amp; Primarchs" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false"/>
+        <categoryLink id="9de2-18e7-2489-6f6a" name="LoW &amp; Primarchs (25% Limit)" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="877c-1463-cab0-6661" name="Forgebreaker Desecrated" hidden="false" collective="false" import="true" type="upgrade">
@@ -3392,7 +3392,7 @@
         </infoLink>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="ee64-c915-d9f8-3b09" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+        <categoryLink id="ee64-c915-d9f8-3b09" name="Heavy Sub-type:" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
         <categoryLink id="57e9-d1c5-973b-1aca" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="32ae-ac04-cb33-39c9" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
       </categoryLinks>
@@ -3720,9 +3720,9 @@
         </infoLink>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="5f56-93f9-d0e5-627d" name="Automata:" hidden="false" targetId="d8ab-8e21-e193-63ba" primary="false"/>
+        <categoryLink id="5f56-93f9-d0e5-627d" name="Automata Unit-type:" hidden="false" targetId="d8ab-8e21-e193-63ba" primary="false"/>
         <categoryLink id="f1af-9bb8-90df-4ae6" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="dfac-bd55-47dd-cf0f" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+        <categoryLink id="dfac-bd55-47dd-cf0f" name="Heavy Sub-type:" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="44e0-946b-0a3a-ae22" name="Domitar-ferrum" hidden="false" collective="false" import="true" type="model">
@@ -3823,7 +3823,7 @@
       <categoryLinks>
         <categoryLink id="7a42-24a0-f251-742d" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="d025-1500-764b-7cb1" name="Terminators:" hidden="false" targetId="bab3-f50d-3e5f-2f78" primary="false"/>
-        <categoryLink id="1084-a64f-bae5-5999" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+        <categoryLink id="1084-a64f-bae5-5999" name="Heavy Sub-type:" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
         <categoryLink id="029a-d8b2-d712-01df" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
@@ -4642,7 +4642,7 @@
       <categoryLinks>
         <categoryLink id="0be3-3ef2-06d5-513f" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="7d54-110a-f4d0-fbac" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="eb9f-a770-ac11-f3c5" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+        <categoryLink id="eb9f-a770-ac11-f3c5" name="Heavy Sub-type:" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
         <categoryLink id="2c06-dd4a-568c-f5f3" name="Terminators:" hidden="false" targetId="bab3-f50d-3e5f-2f78" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
@@ -4911,7 +4911,7 @@
             </modifier>
           </modifiers>
         </entryLink>
-        <entryLink id="fc39-8924-a69f-10b5" name="Tartaros Command Squad" hidden="false" collective="false" import="true" targetId="58d0-a0fd-d20b-cb1b" type="selectionEntry"/>
+        <entryLink id="fc39-8924-a69f-10b5" name="Command Squad, Tartaros" hidden="false" collective="false" import="true" targetId="58d0-a0fd-d20b-cb1b" type="selectionEntry"/>
         <entryLink id="cd97-51bf-2a68-1186" name="Command Squad" hidden="false" collective="false" import="true" targetId="0aca-632d-1642-8af9" type="selectionEntry"/>
         <entryLink id="9b82-c43c-3987-cea4" name="Iron Circle Maniple" hidden="true" collective="false" import="true" targetId="a6e3-baab-45b9-7fea" type="selectionEntry">
           <modifiers>
@@ -5025,6 +5025,6 @@
     </selectionEntryGroup>
   </sharedSelectionEntryGroups>
   <catalogueLinks>
-    <catalogueLink id="2f60-18fb-e6ed-8574" name="(HH V2) Legions Astartes" targetId="6393-649c-7213-a327" type="catalogue" importRootEntries="true"/>
+    <catalogueLink id="2f60-18fb-e6ed-8574" name="Legions Astartes" targetId="6393-649c-7213-a327" type="catalogue" importRootEntries="true"/>
   </catalogueLinks>
 </catalogue>

--- a/2022 - LA - Night Lords.cat
+++ b/2022 - LA - Night Lords.cat
@@ -17,7 +17,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="037c-77b8-6f60-cefc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="9908-6951-cb40-369c" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="9908-6951-cb40-369c" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="1132-38e8-0e5f-6d62" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -36,7 +36,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="c700-6253-d5c4-b462" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="dead-a3bc-6447-64ea" name="New CategoryLink" hidden="false" targetId="ad5f-31db-8bc7-5c46" primary="true"/>
+        <categoryLink id="dead-a3bc-6447-64ea" name="Primarch:" hidden="false" targetId="ad5f-31db-8bc7-5c46" primary="true"/>
       </categoryLinks>
       <entryLinks>
         <entryLink id="6585-f156-4a2a-d71c" name="Retinue" hidden="false" collective="false" import="true" targetId="f728-26bf-3c99-1529" type="selectionEntryGroup">
@@ -73,7 +73,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="57a9-a024-e7a3-e8bf" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="5356-33e7-612f-b258" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="5356-33e7-612f-b258" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="2f21-d05c-f877-7bf7" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -87,7 +87,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="8ce1-4ddc-5784-6fda" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="43cb-1a57-baf5-c366" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="43cb-1a57-baf5-c366" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="d00f-0db6-3c89-7da8" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -100,7 +100,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="7d2a-c0c6-7ad0-b12b" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="7d2a-c0c6-7ad0-b12b" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="fa99-f56b-04df-4b60" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -117,13 +117,13 @@
         <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e039-6a9a-888c-e4cb" type="max"/>
       </constraints>
       <categoryLinks>
-        <categoryLink id="f61c-859c-a747-e46c" name="New CategoryLink" hidden="false" targetId="e90d-e5a8-f42d-da84" primary="true"/>
+        <categoryLink id="f61c-859c-a747-e46c" name="Allegiance:" hidden="false" targetId="e90d-e5a8-f42d-da84" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="32c0-440e-bcd3-31d0" name="Contekar Terminator Squad" hidden="false" collective="false" import="false" targetId="837e-c3ca-437e-dfbf" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="90fa-b324-1d69-b9f7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="8a66-cd15-98b3-053b" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="8a66-cd15-98b3-053b" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="d441-3ddb-a503-2d25" name="Flaymaster Mawdrym Llansahai" hidden="true" collective="false" import="false" targetId="71e4-4f49-a389-b80d" type="selectionEntry">
@@ -164,7 +164,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="6383-da25-4d31-9d0f" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="6383-da25-4d31-9d0f" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="fd32-a0de-1d51-721e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="88e9-963c-1da4-2970" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
       </categoryLinks>
@@ -188,7 +188,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="d220-725f-227a-8331" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="d220-725f-227a-8331" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="de2e-45e1-c96a-f8dd" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="e1a5-7428-ea5b-f5c1" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
       </categoryLinks>
@@ -225,7 +225,7 @@
         <categoryLink id="7dcc-af84-42fb-bd0c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_c6d4-581f-4746-bec3</comment>
         </categoryLink>
-        <categoryLink id="477d-5ef3-4ff0-a6f5" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
+        <categoryLink id="477d-5ef3-4ff0-a6f5" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
           <comment>template_id_2489-ee2a-45dd-b384</comment>
         </categoryLink>
       </categoryLinks>
@@ -256,7 +256,7 @@
         <categoryLink id="e20f-d8a9-4bd6-9a40" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_8378-ede4-476d-b657</comment>
         </categoryLink>
-        <categoryLink id="353c-ef8d-419c-8c82" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="353c-ef8d-419c-8c82" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_d64f-ad19-426c-adf7</comment>
         </categoryLink>
       </categoryLinks>
@@ -282,7 +282,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="1c3b-258e-4ff4-aadc" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="1c3b-258e-4ff4-aadc" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_ac26-e639-4d53-9b8b</comment>
         </categoryLink>
         <categoryLink id="0caf-d428-4c28-b427" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -293,7 +293,7 @@
         </categoryLink>
       </categoryLinks>
     </entryLink>
-    <entryLink id="2323-ba5c-0fde-3f7e" name="Avenger Strike Fighter" hidden="true" collective="false" import="false" targetId="b25c-e85c-1c29-9e05" type="selectionEntry">
+    <entryLink id="2323-ba5c-0fde-3f7e" name="Legion Avenger Strike Fighter" hidden="true" collective="false" import="false" targetId="b25c-e85c-1c29-9e05" type="selectionEntry">
       <comment>template_id_1064-175d-4616-9c71</comment>
       <modifiers>
         <modifier type="set" field="hidden" value="false">
@@ -315,7 +315,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="9538-010c-4b21-a6ce" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="9538-010c-4b21-a6ce" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_a009-a597-4b51-b228</comment>
         </categoryLink>
         <categoryLink id="42fe-df5e-4f16-acbe" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -349,7 +349,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="091a-a587-4f76-b255" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="091a-a587-4f76-b255" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_c165-3906-463a-9c73</comment>
         </categoryLink>
         <categoryLink id="1cad-d4a2-48d2-9cd3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -391,7 +391,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="830e-7e63-46c6-8462" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="830e-7e63-46c6-8462" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_3a22-caae-4eea-9bc5</comment>
         </categoryLink>
         <categoryLink id="32fb-ed0a-4dba-830e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -424,7 +424,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="9425-9857-4af3-b1e4" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="9425-9857-4af3-b1e4" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_251a-df5b-4bfd-ad63</comment>
         </categoryLink>
         <categoryLink id="909d-97bd-4d17-a167" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -462,7 +462,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="abc0-af4b-4353-b0f5" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
+        <categoryLink id="abc0-af4b-4353-b0f5" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
           <comment>template_id_67c2-df43-44fc-92d1</comment>
         </categoryLink>
         <categoryLink id="4861-217c-4f4f-bd62" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -523,7 +523,7 @@
         <categoryLink id="4b5e-43ed-44bb-9c45" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_bd6a-0cda-4e0f-80ae</comment>
         </categoryLink>
-        <categoryLink id="1ffb-b70d-47f6-be5a" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
+        <categoryLink id="1ffb-b70d-47f6-be5a" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
           <comment>template_id_ae75-7cca-4701-9d56</comment>
         </categoryLink>
         <categoryLink id="38c0-8a86-4776-ab51" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false">
@@ -565,7 +565,7 @@
         <categoryLink id="1ced-0fde-44b2-824a" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false">
           <comment>template_id_f51c-73d7-4f29-be1c</comment>
         </categoryLink>
-        <categoryLink id="0c4a-6dc5-4748-beca" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
+        <categoryLink id="0c4a-6dc5-4748-beca" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
           <comment>template_id_257d-78c0-4bab-ba65</comment>
         </categoryLink>
       </categoryLinks>
@@ -615,7 +615,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="bf0b-ebc8-48fc-a53a" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="bf0b-ebc8-48fc-a53a" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_f1c8-27fd-4f98-8527</comment>
         </categoryLink>
         <categoryLink id="2580-f2ab-4d8a-909e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -644,7 +644,7 @@
         <categoryLink id="0ff5-1690-4a71-bc80" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_dd44-e0a8-42a8-bdcc</comment>
         </categoryLink>
-        <categoryLink id="4f0a-1682-44b4-88a0" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
+        <categoryLink id="4f0a-1682-44b4-88a0" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
           <comment>template_id_c5b0-f9ae-468d-924a</comment>
         </categoryLink>
       </categoryLinks>
@@ -672,7 +672,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="1ef9-54e1-48a0-bf97" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
+        <categoryLink id="1ef9-54e1-48a0-bf97" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
           <comment>template_id_f926-27fd-4a92-97a1</comment>
         </categoryLink>
         <categoryLink id="9f5d-6f6b-416d-bb66" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -704,7 +704,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="37b3-b94d-fa98-6285" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="37b3-b94d-fa98-6285" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
         <categoryLink id="fd84-59fb-70b2-6e83" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -764,7 +764,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="40b0-b037-48d3-b655" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="40b0-b037-48d3-b655" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_361e-fb90-4b0e-ac3d</comment>
         </categoryLink>
         <categoryLink id="5db3-da36-441c-8a1e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -781,7 +781,7 @@
         <categoryLink id="2521-19ad-47f0-88d9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_473b-e812-4158-9416</comment>
         </categoryLink>
-        <categoryLink id="50f8-5b2f-4fcb-8e60" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
+        <categoryLink id="50f8-5b2f-4fcb-8e60" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
           <comment>template_id_00a2-63ff-4698-a35b</comment>
         </categoryLink>
       </categoryLinks>
@@ -805,7 +805,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="5403-d3a1-408c-9a15" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="5403-d3a1-408c-9a15" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_2a08-4432-42ad-bfdb</comment>
         </categoryLink>
         <categoryLink id="c69e-6eb9-488e-9f53" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -840,7 +840,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="8770-764d-4914-b36b" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="8770-764d-4914-b36b" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_f4c0-4396-4f39-a34f</comment>
         </categoryLink>
         <categoryLink id="8734-d5eb-4373-9790" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -875,7 +875,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="3703-2c7a-4113-b1ce" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="3703-2c7a-4113-b1ce" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_caf6-5548-4b89-8102</comment>
         </categoryLink>
         <categoryLink id="5417-e72a-4bee-8af1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -937,7 +937,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="2c29-6bb8-4d9a-8e0e" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="2c29-6bb8-4d9a-8e0e" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_d53e-113f-4a40-a3d5</comment>
         </categoryLink>
         <categoryLink id="b78b-b915-4119-9242" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -963,7 +963,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="c47b-9f16-460f-bb8f" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="c47b-9f16-460f-bb8f" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_e6f7-a6ca-4825-bfc5</comment>
         </categoryLink>
         <categoryLink id="13e3-d28a-4b97-b563" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -997,7 +997,7 @@
         <categoryLink id="34c3-9322-4a2d-b364" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_cefb-cfd7-4dc8-99c4</comment>
         </categoryLink>
-        <categoryLink id="f2b8-f8c0-4984-8310" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="f2b8-f8c0-4984-8310" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_a9fd-9d16-4a5e-855c</comment>
         </categoryLink>
       </categoryLinks>
@@ -1021,7 +1021,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="8f23-4166-4639-b66a" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="8f23-4166-4639-b66a" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_a56d-347b-4b09-a918</comment>
         </categoryLink>
         <categoryLink id="1c32-6fa0-41e3-bcb5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1054,7 +1054,7 @@
         <categoryLink id="59cb-1ac0-4d47-bbd2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_9441-d79b-4720-9667</comment>
         </categoryLink>
-        <categoryLink id="9bea-0bdf-4cfe-a02d" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="9bea-0bdf-4cfe-a02d" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_7d7e-32d3-4692-b401</comment>
         </categoryLink>
       </categoryLinks>
@@ -1084,7 +1084,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="54af-a36f-4998-9914" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="54af-a36f-4998-9914" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_f65b-8958-49b3-92a5</comment>
         </categoryLink>
         <categoryLink id="da9d-0523-4242-a44f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1117,7 +1117,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="a52d-649a-49bd-8d54" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="a52d-649a-49bd-8d54" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_c6a8-22a8-4d41-b969</comment>
         </categoryLink>
         <categoryLink id="477f-7e31-47ce-9dad" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1180,7 +1180,7 @@
         <categoryLink id="c9aa-124d-4314-8cac" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_bc67-ce1f-4004-aeb7</comment>
         </categoryLink>
-        <categoryLink id="5d2b-5b8d-4748-8cbb" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="5d2b-5b8d-4748-8cbb" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_9a45-9699-4475-aeef</comment>
         </categoryLink>
       </categoryLinks>
@@ -1245,7 +1245,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="cd66-d7f8-4628-910d" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="cd66-d7f8-4628-910d" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_3610-c975-4d55-bdfe</comment>
         </categoryLink>
         <categoryLink id="e3b9-1b4a-432e-ac21" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1283,7 +1283,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="7191-94cf-45c4-b1dd" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="7191-94cf-45c4-b1dd" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_f81d-9435-4f11-99c1</comment>
         </categoryLink>
         <categoryLink id="9aaa-bb7c-4480-9542" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1321,7 +1321,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="7897-ea6c-4555-b94b" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="7897-ea6c-4555-b94b" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_b24f-3ae0-4cbb-b016</comment>
         </categoryLink>
         <categoryLink id="2e6d-a5bc-484e-b30a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1354,7 +1354,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="6803-c8b6-465b-b4df" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="6803-c8b6-465b-b4df" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_c77f-0819-473b-a8a2</comment>
         </categoryLink>
         <categoryLink id="e6c5-ead9-4d61-9482" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1389,7 +1389,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="bb6d-4e56-45f6-b5c4" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="bb6d-4e56-45f6-b5c4" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_0397-c837-4fea-a527</comment>
         </categoryLink>
         <categoryLink id="04f4-4a49-4cd9-be5b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1427,7 +1427,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="8410-7398-4d4e-b5ea" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="8410-7398-4d4e-b5ea" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_c1cf-cea4-4278-8f27</comment>
         </categoryLink>
         <categoryLink id="4794-085e-4397-97ed" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1465,7 +1465,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="768b-5fde-4dbc-9b68" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="768b-5fde-4dbc-9b68" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_0c16-6841-42b2-b02d</comment>
         </categoryLink>
         <categoryLink id="e66f-8d16-4aa7-ba91" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1503,7 +1503,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="a4cd-ccb4-46e2-beab" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="a4cd-ccb4-46e2-beab" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_3632-0b5d-4622-ae33</comment>
         </categoryLink>
         <categoryLink id="c3a9-a6c6-4053-9ea7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1541,7 +1541,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="a4e7-d254-4b62-ad9c" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="a4e7-d254-4b62-ad9c" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_5ad5-8701-42cd-b2b6</comment>
         </categoryLink>
         <categoryLink id="3a01-c9c9-4eff-ba30" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1611,7 +1611,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="822a-508a-4eb6-b16b" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="822a-508a-4eb6-b16b" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_4d7c-201f-4c99-b89a</comment>
         </categoryLink>
         <categoryLink id="1905-2aea-47ba-9b72" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1645,7 +1645,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="e074-bf55-4a58-8723" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="e074-bf55-4a58-8723" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_4e52-ad1b-48d4-8eed</comment>
         </categoryLink>
         <categoryLink id="9346-5dec-4537-b9ca" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false">
@@ -1659,7 +1659,7 @@
         <categoryLink id="1652-a9e2-4016-99f9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_6140-2404-46f9-bd42</comment>
         </categoryLink>
-        <categoryLink id="7a25-0f2f-4f0e-93c6" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
+        <categoryLink id="7a25-0f2f-4f0e-93c6" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
           <comment>template_id_1c86-fad8-46ec-a0b0</comment>
         </categoryLink>
       </categoryLinks>
@@ -1685,7 +1685,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="7a38-01cf-4342-ba85" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
+        <categoryLink id="7a38-01cf-4342-ba85" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
           <comment>template_id_0af1-d052-4bd7-aab6</comment>
         </categoryLink>
         <categoryLink id="9d88-31e8-4eae-8aee" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1735,7 +1735,7 @@
         <categoryLink id="7732-7063-4457-83ce" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_4272-9b9d-4c59-95f0</comment>
         </categoryLink>
-        <categoryLink id="0aeb-bf60-4a84-9103" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="0aeb-bf60-4a84-9103" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_d85b-1ae7-40d5-9341</comment>
         </categoryLink>
       </categoryLinks>
@@ -1753,7 +1753,7 @@
         <categoryLink id="e031-c589-47f4-8bfd" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_ff9f-01cb-41b9-800e</comment>
         </categoryLink>
-        <categoryLink id="d083-ec62-83f5-6915" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="d083-ec62-83f5-6915" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="4a0e-e4d0-1493-84ed" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -1776,7 +1776,7 @@
         <constraint field="selections" scope="parent" value="-1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="654a-5bdc-e542-6ca4" type="min"/>
       </constraints>
       <categoryLinks>
-        <categoryLink id="b6e2-a6f7-44a6-983c" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
+        <categoryLink id="b6e2-a6f7-44a6-983c" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
           <comment>template_id_b084-df23-4f99-812f</comment>
         </categoryLink>
         <categoryLink id="8524-eab4-42bb-8423" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false">
@@ -1918,7 +1918,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="abfa-fc3b-4c42-9d61" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="abfa-fc3b-4c42-9d61" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_b822-3417-4613-be37</comment>
         </categoryLink>
         <categoryLink id="a53d-e0d7-4eb7-b415" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1945,7 +1945,7 @@
         <categoryLink id="80c9-5218-4641-bae1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_75a7-dc06-445b-b2dc</comment>
         </categoryLink>
-        <categoryLink id="2580-4207-489e-aa4d" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="2580-4207-489e-aa4d" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_e21a-c03b-4885-ac46</comment>
         </categoryLink>
       </categoryLinks>
@@ -1968,7 +1968,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="f82b-91ed-484c-9b9f" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
+        <categoryLink id="f82b-91ed-484c-9b9f" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
           <comment>template_id_f55b-7555-444b-beee</comment>
         </categoryLink>
         <categoryLink id="9cf3-d17d-48cd-8dcb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1989,7 +1989,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="a745-eb7d-44f6-8bbc" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="a745-eb7d-44f6-8bbc" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_79fa-3370-4ae0-9e12</comment>
         </categoryLink>
         <categoryLink id="29a3-13c8-4e5f-91db" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2015,7 +2015,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="649f-c4fa-4936-b7ab" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="649f-c4fa-4936-b7ab" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_8d82-3279-4481-84bb</comment>
         </categoryLink>
         <categoryLink id="da31-6be4-44ce-9e02" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2048,7 +2048,7 @@
         <categoryLink id="4ceb-e727-472e-ba8f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_7010-be56-4709-b058</comment>
         </categoryLink>
-        <categoryLink id="921f-ae19-4188-a45e" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="921f-ae19-4188-a45e" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_7379-a740-47ba-a054</comment>
         </categoryLink>
       </categoryLinks>
@@ -2066,7 +2066,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="f50c-5d0b-4f94-a4b4" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="f50c-5d0b-4f94-a4b4" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_944f-7420-4982-8ea9</comment>
         </categoryLink>
         <categoryLink id="65e9-ac49-4ae4-b9fb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2110,7 +2110,7 @@
         <categoryLink id="4098-ae63-4093-a4ba" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_c6ff-0977-4c92-bb28</comment>
         </categoryLink>
-        <categoryLink id="cc26-2614-43ad-af91" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="cc26-2614-43ad-af91" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_f555-7d39-458f-84c9</comment>
         </categoryLink>
       </categoryLinks>
@@ -2140,7 +2140,7 @@
         <categoryLink id="967d-ba66-44bf-bf8a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_39e5-eda5-45d1-a643</comment>
         </categoryLink>
-        <categoryLink id="9575-3728-4c83-ad11" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="9575-3728-4c83-ad11" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_6416-21bb-4df4-9de8</comment>
         </categoryLink>
       </categoryLinks>
@@ -2170,7 +2170,7 @@
         <categoryLink id="fd20-4928-46a6-8c86" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_5528-2dac-4be5-900c</comment>
         </categoryLink>
-        <categoryLink id="77a6-1638-4c62-88f7" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="77a6-1638-4c62-88f7" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_dc8f-d888-4585-991d</comment>
         </categoryLink>
       </categoryLinks>
@@ -2200,7 +2200,7 @@
         <categoryLink id="0e50-9150-4de2-87a6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_899e-b052-4d5b-8c18</comment>
         </categoryLink>
-        <categoryLink id="d59f-1b0a-4978-84f6" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="d59f-1b0a-4978-84f6" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_f5e9-cff6-41d2-a016</comment>
         </categoryLink>
       </categoryLinks>
@@ -2230,7 +2230,7 @@
         <categoryLink id="71f5-1695-46f9-aa7a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_09cd-2176-40af-bba6</comment>
         </categoryLink>
-        <categoryLink id="dda6-2363-43ce-b9c8" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="dda6-2363-43ce-b9c8" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_05e6-7c63-4a35-9ba0</comment>
         </categoryLink>
       </categoryLinks>
@@ -2254,7 +2254,7 @@
         <categoryLink id="987e-af6c-4b9a-8849" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_0dfa-4004-4751-8022</comment>
         </categoryLink>
-        <categoryLink id="13f9-946d-4e08-8c64" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="13f9-946d-4e08-8c64" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_a669-0f5d-4fd3-811b</comment>
         </categoryLink>
       </categoryLinks>
@@ -2282,7 +2282,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="f54d-5040-4c15-a26e" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="f54d-5040-4c15-a26e" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_4f60-472b-45a9-ab9e</comment>
         </categoryLink>
         <categoryLink id="e580-53be-45e2-b406" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2335,7 +2335,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="e4c4-baf0-45c9-8cec" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="e4c4-baf0-45c9-8cec" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_2008-f1c4-4285-a14f</comment>
         </categoryLink>
         <categoryLink id="d87f-5e2d-4855-947b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2367,7 +2367,7 @@
         <categoryLink id="83ce-b9ce-4eeb-91a0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_9189-836c-475d-a52e</comment>
         </categoryLink>
-        <categoryLink id="2004-7997-40ad-ab5f" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="2004-7997-40ad-ab5f" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_e1fa-b7d8-47b0-a88a</comment>
         </categoryLink>
         <categoryLink id="6419-803a-4026-9ad1" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false">
@@ -2381,7 +2381,7 @@
         <categoryLink id="a753-5733-4c87-aec7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_b1d5-fd75-4f17-bbf4</comment>
         </categoryLink>
-        <categoryLink id="32cc-ba06-4450-8d43" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="32cc-ba06-4450-8d43" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_f221-bf81-4045-849b</comment>
         </categoryLink>
       </categoryLinks>
@@ -2408,7 +2408,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="7251-f5a7-4564-aef0" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="7251-f5a7-4564-aef0" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_f203-bc26-421f-b79e</comment>
         </categoryLink>
         <categoryLink id="3c09-b651-4e83-8c21" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2422,7 +2422,7 @@
         <categoryLink id="1021-bda8-4fd8-9dc9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_51af-a137-4a1c-97a4</comment>
         </categoryLink>
-        <categoryLink id="5eb3-a972-482b-bd54" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
+        <categoryLink id="5eb3-a972-482b-bd54" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
           <comment>template_id_ec1f-c326-40a8-9d1f</comment>
         </categoryLink>
       </categoryLinks>
@@ -2480,7 +2480,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="f455-4b29-440e-b681" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="f455-4b29-440e-b681" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_fce3-801c-49c8-85d4</comment>
         </categoryLink>
         <categoryLink id="3e1e-9cd9-4ea7-9c0d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2491,7 +2491,7 @@
     <entryLink id="b7b4-0041-6e28-3c10" name="Terminator Tartaros Squad" hidden="false" collective="false" import="false" targetId="1a8e-0ded-a4dc-2b4e" type="selectionEntry">
       <comment>template_id_0848-4e03-417a-b224</comment>
       <categoryLinks>
-        <categoryLink id="9a72-2f92-48ba-816d" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
+        <categoryLink id="9a72-2f92-48ba-816d" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
           <comment>template_id_ac1c-b3bf-4011-918a</comment>
         </categoryLink>
         <categoryLink id="8dd3-6f4f-4a1c-a60c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2521,7 +2521,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="6899-41fb-496b-a002" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="6899-41fb-496b-a002" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_5a04-9847-4c91-a49a</comment>
         </categoryLink>
         <categoryLink id="08e6-e6db-4a84-9755" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2552,7 +2552,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="ca2b-ef56-4fa4-a834" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="ca2b-ef56-4fa4-a834" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_7d4f-547c-43ed-a520</comment>
         </categoryLink>
         <categoryLink id="2052-e30a-455c-945e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2581,7 +2581,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="2fbe-e6e7-4ce4-9cba" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
+        <categoryLink id="2fbe-e6e7-4ce4-9cba" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
           <comment>template_id_28e0-91e7-4ada-9fac</comment>
         </categoryLink>
         <categoryLink id="9d4f-b1f1-4efa-80e2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2616,7 +2616,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="bd11-a3ea-44c8-8c33" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="bd11-a3ea-44c8-8c33" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_e22a-c5f8-4825-a45f</comment>
         </categoryLink>
         <categoryLink id="7e44-ba6b-4c81-b786" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2633,7 +2633,7 @@
         <categoryLink id="72c5-25f7-447e-bbc1" name="Compulsory Elite:" hidden="false" targetId="bb1f-ae32-b587-c3e1" primary="false">
           <comment>template_id_7d5a-62e7-43ee-b79b</comment>
         </categoryLink>
-        <categoryLink id="47b4-6372-46af-9acc" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
+        <categoryLink id="47b4-6372-46af-9acc" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
           <comment>template_id_4986-9157-49f2-b670</comment>
         </categoryLink>
       </categoryLinks>
@@ -2663,7 +2663,7 @@
         <categoryLink id="d66a-c62c-4fc3-a4e1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_1b86-0977-4a8b-adac</comment>
         </categoryLink>
-        <categoryLink id="befd-1b8a-4761-b747" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="befd-1b8a-4761-b747" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_b449-403a-4e42-9239</comment>
         </categoryLink>
       </categoryLinks>
@@ -2724,7 +2724,7 @@
         <categoryLink id="486d-1d49-4ae5-9ffd" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_4f71-446f-4cff-afda</comment>
         </categoryLink>
-        <categoryLink id="bef6-be75-43a9-861b" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="bef6-be75-43a9-861b" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_3f44-8647-43a4-ac22</comment>
         </categoryLink>
       </categoryLinks>
@@ -2745,7 +2745,7 @@
         <categoryLink id="555b-514f-4c5a-a739" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_b6b1-886e-4194-8bcd</comment>
         </categoryLink>
-        <categoryLink id="c5cb-077d-4210-9c26" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="c5cb-077d-4210-9c26" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_51b5-f9c1-4587-8fc7</comment>
         </categoryLink>
       </categoryLinks>
@@ -2777,7 +2777,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="dc16-16d0-4890-a8e8" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="dc16-16d0-4890-a8e8" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="4b1e-3f1f-49cb-8343" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -2800,7 +2800,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="32cb-7077-4d54-9f38" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="2c35-def7-4c44-9b02" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="2c35-def7-4c44-9b02" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="0c9a-d272-491c-a4a0" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -2822,7 +2822,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="5b41-a9f0-4801-9dff" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="5b41-a9f0-4801-9dff" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="d64e-e976-4668-bb95" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
         <categoryLink id="17a6-f363-4094-9a7c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
@@ -2846,7 +2846,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="fe4f-c8f2-470f-901c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="f3f0-973b-4a45-ac41" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="f3f0-973b-4a45-ac41" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="b8e7-c647-485d-a1b3" name="Sky-Hunter Squadron" hidden="true" collective="false" import="false" targetId="6263-c696-2f2e-c105" type="selectionEntry">
@@ -2869,7 +2869,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="63ff-0a92-42ab-ae8c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="204c-7b0f-4fb9-b1b3" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="204c-7b0f-4fb9-b1b3" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="85e6-cb31-427c-a040" name="Line Sub-type:" hidden="false" targetId="6399-5c65-7833-1025" primary="false"/>
         <categoryLink id="851a-3846-6367-9337" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
       </categoryLinks>
@@ -2894,7 +2894,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="68dd-fc0f-4fde-8adc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="74ca-dd4f-46be-8be7" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="74ca-dd4f-46be-8be7" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="9c6e-bcb9-3529-3d76" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -2985,7 +2985,7 @@
       <categoryLinks>
         <categoryLink id="0d5b-be56-47af-a22e" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="2e59-1043-4719-96c4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="52fa-8c3c-49d4-a321" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="52fa-8c3c-49d4-a321" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="af62-8bb1-458a-aa80" name="Termite Assault Drill" hidden="true" collective="false" import="false" targetId="cb30-307a-f0d7-3b13" type="selectionEntry">
@@ -3009,7 +3009,7 @@
       <categoryLinks>
         <categoryLink id="1fef-4409-4fab-93fc" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="ca2d-245e-48b4-a1cf" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="6692-6e39-44f0-ad8e" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="6692-6e39-44f0-ad8e" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="02ef-3013-4137-a973" name="Venerable Ancient Contemptor Dreadnought" hidden="true" collective="false" import="false" targetId="dad1-0807-e254-d498" type="selectionEntry">
@@ -3026,7 +3026,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="9261-acb5-4230-8d89" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="1a5d-cbc8-418f-91a3" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="1a5d-cbc8-418f-91a3" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="c0cb-406f-4b46-9d8d" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
       </categoryLinks>
       <entryLinks>
@@ -3049,7 +3049,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="c0b2-dd90-46c1-a2a9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="9a94-76fb-4a89-ad5d" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="9a94-76fb-4a89-ad5d" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="e9fb-8d43-3ccd-b862" name="Vorax Battle-automata Maniple" hidden="true" collective="false" import="false" targetId="f144-1079-11ff-019d" type="selectionEntry">
@@ -3062,7 +3062,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="cd8d-d10e-88e0-d28b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="18dd-b063-65c3-ecba" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="18dd-b063-65c3-ecba" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="cf73-cd4b-2fbd-a8e5" name="Thanatar Siege-automata Maniple" hidden="true" collective="false" import="false" targetId="2903-fef6-e839-368b" type="selectionEntry">
@@ -3079,7 +3079,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="5f10-53a5-9165-8236" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="03e8-206b-a4d8-6dc0" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="03e8-206b-a4d8-6dc0" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="bcd2-8ef1-440a-5a06" name="Domitar Battle-Automata Maniple" hidden="true" collective="false" import="false" targetId="1a1b-fa35-a6a2-ca78" type="selectionEntry">
@@ -3092,7 +3092,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="b9e4-a351-1eb9-9df5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="6da5-ccfe-febc-8c55" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="6da5-ccfe-febc-8c55" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="91d1-dd40-f5c2-a08d" name="Castellax Battle-Automata Maniple" hidden="true" collective="false" import="false" targetId="537f-846d-90e3-2526" type="selectionEntry">
@@ -3105,7 +3105,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="8403-39bb-33b2-8dc7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="0f97-9cd7-ff88-9dc3" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="0f97-9cd7-ff88-9dc3" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="4c72-b2cf-8ee0-edd1" name="Contekar Terminator Squad" hidden="true" collective="false" import="false" targetId="837e-c3ca-437e-dfbf" type="selectionEntry">
@@ -3118,7 +3118,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="59ee-45d3-e0ed-d307" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="f3f0-cedc-4b34-835f" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="f3f0-cedc-4b34-835f" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="680f-f823-e1df-e641" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -3144,19 +3144,19 @@
         <constraint field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0167-8e6b-6138-771b" type="max"/>
       </constraints>
       <categoryLinks>
-        <categoryLink id="aea8-3057-f33c-8694" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="aea8-3057-f33c-8694" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="e6d5-1599-4fa3-98c4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="4e26-f260-25e1-a784" name="Night Raptor Squad" hidden="false" collective="false" import="false" targetId="9bb8-8fe4-11c1-9e50" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="06f0-e8f6-c870-0402" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="06f0-e8f6-c870-0402" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="2a64-1d3f-e411-c53b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="66e2-53d1-cf15-3acb" name="Terror Squad" hidden="false" collective="false" import="false" targetId="53ce-6dc9-aa69-fbaa" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="3ab3-2837-3e08-498f" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="3ab3-2837-3e08-498f" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="bfe0-0539-377d-369d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -3177,7 +3177,7 @@
         <categoryLink id="c54f-4baf-9c3e-10af" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_ff9f-01cb-41b9-800e</comment>
         </categoryLink>
-        <categoryLink id="8ca3-e7bc-7797-bb0b" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="8ca3-e7bc-7797-bb0b" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_1315-6051-4a46-b070</comment>
         </categoryLink>
       </categoryLinks>
@@ -5636,8 +5636,8 @@ Additionally, all models with the Infantry or Cavalry Unit Types in a unit that 
             </modifier>
           </modifiers>
         </entryLink>
-        <entryLink id="be72-b7b1-3b03-d38b" name="Command Squad (Placeholder Points)" hidden="false" collective="false" import="true" targetId="0aca-632d-1642-8af9" type="selectionEntry"/>
-        <entryLink id="4c57-238e-e66f-d49a" name="Tartaros Command Squad" hidden="false" collective="false" import="true" targetId="58d0-a0fd-d20b-cb1b" type="selectionEntry"/>
+        <entryLink id="be72-b7b1-3b03-d38b" name="Command Squad" hidden="false" collective="false" import="true" targetId="0aca-632d-1642-8af9" type="selectionEntry"/>
+        <entryLink id="4c57-238e-e66f-d49a" name="Command Squad, Tartaros" hidden="false" collective="false" import="true" targetId="58d0-a0fd-d20b-cb1b" type="selectionEntry"/>
       </entryLinks>
     </selectionEntryGroup>
     <selectionEntryGroup id="7923-f342-c07f-4967" name="Warlord Traits" hidden="false" collective="false" import="true">
@@ -5786,6 +5786,6 @@ whose Warlord has this Trait may make an additional Reaction during the opposing
     </selectionEntryGroup>
   </sharedSelectionEntryGroups>
   <catalogueLinks>
-    <catalogueLink id="2f60-18fb-e6ed-8574" name="(HH V2) Legions Astartes" targetId="6393-649c-7213-a327" type="catalogue" importRootEntries="true"/>
+    <catalogueLink id="2f60-18fb-e6ed-8574" name="Legions Astartes" targetId="6393-649c-7213-a327" type="catalogue" importRootEntries="true"/>
   </catalogueLinks>
 </catalogue>

--- a/2022 - LA - Raven Guard.cat
+++ b/2022 - LA - Raven Guard.cat
@@ -3,7 +3,7 @@
   <entryLinks>
     <entryLink id="84cc-e59c-174e-fb25" name="Mor Deythan Squad" hidden="false" collective="false" import="false" targetId="c268-08ac-5b90-d034" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="2e94-0345-48a1-212d" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="2e94-0345-48a1-212d" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="b955-7a72-615e-214c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -16,13 +16,13 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="de3b-7a9e-8db8-3522" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="de3b-7a9e-8db8-3522" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="9642-f478-08f5-086c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="4d01-e777-0fc3-5af0" name="Dark Furies" hidden="false" collective="false" import="false" targetId="58f4-3d8d-f243-6e5d" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="b3bf-9ad9-9085-e594" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="b3bf-9ad9-9085-e594" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
         <categoryLink id="c981-a1a9-1e0e-a0c6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -35,7 +35,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="09fb-5221-1260-a028" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="09fb-5221-1260-a028" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="35aa-395e-a852-77e8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="ca61-d4be-80ed-be27" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
       </categoryLinks>
@@ -49,7 +49,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="f2cb-5a4e-7c3e-733a" name="New CategoryLink" hidden="false" targetId="ad5f-31db-8bc7-5c46" primary="true"/>
+        <categoryLink id="f2cb-5a4e-7c3e-733a" name="Primarch:" hidden="false" targetId="ad5f-31db-8bc7-5c46" primary="true"/>
         <categoryLink id="393b-c443-85dd-4f06" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
       <entryLinks>
@@ -71,7 +71,7 @@
         <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5c91-701b-fcc4-bd97" type="max"/>
       </constraints>
       <categoryLinks>
-        <categoryLink id="12a0-1ec0-e39d-2b3f" name="New CategoryLink" hidden="false" targetId="e90d-e5a8-f42d-da84" primary="true"/>
+        <categoryLink id="12a0-1ec0-e39d-2b3f" name="Allegiance:" hidden="false" targetId="e90d-e5a8-f42d-da84" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="eaff-3c75-ef08-341e" name="Deliverers Squad" hidden="true" collective="false" import="false" targetId="5d1d-8348-ed95-d366" type="selectionEntry">
@@ -88,7 +88,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="493d-2397-2ace-e10d" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="493d-2397-2ace-e10d" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="b526-7584-0877-2f74" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -98,7 +98,7 @@
         <categoryLink id="63e5-1c89-414e-8f83" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_c6d4-581f-4746-bec3</comment>
         </categoryLink>
-        <categoryLink id="9bbc-33f0-4bc2-a090" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
+        <categoryLink id="9bbc-33f0-4bc2-a090" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
           <comment>template_id_2489-ee2a-45dd-b384</comment>
         </categoryLink>
       </categoryLinks>
@@ -129,7 +129,7 @@
         <categoryLink id="b72e-bcf2-49cc-8730" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_8378-ede4-476d-b657</comment>
         </categoryLink>
-        <categoryLink id="9cf6-1cc4-4058-93eb" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="9cf6-1cc4-4058-93eb" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_d64f-ad19-426c-adf7</comment>
         </categoryLink>
       </categoryLinks>
@@ -155,7 +155,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="b19c-4fe6-4139-b847" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="b19c-4fe6-4139-b847" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_ac26-e639-4d53-9b8b</comment>
         </categoryLink>
         <categoryLink id="2f2d-e8c3-4165-8da2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -166,7 +166,7 @@
         </categoryLink>
       </categoryLinks>
     </entryLink>
-    <entryLink id="8cd4-b4d6-ce65-83af" name="Avenger Strike Fighter" hidden="true" collective="false" import="false" targetId="b25c-e85c-1c29-9e05" type="selectionEntry">
+    <entryLink id="8cd4-b4d6-ce65-83af" name="Legion Avenger Strike Fighter" hidden="true" collective="false" import="false" targetId="b25c-e85c-1c29-9e05" type="selectionEntry">
       <comment>template_id_1064-175d-4616-9c71</comment>
       <modifiers>
         <modifier type="set" field="hidden" value="false">
@@ -188,7 +188,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="316d-d9e7-405f-b651" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="316d-d9e7-405f-b651" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_a009-a597-4b51-b228</comment>
         </categoryLink>
         <categoryLink id="af7f-1eff-41e7-9bad" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -222,7 +222,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="79e6-cbc0-472e-ae1f" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="79e6-cbc0-472e-ae1f" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_c165-3906-463a-9c73</comment>
         </categoryLink>
         <categoryLink id="1b0f-2255-4236-b27c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -264,7 +264,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="bf1e-7bf4-4c1f-8e76" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="bf1e-7bf4-4c1f-8e76" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_3a22-caae-4eea-9bc5</comment>
         </categoryLink>
         <categoryLink id="d271-a153-4c71-991c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -297,7 +297,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="bbf6-df65-41e7-ac21" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="bbf6-df65-41e7-ac21" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_251a-df5b-4bfd-ad63</comment>
         </categoryLink>
         <categoryLink id="e7b2-8f50-4d52-b751" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -335,7 +335,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="423b-93b9-4581-a30c" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
+        <categoryLink id="423b-93b9-4581-a30c" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
           <comment>template_id_67c2-df43-44fc-92d1</comment>
         </categoryLink>
         <categoryLink id="b560-4eb5-49af-b5c9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -396,7 +396,7 @@
         <categoryLink id="7c4b-d40c-48e5-ae27" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_bd6a-0cda-4e0f-80ae</comment>
         </categoryLink>
-        <categoryLink id="9e30-2435-4f76-b990" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
+        <categoryLink id="9e30-2435-4f76-b990" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
           <comment>template_id_ae75-7cca-4701-9d56</comment>
         </categoryLink>
         <categoryLink id="1e2d-0f46-4772-85bf" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false">
@@ -431,7 +431,7 @@
         <categoryLink id="cfe0-ee8b-4dc0-8ed7" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false">
           <comment>template_id_f51c-73d7-4f29-be1c</comment>
         </categoryLink>
-        <categoryLink id="39c0-e6e9-42c9-9cfd" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
+        <categoryLink id="39c0-e6e9-42c9-9cfd" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
           <comment>template_id_257d-78c0-4bab-ba65</comment>
         </categoryLink>
       </categoryLinks>
@@ -479,7 +479,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="e652-6315-4694-87fb" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="e652-6315-4694-87fb" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_f1c8-27fd-4f98-8527</comment>
         </categoryLink>
         <categoryLink id="8fed-b877-4cf0-9433" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -508,7 +508,7 @@
         <categoryLink id="eb1e-d785-45c8-b12a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_dd44-e0a8-42a8-bdcc</comment>
         </categoryLink>
-        <categoryLink id="8eba-dd10-432d-9091" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
+        <categoryLink id="8eba-dd10-432d-9091" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
           <comment>template_id_c5b0-f9ae-468d-924a</comment>
         </categoryLink>
       </categoryLinks>
@@ -535,7 +535,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="e7eb-6d34-41a3-8ccb" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
+        <categoryLink id="e7eb-6d34-41a3-8ccb" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
           <comment>template_id_f926-27fd-4a92-97a1</comment>
         </categoryLink>
         <categoryLink id="25b6-6e9d-426f-9ae4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -567,7 +567,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="3b3a-5a53-f2ce-abf5" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="3b3a-5a53-f2ce-abf5" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
         <categoryLink id="b2d9-9aea-673a-eb95" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -627,7 +627,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="7e4a-65e9-4a91-85bd" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="7e4a-65e9-4a91-85bd" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_361e-fb90-4b0e-ac3d</comment>
         </categoryLink>
         <categoryLink id="6392-815a-4d97-8cc3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -644,7 +644,7 @@
         <categoryLink id="81f8-f777-461f-98c8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_473b-e812-4158-9416</comment>
         </categoryLink>
-        <categoryLink id="18a0-c4f3-4278-96a7" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
+        <categoryLink id="18a0-c4f3-4278-96a7" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
           <comment>template_id_00a2-63ff-4698-a35b</comment>
         </categoryLink>
       </categoryLinks>
@@ -667,7 +667,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="f76a-b401-4bd1-8962" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="f76a-b401-4bd1-8962" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_2a08-4432-42ad-bfdb</comment>
         </categoryLink>
         <categoryLink id="668d-e81a-4bab-bcda" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -700,7 +700,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="6cf5-e741-48ae-aa61" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="6cf5-e741-48ae-aa61" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_f4c0-4396-4f39-a34f</comment>
         </categoryLink>
         <categoryLink id="cb3c-99ec-4c48-9433" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -733,7 +733,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="4cc5-34c1-4d18-ad47" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="4cc5-34c1-4d18-ad47" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_caf6-5548-4b89-8102</comment>
         </categoryLink>
         <categoryLink id="15a4-02cd-436a-9d31" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -793,7 +793,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="2464-9ef2-4105-9a60" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="2464-9ef2-4105-9a60" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_d53e-113f-4a40-a3d5</comment>
         </categoryLink>
         <categoryLink id="a692-5c4e-4af2-8cf0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -819,7 +819,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="b216-ae17-4883-b58e" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="b216-ae17-4883-b58e" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_e6f7-a6ca-4825-bfc5</comment>
         </categoryLink>
         <categoryLink id="a43d-081d-49ea-af4b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -853,7 +853,7 @@
         <categoryLink id="b09a-c42b-46b8-b638" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_cefb-cfd7-4dc8-99c4</comment>
         </categoryLink>
-        <categoryLink id="7a13-d258-4b91-8987" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="7a13-d258-4b91-8987" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_a9fd-9d16-4a5e-855c</comment>
         </categoryLink>
       </categoryLinks>
@@ -877,7 +877,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="209b-a083-4aba-9e32" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="209b-a083-4aba-9e32" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_a56d-347b-4b09-a918</comment>
         </categoryLink>
         <categoryLink id="5153-ebd6-4b95-bf5b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -910,7 +910,7 @@
         <categoryLink id="95d3-c386-4cfa-bbec" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_9441-d79b-4720-9667</comment>
         </categoryLink>
-        <categoryLink id="bfd5-eb9b-4f75-9b7b" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="bfd5-eb9b-4f75-9b7b" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_7d7e-32d3-4692-b401</comment>
         </categoryLink>
       </categoryLinks>
@@ -940,7 +940,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="4a16-fdc2-4789-904b" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="4a16-fdc2-4789-904b" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_f65b-8958-49b3-92a5</comment>
         </categoryLink>
         <categoryLink id="d522-c21f-4759-837e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -973,7 +973,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="b1de-1c2d-4f09-a5bf" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="b1de-1c2d-4f09-a5bf" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_c6a8-22a8-4d41-b969</comment>
         </categoryLink>
         <categoryLink id="5711-8926-47ca-9779" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1036,7 +1036,7 @@
         <categoryLink id="784d-988c-43f2-89b4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_bc67-ce1f-4004-aeb7</comment>
         </categoryLink>
-        <categoryLink id="5b22-8837-4f07-b17c" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="5b22-8837-4f07-b17c" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_9a45-9699-4475-aeef</comment>
         </categoryLink>
       </categoryLinks>
@@ -1099,7 +1099,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="0219-3d5a-44fd-b899" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="0219-3d5a-44fd-b899" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_3610-c975-4d55-bdfe</comment>
         </categoryLink>
         <categoryLink id="303a-a24a-4086-b1de" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1135,7 +1135,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="aa4b-ac62-4bd9-85ef" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="aa4b-ac62-4bd9-85ef" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_f81d-9435-4f11-99c1</comment>
         </categoryLink>
         <categoryLink id="37c1-a2d9-4e2a-a999" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1171,7 +1171,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="3b6d-2bfd-4d68-8e07" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="3b6d-2bfd-4d68-8e07" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_b24f-3ae0-4cbb-b016</comment>
         </categoryLink>
         <categoryLink id="3e5e-e13f-4248-9b38" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1204,7 +1204,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="36e8-41a4-4b0d-8c63" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="36e8-41a4-4b0d-8c63" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_c77f-0819-473b-a8a2</comment>
         </categoryLink>
         <categoryLink id="f39b-e2b6-4428-b550" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1237,7 +1237,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="45ed-a549-4858-beef" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="45ed-a549-4858-beef" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_0397-c837-4fea-a527</comment>
         </categoryLink>
         <categoryLink id="4353-c50b-4b70-8329" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1273,7 +1273,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="3a8d-7f7b-40cd-84cb" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="3a8d-7f7b-40cd-84cb" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_c1cf-cea4-4278-8f27</comment>
         </categoryLink>
         <categoryLink id="63b6-fb4c-47c3-a604" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1309,7 +1309,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="0598-4a1e-4b51-830b" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="0598-4a1e-4b51-830b" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_0c16-6841-42b2-b02d</comment>
         </categoryLink>
         <categoryLink id="44b9-6897-4af3-be85" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1345,7 +1345,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="4c91-0fc3-41d7-8721" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="4c91-0fc3-41d7-8721" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_3632-0b5d-4622-ae33</comment>
         </categoryLink>
         <categoryLink id="adf6-a145-463a-83c4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1381,7 +1381,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="72e8-deea-4936-a964" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="72e8-deea-4936-a964" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_5ad5-8701-42cd-b2b6</comment>
         </categoryLink>
         <categoryLink id="be43-3a01-4c3a-9cb6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1449,7 +1449,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="5e79-4b95-4fe1-8e66" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="5e79-4b95-4fe1-8e66" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_4d7c-201f-4c99-b89a</comment>
         </categoryLink>
         <categoryLink id="eeb6-c8e0-4959-a9b3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1483,7 +1483,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="5ac9-82bf-494c-9124" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="5ac9-82bf-494c-9124" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_4e52-ad1b-48d4-8eed</comment>
         </categoryLink>
         <categoryLink id="3546-a4a8-4ee4-af96" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false">
@@ -1497,7 +1497,7 @@
         <categoryLink id="818e-9544-4faa-b645" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_6140-2404-46f9-bd42</comment>
         </categoryLink>
-        <categoryLink id="4a6f-02a8-4ffd-a013" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
+        <categoryLink id="4a6f-02a8-4ffd-a013" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
           <comment>template_id_1c86-fad8-46ec-a0b0</comment>
         </categoryLink>
       </categoryLinks>
@@ -1523,7 +1523,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="f81b-595b-4c8a-ab0f" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
+        <categoryLink id="f81b-595b-4c8a-ab0f" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
           <comment>template_id_0af1-d052-4bd7-aab6</comment>
         </categoryLink>
         <categoryLink id="d112-6051-49aa-9cb6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1564,7 +1564,7 @@
         <categoryLink id="d680-2aa4-445e-8a47" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_4272-9b9d-4c59-95f0</comment>
         </categoryLink>
-        <categoryLink id="4411-a034-461d-a1f9" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="4411-a034-461d-a1f9" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_d85b-1ae7-40d5-9341</comment>
         </categoryLink>
       </categoryLinks>
@@ -1586,7 +1586,7 @@
         <categoryLink id="117d-e805-49c4-b960" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_ff9f-01cb-41b9-800e</comment>
         </categoryLink>
-        <categoryLink id="1313-b6de-48ca-a5a9" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="1313-b6de-48ca-a5a9" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_1315-6051-4a46-b070</comment>
         </categoryLink>
       </categoryLinks>
@@ -1594,7 +1594,7 @@
     <entryLink id="2b66-97ab-581b-f341" name="Praetor" hidden="false" collective="false" import="false" targetId="03be-5d55-d05a-771d" type="selectionEntry">
       <comment>template_id_5798-3fc7-4d4c-ad41</comment>
       <categoryLinks>
-        <categoryLink id="d615-0120-420c-8c9d" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
+        <categoryLink id="d615-0120-420c-8c9d" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
           <comment>template_id_b084-df23-4f99-812f</comment>
         </categoryLink>
         <categoryLink id="0fe6-a94d-4a98-add3" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false">
@@ -1724,7 +1724,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="b69b-8ff5-4ea2-af1b" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="b69b-8ff5-4ea2-af1b" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_b822-3417-4613-be37</comment>
         </categoryLink>
         <categoryLink id="b9ac-bba8-43d4-a25f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1751,7 +1751,7 @@
         <categoryLink id="e97c-1261-431e-b132" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_75a7-dc06-445b-b2dc</comment>
         </categoryLink>
-        <categoryLink id="6473-65c5-4214-a6a8" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="6473-65c5-4214-a6a8" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_e21a-c03b-4885-ac46</comment>
         </categoryLink>
       </categoryLinks>
@@ -1774,7 +1774,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="2eb6-9bbd-4b22-b1ed" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
+        <categoryLink id="2eb6-9bbd-4b22-b1ed" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
           <comment>template_id_f55b-7555-444b-beee</comment>
         </categoryLink>
         <categoryLink id="10fd-6aa1-4f5b-93f2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1795,7 +1795,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="bd1c-6d99-4f1e-b99d" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="bd1c-6d99-4f1e-b99d" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_79fa-3370-4ae0-9e12</comment>
         </categoryLink>
         <categoryLink id="f1fe-703f-45e9-b198" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1821,7 +1821,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="3a59-42a9-4f4a-a4d4" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="3a59-42a9-4f4a-a4d4" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_8d82-3279-4481-84bb</comment>
         </categoryLink>
         <categoryLink id="bfb1-2c19-46c5-897c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1854,7 +1854,7 @@
         <categoryLink id="558a-bf56-43b2-9f45" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_7010-be56-4709-b058</comment>
         </categoryLink>
-        <categoryLink id="3840-4c77-4a41-b3d0" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="3840-4c77-4a41-b3d0" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_7379-a740-47ba-a054</comment>
         </categoryLink>
       </categoryLinks>
@@ -1872,7 +1872,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="5e26-1a5a-4eca-b8a5" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="5e26-1a5a-4eca-b8a5" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_944f-7420-4982-8ea9</comment>
         </categoryLink>
         <categoryLink id="b56a-4992-4c56-b510" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1916,7 +1916,7 @@
         <categoryLink id="edb5-e16b-4f6e-8f58" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_c6ff-0977-4c92-bb28</comment>
         </categoryLink>
-        <categoryLink id="9315-ebd6-47a5-b414" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="9315-ebd6-47a5-b414" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_f555-7d39-458f-84c9</comment>
         </categoryLink>
       </categoryLinks>
@@ -1946,7 +1946,7 @@
         <categoryLink id="7173-2bd4-46b3-9fca" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_39e5-eda5-45d1-a643</comment>
         </categoryLink>
-        <categoryLink id="27ce-cfbd-465b-8c7f" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="27ce-cfbd-465b-8c7f" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_6416-21bb-4df4-9de8</comment>
         </categoryLink>
       </categoryLinks>
@@ -1976,7 +1976,7 @@
         <categoryLink id="2d99-4607-4d9d-94cd" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_5528-2dac-4be5-900c</comment>
         </categoryLink>
-        <categoryLink id="f587-fc12-4d71-98e6" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="f587-fc12-4d71-98e6" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_dc8f-d888-4585-991d</comment>
         </categoryLink>
       </categoryLinks>
@@ -2006,7 +2006,7 @@
         <categoryLink id="743c-0882-48ec-8d04" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_899e-b052-4d5b-8c18</comment>
         </categoryLink>
-        <categoryLink id="1ee2-6adf-4a6a-b672" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="1ee2-6adf-4a6a-b672" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_f5e9-cff6-41d2-a016</comment>
         </categoryLink>
       </categoryLinks>
@@ -2036,7 +2036,7 @@
         <categoryLink id="7e50-ba01-4e46-ba63" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_09cd-2176-40af-bba6</comment>
         </categoryLink>
-        <categoryLink id="cfde-ee52-4458-89c5" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="cfde-ee52-4458-89c5" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_05e6-7c63-4a35-9ba0</comment>
         </categoryLink>
       </categoryLinks>
@@ -2060,7 +2060,7 @@
         <categoryLink id="d80f-e8f8-46c9-996f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_0dfa-4004-4751-8022</comment>
         </categoryLink>
-        <categoryLink id="0980-70d9-4334-812d" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="0980-70d9-4334-812d" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_a669-0f5d-4fd3-811b</comment>
         </categoryLink>
       </categoryLinks>
@@ -2087,7 +2087,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="6071-c953-4ab2-80f0" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="6071-c953-4ab2-80f0" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_4f60-472b-45a9-ab9e</comment>
         </categoryLink>
         <categoryLink id="43c0-ab0a-4ea1-9d32" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2140,7 +2140,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="657a-ebf7-4c58-892e" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="657a-ebf7-4c58-892e" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_2008-f1c4-4285-a14f</comment>
         </categoryLink>
         <categoryLink id="c983-6ea6-438c-bb93" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2172,7 +2172,7 @@
         <categoryLink id="487c-f6fb-453a-8cd0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_9189-836c-475d-a52e</comment>
         </categoryLink>
-        <categoryLink id="fd29-fedd-4934-ada9" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="fd29-fedd-4934-ada9" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_e1fa-b7d8-47b0-a88a</comment>
         </categoryLink>
         <categoryLink id="fac6-ec9d-482f-b18d" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false">
@@ -2186,7 +2186,7 @@
         <categoryLink id="a564-4822-444a-ac72" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_b1d5-fd75-4f17-bbf4</comment>
         </categoryLink>
-        <categoryLink id="bfef-a58b-4804-9758" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="bfef-a58b-4804-9758" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_f221-bf81-4045-849b</comment>
         </categoryLink>
       </categoryLinks>
@@ -2213,7 +2213,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="32a6-76d2-4a94-8416" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="32a6-76d2-4a94-8416" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_f203-bc26-421f-b79e</comment>
         </categoryLink>
         <categoryLink id="8a8c-93d8-4c75-afc5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2227,7 +2227,7 @@
         <categoryLink id="c3e3-d8ba-41fb-8afa" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_51af-a137-4a1c-97a4</comment>
         </categoryLink>
-        <categoryLink id="dd72-9188-43cc-b502" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
+        <categoryLink id="dd72-9188-43cc-b502" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
           <comment>template_id_ec1f-c326-40a8-9d1f</comment>
         </categoryLink>
       </categoryLinks>
@@ -2289,7 +2289,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="d056-e98f-4fe1-a660" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="d056-e98f-4fe1-a660" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_fce3-801c-49c8-85d4</comment>
         </categoryLink>
         <categoryLink id="36cc-d983-4f05-9bab" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2300,7 +2300,7 @@
     <entryLink id="33c1-628d-e7c8-122c" name="Terminator Tartaros Squad" hidden="false" collective="false" import="false" targetId="1a8e-0ded-a4dc-2b4e" type="selectionEntry">
       <comment>template_id_0848-4e03-417a-b224</comment>
       <categoryLinks>
-        <categoryLink id="fc58-17bc-4622-8760" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
+        <categoryLink id="fc58-17bc-4622-8760" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
           <comment>template_id_ac1c-b3bf-4011-918a</comment>
         </categoryLink>
         <categoryLink id="00a7-4805-44f6-869f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2330,7 +2330,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="3ae4-1d81-42fd-8801" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="3ae4-1d81-42fd-8801" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_5a04-9847-4c91-a49a</comment>
         </categoryLink>
         <categoryLink id="e79e-6e12-41cc-b516" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2360,7 +2360,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="3970-9c1f-444d-a779" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="3970-9c1f-444d-a779" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_7d4f-547c-43ed-a520</comment>
         </categoryLink>
         <categoryLink id="a279-c317-4781-8829" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2389,7 +2389,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="f047-bb66-44e6-bc5f" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
+        <categoryLink id="f047-bb66-44e6-bc5f" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
           <comment>template_id_28e0-91e7-4ada-9fac</comment>
         </categoryLink>
         <categoryLink id="0252-d8a2-403b-bcd7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2422,7 +2422,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="23bb-d145-4e0c-9fbe" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="23bb-d145-4e0c-9fbe" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_e22a-c5f8-4825-a45f</comment>
         </categoryLink>
         <categoryLink id="22ee-d30b-4180-94e1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2439,7 +2439,7 @@
         <categoryLink id="dc90-bb8a-4c8d-854d" name="Compulsory Elite:" hidden="false" targetId="bb1f-ae32-b587-c3e1" primary="false">
           <comment>template_id_7d5a-62e7-43ee-b79b</comment>
         </categoryLink>
-        <categoryLink id="393c-263c-4b33-9f24" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
+        <categoryLink id="393c-263c-4b33-9f24" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
           <comment>template_id_4986-9157-49f2-b670</comment>
         </categoryLink>
       </categoryLinks>
@@ -2469,7 +2469,7 @@
         <categoryLink id="f196-06c7-426a-8386" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_1b86-0977-4a8b-adac</comment>
         </categoryLink>
-        <categoryLink id="0706-b651-4a0d-af76" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="0706-b651-4a0d-af76" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_b449-403a-4e42-9239</comment>
         </categoryLink>
       </categoryLinks>
@@ -2529,7 +2529,7 @@
         <categoryLink id="097b-11ff-4ff9-af73" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_4f71-446f-4cff-afda</comment>
         </categoryLink>
-        <categoryLink id="6d64-5f7b-448b-bdd8" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="6d64-5f7b-448b-bdd8" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_3f44-8647-43a4-ac22</comment>
         </categoryLink>
       </categoryLinks>
@@ -2550,7 +2550,7 @@
         <categoryLink id="5172-d6d2-4505-a0b7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_b6b1-886e-4194-8bcd</comment>
         </categoryLink>
-        <categoryLink id="1322-91e0-4cec-8bd1" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="1322-91e0-4cec-8bd1" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_51b5-f9c1-4587-8fc7</comment>
         </categoryLink>
       </categoryLinks>
@@ -2582,7 +2582,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="dc16-16d0-4890-a8e8" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="dc16-16d0-4890-a8e8" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="4b1e-3f1f-49cb-8343" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -2605,7 +2605,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="32cb-7077-4d54-9f38" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="2c35-def7-4c44-9b02" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="2c35-def7-4c44-9b02" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="0c9a-d272-491c-a4a0" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -2627,7 +2627,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="5b41-a9f0-4801-9dff" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="5b41-a9f0-4801-9dff" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="d64e-e976-4668-bb95" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
         <categoryLink id="17a6-f363-4094-9a7c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
@@ -2651,7 +2651,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="fe4f-c8f2-470f-901c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="f3f0-973b-4a45-ac41" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="f3f0-973b-4a45-ac41" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="3979-6aab-4c82-a1ca" name="Sky-Hunter Squadron" hidden="true" collective="false" import="false" targetId="6263-c696-2f2e-c105" type="selectionEntry">
@@ -2674,7 +2674,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="63ff-0a92-42ab-ae8c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="204c-7b0f-4fb9-b1b3" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="204c-7b0f-4fb9-b1b3" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="85e6-cb31-427c-a040" name="Line Sub-type:" hidden="false" targetId="6399-5c65-7833-1025" primary="false"/>
         <categoryLink id="b53d-b5f0-f9fb-2f00" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
       </categoryLinks>
@@ -2699,7 +2699,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="68dd-fc0f-4fde-8adc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="74ca-dd4f-46be-8be7" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="74ca-dd4f-46be-8be7" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="04a4-f151-12f5-30ae" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -2790,7 +2790,7 @@
       <categoryLinks>
         <categoryLink id="0d5b-be56-47af-a22e" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="2e59-1043-4719-96c4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="52fa-8c3c-49d4-a321" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="52fa-8c3c-49d4-a321" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="6a5d-bd56-4741-bf93" name="Termite Assault Drill" hidden="true" collective="false" import="false" targetId="cb30-307a-f0d7-3b13" type="selectionEntry">
@@ -2814,7 +2814,7 @@
       <categoryLinks>
         <categoryLink id="1fef-4409-4fab-93fc" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="ca2d-245e-48b4-a1cf" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="6692-6e39-44f0-ad8e" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="6692-6e39-44f0-ad8e" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="1890-6fe1-4b79-94a4" name="Venerable Ancient Contemptor Dreadnought" hidden="true" collective="false" import="false" targetId="dad1-0807-e254-d498" type="selectionEntry">
@@ -2831,7 +2831,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="9261-acb5-4230-8d89" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="1a5d-cbc8-418f-91a3" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="1a5d-cbc8-418f-91a3" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="c0cb-406f-4b46-9d8d" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
       </categoryLinks>
       <entryLinks>
@@ -2854,7 +2854,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="c0b2-dd90-46c1-a2a9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="9a94-76fb-4a89-ad5d" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="9a94-76fb-4a89-ad5d" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="6d31-360b-8669-fe74" name="Castellax Battle-Automata Maniple" hidden="true" collective="false" import="false" targetId="537f-846d-90e3-2526" type="selectionEntry">
@@ -2867,7 +2867,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="f8de-898b-ffc7-cdc5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="ac68-8f88-f50e-ca36" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="ac68-8f88-f50e-ca36" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="68c2-cfb8-2695-1dcc" name="Domitar Battle-Automata Maniple" hidden="true" collective="false" import="false" targetId="1a1b-fa35-a6a2-ca78" type="selectionEntry">
@@ -2880,7 +2880,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="51ab-5416-cac4-ee7c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="8957-af28-c0bb-cad0" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="8957-af28-c0bb-cad0" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="c528-ceda-5304-9592" name="Thanatar Siege-automata Maniple" hidden="true" collective="false" import="false" targetId="2903-fef6-e839-368b" type="selectionEntry">
@@ -2897,7 +2897,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="16e6-dbe1-c73b-51b5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="128e-33ab-e787-1844" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="128e-33ab-e787-1844" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="7f07-0747-bb2b-da0b" name="Vorax Battle-automata Maniple" hidden="true" collective="false" import="false" targetId="f144-1079-11ff-019d" type="selectionEntry">
@@ -2910,7 +2910,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="a32a-56c9-39b1-c178" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="973c-c4aa-71a2-07d4" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="973c-c4aa-71a2-07d4" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="db50-932a-c093-a55d" name="Deliverers Squad" hidden="true" collective="false" import="false" targetId="5d1d-8348-ed95-d366" type="selectionEntry">
@@ -2931,7 +2931,7 @@
       <categoryLinks>
         <categoryLink id="f455-fd7f-a13e-5e92" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="a8e4-4793-af2c-cd23" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
-        <categoryLink id="ccca-8d61-121e-ee86" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="ccca-8d61-121e-ee86" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="c150-0a6a-883e-0408" name="Thallax Cohort" hidden="true" collective="false" import="false" targetId="25c8-3e0f-e22d-a7eb" type="selectionEntry">
@@ -2956,7 +2956,7 @@
         <constraint field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1259-f027-22c2-f4c9" type="max"/>
       </constraints>
       <categoryLinks>
-        <categoryLink id="0659-2f13-b48e-e9c6" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="0659-2f13-b48e-e9c6" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="e6db-eeb9-37c4-fa62" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -3304,7 +3304,7 @@ Corvus Corax may still Run on a turn when the Korvidine Pinions have been activa
       </infoLinks>
       <categoryLinks>
         <categoryLink id="9bde-6d45-2c6d-9437" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="9b5d-cc1c-07cf-48a2" name="Skirmish:" hidden="false" targetId="59a4-7b61-600a-c457" primary="false"/>
+        <categoryLink id="9b5d-cc1c-07cf-48a2" name="Skirmish Sub-type:" hidden="false" targetId="59a4-7b61-600a-c457" primary="false"/>
         <categoryLink id="af53-7c6c-7d0b-18f1" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
@@ -4342,7 +4342,7 @@ Additionally, if selected as part of an army that includes Corvus Corax, no mode
       </infoLinks>
       <categoryLinks>
         <categoryLink id="188c-d76b-84a6-638f" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="9cc5-6040-2587-922f" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+        <categoryLink id="9cc5-6040-2587-922f" name="Heavy Sub-type:" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
         <categoryLink id="c489-7c99-cc6f-01d0" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="5877-4eb0-e84d-2158" name="Terminators:" hidden="false" targetId="bab3-f50d-3e5f-2f78" primary="false"/>
       </categoryLinks>
@@ -4812,6 +4812,6 @@ When in base to base contact with an enemy Infantry or Cavalry model whose Weapo
     </selectionEntryGroup>
   </sharedSelectionEntryGroups>
   <catalogueLinks>
-    <catalogueLink id="2f60-18fb-e6ed-8574" name="(HH V2) Legions Astartes" targetId="6393-649c-7213-a327" type="catalogue" importRootEntries="true"/>
+    <catalogueLink id="2f60-18fb-e6ed-8574" name="Legions Astartes" targetId="6393-649c-7213-a327" type="catalogue" importRootEntries="true"/>
   </catalogueLinks>
 </catalogue>

--- a/2022 - LA - Salamanders.cat
+++ b/2022 - LA - Salamanders.cat
@@ -14,7 +14,7 @@
         <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="57d2-e62d-e196-295b" type="max"/>
       </constraints>
       <categoryLinks>
-        <categoryLink id="e7bb-068e-33b8-7e33" name="New CategoryLink" hidden="false" targetId="e90d-e5a8-f42d-da84" primary="true"/>
+        <categoryLink id="e7bb-068e-33b8-7e33" name="Allegiance:" hidden="false" targetId="e90d-e5a8-f42d-da84" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="a4b6-92c9-7e8b-bfcd" name="Cassian Dracos Reborn" hidden="true" collective="false" import="false" targetId="fb8a-ab72-52ce-38f3" type="selectionEntry">
@@ -36,7 +36,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="2de5-e3bc-f6bc-5558" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="2de5-e3bc-f6bc-5558" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="b475-cb4a-5a9b-cf9b" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
         <categoryLink id="e43c-2895-7503-366a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
@@ -50,7 +50,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="26b1-529c-841e-80c6" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="26b1-529c-841e-80c6" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="1975-3b0c-9330-e098" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
       <entryLinks>
@@ -82,14 +82,14 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="ac1a-5683-b0a6-a1f5" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="ac1a-5683-b0a6-a1f5" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="2ac4-69c5-3a1e-7314" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
         <categoryLink id="1b50-8e8f-a15c-45d0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="5e51-de9f-0a93-825b" name="Pyroclast Squad" hidden="false" collective="false" import="false" targetId="71fe-d3bc-b7f9-75ca" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="eaf6-1e7a-32ab-b017" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="eaf6-1e7a-32ab-b017" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="00dc-c4a6-a6fe-adf5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
       <entryLinks>
@@ -121,7 +121,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="64a8-ba7d-4c9b-3f3e" name="New CategoryLink" hidden="false" targetId="ad5f-31db-8bc7-5c46" primary="true"/>
+        <categoryLink id="64a8-ba7d-4c9b-3f3e" name="Primarch:" hidden="false" targetId="ad5f-31db-8bc7-5c46" primary="true"/>
         <categoryLink id="6d75-8f0a-3caa-689d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
       <entryLinks>
@@ -144,7 +144,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="61c9-1410-be7e-6c64" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="61c9-1410-be7e-6c64" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="28d1-eb1c-4e2e-0ce6" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -154,7 +154,7 @@
         <categoryLink id="1cae-4341-45fd-bcde" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_c6d4-581f-4746-bec3</comment>
         </categoryLink>
-        <categoryLink id="c0d3-a31b-4300-aa17" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
+        <categoryLink id="c0d3-a31b-4300-aa17" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
           <comment>template_id_2489-ee2a-45dd-b384</comment>
         </categoryLink>
       </categoryLinks>
@@ -184,7 +184,7 @@
         <categoryLink id="0ccf-1f3f-481e-85c1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_8378-ede4-476d-b657</comment>
         </categoryLink>
-        <categoryLink id="018d-836e-4382-afa8" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="018d-836e-4382-afa8" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_d64f-ad19-426c-adf7</comment>
         </categoryLink>
       </categoryLinks>
@@ -215,7 +215,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="5bf5-4ac8-43a4-a38e" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="5bf5-4ac8-43a4-a38e" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_ac26-e639-4d53-9b8b</comment>
         </categoryLink>
         <categoryLink id="43b2-c165-47b1-8203" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -240,7 +240,7 @@
         </entryLink>
       </entryLinks>
     </entryLink>
-    <entryLink id="0898-4828-d0b4-f629" name="Avenger Strike Fighter" hidden="true" collective="false" import="false" targetId="b25c-e85c-1c29-9e05" type="selectionEntry">
+    <entryLink id="0898-4828-d0b4-f629" name="Legion Avenger Strike Fighter" hidden="true" collective="false" import="false" targetId="b25c-e85c-1c29-9e05" type="selectionEntry">
       <comment>template_id_1064-175d-4616-9c71</comment>
       <modifiers>
         <modifier type="set" field="hidden" value="false">
@@ -262,7 +262,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="7953-5224-4c78-b2a2" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="7953-5224-4c78-b2a2" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_a009-a597-4b51-b228</comment>
         </categoryLink>
         <categoryLink id="9286-37b6-4590-9652" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -295,7 +295,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="dd14-1d3d-4948-9026" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="dd14-1d3d-4948-9026" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_c165-3906-463a-9c73</comment>
         </categoryLink>
         <categoryLink id="5570-22c6-4883-816d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -332,7 +332,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="0ab7-cfe4-4181-b426" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="0ab7-cfe4-4181-b426" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_3a22-caae-4eea-9bc5</comment>
         </categoryLink>
         <categoryLink id="5417-f8d1-429a-be73" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -379,7 +379,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="a152-cf3a-4ae7-ae76" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="a152-cf3a-4ae7-ae76" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_251a-df5b-4bfd-ad63</comment>
         </categoryLink>
         <categoryLink id="c335-7798-46bf-b262" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -416,7 +416,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="e71e-4bde-4fb5-a257" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
+        <categoryLink id="e71e-4bde-4fb5-a257" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
           <comment>template_id_67c2-df43-44fc-92d1</comment>
         </categoryLink>
         <categoryLink id="77fa-b4f4-4489-8590" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -472,7 +472,7 @@
         <categoryLink id="7c7f-7da2-4096-b255" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_bd6a-0cda-4e0f-80ae</comment>
         </categoryLink>
-        <categoryLink id="c7bf-deff-4f8a-a375" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
+        <categoryLink id="c7bf-deff-4f8a-a375" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
           <comment>template_id_ae75-7cca-4701-9d56</comment>
         </categoryLink>
         <categoryLink id="bc9d-aa70-42f9-bb35" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false">
@@ -507,7 +507,7 @@
         <categoryLink id="a13d-b111-4497-a336" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false">
           <comment>template_id_f51c-73d7-4f29-be1c</comment>
         </categoryLink>
-        <categoryLink id="4e60-69e0-408a-ae50" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
+        <categoryLink id="4e60-69e0-408a-ae50" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
           <comment>template_id_257d-78c0-4bab-ba65</comment>
         </categoryLink>
       </categoryLinks>
@@ -555,7 +555,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="a4dd-958d-479a-af3b" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="a4dd-958d-479a-af3b" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_f1c8-27fd-4f98-8527</comment>
         </categoryLink>
         <categoryLink id="cb13-6872-45b5-86e8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -584,7 +584,7 @@
         <categoryLink id="74ea-64df-45e2-9fa5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_dd44-e0a8-42a8-bdcc</comment>
         </categoryLink>
-        <categoryLink id="0b27-e58e-41c7-b4a9" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
+        <categoryLink id="0b27-e58e-41c7-b4a9" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
           <comment>template_id_c5b0-f9ae-468d-924a</comment>
         </categoryLink>
       </categoryLinks>
@@ -611,7 +611,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="981e-f795-4464-af3a" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
+        <categoryLink id="981e-f795-4464-af3a" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
           <comment>template_id_f926-27fd-4a92-97a1</comment>
         </categoryLink>
         <categoryLink id="cd18-7307-4146-a32a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -643,7 +643,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="c2cb-7510-cd37-984e" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="c2cb-7510-cd37-984e" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
         <categoryLink id="a882-1a9b-4d57-93b5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -702,7 +702,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="1496-307f-4945-a0dc" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="1496-307f-4945-a0dc" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_361e-fb90-4b0e-ac3d</comment>
         </categoryLink>
         <categoryLink id="6514-e5f0-4870-bbfd" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -747,7 +747,7 @@
         <categoryLink id="80cc-f566-427e-bd5d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_473b-e812-4158-9416</comment>
         </categoryLink>
-        <categoryLink id="69fa-bb22-4f28-b83a" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
+        <categoryLink id="69fa-bb22-4f28-b83a" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
           <comment>template_id_00a2-63ff-4698-a35b</comment>
         </categoryLink>
       </categoryLinks>
@@ -785,7 +785,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="7be5-6d3f-44b0-9aa1" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="7be5-6d3f-44b0-9aa1" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_2a08-4432-42ad-bfdb</comment>
         </categoryLink>
         <categoryLink id="09f3-072c-4641-b9ba" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -818,7 +818,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="8846-ea24-4848-951e" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="8846-ea24-4848-951e" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_f4c0-4396-4f39-a34f</comment>
         </categoryLink>
         <categoryLink id="c4db-81c0-48c9-bc6c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -851,7 +851,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="a067-d86b-4ac7-a71c" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="a067-d86b-4ac7-a71c" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_caf6-5548-4b89-8102</comment>
         </categoryLink>
         <categoryLink id="d396-b44b-47ce-b4a8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -911,7 +911,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="46ae-7a73-4b06-926d" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="46ae-7a73-4b06-926d" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_d53e-113f-4a40-a3d5</comment>
         </categoryLink>
         <categoryLink id="b9da-1e07-4a3d-8bd0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -932,7 +932,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="c0ce-092c-4f65-89e0" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="c0ce-092c-4f65-89e0" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_e6f7-a6ca-4825-bfc5</comment>
         </categoryLink>
         <categoryLink id="e6be-f33b-4b5b-8f8b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -986,7 +986,7 @@
         <categoryLink id="e934-c99a-4eda-91ec" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_cefb-cfd7-4dc8-99c4</comment>
         </categoryLink>
-        <categoryLink id="ef73-a9db-483f-a9eb" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="ef73-a9db-483f-a9eb" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_a9fd-9d16-4a5e-855c</comment>
         </categoryLink>
       </categoryLinks>
@@ -1010,7 +1010,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="6606-dbb1-42ef-840a" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="6606-dbb1-42ef-840a" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_a56d-347b-4b09-a918</comment>
         </categoryLink>
         <categoryLink id="b0fb-505b-4e3f-a93e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1043,7 +1043,7 @@
         <categoryLink id="d754-4c0f-4f7c-a9e8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_9441-d79b-4720-9667</comment>
         </categoryLink>
-        <categoryLink id="36d8-7297-4bc8-9764" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="36d8-7297-4bc8-9764" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_7d7e-32d3-4692-b401</comment>
         </categoryLink>
       </categoryLinks>
@@ -1073,7 +1073,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="6656-86b1-4cda-8ebd" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="6656-86b1-4cda-8ebd" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_f65b-8958-49b3-92a5</comment>
         </categoryLink>
         <categoryLink id="dc31-5e3c-470a-86e7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1106,7 +1106,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="18ac-f3d1-428d-99d1" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="18ac-f3d1-428d-99d1" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_c6a8-22a8-4d41-b969</comment>
         </categoryLink>
         <categoryLink id="b025-4b35-454b-a556" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1169,7 +1169,7 @@
         <categoryLink id="2750-bb7f-44e3-8cc1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_bc67-ce1f-4004-aeb7</comment>
         </categoryLink>
-        <categoryLink id="f03b-c06e-4ff2-97c3" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="f03b-c06e-4ff2-97c3" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_9a45-9699-4475-aeef</comment>
         </categoryLink>
       </categoryLinks>
@@ -1232,7 +1232,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="01ec-d0cc-487b-867c" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="01ec-d0cc-487b-867c" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_3610-c975-4d55-bdfe</comment>
         </categoryLink>
         <categoryLink id="cdb7-5d12-45b0-a845" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1268,7 +1268,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="69ca-f7f0-4929-ac23" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="69ca-f7f0-4929-ac23" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_f81d-9435-4f11-99c1</comment>
         </categoryLink>
         <categoryLink id="b335-75fc-482a-85ea" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1304,7 +1304,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="71e8-7a48-4046-abdf" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="71e8-7a48-4046-abdf" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_b24f-3ae0-4cbb-b016</comment>
         </categoryLink>
         <categoryLink id="272b-0b4b-42b4-ae10" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1337,7 +1337,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="2705-a4d2-4d22-b8d8" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="2705-a4d2-4d22-b8d8" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_c77f-0819-473b-a8a2</comment>
         </categoryLink>
         <categoryLink id="478b-8a8b-489c-9b7e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1370,7 +1370,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="ed4b-75d9-42bd-8ded" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="ed4b-75d9-42bd-8ded" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_0397-c837-4fea-a527</comment>
         </categoryLink>
         <categoryLink id="44ac-7162-498d-b82c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1406,7 +1406,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="2e72-864f-4422-99a9" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="2e72-864f-4422-99a9" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_c1cf-cea4-4278-8f27</comment>
         </categoryLink>
         <categoryLink id="ebfe-e386-404e-a965" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1442,7 +1442,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="6d6e-e57c-4e9a-83be" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="6d6e-e57c-4e9a-83be" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_0c16-6841-42b2-b02d</comment>
         </categoryLink>
         <categoryLink id="6c1c-ab26-4aa4-b0af" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1478,7 +1478,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="41dd-ba00-4196-a48f" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="41dd-ba00-4196-a48f" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_3632-0b5d-4622-ae33</comment>
         </categoryLink>
         <categoryLink id="46ae-1740-4210-9293" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1514,7 +1514,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="a243-71d1-4cc9-80ed" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="a243-71d1-4cc9-80ed" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_5ad5-8701-42cd-b2b6</comment>
         </categoryLink>
         <categoryLink id="5886-339c-4144-878d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1581,7 +1581,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="145b-94c6-4a23-af84" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="145b-94c6-4a23-af84" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_4d7c-201f-4c99-b89a</comment>
         </categoryLink>
         <categoryLink id="7b99-7def-4474-91bf" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1614,7 +1614,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="d6ef-0e36-4863-8074" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="d6ef-0e36-4863-8074" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_4e52-ad1b-48d4-8eed</comment>
         </categoryLink>
         <categoryLink id="4723-fbbc-4254-8aca" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false">
@@ -1637,7 +1637,7 @@
         <categoryLink id="b8bc-0d89-41f0-8249" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_6140-2404-46f9-bd42</comment>
         </categoryLink>
-        <categoryLink id="1103-70b8-4b8d-bc94" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
+        <categoryLink id="1103-70b8-4b8d-bc94" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
           <comment>template_id_1c86-fad8-46ec-a0b0</comment>
         </categoryLink>
       </categoryLinks>
@@ -1677,7 +1677,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="416c-072a-4747-80c4" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
+        <categoryLink id="416c-072a-4747-80c4" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
           <comment>template_id_0af1-d052-4bd7-aab6</comment>
         </categoryLink>
         <categoryLink id="a4f9-3b02-467e-b17b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1726,7 +1726,7 @@
         <categoryLink id="ff76-5613-4e5f-8595" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_4272-9b9d-4c59-95f0</comment>
         </categoryLink>
-        <categoryLink id="0f31-b64d-4032-8eca" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="0f31-b64d-4032-8eca" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_d85b-1ae7-40d5-9341</comment>
         </categoryLink>
       </categoryLinks>
@@ -1769,7 +1769,7 @@
         <categoryLink id="e6fc-b1af-43bd-a58c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_ff9f-01cb-41b9-800e</comment>
         </categoryLink>
-        <categoryLink id="eabd-24ca-4bcb-ba26" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="eabd-24ca-4bcb-ba26" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_1315-6051-4a46-b070</comment>
         </categoryLink>
       </categoryLinks>
@@ -1777,7 +1777,7 @@
     <entryLink id="7db3-340c-ba11-4a1e" name="Praetor" hidden="false" collective="false" import="false" targetId="03be-5d55-d05a-771d" type="selectionEntry">
       <comment>template_id_5798-3fc7-4d4c-ad41</comment>
       <categoryLinks>
-        <categoryLink id="7bc5-049e-45bd-b4c0" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
+        <categoryLink id="7bc5-049e-45bd-b4c0" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
           <comment>template_id_b084-df23-4f99-812f</comment>
         </categoryLink>
         <categoryLink id="a1ba-0bee-4b82-b4a8" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false">
@@ -1902,7 +1902,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="1faf-7c3f-4ad2-afa1" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="1faf-7c3f-4ad2-afa1" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_b822-3417-4613-be37</comment>
         </categoryLink>
         <categoryLink id="0359-ab9a-40e4-b348" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1927,7 +1927,7 @@
         <categoryLink id="c231-43da-4bdf-ad6d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_75a7-dc06-445b-b2dc</comment>
         </categoryLink>
-        <categoryLink id="59c6-9d76-4eeb-8c0a" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="59c6-9d76-4eeb-8c0a" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_e21a-c03b-4885-ac46</comment>
         </categoryLink>
       </categoryLinks>
@@ -1945,7 +1945,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="2d02-539b-4fd4-8199" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
+        <categoryLink id="2d02-539b-4fd4-8199" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
           <comment>template_id_f55b-7555-444b-beee</comment>
         </categoryLink>
         <categoryLink id="49d9-93dc-4855-b053" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1966,7 +1966,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="ba8a-068c-4551-94a4" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="ba8a-068c-4551-94a4" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_79fa-3370-4ae0-9e12</comment>
         </categoryLink>
         <categoryLink id="bd26-56ea-4a13-9d13" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2006,7 +2006,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="65c9-fe5f-486d-b4ee" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="65c9-fe5f-486d-b4ee" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_8d82-3279-4481-84bb</comment>
         </categoryLink>
         <categoryLink id="2a63-4514-418d-bd54" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2039,7 +2039,7 @@
         <categoryLink id="6ead-3a6f-4149-b385" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_7010-be56-4709-b058</comment>
         </categoryLink>
-        <categoryLink id="9f21-e814-4265-8f36" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="9f21-e814-4265-8f36" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_7379-a740-47ba-a054</comment>
         </categoryLink>
       </categoryLinks>
@@ -2057,7 +2057,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="d894-2f95-472a-b711" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="d894-2f95-472a-b711" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_944f-7420-4982-8ea9</comment>
         </categoryLink>
         <categoryLink id="2e2d-ea81-47fb-9f43" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2129,7 +2129,7 @@
         <categoryLink id="ab19-fc5c-4a42-92e6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_c6ff-0977-4c92-bb28</comment>
         </categoryLink>
-        <categoryLink id="4507-3c66-489e-b780" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="4507-3c66-489e-b780" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_f555-7d39-458f-84c9</comment>
         </categoryLink>
       </categoryLinks>
@@ -2159,7 +2159,7 @@
         <categoryLink id="817a-c93f-45b0-bcd2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_39e5-eda5-45d1-a643</comment>
         </categoryLink>
-        <categoryLink id="5e8a-79ac-4504-b09c" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="5e8a-79ac-4504-b09c" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_6416-21bb-4df4-9de8</comment>
         </categoryLink>
       </categoryLinks>
@@ -2189,7 +2189,7 @@
         <categoryLink id="2256-10e8-43dd-adbd" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_5528-2dac-4be5-900c</comment>
         </categoryLink>
-        <categoryLink id="36bc-8b75-4922-8308" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="36bc-8b75-4922-8308" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_dc8f-d888-4585-991d</comment>
         </categoryLink>
       </categoryLinks>
@@ -2219,7 +2219,7 @@
         <categoryLink id="e82f-6d5f-4922-b22f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_899e-b052-4d5b-8c18</comment>
         </categoryLink>
-        <categoryLink id="ba44-9d38-42ff-baa0" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="ba44-9d38-42ff-baa0" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_f5e9-cff6-41d2-a016</comment>
         </categoryLink>
       </categoryLinks>
@@ -2249,7 +2249,7 @@
         <categoryLink id="562c-08de-4b1b-a309" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_09cd-2176-40af-bba6</comment>
         </categoryLink>
-        <categoryLink id="5877-e84f-47de-b33a" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="5877-e84f-47de-b33a" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_05e6-7c63-4a35-9ba0</comment>
         </categoryLink>
       </categoryLinks>
@@ -2278,7 +2278,7 @@
         <categoryLink id="5d7b-d511-4ebe-a057" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_0dfa-4004-4751-8022</comment>
         </categoryLink>
-        <categoryLink id="a8c8-3399-4fde-90f7" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="a8c8-3399-4fde-90f7" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_a669-0f5d-4fd3-811b</comment>
         </categoryLink>
       </categoryLinks>
@@ -2305,7 +2305,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="6c74-00b7-4662-b4df" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="6c74-00b7-4662-b4df" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_4f60-472b-45a9-ab9e</comment>
         </categoryLink>
         <categoryLink id="e216-561d-443b-a51e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2365,7 +2365,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="7f62-be9a-433f-94fc" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="7f62-be9a-433f-94fc" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_2008-f1c4-4285-a14f</comment>
         </categoryLink>
         <categoryLink id="4735-ce4d-4885-8839" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2397,7 +2397,7 @@
         <categoryLink id="0f80-3dd8-4f99-b565" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_9189-836c-475d-a52e</comment>
         </categoryLink>
-        <categoryLink id="b020-df82-470f-bc13" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="b020-df82-470f-bc13" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_e1fa-b7d8-47b0-a88a</comment>
         </categoryLink>
         <categoryLink id="6350-9690-4a19-9ad6" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false">
@@ -2425,7 +2425,7 @@
         <categoryLink id="5407-509b-49cf-9215" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_b1d5-fd75-4f17-bbf4</comment>
         </categoryLink>
-        <categoryLink id="1e6d-cbd1-45ac-9f3d" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="1e6d-cbd1-45ac-9f3d" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_f221-bf81-4045-849b</comment>
         </categoryLink>
       </categoryLinks>
@@ -2465,7 +2465,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="dd18-fa3b-40dc-be53" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="dd18-fa3b-40dc-be53" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_f203-bc26-421f-b79e</comment>
         </categoryLink>
         <categoryLink id="ebe8-898a-4a90-8536" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2479,7 +2479,7 @@
         <categoryLink id="b74e-3965-4ca6-98f1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_51af-a137-4a1c-97a4</comment>
         </categoryLink>
-        <categoryLink id="684b-63ac-46c0-bf6c" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
+        <categoryLink id="684b-63ac-46c0-bf6c" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
           <comment>template_id_ec1f-c326-40a8-9d1f</comment>
         </categoryLink>
       </categoryLinks>
@@ -2545,7 +2545,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="8adc-ba37-4b11-a3ce" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="8adc-ba37-4b11-a3ce" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_fce3-801c-49c8-85d4</comment>
         </categoryLink>
         <categoryLink id="81cf-2649-4a75-8912" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2570,7 +2570,7 @@
     <entryLink id="86ed-08f1-a8ec-dc32" name="Terminator Tartaros Squad" hidden="false" collective="false" import="false" targetId="1a8e-0ded-a4dc-2b4e" type="selectionEntry">
       <comment>template_id_0848-4e03-417a-b224</comment>
       <categoryLinks>
-        <categoryLink id="f080-7b36-41e2-8c93" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
+        <categoryLink id="f080-7b36-41e2-8c93" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
           <comment>template_id_ac1c-b3bf-4011-918a</comment>
         </categoryLink>
         <categoryLink id="fede-89c6-4290-8196" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2614,7 +2614,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="669a-f74f-4673-99cd" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="669a-f74f-4673-99cd" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_5a04-9847-4c91-a49a</comment>
         </categoryLink>
         <categoryLink id="cec4-5a61-463d-9fcc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2644,7 +2644,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="5778-c398-4077-8e3e" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="5778-c398-4077-8e3e" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_7d4f-547c-43ed-a520</comment>
         </categoryLink>
         <categoryLink id="8d61-b60a-494f-bd73" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2673,7 +2673,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="b173-c139-4503-947a" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
+        <categoryLink id="b173-c139-4503-947a" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
           <comment>template_id_28e0-91e7-4ada-9fac</comment>
         </categoryLink>
         <categoryLink id="dda5-59dd-4d84-a33d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2706,7 +2706,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="aea1-4aa2-4fcc-84ea" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="aea1-4aa2-4fcc-84ea" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_e22a-c5f8-4825-a45f</comment>
         </categoryLink>
         <categoryLink id="7d9a-5044-44d5-84a5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2723,7 +2723,7 @@
         <categoryLink id="a9bf-b170-4fa6-8a89" name="Compulsory Elite:" hidden="false" targetId="bb1f-ae32-b587-c3e1" primary="false">
           <comment>template_id_7d5a-62e7-43ee-b79b</comment>
         </categoryLink>
-        <categoryLink id="91fe-6998-4b02-ae9f" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
+        <categoryLink id="91fe-6998-4b02-ae9f" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
           <comment>template_id_4986-9157-49f2-b670</comment>
         </categoryLink>
       </categoryLinks>
@@ -2767,7 +2767,7 @@
         <categoryLink id="ee3d-9435-44e3-9306" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_1b86-0977-4a8b-adac</comment>
         </categoryLink>
-        <categoryLink id="f9b4-8aad-400c-9ed9" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="f9b4-8aad-400c-9ed9" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_b449-403a-4e42-9239</comment>
         </categoryLink>
       </categoryLinks>
@@ -2827,7 +2827,7 @@
         <categoryLink id="76d9-46cd-4e06-a4fe" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_4f71-446f-4cff-afda</comment>
         </categoryLink>
-        <categoryLink id="2e16-c0a3-498b-850c" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="2e16-c0a3-498b-850c" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_3f44-8647-43a4-ac22</comment>
         </categoryLink>
       </categoryLinks>
@@ -2848,7 +2848,7 @@
         <categoryLink id="0516-c7ef-446e-8d09" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_b6b1-886e-4194-8bcd</comment>
         </categoryLink>
-        <categoryLink id="0d06-495a-4c6a-9dc4" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="0d06-495a-4c6a-9dc4" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_51b5-f9c1-4587-8fc7</comment>
         </categoryLink>
       </categoryLinks>
@@ -2879,7 +2879,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="dc16-16d0-4890-a8e8" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="dc16-16d0-4890-a8e8" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="4b1e-3f1f-49cb-8343" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
       <entryLinks>
@@ -2916,7 +2916,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="32cb-7077-4d54-9f38" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="2c35-def7-4c44-9b02" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="2c35-def7-4c44-9b02" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="0c9a-d272-491c-a4a0" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -2938,7 +2938,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="5b41-a9f0-4801-9dff" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="5b41-a9f0-4801-9dff" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="d64e-e976-4668-bb95" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
         <categoryLink id="17a6-f363-4094-9a7c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
@@ -2962,7 +2962,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="fe4f-c8f2-470f-901c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="f3f0-973b-4a45-ac41" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="f3f0-973b-4a45-ac41" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="106d-ae42-4136-8e9f" name="Sky-Hunter Squadron" hidden="true" collective="false" import="false" targetId="6263-c696-2f2e-c105" type="selectionEntry">
@@ -2985,7 +2985,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="63ff-0a92-42ab-ae8c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="204c-7b0f-4fb9-b1b3" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="204c-7b0f-4fb9-b1b3" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="85e6-cb31-427c-a040" name="Line Sub-type:" hidden="false" targetId="6399-5c65-7833-1025" primary="false"/>
         <categoryLink id="589c-fa50-73d4-0b2d" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
       </categoryLinks>
@@ -3010,7 +3010,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="68dd-fc0f-4fde-8adc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="74ca-dd4f-46be-8be7" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="74ca-dd4f-46be-8be7" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="3eb3-0f00-c135-10be" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -3101,7 +3101,7 @@
       <categoryLinks>
         <categoryLink id="0d5b-be56-47af-a22e" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="2e59-1043-4719-96c4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="52fa-8c3c-49d4-a321" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="52fa-8c3c-49d4-a321" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="cf25-b990-42dd-8b7b" name="Termite Assault Drill" hidden="true" collective="false" import="false" targetId="cb30-307a-f0d7-3b13" type="selectionEntry">
@@ -3125,7 +3125,7 @@
       <categoryLinks>
         <categoryLink id="1fef-4409-4fab-93fc" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="ca2d-245e-48b4-a1cf" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="6692-6e39-44f0-ad8e" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="6692-6e39-44f0-ad8e" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="0ff5-e228-411f-980b" name="Venerable Ancient Contemptor Dreadnought" hidden="true" collective="false" import="false" targetId="dad1-0807-e254-d498" type="selectionEntry">
@@ -3142,7 +3142,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="9261-acb5-4230-8d89" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="1a5d-cbc8-418f-91a3" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="1a5d-cbc8-418f-91a3" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="c0cb-406f-4b46-9d8d" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
       </categoryLinks>
       <entryLinks>
@@ -3165,7 +3165,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="c0b2-dd90-46c1-a2a9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="9a94-76fb-4a89-ad5d" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="9a94-76fb-4a89-ad5d" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="76f8-061c-a768-4874" name="Vorax Battle-automata Maniple" hidden="true" collective="false" import="false" targetId="f144-1079-11ff-019d" type="selectionEntry">
@@ -3178,7 +3178,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="a6cb-6480-d3b5-5863" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="87da-ad68-f53e-8bb0" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="87da-ad68-f53e-8bb0" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="951d-ff51-4438-4460" name="Thanatar Siege-automata Maniple" hidden="true" collective="false" import="false" targetId="2903-fef6-e839-368b" type="selectionEntry">
@@ -3195,7 +3195,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="ae2c-6b93-3ee0-e1ae" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="35ec-bdd9-e2eb-4ab1" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="35ec-bdd9-e2eb-4ab1" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="e2e8-6f4d-2011-c768" name="Domitar Battle-Automata Maniple" hidden="true" collective="false" import="false" targetId="1a1b-fa35-a6a2-ca78" type="selectionEntry">
@@ -3208,7 +3208,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="21d2-adf1-0568-892e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="b7d8-3126-2c56-0312" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="b7d8-3126-2c56-0312" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="7b5e-28ce-8963-982c" name="Castellax Battle-Automata Maniple" hidden="true" collective="false" import="false" targetId="537f-846d-90e3-2526" type="selectionEntry">
@@ -3221,7 +3221,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="058d-0278-0f2e-d243" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="e91a-424f-beb1-aa04" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="e91a-424f-beb1-aa04" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="4b47-e776-689d-16ac" name="Firedrake Terminator Squad" hidden="true" collective="false" import="false" targetId="6775-8379-8d6b-9614" type="selectionEntry">
@@ -3242,7 +3242,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="74b2-7eb7-071c-de33" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="8e3e-8774-ff55-716b" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="8e3e-8774-ff55-716b" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="52f7-4996-75b4-4da2" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -3268,7 +3268,7 @@
         <constraint field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="aff5-6906-d2be-228a" type="max"/>
       </constraints>
       <categoryLinks>
-        <categoryLink id="7ae0-2a39-ba26-9a30" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="7ae0-2a39-ba26-9a30" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="1868-b53d-e734-cefb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -3308,7 +3308,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="6e00-01d9-4660-3c5a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="ca02-a2fc-a804-f0c2" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="ca02-a2fc-a804-f0c2" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="adab-7916-4cb1-5d32" name="Adherents Squad" hidden="true" collective="false" import="false" targetId="b110-ce62-3e2f-79f8" type="selectionEntry">
@@ -3325,7 +3325,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="709f-111e-17a2-a0ed" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="55f5-d260-064c-aa32" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="55f5-d260-064c-aa32" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink import="true" name="Sanctifier Squad" hidden="false" type="selectionEntry" id="50e2-1d9-cd51-c294" targetId="3720-9b50-f599-76ea">
@@ -3790,7 +3790,7 @@
         </infoLink>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="b47e-4128-4626-5ab1" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+        <categoryLink id="b47e-4128-4626-5ab1" name="Heavy Sub-type:" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
         <categoryLink id="0d65-1662-e010-f889" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="f28b-f86f-8c4f-ba4f" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="a1cf-3d0c-18a6-773d" name="Terminators:" hidden="false" targetId="bab3-f50d-3e5f-2f78" primary="false"/>
@@ -4174,7 +4174,7 @@
         </infoLink>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="3af7-46b2-2419-4a55" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+        <categoryLink id="3af7-46b2-2419-4a55" name="Heavy Sub-type:" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
         <categoryLink id="d849-8fbc-0faa-8dfb" name="Dreadnought Unit-type:" hidden="false" targetId="4280-4963-02b5-e31d" primary="false"/>
         <categoryLink id="2ff0-6e13-57f0-e139" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
       </categoryLinks>
@@ -5801,6 +5801,6 @@
     </selectionEntryGroup>
   </sharedSelectionEntryGroups>
   <catalogueLinks>
-    <catalogueLink id="2f60-18fb-e6ed-8574" name="(HH V2) Legions Astartes" targetId="6393-649c-7213-a327" type="catalogue" importRootEntries="true"/>
+    <catalogueLink id="2f60-18fb-e6ed-8574" name="Legions Astartes" targetId="6393-649c-7213-a327" type="catalogue" importRootEntries="true"/>
   </catalogueLinks>
 </catalogue>

--- a/2022 - LA - Sons of Horus.cat
+++ b/2022 - LA - Sons of Horus.cat
@@ -14,7 +14,7 @@
         <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="17ce-5398-8e0c-9aa7" type="max"/>
       </constraints>
       <categoryLinks>
-        <categoryLink id="77a4-df1d-7fb6-75ec" name="New CategoryLink" hidden="false" targetId="e90d-e5a8-f42d-da84" primary="true"/>
+        <categoryLink id="77a4-df1d-7fb6-75ec" name="Allegiance:" hidden="false" targetId="e90d-e5a8-f42d-da84" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="e2c3-2fb9-ad2e-c424" name="Chieftain Squad" hidden="true" collective="false" import="false" targetId="0c73-9141-d1b4-6a40" type="selectionEntry">
@@ -36,7 +36,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="114d-f93f-d7a5-80d7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="f195-05cd-45e6-70af" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="f195-05cd-45e6-70af" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="7742-6ac2-9a35-df68" name="Maloghurst the Twisted" hidden="false" collective="false" import="false" targetId="0b37-0420-b06a-fcc5" type="selectionEntry">
@@ -48,7 +48,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="b32e-3835-5d7e-6f91" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="b32e-3835-5d7e-6f91" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="bd61-dd1a-5314-ed85" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="126c-a234-df65-26be" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
       </categoryLinks>
@@ -68,7 +68,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="aa5f-6290-d3fb-abdc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="0929-6baa-85a0-1f92" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="0929-6baa-85a0-1f92" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="c2bd-dc92-2e11-b309" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
       </categoryLinks>
       <costs>
@@ -84,7 +84,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="0bfe-b991-37d7-ae6d" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="0bfe-b991-37d7-ae6d" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="d2f9-3965-25e2-eaff" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -98,7 +98,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="77a5-bc2d-91c4-f76e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="e465-788c-463b-7b1c" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="e465-788c-463b-7b1c" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="fd37-d09d-cd28-82d8" name="Line Sub-type:" hidden="false" targetId="6399-5c65-7833-1025" primary="false"/>
         <categoryLink id="3da2-228b-fd58-fc4e" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
       </categoryLinks>
@@ -121,7 +121,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="f3d1-a002-2b03-4847" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="f3d1-a002-2b03-4847" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="020a-df9f-429e-a84a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="6e66-b81f-4d44-a873" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
       </categoryLinks>
@@ -135,7 +135,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="2fe4-5c5c-bead-f06e" name="New CategoryLink" hidden="false" targetId="ad5f-31db-8bc7-5c46" primary="true"/>
+        <categoryLink id="2fe4-5c5c-bead-f06e" name="Primarch:" hidden="false" targetId="ad5f-31db-8bc7-5c46" primary="true"/>
         <categoryLink id="734c-b12a-678e-ad6a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
       <entryLinks>
@@ -153,7 +153,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="8cab-2c82-02c7-7545" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="8cab-2c82-02c7-7545" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="faf8-056b-cd6a-94e6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="1272-35e1-e6fe-f231" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
       </categoryLinks>
@@ -167,7 +167,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="1d7a-0e25-aa2d-ac68" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="1d7a-0e25-aa2d-ac68" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="d429-527d-c73b-bddc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -177,7 +177,7 @@
         <categoryLink id="f03f-2f11-4672-ad15" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_c6d4-581f-4746-bec3</comment>
         </categoryLink>
-        <categoryLink id="fa55-54b1-43e9-b9fa" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
+        <categoryLink id="fa55-54b1-43e9-b9fa" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
           <comment>template_id_2489-ee2a-45dd-b384</comment>
         </categoryLink>
       </categoryLinks>
@@ -207,7 +207,7 @@
         <categoryLink id="2400-f7db-433d-bd90" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_8378-ede4-476d-b657</comment>
         </categoryLink>
-        <categoryLink id="99cf-c093-4060-a35e" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="99cf-c093-4060-a35e" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_d64f-ad19-426c-adf7</comment>
         </categoryLink>
       </categoryLinks>
@@ -233,7 +233,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="b599-cb2d-4179-9fed" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="b599-cb2d-4179-9fed" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_ac26-e639-4d53-9b8b</comment>
         </categoryLink>
         <categoryLink id="f8a8-7e1f-41e5-b530" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -244,7 +244,7 @@
         </categoryLink>
       </categoryLinks>
     </entryLink>
-    <entryLink id="5931-079a-7236-2747" name="Avenger Strike Fighter" hidden="true" collective="false" import="false" targetId="b25c-e85c-1c29-9e05" type="selectionEntry">
+    <entryLink id="5931-079a-7236-2747" name="Legion Avenger Strike Fighter" hidden="true" collective="false" import="false" targetId="b25c-e85c-1c29-9e05" type="selectionEntry">
       <comment>template_id_1064-175d-4616-9c71</comment>
       <modifiers>
         <modifier type="set" field="hidden" value="false">
@@ -266,7 +266,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="60d5-a2ee-44bc-9e7a" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="60d5-a2ee-44bc-9e7a" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_a009-a597-4b51-b228</comment>
         </categoryLink>
         <categoryLink id="4d6d-e02b-4b66-a75c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -299,7 +299,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="4533-378f-411d-a983" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="4533-378f-411d-a983" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_c165-3906-463a-9c73</comment>
         </categoryLink>
         <categoryLink id="79ed-a409-4311-a0d9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -336,7 +336,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="a0b0-4f18-46aa-a695" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="a0b0-4f18-46aa-a695" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_3a22-caae-4eea-9bc5</comment>
         </categoryLink>
         <categoryLink id="cfa8-b2dd-4514-b984" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -369,7 +369,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="8e3a-9a3f-4252-be5a" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="8e3a-9a3f-4252-be5a" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_251a-df5b-4bfd-ad63</comment>
         </categoryLink>
         <categoryLink id="6559-b2ac-4150-aec2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -406,7 +406,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="c668-fa82-4239-9528" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
+        <categoryLink id="c668-fa82-4239-9528" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
           <comment>template_id_67c2-df43-44fc-92d1</comment>
         </categoryLink>
         <categoryLink id="167d-b0ab-4a62-910c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -462,7 +462,7 @@
         <categoryLink id="147b-8a43-401f-9c63" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_bd6a-0cda-4e0f-80ae</comment>
         </categoryLink>
-        <categoryLink id="0b33-d83b-4b5b-9db8" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
+        <categoryLink id="0b33-d83b-4b5b-9db8" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
           <comment>template_id_ae75-7cca-4701-9d56</comment>
         </categoryLink>
         <categoryLink id="4b45-474f-4647-8372" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false">
@@ -497,7 +497,7 @@
         <categoryLink id="9499-2ce8-44a7-be45" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false">
           <comment>template_id_f51c-73d7-4f29-be1c</comment>
         </categoryLink>
-        <categoryLink id="2123-b1f8-456e-8c90" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
+        <categoryLink id="2123-b1f8-456e-8c90" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
           <comment>template_id_257d-78c0-4bab-ba65</comment>
         </categoryLink>
       </categoryLinks>
@@ -545,7 +545,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="0409-0ca7-4110-8df9" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="0409-0ca7-4110-8df9" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_f1c8-27fd-4f98-8527</comment>
         </categoryLink>
         <categoryLink id="0ce3-a809-4add-8a1d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -574,7 +574,7 @@
         <categoryLink id="267b-0b05-4e6a-bda5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_dd44-e0a8-42a8-bdcc</comment>
         </categoryLink>
-        <categoryLink id="704e-a9cf-4e39-af22" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
+        <categoryLink id="704e-a9cf-4e39-af22" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
           <comment>template_id_c5b0-f9ae-468d-924a</comment>
         </categoryLink>
       </categoryLinks>
@@ -601,7 +601,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="46cb-a436-45c5-947a" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
+        <categoryLink id="46cb-a436-45c5-947a" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
           <comment>template_id_f926-27fd-4a92-97a1</comment>
         </categoryLink>
         <categoryLink id="093a-ac5c-4f07-9baf" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -633,7 +633,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="0812-2a99-32b8-cfc8" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="0812-2a99-32b8-cfc8" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
         <categoryLink id="0d0d-89a7-4ae2-a798" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -692,7 +692,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="8b85-3de7-4c7e-9687" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="8b85-3de7-4c7e-9687" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_361e-fb90-4b0e-ac3d</comment>
         </categoryLink>
         <categoryLink id="72e8-a3f9-4258-a35b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -709,7 +709,7 @@
         <categoryLink id="b354-3d58-4c35-ade4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_473b-e812-4158-9416</comment>
         </categoryLink>
-        <categoryLink id="de15-6897-4fbe-bc4f" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
+        <categoryLink id="de15-6897-4fbe-bc4f" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
           <comment>template_id_00a2-63ff-4698-a35b</comment>
         </categoryLink>
       </categoryLinks>
@@ -733,7 +733,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="23df-87d4-483d-9fa8" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="23df-87d4-483d-9fa8" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_2a08-4432-42ad-bfdb</comment>
         </categoryLink>
         <categoryLink id="5540-fc5a-4879-aa33" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -765,7 +765,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="d3bf-7cd3-490e-8f98" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="d3bf-7cd3-490e-8f98" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_f4c0-4396-4f39-a34f</comment>
         </categoryLink>
         <categoryLink id="5861-d8d1-414c-8984" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -798,7 +798,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="3e71-3c0f-47de-8692" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="3e71-3c0f-47de-8692" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_caf6-5548-4b89-8102</comment>
         </categoryLink>
         <categoryLink id="dbd9-7ccb-4ec0-b48d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -858,7 +858,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="913a-86b0-4c48-a1b5" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="913a-86b0-4c48-a1b5" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_d53e-113f-4a40-a3d5</comment>
         </categoryLink>
         <categoryLink id="b9d3-be16-4aa8-a007" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -879,7 +879,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="31b7-3726-48d3-9cfa" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="31b7-3726-48d3-9cfa" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_e6f7-a6ca-4825-bfc5</comment>
         </categoryLink>
         <categoryLink id="28c5-8018-41ca-8365" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -912,7 +912,7 @@
         <categoryLink id="516d-e3a7-4c58-8a1a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_cefb-cfd7-4dc8-99c4</comment>
         </categoryLink>
-        <categoryLink id="e88d-d858-4081-82d1" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="e88d-d858-4081-82d1" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_a9fd-9d16-4a5e-855c</comment>
         </categoryLink>
       </categoryLinks>
@@ -936,7 +936,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="7667-d417-4c91-bb88" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="7667-d417-4c91-bb88" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_a56d-347b-4b09-a918</comment>
         </categoryLink>
         <categoryLink id="5b04-3409-49d0-96c1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -969,7 +969,7 @@
         <categoryLink id="5014-fa8e-4b5b-89ec" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_9441-d79b-4720-9667</comment>
         </categoryLink>
-        <categoryLink id="908b-600c-423e-bf71" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="908b-600c-423e-bf71" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_7d7e-32d3-4692-b401</comment>
         </categoryLink>
       </categoryLinks>
@@ -999,7 +999,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="9915-3dbb-459b-8aab" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="9915-3dbb-459b-8aab" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_f65b-8958-49b3-92a5</comment>
         </categoryLink>
         <categoryLink id="2a73-5d83-4492-b4ad" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1032,7 +1032,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="2c83-8a08-45e7-a2ad" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="2c83-8a08-45e7-a2ad" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_c6a8-22a8-4d41-b969</comment>
         </categoryLink>
         <categoryLink id="5c0b-02d3-4cdf-ae26" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1095,7 +1095,7 @@
         <categoryLink id="89c1-45ea-49a2-bf58" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_bc67-ce1f-4004-aeb7</comment>
         </categoryLink>
-        <categoryLink id="aa3b-8566-4f98-b76a" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="aa3b-8566-4f98-b76a" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_9a45-9699-4475-aeef</comment>
         </categoryLink>
       </categoryLinks>
@@ -1158,7 +1158,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="10be-47f3-4451-87db" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="10be-47f3-4451-87db" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_3610-c975-4d55-bdfe</comment>
         </categoryLink>
         <categoryLink id="369a-7560-49a3-b167" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1194,7 +1194,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="f9e4-2eed-4940-8e85" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="f9e4-2eed-4940-8e85" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_f81d-9435-4f11-99c1</comment>
         </categoryLink>
         <categoryLink id="14ed-fc51-4960-bb59" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1230,7 +1230,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="66e9-176d-4684-a526" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="66e9-176d-4684-a526" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_b24f-3ae0-4cbb-b016</comment>
         </categoryLink>
         <categoryLink id="a91a-0b08-408a-a7ba" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1263,7 +1263,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="fcfb-0106-4410-8d3b" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="fcfb-0106-4410-8d3b" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_c77f-0819-473b-a8a2</comment>
         </categoryLink>
         <categoryLink id="50ae-9aa7-4afc-9044" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1296,7 +1296,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="226b-2575-4498-93c4" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="226b-2575-4498-93c4" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_0397-c837-4fea-a527</comment>
         </categoryLink>
         <categoryLink id="de39-3781-4648-9e63" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1332,7 +1332,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="a711-323d-42a3-b623" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="a711-323d-42a3-b623" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_c1cf-cea4-4278-8f27</comment>
         </categoryLink>
         <categoryLink id="bc5d-8b72-41a4-88f5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1368,7 +1368,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="92c5-551d-4ce3-b922" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="92c5-551d-4ce3-b922" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_0c16-6841-42b2-b02d</comment>
         </categoryLink>
         <categoryLink id="6865-5b63-46dd-a2b7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1404,7 +1404,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="9058-32f4-4d72-8c00" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="9058-32f4-4d72-8c00" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_3632-0b5d-4622-ae33</comment>
         </categoryLink>
         <categoryLink id="b857-8ae3-4130-a8fd" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1440,7 +1440,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="ecd7-bdb5-452f-bb1f" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="ecd7-bdb5-452f-bb1f" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_5ad5-8701-42cd-b2b6</comment>
         </categoryLink>
         <categoryLink id="1bfe-0836-4a7e-9c0b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1506,7 +1506,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="d632-8c66-4ebe-bd0e" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="d632-8c66-4ebe-bd0e" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_4d7c-201f-4c99-b89a</comment>
         </categoryLink>
         <categoryLink id="c5f3-9933-46f7-bba7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1539,7 +1539,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="bf1c-9c0a-4945-bca5" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="bf1c-9c0a-4945-bca5" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_4e52-ad1b-48d4-8eed</comment>
         </categoryLink>
         <categoryLink id="eba3-d636-472c-b62c" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false">
@@ -1553,7 +1553,7 @@
         <categoryLink id="28d9-dd4e-4da4-9bf8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_6140-2404-46f9-bd42</comment>
         </categoryLink>
-        <categoryLink id="1886-cc41-4e0f-aa95" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
+        <categoryLink id="1886-cc41-4e0f-aa95" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
           <comment>template_id_1c86-fad8-46ec-a0b0</comment>
         </categoryLink>
       </categoryLinks>
@@ -1579,7 +1579,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="0052-2fdd-434d-9e86" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
+        <categoryLink id="0052-2fdd-434d-9e86" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
           <comment>template_id_0af1-d052-4bd7-aab6</comment>
         </categoryLink>
         <categoryLink id="e82a-10cc-47f4-9afd" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1628,7 +1628,7 @@
         <categoryLink id="1d1f-4110-42ea-9f59" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_4272-9b9d-4c59-95f0</comment>
         </categoryLink>
-        <categoryLink id="34bc-412a-4e0a-879d" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="34bc-412a-4e0a-879d" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_d85b-1ae7-40d5-9341</comment>
         </categoryLink>
       </categoryLinks>
@@ -1650,7 +1650,7 @@
         <categoryLink id="3acc-9a1f-4c56-8568" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_ff9f-01cb-41b9-800e</comment>
         </categoryLink>
-        <categoryLink id="1d0d-3339-4e5a-8e44" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="1d0d-3339-4e5a-8e44" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_1315-6051-4a46-b070</comment>
         </categoryLink>
       </categoryLinks>
@@ -1658,7 +1658,7 @@
     <entryLink id="3930-0089-f27e-cd7c" name="Praetor" hidden="false" collective="false" import="false" targetId="03be-5d55-d05a-771d" type="selectionEntry">
       <comment>template_id_5798-3fc7-4d4c-ad41</comment>
       <categoryLinks>
-        <categoryLink id="a504-c02b-40d5-b166" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
+        <categoryLink id="a504-c02b-40d5-b166" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
           <comment>template_id_b084-df23-4f99-812f</comment>
         </categoryLink>
         <categoryLink id="765f-fd33-41e9-b71b" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false">
@@ -1783,7 +1783,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="989f-34a1-4486-aa64" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="989f-34a1-4486-aa64" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_b822-3417-4613-be37</comment>
         </categoryLink>
         <categoryLink id="3b57-1bfd-415a-99bb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1810,7 +1810,7 @@
         <categoryLink id="ac37-d870-4ed7-98e5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_75a7-dc06-445b-b2dc</comment>
         </categoryLink>
-        <categoryLink id="ab08-c979-458a-85dc" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="ab08-c979-458a-85dc" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_e21a-c03b-4885-ac46</comment>
         </categoryLink>
       </categoryLinks>
@@ -1828,7 +1828,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="5b6f-d425-4087-a8be" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
+        <categoryLink id="5b6f-d425-4087-a8be" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
           <comment>template_id_f55b-7555-444b-beee</comment>
         </categoryLink>
         <categoryLink id="864a-3067-4bb2-b5bd" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1849,7 +1849,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="431a-57a0-4a66-ba7f" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="431a-57a0-4a66-ba7f" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_79fa-3370-4ae0-9e12</comment>
         </categoryLink>
         <categoryLink id="0ff8-977b-46b2-aa43" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1875,7 +1875,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="ff7b-13a9-48d7-b964" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="ff7b-13a9-48d7-b964" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_8d82-3279-4481-84bb</comment>
         </categoryLink>
         <categoryLink id="0608-37fa-4568-855c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1908,7 +1908,7 @@
         <categoryLink id="545c-556e-43fe-9f9c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_7010-be56-4709-b058</comment>
         </categoryLink>
-        <categoryLink id="a7c1-8628-43e3-a862" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="a7c1-8628-43e3-a862" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_7379-a740-47ba-a054</comment>
         </categoryLink>
       </categoryLinks>
@@ -1926,7 +1926,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="9de8-9cfc-4a6c-a179" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="9de8-9cfc-4a6c-a179" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_944f-7420-4982-8ea9</comment>
         </categoryLink>
         <categoryLink id="c7cf-9d42-4215-903a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1970,7 +1970,7 @@
         <categoryLink id="9fed-7606-429e-aee8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_c6ff-0977-4c92-bb28</comment>
         </categoryLink>
-        <categoryLink id="b184-22bb-4d0d-be4a" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="b184-22bb-4d0d-be4a" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_f555-7d39-458f-84c9</comment>
         </categoryLink>
       </categoryLinks>
@@ -2000,7 +2000,7 @@
         <categoryLink id="528e-ed4e-4960-bd7b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_39e5-eda5-45d1-a643</comment>
         </categoryLink>
-        <categoryLink id="a97e-077c-4f2d-815c" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="a97e-077c-4f2d-815c" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_6416-21bb-4df4-9de8</comment>
         </categoryLink>
       </categoryLinks>
@@ -2030,7 +2030,7 @@
         <categoryLink id="8062-a307-438b-be9e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_5528-2dac-4be5-900c</comment>
         </categoryLink>
-        <categoryLink id="25d3-d15a-4177-b769" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="25d3-d15a-4177-b769" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_dc8f-d888-4585-991d</comment>
         </categoryLink>
       </categoryLinks>
@@ -2060,7 +2060,7 @@
         <categoryLink id="ad55-8a6f-4957-ad0a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_899e-b052-4d5b-8c18</comment>
         </categoryLink>
-        <categoryLink id="777c-7a95-42fe-8285" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="777c-7a95-42fe-8285" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_f5e9-cff6-41d2-a016</comment>
         </categoryLink>
       </categoryLinks>
@@ -2090,7 +2090,7 @@
         <categoryLink id="44bf-e48f-4d9c-9f78" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_09cd-2176-40af-bba6</comment>
         </categoryLink>
-        <categoryLink id="2b7f-80cf-471a-b526" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="2b7f-80cf-471a-b526" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_05e6-7c63-4a35-9ba0</comment>
         </categoryLink>
       </categoryLinks>
@@ -2114,7 +2114,7 @@
         <categoryLink id="5057-5dc9-44f7-9413" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_0dfa-4004-4751-8022</comment>
         </categoryLink>
-        <categoryLink id="7cb5-ba02-4e41-95ad" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="7cb5-ba02-4e41-95ad" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_a669-0f5d-4fd3-811b</comment>
         </categoryLink>
       </categoryLinks>
@@ -2141,7 +2141,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="72f7-f4aa-4a5a-912b" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="72f7-f4aa-4a5a-912b" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_4f60-472b-45a9-ab9e</comment>
         </categoryLink>
         <categoryLink id="f58b-d647-4a5c-8f47" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2194,7 +2194,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="31f9-df51-46fd-ae5a" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="31f9-df51-46fd-ae5a" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_2008-f1c4-4285-a14f</comment>
         </categoryLink>
         <categoryLink id="763b-aed3-4e26-8396" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2226,7 +2226,7 @@
         <categoryLink id="795b-8968-465f-8fcf" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_9189-836c-475d-a52e</comment>
         </categoryLink>
-        <categoryLink id="10c3-a1f3-42b4-b74f" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="10c3-a1f3-42b4-b74f" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_e1fa-b7d8-47b0-a88a</comment>
         </categoryLink>
         <categoryLink id="8d14-6614-4bf2-bcab" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false">
@@ -2240,7 +2240,7 @@
         <categoryLink id="b443-1acf-4ff9-a18e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_b1d5-fd75-4f17-bbf4</comment>
         </categoryLink>
-        <categoryLink id="5008-22e0-4a28-addf" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="5008-22e0-4a28-addf" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_f221-bf81-4045-849b</comment>
         </categoryLink>
       </categoryLinks>
@@ -2266,7 +2266,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="c0c5-001d-4ffc-abc9" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="c0c5-001d-4ffc-abc9" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_f203-bc26-421f-b79e</comment>
         </categoryLink>
         <categoryLink id="ce07-a5dd-45e6-a102" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2280,7 +2280,7 @@
         <categoryLink id="108c-636c-4c4c-a2ad" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_51af-a137-4a1c-97a4</comment>
         </categoryLink>
-        <categoryLink id="3176-3d4b-487e-9b82" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
+        <categoryLink id="3176-3d4b-487e-9b82" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
           <comment>template_id_ec1f-c326-40a8-9d1f</comment>
         </categoryLink>
       </categoryLinks>
@@ -2332,7 +2332,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="6e39-c3b5-438a-b9e7" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="6e39-c3b5-438a-b9e7" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_fce3-801c-49c8-85d4</comment>
         </categoryLink>
         <categoryLink id="09e3-fdd4-45b4-9505" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2343,7 +2343,7 @@
     <entryLink id="6470-f57a-424d-00c6" name="Terminator Tartaros Squad" hidden="false" collective="false" import="false" targetId="1a8e-0ded-a4dc-2b4e" type="selectionEntry">
       <comment>template_id_0848-4e03-417a-b224</comment>
       <categoryLinks>
-        <categoryLink id="7ffe-a8e7-4c79-a35e" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
+        <categoryLink id="7ffe-a8e7-4c79-a35e" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
           <comment>template_id_ac1c-b3bf-4011-918a</comment>
         </categoryLink>
         <categoryLink id="900b-a555-4893-8993" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2373,7 +2373,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="a0c5-8ec7-43ff-a702" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="a0c5-8ec7-43ff-a702" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_5a04-9847-4c91-a49a</comment>
         </categoryLink>
         <categoryLink id="4924-13cb-408b-a0e3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2403,7 +2403,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="77ef-880e-4a0e-a4f2" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="77ef-880e-4a0e-a4f2" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_7d4f-547c-43ed-a520</comment>
         </categoryLink>
         <categoryLink id="bd85-a007-43c6-8dfc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2432,7 +2432,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="d0af-dc84-4d20-a213" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
+        <categoryLink id="d0af-dc84-4d20-a213" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
           <comment>template_id_28e0-91e7-4ada-9fac</comment>
         </categoryLink>
         <categoryLink id="cf56-18e9-49eb-8afe" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2465,7 +2465,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="719f-868c-46cc-a33d" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="719f-868c-46cc-a33d" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_e22a-c5f8-4825-a45f</comment>
         </categoryLink>
         <categoryLink id="6028-1cb6-41f6-a547" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2482,7 +2482,7 @@
         <categoryLink id="580e-5100-4881-a488" name="Compulsory Elite:" hidden="false" targetId="bb1f-ae32-b587-c3e1" primary="false">
           <comment>template_id_7d5a-62e7-43ee-b79b</comment>
         </categoryLink>
-        <categoryLink id="8ff0-8adc-48aa-be20" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
+        <categoryLink id="8ff0-8adc-48aa-be20" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
           <comment>template_id_4986-9157-49f2-b670</comment>
         </categoryLink>
       </categoryLinks>
@@ -2512,7 +2512,7 @@
         <categoryLink id="774d-349f-4b8f-9806" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_1b86-0977-4a8b-adac</comment>
         </categoryLink>
-        <categoryLink id="481b-9d6a-4177-b699" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="481b-9d6a-4177-b699" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_b449-403a-4e42-9239</comment>
         </categoryLink>
       </categoryLinks>
@@ -2572,7 +2572,7 @@
         <categoryLink id="3e04-2b63-4d57-bf53" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_4f71-446f-4cff-afda</comment>
         </categoryLink>
-        <categoryLink id="57aa-86c0-4c4c-91bd" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="57aa-86c0-4c4c-91bd" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_3f44-8647-43a4-ac22</comment>
         </categoryLink>
       </categoryLinks>
@@ -2593,7 +2593,7 @@
         <categoryLink id="0e2c-336e-4841-a340" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_b6b1-886e-4194-8bcd</comment>
         </categoryLink>
-        <categoryLink id="5caa-165c-457e-b567" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="5caa-165c-457e-b567" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_51b5-f9c1-4587-8fc7</comment>
         </categoryLink>
       </categoryLinks>
@@ -2614,7 +2614,7 @@
       <categoryLinks>
         <categoryLink id="e12d-b822-47b3-4e92" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="317c-51b9-5bce-4d12" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
-        <categoryLink id="c490-800c-2c91-6890" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="c490-800c-2c91-6890" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="e084-90b6-7d3d-e76d" name="Line Sub-type:" hidden="false" targetId="6399-5c65-7833-1025" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -2644,7 +2644,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="dc16-16d0-4890-a8e8" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="dc16-16d0-4890-a8e8" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="4b1e-3f1f-49cb-8343" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -2667,7 +2667,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="32cb-7077-4d54-9f38" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="2c35-def7-4c44-9b02" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="2c35-def7-4c44-9b02" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="0c9a-d272-491c-a4a0" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -2689,7 +2689,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="5b41-a9f0-4801-9dff" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="5b41-a9f0-4801-9dff" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="d64e-e976-4668-bb95" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
         <categoryLink id="17a6-f363-4094-9a7c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
@@ -2713,7 +2713,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="fe4f-c8f2-470f-901c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="f3f0-973b-4a45-ac41" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="f3f0-973b-4a45-ac41" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="9ff9-8907-4e68-9d24" name="Sky-Hunter Squadron" hidden="true" collective="false" import="false" targetId="6263-c696-2f2e-c105" type="selectionEntry">
@@ -2736,7 +2736,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="63ff-0a92-42ab-ae8c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="204c-7b0f-4fb9-b1b3" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="204c-7b0f-4fb9-b1b3" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="85e6-cb31-427c-a040" name="Line Sub-type:" hidden="false" targetId="6399-5c65-7833-1025" primary="false"/>
         <categoryLink id="9eec-015a-f3e7-3297" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
       </categoryLinks>
@@ -2761,7 +2761,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="68dd-fc0f-4fde-8adc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="74ca-dd4f-46be-8be7" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="74ca-dd4f-46be-8be7" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="10f3-216b-9101-8704" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -2884,7 +2884,7 @@
       <categoryLinks>
         <categoryLink id="0d5b-be56-47af-a22e" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="2e59-1043-4719-96c4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="52fa-8c3c-49d4-a321" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="52fa-8c3c-49d4-a321" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="e827-f2b3-421a-b04f" name="Termite Assault Drill" hidden="true" collective="false" import="false" targetId="cb30-307a-f0d7-3b13" type="selectionEntry">
@@ -2908,7 +2908,7 @@
       <categoryLinks>
         <categoryLink id="1fef-4409-4fab-93fc" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="ca2d-245e-48b4-a1cf" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="6692-6e39-44f0-ad8e" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="6692-6e39-44f0-ad8e" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="f5fd-bb36-4efb-a1c6" name="Venerable Ancient Contemptor Dreadnought" hidden="true" collective="false" import="false" targetId="dad1-0807-e254-d498" type="selectionEntry">
@@ -2925,7 +2925,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="9261-acb5-4230-8d89" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="1a5d-cbc8-418f-91a3" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="1a5d-cbc8-418f-91a3" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="c0cb-406f-4b46-9d8d" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
       </categoryLinks>
       <entryLinks>
@@ -2948,7 +2948,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="c0b2-dd90-46c1-a2a9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="9a94-76fb-4a89-ad5d" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="9a94-76fb-4a89-ad5d" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="1c42-d3c8-7b68-2f16" name="Castellax Battle-Automata Maniple" hidden="true" collective="false" import="false" targetId="537f-846d-90e3-2526" type="selectionEntry">
@@ -2961,7 +2961,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="9813-821e-e590-8907" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="84fe-e1f3-7e24-ebb5" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="84fe-e1f3-7e24-ebb5" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="4f8b-50ef-e811-7c92" name="Domitar Battle-Automata Maniple" hidden="true" collective="false" import="false" targetId="1a1b-fa35-a6a2-ca78" type="selectionEntry">
@@ -2974,7 +2974,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="4861-afcd-079e-e9bc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="0c47-dce8-2643-2913" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="0c47-dce8-2643-2913" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="2784-6aa4-c213-73aa" name="Thanatar Siege-automata Maniple" hidden="true" collective="false" import="false" targetId="2903-fef6-e839-368b" type="selectionEntry">
@@ -2991,7 +2991,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="46bb-d58d-a01c-7341" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="ca73-fd9b-a236-538d" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="ca73-fd9b-a236-538d" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="a704-8261-2ee7-273e" name="Vorax Battle-automata Maniple" hidden="true" collective="false" import="false" targetId="f144-1079-11ff-019d" type="selectionEntry">
@@ -3004,7 +3004,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="ccd3-4553-6aaa-e418" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="030f-8e42-65ef-3b3d" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="030f-8e42-65ef-3b3d" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="4905-d3b0-617e-e7ca" name="Justaerin Terminator Squad" hidden="true" collective="false" import="false" targetId="c45d-ade3-6b28-68a2" type="selectionEntry">
@@ -3023,7 +3023,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="6650-085d-0476-88a7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="de34-dc77-7762-d37c" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="de34-dc77-7762-d37c" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="3d87-e8dd-6c2e-0b63" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -3049,13 +3049,13 @@
         <constraint field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="34d3-9d75-5b0c-18d4" type="max"/>
       </constraints>
       <categoryLinks>
-        <categoryLink id="20b9-fa17-58be-e4e5" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="20b9-fa17-58be-e4e5" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="e24e-8804-dc14-1461" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="9bc2-07ae-24d2-8e41" name="Reaver Attack Squad" hidden="false" collective="false" import="false" targetId="8b29-bf2a-a814-5642" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="d332-4f1a-8244-5166" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="d332-4f1a-8244-5166" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="6bc7-53c4-cadb-0110" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -3088,7 +3088,7 @@
       </infoLinks>
       <categoryLinks>
         <categoryLink id="e5f1-bfce-d4fc-70a5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="60c2-e5ac-eb71-70ff" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="60c2-e5ac-eb71-70ff" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="b4bb-4e3c-f0f8-659e" name="Vheren Ashurhaddon" hidden="false" collective="false" import="false" targetId="8fd9-e76b-4ecf-cc97" type="selectionEntry">
@@ -3104,7 +3104,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="67de-38df-5b5f-b515" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="67de-38df-5b5f-b515" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="8c81-05cb-339b-112e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="dd19-c149-942f-a5b3" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
       </categoryLinks>
@@ -3134,10 +3134,10 @@
       <infoLinks>
         <infoLink id="cdad-84ae-8cf9-e37e" name="Chosen Warriors" hidden="false" targetId="13d1-9270-6539-08ed" type="rule"/>
         <infoLink id="0e0e-3a0b-4a09-5014" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule"/>
-        <infoLink id="1cf2-f06c-9b38-96ea" name="Legiones Astartes (Sons of Hours)" hidden="false" targetId="f4a2-e4ca-b8b2-35a1" type="rule"/>
+        <infoLink id="1cf2-f06c-9b38-96ea" name="Legiones Astartes (Sons of Horus)" hidden="false" targetId="f4a2-e4ca-b8b2-35a1" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="74fd-91d7-6d1c-8edd" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+        <categoryLink id="74fd-91d7-6d1c-8edd" name="Heavy Sub-type:" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
         <categoryLink id="8cac-3a0b-8f04-2877" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="ed45-fc62-5dd5-769f" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
       </categoryLinks>
@@ -4402,7 +4402,7 @@
             </profile>
           </profiles>
           <infoLinks>
-            <infoLink id="73ca-7b51-5381-6eed" name="Legiones Astartes (Sons of Hours)" hidden="false" targetId="f4a2-e4ca-b8b2-35a1" type="rule"/>
+            <infoLink id="73ca-7b51-5381-6eed" name="Legiones Astartes (Sons of Horus)" hidden="false" targetId="f4a2-e4ca-b8b2-35a1" type="rule"/>
             <infoLink id="b33d-d628-cdc3-9482" name="Master of the Legion" hidden="false" targetId="c772-87ea-d49c-c7ba" type="rule"/>
             <infoLink id="56f5-f635-8f53-97f9" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule"/>
             <infoLink id="16ad-203d-8847-4534" name="Adamantium Will (X+)" hidden="false" targetId="4380-44a5-f01a-d964" type="rule">
@@ -4516,7 +4516,7 @@
         </infoLink>
         <infoLink id="1799-0d1a-e91d-0f9d" name="Deep Strike" hidden="false" targetId="f1e1-986f-c783-ca9e" type="rule"/>
         <infoLink id="9468-1e48-8fc4-bf4c" name="Fearless" hidden="false" targetId="b48c-d7e1-2a83-2f5b" type="rule"/>
-        <infoLink id="235e-c0a7-d465-00cc" name="Legiones Astartes (Sons of Hours)" hidden="false" targetId="f4a2-e4ca-b8b2-35a1" type="rule"/>
+        <infoLink id="235e-c0a7-d465-00cc" name="Legiones Astartes (Sons of Horus)" hidden="false" targetId="f4a2-e4ca-b8b2-35a1" type="rule"/>
         <infoLink id="50ed-6313-7966-b1b5" name="Precision Strikes (X)" hidden="false" targetId="2206-8497-8fe1-e973" type="rule">
           <modifiers>
             <modifier type="set" field="name" value="Precision Strikes (4+)"/>
@@ -4641,7 +4641,7 @@
         </rule>
       </rules>
       <infoLinks>
-        <infoLink id="486d-d2b0-1c78-9d56" name="Legiones Astartes (Sons of Hours)" hidden="false" targetId="f4a2-e4ca-b8b2-35a1" type="rule"/>
+        <infoLink id="486d-d2b0-1c78-9d56" name="Legiones Astartes (Sons of Horus)" hidden="false" targetId="f4a2-e4ca-b8b2-35a1" type="rule"/>
         <infoLink id="1603-a22b-5c84-710e" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule"/>
       </infoLinks>
       <categoryLinks>
@@ -4752,7 +4752,7 @@
       </rules>
       <infoLinks>
         <infoLink id="c675-f415-df8c-9198" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule"/>
-        <infoLink id="15fc-6476-1058-2444" name="Legiones Astartes (Sons of Hours)" hidden="false" targetId="f4a2-e4ca-b8b2-35a1" type="rule"/>
+        <infoLink id="15fc-6476-1058-2444" name="Legiones Astartes (Sons of Horus)" hidden="false" targetId="f4a2-e4ca-b8b2-35a1" type="rule"/>
         <infoLink id="fbdd-00cb-3008-825b" name="Bulky (X)" hidden="false" targetId="676c-7b75-4b6f-9405" type="rule">
           <modifiers>
             <modifier type="set" field="name" value="Bulky (2)"/>
@@ -4790,7 +4790,7 @@
         </infoLink>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="705b-da26-7a7c-2f8c" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+        <categoryLink id="705b-da26-7a7c-2f8c" name="Heavy Sub-type:" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
         <categoryLink id="9f47-8b3b-90cc-998d" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="5156-399a-3fcc-8ca9" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="fbc7-2ac6-fa36-63d9" name="Terminators:" hidden="false" targetId="bab3-f50d-3e5f-2f78" primary="false"/>
@@ -6356,6 +6356,6 @@ A Warlord with this Trait gains a bonus of +1 to its Leadership Characteristic w
     </selectionEntryGroup>
   </sharedSelectionEntryGroups>
   <catalogueLinks>
-    <catalogueLink id="2f60-18fb-e6ed-8574" name="(HH V2) Legions Astartes" targetId="6393-649c-7213-a327" type="catalogue" importRootEntries="true"/>
+    <catalogueLink id="2f60-18fb-e6ed-8574" name="Legions Astartes" targetId="6393-649c-7213-a327" type="catalogue" importRootEntries="true"/>
   </catalogueLinks>
 </catalogue>

--- a/2022 - LA - Space Wolves.cat
+++ b/2022 - LA - Space Wolves.cat
@@ -14,7 +14,7 @@
         <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d1d3-74cd-b6b9-0bf2" type="max"/>
       </constraints>
       <categoryLinks>
-        <categoryLink id="d95c-fe4e-9f85-5c49" name="New CategoryLink" hidden="false" targetId="e90d-e5a8-f42d-da84" primary="true"/>
+        <categoryLink id="d95c-fe4e-9f85-5c49" name="Allegiance:" hidden="false" targetId="e90d-e5a8-f42d-da84" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="1c86-f3f7-7462-c9a1" name="Deathsworn Pack" hidden="false" collective="false" import="false" targetId="3fa0-d6ed-981b-e361" type="selectionEntry">
@@ -26,7 +26,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="afb7-b32a-da09-ad2f" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="afb7-b32a-da09-ad2f" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="90f3-333e-c096-a39d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -39,7 +39,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="6535-c9ec-ed83-7d89" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="6535-c9ec-ed83-7d89" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="1147-77ac-040c-ff0f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="e2f9-db44-a72b-c576" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
       </categoryLinks>
@@ -58,7 +58,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="37a5-e559-aa6f-a23d" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="37a5-e559-aa6f-a23d" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="9fab-f8f9-82e9-e115" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="a657-599b-10e2-1ae1" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
       </categoryLinks>
@@ -77,7 +77,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="c550-0f2f-8b47-f6ed" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="c550-0f2f-8b47-f6ed" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="cc44-9321-b02a-11a5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="9dee-400e-17b5-10cf" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
       </categoryLinks>
@@ -91,7 +91,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="76e8-88e7-36d9-7a91" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="76e8-88e7-36d9-7a91" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="f177-b333-d0fd-981c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="f78b-4136-ea01-903f" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
       </categoryLinks>
@@ -105,7 +105,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="2b8c-b008-2f79-76cb" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="2b8c-b008-2f79-76cb" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="6596-a629-9cda-0b3b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -118,7 +118,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="02d9-6d81-e872-d7b7" name="New CategoryLink" hidden="false" targetId="ad5f-31db-8bc7-5c46" primary="true"/>
+        <categoryLink id="02d9-6d81-e872-d7b7" name="Primarch:" hidden="false" targetId="ad5f-31db-8bc7-5c46" primary="true"/>
         <categoryLink id="1b8f-f807-3d22-80df" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
       <entryLinks>
@@ -136,7 +136,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="2286-5f51-f705-f752" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="2286-5f51-f705-f752" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="071a-b942-24b6-7962" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -146,7 +146,7 @@
         <categoryLink id="b7df-2265-4594-bf7e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_c6d4-581f-4746-bec3</comment>
         </categoryLink>
-        <categoryLink id="4e9f-4cb2-420a-8770" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
+        <categoryLink id="4e9f-4cb2-420a-8770" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
           <comment>template_id_2489-ee2a-45dd-b384</comment>
         </categoryLink>
       </categoryLinks>
@@ -176,7 +176,7 @@
         <categoryLink id="cd05-063f-4295-ab9f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_8378-ede4-476d-b657</comment>
         </categoryLink>
-        <categoryLink id="8faa-17e4-46d2-a14d" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="8faa-17e4-46d2-a14d" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_d64f-ad19-426c-adf7</comment>
         </categoryLink>
       </categoryLinks>
@@ -202,7 +202,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="e5ae-cf8f-4019-bf88" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="e5ae-cf8f-4019-bf88" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_ac26-e639-4d53-9b8b</comment>
         </categoryLink>
         <categoryLink id="c3d2-3220-48d5-b9e3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -213,7 +213,7 @@
         </categoryLink>
       </categoryLinks>
     </entryLink>
-    <entryLink id="eb51-6d1f-6a43-2a87" name="Avenger Strike Fighter" hidden="true" collective="false" import="false" targetId="b25c-e85c-1c29-9e05" type="selectionEntry">
+    <entryLink id="eb51-6d1f-6a43-2a87" name="Legion Avenger Strike Fighter" hidden="true" collective="false" import="false" targetId="b25c-e85c-1c29-9e05" type="selectionEntry">
       <comment>template_id_1064-175d-4616-9c71</comment>
       <modifiers>
         <modifier type="set" field="hidden" value="false">
@@ -235,7 +235,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="ea0e-a372-4c0c-b52a" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="ea0e-a372-4c0c-b52a" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_a009-a597-4b51-b228</comment>
         </categoryLink>
         <categoryLink id="12ea-2a73-4007-bd60" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -268,7 +268,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="34ea-54ce-4192-ab44" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="34ea-54ce-4192-ab44" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_c165-3906-463a-9c73</comment>
         </categoryLink>
         <categoryLink id="16bd-26c6-45db-aada" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -305,7 +305,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="159a-0184-4f9c-a433" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="159a-0184-4f9c-a433" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_3a22-caae-4eea-9bc5</comment>
         </categoryLink>
         <categoryLink id="3b6e-663c-4102-9b81" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -338,7 +338,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="053d-d261-450a-a264" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="053d-d261-450a-a264" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_251a-df5b-4bfd-ad63</comment>
         </categoryLink>
         <categoryLink id="df89-d370-444c-93ce" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -375,7 +375,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="e368-f46b-4680-964c" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
+        <categoryLink id="e368-f46b-4680-964c" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
           <comment>template_id_67c2-df43-44fc-92d1</comment>
         </categoryLink>
         <categoryLink id="953d-f285-4d0b-a04e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -450,7 +450,7 @@
         <categoryLink id="66f4-f6fc-4f8b-b4cb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_bd6a-0cda-4e0f-80ae</comment>
         </categoryLink>
-        <categoryLink id="92fd-11b5-46cb-8206" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
+        <categoryLink id="92fd-11b5-46cb-8206" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
           <comment>template_id_ae75-7cca-4701-9d56</comment>
         </categoryLink>
         <categoryLink id="b49e-56fc-4044-aebc" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false">
@@ -485,7 +485,7 @@
         <categoryLink id="917b-c233-4dd3-abdf" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false">
           <comment>template_id_f51c-73d7-4f29-be1c</comment>
         </categoryLink>
-        <categoryLink id="eb29-8484-4752-9822" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
+        <categoryLink id="eb29-8484-4752-9822" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
           <comment>template_id_257d-78c0-4bab-ba65</comment>
         </categoryLink>
       </categoryLinks>
@@ -533,7 +533,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="8ab4-c75b-434f-abe6" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="8ab4-c75b-434f-abe6" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_f1c8-27fd-4f98-8527</comment>
         </categoryLink>
         <categoryLink id="ce34-de82-4a0d-b5a0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -562,7 +562,7 @@
         <categoryLink id="e355-5827-4bf3-bff8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_dd44-e0a8-42a8-bdcc</comment>
         </categoryLink>
-        <categoryLink id="6f5a-cea3-429d-9281" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
+        <categoryLink id="6f5a-cea3-429d-9281" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
           <comment>template_id_c5b0-f9ae-468d-924a</comment>
         </categoryLink>
       </categoryLinks>
@@ -589,7 +589,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="3d0d-8266-4608-ab97" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
+        <categoryLink id="3d0d-8266-4608-ab97" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
           <comment>template_id_f926-27fd-4a92-97a1</comment>
         </categoryLink>
         <categoryLink id="12a8-2aee-410a-ae00" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -621,7 +621,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="a7fe-cc33-a15d-5e87" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="a7fe-cc33-a15d-5e87" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
         <categoryLink id="7814-2b4d-9ca5-67f6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -680,7 +680,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="55a3-ba5d-4a5b-adb8" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="55a3-ba5d-4a5b-adb8" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_361e-fb90-4b0e-ac3d</comment>
         </categoryLink>
         <categoryLink id="328c-255a-4d32-af10" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -697,7 +697,7 @@
         <categoryLink id="672f-321b-495d-8c0e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_473b-e812-4158-9416</comment>
         </categoryLink>
-        <categoryLink id="cc29-ba3b-4639-a13a" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
+        <categoryLink id="cc29-ba3b-4639-a13a" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
           <comment>template_id_00a2-63ff-4698-a35b</comment>
         </categoryLink>
       </categoryLinks>
@@ -721,7 +721,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="4a90-60c2-4307-8244" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="4a90-60c2-4307-8244" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_2a08-4432-42ad-bfdb</comment>
         </categoryLink>
         <categoryLink id="14b1-2992-4760-8ad8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -754,7 +754,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="fabc-1717-4342-84e2" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="fabc-1717-4342-84e2" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_f4c0-4396-4f39-a34f</comment>
         </categoryLink>
         <categoryLink id="31f3-824b-4fde-aca6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -787,7 +787,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="f68b-6723-43b3-b1ea" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="f68b-6723-43b3-b1ea" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_caf6-5548-4b89-8102</comment>
         </categoryLink>
         <categoryLink id="6b8a-5631-4fa9-a668" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -847,7 +847,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="1c2e-5803-4e2b-872e" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="1c2e-5803-4e2b-872e" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_d53e-113f-4a40-a3d5</comment>
         </categoryLink>
         <categoryLink id="4512-cc4d-475d-93c9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -868,7 +868,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="4e06-0cdc-4890-a99c" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="4e06-0cdc-4890-a99c" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_e6f7-a6ca-4825-bfc5</comment>
         </categoryLink>
         <categoryLink id="15f9-ab49-4c8d-bbe5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -901,7 +901,7 @@
         <categoryLink id="a0d4-e561-4398-9be7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_cefb-cfd7-4dc8-99c4</comment>
         </categoryLink>
-        <categoryLink id="f115-8903-4fe8-bbcc" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="f115-8903-4fe8-bbcc" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_a9fd-9d16-4a5e-855c</comment>
         </categoryLink>
       </categoryLinks>
@@ -925,7 +925,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="fa6e-dfe5-4b3a-a4cd" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="fa6e-dfe5-4b3a-a4cd" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_a56d-347b-4b09-a918</comment>
         </categoryLink>
         <categoryLink id="648a-d112-4751-9c74" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -958,7 +958,7 @@
         <categoryLink id="4a64-2336-4559-848d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_9441-d79b-4720-9667</comment>
         </categoryLink>
-        <categoryLink id="355e-f349-4341-bc6f" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="355e-f349-4341-bc6f" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_7d7e-32d3-4692-b401</comment>
         </categoryLink>
       </categoryLinks>
@@ -988,7 +988,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="5f0b-2ef2-49a1-805f" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="5f0b-2ef2-49a1-805f" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_f65b-8958-49b3-92a5</comment>
         </categoryLink>
         <categoryLink id="dcc7-ec1f-4065-8e55" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1021,7 +1021,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="5b36-5ac8-437f-9e3b" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="5b36-5ac8-437f-9e3b" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_c6a8-22a8-4d41-b969</comment>
         </categoryLink>
         <categoryLink id="0173-ddca-4e50-ac86" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1084,7 +1084,7 @@
         <categoryLink id="698a-41c5-4f93-8040" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_bc67-ce1f-4004-aeb7</comment>
         </categoryLink>
-        <categoryLink id="6d5a-495f-4aa3-b03c" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="6d5a-495f-4aa3-b03c" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_9a45-9699-4475-aeef</comment>
         </categoryLink>
       </categoryLinks>
@@ -1147,7 +1147,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="b9c9-e2aa-4051-bc51" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="b9c9-e2aa-4051-bc51" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_3610-c975-4d55-bdfe</comment>
         </categoryLink>
         <categoryLink id="6126-acbb-4c05-9fb7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1183,7 +1183,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="353d-29ad-4cbb-8116" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="353d-29ad-4cbb-8116" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_f81d-9435-4f11-99c1</comment>
         </categoryLink>
         <categoryLink id="06a0-48a8-4343-80a9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1219,7 +1219,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="b9d3-b88b-4b59-b9f2" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="b9d3-b88b-4b59-b9f2" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_b24f-3ae0-4cbb-b016</comment>
         </categoryLink>
         <categoryLink id="3734-4b61-4a4c-a180" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1252,7 +1252,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="dabb-37ef-4a32-b3cb" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="dabb-37ef-4a32-b3cb" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_c77f-0819-473b-a8a2</comment>
         </categoryLink>
         <categoryLink id="d866-326a-4f70-b83d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1285,7 +1285,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="8b97-e65f-4ca6-8882" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="8b97-e65f-4ca6-8882" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_0397-c837-4fea-a527</comment>
         </categoryLink>
         <categoryLink id="5836-6d13-4766-9c3f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1321,7 +1321,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="d1c0-61a7-48fa-b90d" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="d1c0-61a7-48fa-b90d" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_c1cf-cea4-4278-8f27</comment>
         </categoryLink>
         <categoryLink id="6d8f-5ff8-4c9e-a80d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1357,7 +1357,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="99bf-5233-4e1c-be12" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="99bf-5233-4e1c-be12" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_0c16-6841-42b2-b02d</comment>
         </categoryLink>
         <categoryLink id="096e-97e6-4528-b95a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1393,7 +1393,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="5644-99f4-46e3-acca" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="5644-99f4-46e3-acca" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_3632-0b5d-4622-ae33</comment>
         </categoryLink>
         <categoryLink id="1611-bcd5-4331-8219" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1429,7 +1429,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="eedf-ebfd-4132-9cc5" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="eedf-ebfd-4132-9cc5" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_5ad5-8701-42cd-b2b6</comment>
         </categoryLink>
         <categoryLink id="9c2a-a315-47c3-9f77" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1496,7 +1496,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="ae7a-7c11-48fb-94da" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="ae7a-7c11-48fb-94da" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_4d7c-201f-4c99-b89a</comment>
         </categoryLink>
         <categoryLink id="bba6-fb07-4849-9a86" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1529,7 +1529,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="548a-d6f2-4079-897d" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="548a-d6f2-4079-897d" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_4e52-ad1b-48d4-8eed</comment>
         </categoryLink>
         <categoryLink id="78df-065f-46c8-8e10" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false">
@@ -1543,7 +1543,7 @@
         <categoryLink id="dc08-0ef8-41ec-b9a9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_6140-2404-46f9-bd42</comment>
         </categoryLink>
-        <categoryLink id="1380-be68-4f75-b778" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
+        <categoryLink id="1380-be68-4f75-b778" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
           <comment>template_id_1c86-fad8-46ec-a0b0</comment>
         </categoryLink>
       </categoryLinks>
@@ -1569,7 +1569,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="7a2c-dbc6-4099-b5f8" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
+        <categoryLink id="7a2c-dbc6-4099-b5f8" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
           <comment>template_id_0af1-d052-4bd7-aab6</comment>
         </categoryLink>
         <categoryLink id="e8ee-1a23-45ce-9d80" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1618,7 +1618,7 @@
         <categoryLink id="7ade-a8dc-48ca-aef2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_4272-9b9d-4c59-95f0</comment>
         </categoryLink>
-        <categoryLink id="597c-95b8-41b2-863b" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="597c-95b8-41b2-863b" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_d85b-1ae7-40d5-9341</comment>
         </categoryLink>
       </categoryLinks>
@@ -1640,7 +1640,7 @@
         <categoryLink id="0060-e508-4793-a9c5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_ff9f-01cb-41b9-800e</comment>
         </categoryLink>
-        <categoryLink id="2c86-7332-488d-9d32" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="2c86-7332-488d-9d32" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_1315-6051-4a46-b070</comment>
         </categoryLink>
       </categoryLinks>
@@ -1648,7 +1648,7 @@
     <entryLink id="4e43-5156-847b-8c66" name="Praetor" hidden="false" collective="false" import="false" targetId="03be-5d55-d05a-771d" type="selectionEntry">
       <comment>template_id_5798-3fc7-4d4c-ad41</comment>
       <categoryLinks>
-        <categoryLink id="a397-9a8a-40ca-b71d" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
+        <categoryLink id="a397-9a8a-40ca-b71d" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
           <comment>template_id_b084-df23-4f99-812f</comment>
         </categoryLink>
         <categoryLink id="b6a5-8aad-482d-bc2b" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false">
@@ -1773,7 +1773,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="0627-08cc-4c9c-b515" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="0627-08cc-4c9c-b515" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_b822-3417-4613-be37</comment>
         </categoryLink>
         <categoryLink id="3193-ae77-4023-a5ec" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1800,7 +1800,7 @@
         <categoryLink id="516a-fa8b-42f1-8bfe" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_75a7-dc06-445b-b2dc</comment>
         </categoryLink>
-        <categoryLink id="172f-5b69-467b-885a" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="172f-5b69-467b-885a" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_e21a-c03b-4885-ac46</comment>
         </categoryLink>
       </categoryLinks>
@@ -1818,7 +1818,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="00be-75ea-422e-9236" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
+        <categoryLink id="00be-75ea-422e-9236" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
           <comment>template_id_f55b-7555-444b-beee</comment>
         </categoryLink>
         <categoryLink id="ee9e-e13d-4ae0-adde" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1839,7 +1839,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="4b83-4c6e-431b-b169" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="4b83-4c6e-431b-b169" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_79fa-3370-4ae0-9e12</comment>
         </categoryLink>
         <categoryLink id="6ddb-ab24-4a31-bf51" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1865,7 +1865,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="0f9b-d7b1-4790-a7a4" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="0f9b-d7b1-4790-a7a4" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_8d82-3279-4481-84bb</comment>
         </categoryLink>
         <categoryLink id="288b-db66-48b6-afb0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1898,7 +1898,7 @@
         <categoryLink id="14a8-dd49-4761-bfce" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_7010-be56-4709-b058</comment>
         </categoryLink>
-        <categoryLink id="f10a-e01a-44e8-b59c" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="f10a-e01a-44e8-b59c" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_7379-a740-47ba-a054</comment>
         </categoryLink>
       </categoryLinks>
@@ -1916,7 +1916,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="1332-9f96-4fb7-bdd0" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="1332-9f96-4fb7-bdd0" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_944f-7420-4982-8ea9</comment>
         </categoryLink>
         <categoryLink id="3925-39e2-4820-8089" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1960,7 +1960,7 @@
         <categoryLink id="ba18-cb32-46bf-8816" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_c6ff-0977-4c92-bb28</comment>
         </categoryLink>
-        <categoryLink id="a7f0-48e7-4413-918c" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="a7f0-48e7-4413-918c" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_f555-7d39-458f-84c9</comment>
         </categoryLink>
       </categoryLinks>
@@ -1990,7 +1990,7 @@
         <categoryLink id="0eaf-0846-4971-a239" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_39e5-eda5-45d1-a643</comment>
         </categoryLink>
-        <categoryLink id="3c26-8357-42d4-9947" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="3c26-8357-42d4-9947" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_6416-21bb-4df4-9de8</comment>
         </categoryLink>
       </categoryLinks>
@@ -2020,7 +2020,7 @@
         <categoryLink id="b84a-4f32-42a8-9e80" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_5528-2dac-4be5-900c</comment>
         </categoryLink>
-        <categoryLink id="0867-f1ab-4d70-b34d" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="0867-f1ab-4d70-b34d" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_dc8f-d888-4585-991d</comment>
         </categoryLink>
       </categoryLinks>
@@ -2050,7 +2050,7 @@
         <categoryLink id="558b-ccac-4b81-8509" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_899e-b052-4d5b-8c18</comment>
         </categoryLink>
-        <categoryLink id="4bfc-b5e8-438c-bed6" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="4bfc-b5e8-438c-bed6" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_f5e9-cff6-41d2-a016</comment>
         </categoryLink>
       </categoryLinks>
@@ -2080,7 +2080,7 @@
         <categoryLink id="55ae-2e77-4d5d-aaeb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_09cd-2176-40af-bba6</comment>
         </categoryLink>
-        <categoryLink id="b536-2ae9-4179-83c9" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="b536-2ae9-4179-83c9" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_05e6-7c63-4a35-9ba0</comment>
         </categoryLink>
       </categoryLinks>
@@ -2104,7 +2104,7 @@
         <categoryLink id="b2d2-e500-498e-9493" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_0dfa-4004-4751-8022</comment>
         </categoryLink>
-        <categoryLink id="1fd8-192e-4fad-bbaf" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="1fd8-192e-4fad-bbaf" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_a669-0f5d-4fd3-811b</comment>
         </categoryLink>
       </categoryLinks>
@@ -2131,7 +2131,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="e2ca-b758-4b3c-b0e1" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="e2ca-b758-4b3c-b0e1" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_4f60-472b-45a9-ab9e</comment>
         </categoryLink>
         <categoryLink id="37ee-5b04-4acc-8fad" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2184,7 +2184,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="dcd8-bb5d-472e-84d9" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="dcd8-bb5d-472e-84d9" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_2008-f1c4-4285-a14f</comment>
         </categoryLink>
         <categoryLink id="599c-768d-43f3-80db" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2216,7 +2216,7 @@
         <categoryLink id="e681-f6f2-499e-acc5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_9189-836c-475d-a52e</comment>
         </categoryLink>
-        <categoryLink id="9110-c884-45d6-9b58" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="9110-c884-45d6-9b58" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_e1fa-b7d8-47b0-a88a</comment>
         </categoryLink>
         <categoryLink id="662c-0221-45f9-8ce3" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false">
@@ -2230,7 +2230,7 @@
         <categoryLink id="440f-8c96-432b-a1ec" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_b1d5-fd75-4f17-bbf4</comment>
         </categoryLink>
-        <categoryLink id="d4d8-ed30-45a9-a93a" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="d4d8-ed30-45a9-a93a" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_f221-bf81-4045-849b</comment>
         </categoryLink>
       </categoryLinks>
@@ -2256,7 +2256,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="6fba-8f8b-43cc-b380" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="6fba-8f8b-43cc-b380" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_f203-bc26-421f-b79e</comment>
         </categoryLink>
         <categoryLink id="3fe9-1db9-4585-8cbb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2270,7 +2270,7 @@
         <categoryLink id="1a2f-d881-43d9-9279" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_51af-a137-4a1c-97a4</comment>
         </categoryLink>
-        <categoryLink id="af2e-7971-47c2-bbcb" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
+        <categoryLink id="af2e-7971-47c2-bbcb" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
           <comment>template_id_ec1f-c326-40a8-9d1f</comment>
         </categoryLink>
       </categoryLinks>
@@ -2322,7 +2322,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="6084-4116-42de-b78a" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="6084-4116-42de-b78a" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_fce3-801c-49c8-85d4</comment>
         </categoryLink>
         <categoryLink id="476a-4c2a-451f-8dc1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2333,7 +2333,7 @@
     <entryLink id="1b00-d14d-b1b4-38aa" name="Terminator Tartaros Squad" hidden="false" collective="false" import="false" targetId="1a8e-0ded-a4dc-2b4e" type="selectionEntry">
       <comment>template_id_0848-4e03-417a-b224</comment>
       <categoryLinks>
-        <categoryLink id="727a-4271-48b7-9d9c" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
+        <categoryLink id="727a-4271-48b7-9d9c" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
           <comment>template_id_ac1c-b3bf-4011-918a</comment>
         </categoryLink>
         <categoryLink id="b012-8dbe-4444-8aa8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2363,7 +2363,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="4e84-11c8-40bf-b985" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="4e84-11c8-40bf-b985" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_5a04-9847-4c91-a49a</comment>
         </categoryLink>
         <categoryLink id="06be-a46a-4dd4-91d1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2393,7 +2393,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="c88e-56d6-45a4-9bd4" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="c88e-56d6-45a4-9bd4" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_7d4f-547c-43ed-a520</comment>
         </categoryLink>
         <categoryLink id="bec1-ef5c-428b-97e4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2422,7 +2422,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="e855-bea3-4f32-b772" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
+        <categoryLink id="e855-bea3-4f32-b772" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
           <comment>template_id_28e0-91e7-4ada-9fac</comment>
         </categoryLink>
         <categoryLink id="8b9c-918d-45c2-936b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2455,7 +2455,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="6cea-3fc0-4af4-b83d" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="6cea-3fc0-4af4-b83d" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_e22a-c5f8-4825-a45f</comment>
         </categoryLink>
         <categoryLink id="b80d-1d83-4ba9-9c85" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2472,7 +2472,7 @@
         <categoryLink id="4286-b203-47c4-a447" name="Compulsory Elite:" hidden="false" targetId="bb1f-ae32-b587-c3e1" primary="false">
           <comment>template_id_7d5a-62e7-43ee-b79b</comment>
         </categoryLink>
-        <categoryLink id="7195-be81-4c80-b973" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
+        <categoryLink id="7195-be81-4c80-b973" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
           <comment>template_id_4986-9157-49f2-b670</comment>
         </categoryLink>
       </categoryLinks>
@@ -2502,7 +2502,7 @@
         <categoryLink id="a3f8-4d31-4268-b8cc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_1b86-0977-4a8b-adac</comment>
         </categoryLink>
-        <categoryLink id="73e2-735e-41db-a4f0" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="73e2-735e-41db-a4f0" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_b449-403a-4e42-9239</comment>
         </categoryLink>
       </categoryLinks>
@@ -2562,7 +2562,7 @@
         <categoryLink id="ceec-7125-4ce1-8b95" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_4f71-446f-4cff-afda</comment>
         </categoryLink>
-        <categoryLink id="9404-a80d-436d-af7e" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="9404-a80d-436d-af7e" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_3f44-8647-43a4-ac22</comment>
         </categoryLink>
       </categoryLinks>
@@ -2583,7 +2583,7 @@
         <categoryLink id="856f-7564-43a0-974e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_b6b1-886e-4194-8bcd</comment>
         </categoryLink>
-        <categoryLink id="caef-c243-4e2d-aee1" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="caef-c243-4e2d-aee1" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_51b5-f9c1-4587-8fc7</comment>
         </categoryLink>
       </categoryLinks>
@@ -2614,7 +2614,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="dc16-16d0-4890-a8e8" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="dc16-16d0-4890-a8e8" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="4b1e-3f1f-49cb-8343" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -2637,7 +2637,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="32cb-7077-4d54-9f38" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="2c35-def7-4c44-9b02" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="2c35-def7-4c44-9b02" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="0c9a-d272-491c-a4a0" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -2659,7 +2659,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="5b41-a9f0-4801-9dff" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="5b41-a9f0-4801-9dff" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="d64e-e976-4668-bb95" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
         <categoryLink id="17a6-f363-4094-9a7c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
@@ -2683,7 +2683,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="fe4f-c8f2-470f-901c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="f3f0-973b-4a45-ac41" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="f3f0-973b-4a45-ac41" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="4950-acd5-4aec-9cf2" name="Sky-Hunter Squadron" hidden="true" collective="false" import="false" targetId="6263-c696-2f2e-c105" type="selectionEntry">
@@ -2706,7 +2706,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="63ff-0a92-42ab-ae8c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="204c-7b0f-4fb9-b1b3" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="204c-7b0f-4fb9-b1b3" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="85e6-cb31-427c-a040" name="Line Sub-type:" hidden="false" targetId="6399-5c65-7833-1025" primary="false"/>
         <categoryLink id="0e83-d847-9c24-8a81" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
       </categoryLinks>
@@ -2731,7 +2731,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="68dd-fc0f-4fde-8adc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="74ca-dd4f-46be-8be7" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="74ca-dd4f-46be-8be7" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="e3e2-0c26-4d11-e3ff" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -2822,7 +2822,7 @@
       <categoryLinks>
         <categoryLink id="0d5b-be56-47af-a22e" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="2e59-1043-4719-96c4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="52fa-8c3c-49d4-a321" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="52fa-8c3c-49d4-a321" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="eaad-2f13-46e4-95e9" name="Termite Assault Drill" hidden="true" collective="false" import="false" targetId="cb30-307a-f0d7-3b13" type="selectionEntry">
@@ -2846,7 +2846,7 @@
       <categoryLinks>
         <categoryLink id="1fef-4409-4fab-93fc" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="ca2d-245e-48b4-a1cf" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="6692-6e39-44f0-ad8e" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="6692-6e39-44f0-ad8e" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="e4bf-0555-4162-aed2" name="Venerable Ancient Contemptor Dreadnought" hidden="true" collective="false" import="false" targetId="dad1-0807-e254-d498" type="selectionEntry">
@@ -2863,7 +2863,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="9261-acb5-4230-8d89" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="1a5d-cbc8-418f-91a3" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="1a5d-cbc8-418f-91a3" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="c0cb-406f-4b46-9d8d" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
       </categoryLinks>
       <entryLinks>
@@ -2886,7 +2886,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="c0b2-dd90-46c1-a2a9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="9a94-76fb-4a89-ad5d" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="9a94-76fb-4a89-ad5d" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="49f6-9e98-8f7d-bb7d" name="Vorax Battle-automata Maniple" hidden="true" collective="false" import="false" targetId="f144-1079-11ff-019d" type="selectionEntry">
@@ -2899,7 +2899,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="7cc9-0564-8a22-b53c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="2591-4b8c-9f45-2bb7" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="2591-4b8c-9f45-2bb7" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="cb6d-7ae3-0fbe-7321" name="Thanatar Siege-automata Maniple" hidden="true" collective="false" import="false" targetId="2903-fef6-e839-368b" type="selectionEntry">
@@ -2916,7 +2916,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="728f-b4df-3c94-da42" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="6107-b562-e085-949b" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="6107-b562-e085-949b" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="ae94-1d07-37e7-198c" name="Domitar Battle-Automata Maniple" hidden="true" collective="false" import="false" targetId="1a1b-fa35-a6a2-ca78" type="selectionEntry">
@@ -2929,7 +2929,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="1c61-4cb5-daa2-805c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="2334-aaaf-d8bd-94af" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="2334-aaaf-d8bd-94af" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="b471-f213-1002-5345" name="Castellax Battle-Automata Maniple" hidden="true" collective="false" import="false" targetId="537f-846d-90e3-2526" type="selectionEntry">
@@ -2942,7 +2942,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="e3d1-aec5-71b3-fc38" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="57a4-e369-9fbe-fa76" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="57a4-e369-9fbe-fa76" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="310c-e353-62bb-c3bf" name="Varagyr Wolf Guard Terminator Squad" hidden="true" collective="false" import="false" targetId="9359-61a5-fcdb-c28e" type="selectionEntry">
@@ -2963,7 +2963,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="31cc-2e73-0633-9ca3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="265c-c40f-9d83-9212" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="265c-c40f-9d83-9212" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="1f0b-f9e9-789c-aa49" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -2989,7 +2989,7 @@
         <constraint field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e84c-0329-bc38-3af6" type="max"/>
       </constraints>
       <categoryLinks>
-        <categoryLink id="72f0-02a6-a08d-5326" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="72f0-02a6-a08d-5326" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="e9d4-22cc-4d94-cde2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -3011,7 +3011,7 @@
       <categoryLinks>
         <categoryLink id="935c-5280-2665-ebbe" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="94c4-d1c1-31a4-0cce" name="Skirmish Sub-type:" hidden="false" targetId="59a4-7b61-600a-c457" primary="false"/>
-        <categoryLink id="0a97-1c28-655b-6262" name="LoW &amp; Primarchs" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false"/>
+        <categoryLink id="0a97-1c28-655b-6262" name="LoW &amp; Primarchs (25% Limit)" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="1c95-89ac-6ffc-46f3" name="Leman Russ" hidden="false" collective="false" import="true" type="model">
@@ -3202,7 +3202,7 @@
         </rule>
       </rules>
       <categoryLinks>
-        <categoryLink id="a231-01f6-2c07-1d34" name="Skirmish:" hidden="false" targetId="59a4-7b61-600a-c457" primary="false"/>
+        <categoryLink id="a231-01f6-2c07-1d34" name="Skirmish Sub-type:" hidden="false" targetId="59a4-7b61-600a-c457" primary="false"/>
         <categoryLink id="aa46-1901-68ca-1c6f" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="e1f3-747e-4b46-0a8e" name="Light Sub-type:" hidden="false" targetId="bff2-ae16-74a8-8712" primary="false"/>
         <categoryLink id="f919-6f26-e787-b770" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
@@ -3380,7 +3380,7 @@
       </infoLinks>
       <categoryLinks>
         <categoryLink id="e579-d4c0-6f64-2eb2" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="1ebc-e9e5-35d4-88c3" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+        <categoryLink id="1ebc-e9e5-35d4-88c3" name="Heavy Sub-type:" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
         <categoryLink id="81a2-f758-8265-d1a6" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
       </categoryLinks>
       <selectionEntries>
@@ -3661,7 +3661,7 @@
         </infoLink>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="2ee4-2abc-3c87-55e6" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+        <categoryLink id="2ee4-2abc-3c87-55e6" name="Heavy Sub-type:" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
         <categoryLink id="7469-45b8-1b62-5427" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="0ef2-5d12-a22c-7300" name="Terminators:" hidden="false" targetId="bab3-f50d-3e5f-2f78" primary="false"/>
         <categoryLink id="38da-50e3-302b-8975" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
@@ -4151,7 +4151,7 @@
         </infoLink>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="bbe7-7ff2-451e-b829" name="New CategoryLink" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="bbe7-7ff2-451e-b829" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="b448-e7f9-63a5-1209" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="1b8f-457a-d55c-4e91" name="Skirmish Sub-type:" hidden="false" targetId="59a4-7b61-600a-c457" primary="false"/>
         <categoryLink id="1d25-440b-a838-dfd4" name="Line Sub-type:" hidden="false" targetId="6399-5c65-7833-1025" primary="false"/>
@@ -5142,7 +5142,7 @@
         </infoLink>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="b526-a925-98fa-3c1b" name="New CategoryLink" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="b526-a925-98fa-3c1b" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="4d9c-b591-869f-72e1" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="cebe-84b9-86a9-ad58" name="Skirmish Sub-type:" hidden="false" targetId="59a4-7b61-600a-c457" primary="false"/>
         <categoryLink id="b50f-33ce-bd61-3d78" name="Line Sub-type:" hidden="false" targetId="6399-5c65-7833-1025" primary="false"/>
@@ -5962,7 +5962,7 @@
       </constraints>
       <categoryLinks>
         <categoryLink id="d60f-4d22-ec3a-4ff4" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="d837-ea6b-4c27-6d28" name="Skirmish:" hidden="false" targetId="59a4-7b61-600a-c457" primary="false"/>
+        <categoryLink id="d837-ea6b-4c27-6d28" name="Skirmish Sub-type:" hidden="false" targetId="59a4-7b61-600a-c457" primary="false"/>
         <categoryLink id="630f-3af2-6436-6e5f" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
       </categoryLinks>
       <selectionEntries>
@@ -6862,7 +6862,7 @@
             </modifier>
           </modifiers>
         </entryLink>
-        <entryLink id="98fa-f5c5-68da-a472" name="Tartaros Command Squad (Placeholder Points)" hidden="false" collective="false" import="true" targetId="58d0-a0fd-d20b-cb1b" type="selectionEntry"/>
+        <entryLink id="98fa-f5c5-68da-a472" name="Command Squad, Tartaros" hidden="false" collective="false" import="true" targetId="58d0-a0fd-d20b-cb1b" type="selectionEntry"/>
         <entryLink id="3df3-f24f-ade5-13a5" name="Command Squad" hidden="false" collective="false" import="true" targetId="0aca-632d-1642-8af9" type="selectionEntry"/>
         <entryLink id="7954-2299-eaa4-0299" name="Fenrisian Wolf Pack" hidden="true" collective="false" import="true" targetId="f47e-c270-b62a-4205" type="selectionEntry">
           <modifiers>
@@ -6928,6 +6928,6 @@
     </profile>
   </sharedProfiles>
   <catalogueLinks>
-    <catalogueLink id="2f60-18fb-e6ed-8574" name="(HH V2) Legions Astartes" targetId="6393-649c-7213-a327" type="catalogue" importRootEntries="true"/>
+    <catalogueLink id="2f60-18fb-e6ed-8574" name="Legions Astartes" targetId="6393-649c-7213-a327" type="catalogue" importRootEntries="true"/>
   </catalogueLinks>
 </catalogue>

--- a/2022 - LA - Thousand Sons.cat
+++ b/2022 - LA - Thousand Sons.cat
@@ -24,7 +24,7 @@
         </profile>
       </profiles>
       <categoryLinks>
-        <categoryLink id="5f54-eecd-70e9-68ae" name="New CategoryLink" hidden="false" targetId="e90d-e5a8-f42d-da84" primary="true"/>
+        <categoryLink id="5f54-eecd-70e9-68ae" name="Allegiance:" hidden="false" targetId="e90d-e5a8-f42d-da84" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="4ca2-991b-8a05-495b" name="Ahzek Ahriman" hidden="false" collective="false" import="false" targetId="f1d9-5c86-f496-61f0" type="selectionEntry">
@@ -50,14 +50,14 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="355f-01ed-32c7-4131" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="355f-01ed-32c7-4131" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
         <categoryLink id="a731-aa94-4f2c-24d5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="eccd-7e17-7359-665c" name="Castellax-Achea Automata" hidden="false" collective="false" import="false" targetId="95cb-9366-295e-f10d" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="96c0-503c-eb35-b5c3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="dc90-d478-5300-3dd9" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="dc90-d478-5300-3dd9" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="803c-bb4e-a743-cfe2" name="Magistus Amon" hidden="false" collective="false" import="false" targetId="161b-2f2a-8616-9d4f" type="selectionEntry">
@@ -70,7 +70,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="4f1c-f718-fd3a-7b34" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="f9a9-61a7-3163-99e5" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="f9a9-61a7-3163-99e5" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="dca3-8510-af4c-2eba" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -83,7 +83,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="9eae-bf6a-4193-af6b" name="New CategoryLink" hidden="false" targetId="ad5f-31db-8bc7-5c46" primary="true"/>
+        <categoryLink id="9eae-bf6a-4193-af6b" name="Primarch:" hidden="false" targetId="ad5f-31db-8bc7-5c46" primary="true"/>
         <categoryLink id="922a-8088-b111-6bad" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
       <entryLinks>
@@ -101,19 +101,19 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="ac58-0cd7-c143-5583" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="ac58-0cd7-c143-5583" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="993d-e85b-bfeb-8a0e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="b132-3f20-976c-ff1c" name="Khenetai Occult Cabal" hidden="false" collective="false" import="false" targetId="faa7-27d5-2ee2-5d58" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="a55f-2ae6-b17c-e872" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="7bfb-d732-cefe-f207" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="7bfb-d732-cefe-f207" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="396f-5ab5-e4c1-89c4" name="Contemptor-Osiron Dreadnought Talon" hidden="false" collective="false" import="false" targetId="eef1-0f91-a59f-b3e2" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="8ada-aa38-fcb3-d993" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="8ada-aa38-fcb3-d993" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="497d-849e-d9b4-be08" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -123,7 +123,7 @@
         <categoryLink id="c10f-85c7-4e8d-8292" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_c6d4-581f-4746-bec3</comment>
         </categoryLink>
-        <categoryLink id="4ff6-a50a-4f99-843f" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
+        <categoryLink id="4ff6-a50a-4f99-843f" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
           <comment>template_id_2489-ee2a-45dd-b384</comment>
         </categoryLink>
       </categoryLinks>
@@ -153,7 +153,7 @@
         <categoryLink id="304d-9cad-4281-99c2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_8378-ede4-476d-b657</comment>
         </categoryLink>
-        <categoryLink id="ef77-8316-4602-9268" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="ef77-8316-4602-9268" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_d64f-ad19-426c-adf7</comment>
         </categoryLink>
       </categoryLinks>
@@ -179,7 +179,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="41ed-ac9f-4667-ae92" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="41ed-ac9f-4667-ae92" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_ac26-e639-4d53-9b8b</comment>
         </categoryLink>
         <categoryLink id="bc15-407c-466c-afd0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -190,7 +190,7 @@
         </categoryLink>
       </categoryLinks>
     </entryLink>
-    <entryLink id="760c-2ea5-4492-6e3c" name="Avenger Strike Fighter" hidden="true" collective="false" import="false" targetId="b25c-e85c-1c29-9e05" type="selectionEntry">
+    <entryLink id="760c-2ea5-4492-6e3c" name="Legion Avenger Strike Fighter" hidden="true" collective="false" import="false" targetId="b25c-e85c-1c29-9e05" type="selectionEntry">
       <comment>template_id_1064-175d-4616-9c71</comment>
       <modifiers>
         <modifier type="set" field="hidden" value="false">
@@ -212,7 +212,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="c740-6d2a-4e2f-8837" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="c740-6d2a-4e2f-8837" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_a009-a597-4b51-b228</comment>
         </categoryLink>
         <categoryLink id="3f3c-abdb-4001-a527" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -245,7 +245,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="048b-297e-4a31-a975" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="048b-297e-4a31-a975" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_c165-3906-463a-9c73</comment>
         </categoryLink>
         <categoryLink id="ec07-c419-4ccb-8fd9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -282,7 +282,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="3ab1-272e-44d6-b20e" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="3ab1-272e-44d6-b20e" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_3a22-caae-4eea-9bc5</comment>
         </categoryLink>
         <categoryLink id="399d-b8d1-4ea7-bfa8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -315,7 +315,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="9cca-ba09-43a3-b09e" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="9cca-ba09-43a3-b09e" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_251a-df5b-4bfd-ad63</comment>
         </categoryLink>
         <categoryLink id="188d-829a-4030-9f81" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -352,7 +352,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="515c-31c8-4ecc-9df6" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
+        <categoryLink id="515c-31c8-4ecc-9df6" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
           <comment>template_id_67c2-df43-44fc-92d1</comment>
         </categoryLink>
         <categoryLink id="167f-4975-484b-9eee" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -408,7 +408,7 @@
         <categoryLink id="69e8-ff52-4bb0-8670" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_bd6a-0cda-4e0f-80ae</comment>
         </categoryLink>
-        <categoryLink id="2fa4-9036-42e9-bc3d" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
+        <categoryLink id="2fa4-9036-42e9-bc3d" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
           <comment>template_id_ae75-7cca-4701-9d56</comment>
         </categoryLink>
         <categoryLink id="43d0-a7e7-4d98-8429" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false">
@@ -443,7 +443,7 @@
         <categoryLink id="55ad-5002-4511-8bc3" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false">
           <comment>template_id_f51c-73d7-4f29-be1c</comment>
         </categoryLink>
-        <categoryLink id="3809-fa0a-49e1-88da" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
+        <categoryLink id="3809-fa0a-49e1-88da" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
           <comment>template_id_257d-78c0-4bab-ba65</comment>
         </categoryLink>
       </categoryLinks>
@@ -491,7 +491,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="ce9d-ba16-41a2-a47f" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="ce9d-ba16-41a2-a47f" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_f1c8-27fd-4f98-8527</comment>
         </categoryLink>
         <categoryLink id="4fd2-aca5-4de8-8946" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -520,7 +520,7 @@
         <categoryLink id="eb73-432c-40b3-9b96" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_dd44-e0a8-42a8-bdcc</comment>
         </categoryLink>
-        <categoryLink id="1210-f963-470e-bd56" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
+        <categoryLink id="1210-f963-470e-bd56" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
           <comment>template_id_c5b0-f9ae-468d-924a</comment>
         </categoryLink>
       </categoryLinks>
@@ -547,7 +547,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="8db3-4f3a-432e-8e7b" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
+        <categoryLink id="8db3-4f3a-432e-8e7b" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
           <comment>template_id_f926-27fd-4a92-97a1</comment>
         </categoryLink>
         <categoryLink id="7a3f-3db1-4b57-8bec" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -579,7 +579,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="e724-bf87-c22c-2ee9" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="e724-bf87-c22c-2ee9" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
         <categoryLink id="4b03-986e-8a8f-7787" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -638,7 +638,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="f7bb-fcb8-4b80-8b55" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="f7bb-fcb8-4b80-8b55" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_361e-fb90-4b0e-ac3d</comment>
         </categoryLink>
         <categoryLink id="48ad-3019-4681-8ed9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -655,7 +655,7 @@
         <categoryLink id="adc8-237c-462c-ad5d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_473b-e812-4158-9416</comment>
         </categoryLink>
-        <categoryLink id="2c87-2acc-4084-932f" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
+        <categoryLink id="2c87-2acc-4084-932f" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
           <comment>template_id_00a2-63ff-4698-a35b</comment>
         </categoryLink>
       </categoryLinks>
@@ -679,7 +679,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="1720-f31e-4e65-8842" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="1720-f31e-4e65-8842" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_2a08-4432-42ad-bfdb</comment>
         </categoryLink>
         <categoryLink id="d76b-e45f-49e3-8fea" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -712,7 +712,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="a435-6de8-491b-b430" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="a435-6de8-491b-b430" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_f4c0-4396-4f39-a34f</comment>
         </categoryLink>
         <categoryLink id="7a25-cd6e-419e-9324" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -745,7 +745,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="2640-23b1-4684-a0e4" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="2640-23b1-4684-a0e4" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_caf6-5548-4b89-8102</comment>
         </categoryLink>
         <categoryLink id="f52e-ec5b-45cc-a862" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -805,7 +805,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="523a-4823-4d02-87dc" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="523a-4823-4d02-87dc" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_d53e-113f-4a40-a3d5</comment>
         </categoryLink>
         <categoryLink id="5650-1132-4bf7-ab3a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -826,7 +826,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="4ae6-97a7-4dbc-948e" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="4ae6-97a7-4dbc-948e" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_e6f7-a6ca-4825-bfc5</comment>
         </categoryLink>
         <categoryLink id="b62e-b779-4523-9055" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -861,7 +861,7 @@
         <categoryLink id="81cf-63ff-451c-98fd" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_cefb-cfd7-4dc8-99c4</comment>
         </categoryLink>
-        <categoryLink id="f485-d407-43b0-ba95" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="f485-d407-43b0-ba95" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_a9fd-9d16-4a5e-855c</comment>
         </categoryLink>
       </categoryLinks>
@@ -885,7 +885,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="7ee4-1602-4b35-ae9c" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="7ee4-1602-4b35-ae9c" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_a56d-347b-4b09-a918</comment>
         </categoryLink>
         <categoryLink id="ce83-860a-41cc-bf52" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -918,7 +918,7 @@
         <categoryLink id="becf-a5d8-4a1b-9dee" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_9441-d79b-4720-9667</comment>
         </categoryLink>
-        <categoryLink id="baa6-df49-4429-9e68" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="baa6-df49-4429-9e68" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_7d7e-32d3-4692-b401</comment>
         </categoryLink>
       </categoryLinks>
@@ -948,7 +948,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="c686-9249-4d26-8736" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="c686-9249-4d26-8736" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_f65b-8958-49b3-92a5</comment>
         </categoryLink>
         <categoryLink id="3981-9482-422c-96bc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -981,7 +981,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="4d52-eb41-4b81-9c18" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="4d52-eb41-4b81-9c18" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_c6a8-22a8-4d41-b969</comment>
         </categoryLink>
         <categoryLink id="df3f-1170-4260-bb67" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1044,7 +1044,7 @@
         <categoryLink id="7aa1-831c-4f6e-8555" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_bc67-ce1f-4004-aeb7</comment>
         </categoryLink>
-        <categoryLink id="825a-f3a6-4c3a-a264" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="825a-f3a6-4c3a-a264" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_9a45-9699-4475-aeef</comment>
         </categoryLink>
       </categoryLinks>
@@ -1107,7 +1107,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="8981-35f8-495e-a1aa" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="8981-35f8-495e-a1aa" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_3610-c975-4d55-bdfe</comment>
         </categoryLink>
         <categoryLink id="4276-5794-4e99-afac" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1143,7 +1143,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="649e-4277-4d31-807e" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="649e-4277-4d31-807e" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_f81d-9435-4f11-99c1</comment>
         </categoryLink>
         <categoryLink id="ce7c-86cc-4b63-8137" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1179,7 +1179,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="d9b7-69c1-4350-8bdc" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="d9b7-69c1-4350-8bdc" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_b24f-3ae0-4cbb-b016</comment>
         </categoryLink>
         <categoryLink id="f205-5930-46d8-bfe7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1212,7 +1212,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="13c2-30bb-4b43-9993" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="13c2-30bb-4b43-9993" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_c77f-0819-473b-a8a2</comment>
         </categoryLink>
         <categoryLink id="d09a-ddb1-4699-b8f1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1245,7 +1245,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="0d56-0632-4a19-8c97" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="0d56-0632-4a19-8c97" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_0397-c837-4fea-a527</comment>
         </categoryLink>
         <categoryLink id="9582-6d96-44b3-af54" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1281,7 +1281,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="668c-e26b-4c0a-b9fc" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="668c-e26b-4c0a-b9fc" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_c1cf-cea4-4278-8f27</comment>
         </categoryLink>
         <categoryLink id="b475-3f5f-40f1-b346" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1317,7 +1317,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="efea-baab-4717-82ed" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="efea-baab-4717-82ed" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_0c16-6841-42b2-b02d</comment>
         </categoryLink>
         <categoryLink id="ba23-54a7-4140-99ab" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1353,7 +1353,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="bf6a-ebd6-4360-88a5" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="bf6a-ebd6-4360-88a5" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_3632-0b5d-4622-ae33</comment>
         </categoryLink>
         <categoryLink id="f360-57e8-4df5-8dcb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1389,7 +1389,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="a682-09c9-4625-a2f3" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="a682-09c9-4625-a2f3" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_5ad5-8701-42cd-b2b6</comment>
         </categoryLink>
         <categoryLink id="74c8-b5d3-412a-ab20" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1456,7 +1456,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="30da-c976-4e26-bd6d" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="30da-c976-4e26-bd6d" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_4d7c-201f-4c99-b89a</comment>
         </categoryLink>
         <categoryLink id="556c-ddc6-40e4-bc7a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1489,7 +1489,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="c589-7535-4852-bdf6" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="c589-7535-4852-bdf6" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_4e52-ad1b-48d4-8eed</comment>
         </categoryLink>
         <categoryLink id="6750-d52a-4317-8704" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false">
@@ -1503,7 +1503,7 @@
         <categoryLink id="d3cb-4905-4959-9607" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_6140-2404-46f9-bd42</comment>
         </categoryLink>
-        <categoryLink id="2c19-68fc-492f-8abe" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
+        <categoryLink id="2c19-68fc-492f-8abe" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
           <comment>template_id_1c86-fad8-46ec-a0b0</comment>
         </categoryLink>
       </categoryLinks>
@@ -1529,7 +1529,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="dcdd-c72e-4553-ae6a" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
+        <categoryLink id="dcdd-c72e-4553-ae6a" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
           <comment>template_id_0af1-d052-4bd7-aab6</comment>
         </categoryLink>
         <categoryLink id="3096-9e25-4808-b4fd" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1578,7 +1578,7 @@
         <categoryLink id="1802-2ed8-45fc-af94" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_4272-9b9d-4c59-95f0</comment>
         </categoryLink>
-        <categoryLink id="1d07-6860-4db3-a74c" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="1d07-6860-4db3-a74c" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_d85b-1ae7-40d5-9341</comment>
         </categoryLink>
       </categoryLinks>
@@ -1600,7 +1600,7 @@
         <categoryLink id="d766-8463-4c2b-bb2d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_ff9f-01cb-41b9-800e</comment>
         </categoryLink>
-        <categoryLink id="3e35-267f-4f08-9034" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="3e35-267f-4f08-9034" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_1315-6051-4a46-b070</comment>
         </categoryLink>
       </categoryLinks>
@@ -1608,7 +1608,7 @@
     <entryLink id="19dd-ef2a-c108-1bf6" name="Praetor" hidden="false" collective="false" import="false" targetId="03be-5d55-d05a-771d" type="selectionEntry">
       <comment>template_id_5798-3fc7-4d4c-ad41</comment>
       <categoryLinks>
-        <categoryLink id="f53a-d6d7-4f8f-aa72" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
+        <categoryLink id="f53a-d6d7-4f8f-aa72" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
           <comment>template_id_b084-df23-4f99-812f</comment>
         </categoryLink>
         <categoryLink id="554d-13a7-43ad-8088" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false">
@@ -1733,7 +1733,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="a991-b0a3-4228-a66c" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="a991-b0a3-4228-a66c" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_b822-3417-4613-be37</comment>
         </categoryLink>
         <categoryLink id="e41f-fb38-4424-9fda" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1760,7 +1760,7 @@
         <categoryLink id="6239-ee6f-4f16-819f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_75a7-dc06-445b-b2dc</comment>
         </categoryLink>
-        <categoryLink id="a8ff-f2fd-42e9-a601" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="a8ff-f2fd-42e9-a601" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_e21a-c03b-4885-ac46</comment>
         </categoryLink>
       </categoryLinks>
@@ -1778,7 +1778,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="5e55-87e1-4eef-8322" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
+        <categoryLink id="5e55-87e1-4eef-8322" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
           <comment>template_id_f55b-7555-444b-beee</comment>
         </categoryLink>
         <categoryLink id="6a2a-d28c-41b4-84aa" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1799,7 +1799,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="b93f-878c-43f0-90ea" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="b93f-878c-43f0-90ea" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_79fa-3370-4ae0-9e12</comment>
         </categoryLink>
         <categoryLink id="c95b-5096-4c73-817f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1825,7 +1825,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="1fc9-0135-421c-837c" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="1fc9-0135-421c-837c" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_8d82-3279-4481-84bb</comment>
         </categoryLink>
         <categoryLink id="440c-a7cb-4d10-99cf" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1858,7 +1858,7 @@
         <categoryLink id="f2aa-efef-499c-862e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_7010-be56-4709-b058</comment>
         </categoryLink>
-        <categoryLink id="16f6-3deb-4aa3-9881" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="16f6-3deb-4aa3-9881" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_7379-a740-47ba-a054</comment>
         </categoryLink>
       </categoryLinks>
@@ -1876,7 +1876,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="f919-038f-48ff-91da" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="f919-038f-48ff-91da" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_944f-7420-4982-8ea9</comment>
         </categoryLink>
         <categoryLink id="e232-f5c4-4919-a04c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1920,7 +1920,7 @@
         <categoryLink id="0ea8-f34e-4928-ae95" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_c6ff-0977-4c92-bb28</comment>
         </categoryLink>
-        <categoryLink id="5ca2-1061-4d96-b037" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="5ca2-1061-4d96-b037" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_f555-7d39-458f-84c9</comment>
         </categoryLink>
       </categoryLinks>
@@ -1950,7 +1950,7 @@
         <categoryLink id="941c-7e71-4424-8ef4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_39e5-eda5-45d1-a643</comment>
         </categoryLink>
-        <categoryLink id="9299-1c88-4814-97ac" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="9299-1c88-4814-97ac" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_6416-21bb-4df4-9de8</comment>
         </categoryLink>
       </categoryLinks>
@@ -1980,7 +1980,7 @@
         <categoryLink id="7656-328d-426c-85e5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_5528-2dac-4be5-900c</comment>
         </categoryLink>
-        <categoryLink id="1d84-3099-419a-8a08" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="1d84-3099-419a-8a08" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_dc8f-d888-4585-991d</comment>
         </categoryLink>
       </categoryLinks>
@@ -2010,7 +2010,7 @@
         <categoryLink id="797e-72f4-4dd7-a740" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_899e-b052-4d5b-8c18</comment>
         </categoryLink>
-        <categoryLink id="86fb-2f08-45c8-bd7e" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="86fb-2f08-45c8-bd7e" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_f5e9-cff6-41d2-a016</comment>
         </categoryLink>
       </categoryLinks>
@@ -2040,7 +2040,7 @@
         <categoryLink id="4373-1e9f-48f4-9b68" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_09cd-2176-40af-bba6</comment>
         </categoryLink>
-        <categoryLink id="4c07-e2c5-4395-b6ba" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="4c07-e2c5-4395-b6ba" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_05e6-7c63-4a35-9ba0</comment>
         </categoryLink>
       </categoryLinks>
@@ -2064,7 +2064,7 @@
         <categoryLink id="cd9a-5e26-4846-aad8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_0dfa-4004-4751-8022</comment>
         </categoryLink>
-        <categoryLink id="c07d-c334-419c-a718" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="c07d-c334-419c-a718" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_a669-0f5d-4fd3-811b</comment>
         </categoryLink>
       </categoryLinks>
@@ -2091,7 +2091,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="54a5-0b0c-4491-93c7" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="54a5-0b0c-4491-93c7" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_4f60-472b-45a9-ab9e</comment>
         </categoryLink>
         <categoryLink id="a059-8961-405f-9160" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2144,7 +2144,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="8387-307f-46e0-8f80" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="8387-307f-46e0-8f80" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_2008-f1c4-4285-a14f</comment>
         </categoryLink>
         <categoryLink id="44e5-b0f2-433f-b275" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2176,7 +2176,7 @@
         <categoryLink id="166f-9368-4883-b9ca" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_9189-836c-475d-a52e</comment>
         </categoryLink>
-        <categoryLink id="32a1-447c-4246-96ee" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="32a1-447c-4246-96ee" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_e1fa-b7d8-47b0-a88a</comment>
         </categoryLink>
         <categoryLink id="6528-46fe-4454-a5e9" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false">
@@ -2190,7 +2190,7 @@
         <categoryLink id="d204-cfab-493d-808c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_b1d5-fd75-4f17-bbf4</comment>
         </categoryLink>
-        <categoryLink id="b3b4-c04d-47d5-b82d" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="b3b4-c04d-47d5-b82d" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_f221-bf81-4045-849b</comment>
         </categoryLink>
       </categoryLinks>
@@ -2216,7 +2216,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="0c83-37db-456c-a292" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="0c83-37db-456c-a292" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_f203-bc26-421f-b79e</comment>
         </categoryLink>
         <categoryLink id="4a9c-8aae-4b56-aead" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2230,7 +2230,7 @@
         <categoryLink id="2bdc-5018-41da-aac6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_51af-a137-4a1c-97a4</comment>
         </categoryLink>
-        <categoryLink id="93c0-8933-41de-bd88" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
+        <categoryLink id="93c0-8933-41de-bd88" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
           <comment>template_id_ec1f-c326-40a8-9d1f</comment>
         </categoryLink>
       </categoryLinks>
@@ -2282,7 +2282,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="e124-9bed-4310-97e4" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="e124-9bed-4310-97e4" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_fce3-801c-49c8-85d4</comment>
         </categoryLink>
         <categoryLink id="eeb3-f16d-4d37-beda" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2293,7 +2293,7 @@
     <entryLink id="5034-2e8a-21c5-06bb" name="Terminator Tartaros Squad" hidden="false" collective="false" import="false" targetId="1a8e-0ded-a4dc-2b4e" type="selectionEntry">
       <comment>template_id_0848-4e03-417a-b224</comment>
       <categoryLinks>
-        <categoryLink id="2acd-a123-4de7-849d" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
+        <categoryLink id="2acd-a123-4de7-849d" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
           <comment>template_id_ac1c-b3bf-4011-918a</comment>
         </categoryLink>
         <categoryLink id="8179-cb1c-4529-9688" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2323,7 +2323,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="09b1-f990-4c12-ade9" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="09b1-f990-4c12-ade9" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_5a04-9847-4c91-a49a</comment>
         </categoryLink>
         <categoryLink id="add5-9f92-4919-bc70" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2353,7 +2353,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="8691-a29b-45e6-a9f8" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="8691-a29b-45e6-a9f8" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_7d4f-547c-43ed-a520</comment>
         </categoryLink>
         <categoryLink id="8a5c-5fca-4294-8c70" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2382,7 +2382,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="60ed-4a72-443d-9e8f" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
+        <categoryLink id="60ed-4a72-443d-9e8f" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
           <comment>template_id_28e0-91e7-4ada-9fac</comment>
         </categoryLink>
         <categoryLink id="f91a-89ca-4253-894c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2415,7 +2415,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="e7e7-5f34-4114-a5af" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="e7e7-5f34-4114-a5af" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_e22a-c5f8-4825-a45f</comment>
         </categoryLink>
         <categoryLink id="02ff-7ff3-4f18-a10d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2432,7 +2432,7 @@
         <categoryLink id="11f9-36ff-43ae-9f79" name="Compulsory Elite:" hidden="false" targetId="bb1f-ae32-b587-c3e1" primary="false">
           <comment>template_id_7d5a-62e7-43ee-b79b</comment>
         </categoryLink>
-        <categoryLink id="5f14-1a64-4e56-809f" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
+        <categoryLink id="5f14-1a64-4e56-809f" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
           <comment>template_id_4986-9157-49f2-b670</comment>
         </categoryLink>
       </categoryLinks>
@@ -2462,7 +2462,7 @@
         <categoryLink id="ae0c-7705-40e5-be4e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_1b86-0977-4a8b-adac</comment>
         </categoryLink>
-        <categoryLink id="de81-ff1e-49b8-8218" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="de81-ff1e-49b8-8218" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_b449-403a-4e42-9239</comment>
         </categoryLink>
       </categoryLinks>
@@ -2522,7 +2522,7 @@
         <categoryLink id="2b92-ccfe-4994-8909" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_4f71-446f-4cff-afda</comment>
         </categoryLink>
-        <categoryLink id="1400-9c6f-49c7-84bc" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="1400-9c6f-49c7-84bc" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_3f44-8647-43a4-ac22</comment>
         </categoryLink>
       </categoryLinks>
@@ -2543,7 +2543,7 @@
         <categoryLink id="ee64-9503-4fb9-860d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_b6b1-886e-4194-8bcd</comment>
         </categoryLink>
-        <categoryLink id="fd48-5425-4c33-a7a9" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="fd48-5425-4c33-a7a9" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_51b5-f9c1-4587-8fc7</comment>
         </categoryLink>
       </categoryLinks>
@@ -2557,7 +2557,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="d4c0-d8df-f1a9-dc78" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="d4c0-d8df-f1a9-dc78" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="917a-7a8b-060f-5d86" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -2587,7 +2587,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="dc16-16d0-4890-a8e8" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="dc16-16d0-4890-a8e8" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="4b1e-3f1f-49cb-8343" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -2610,7 +2610,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="32cb-7077-4d54-9f38" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="2c35-def7-4c44-9b02" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="2c35-def7-4c44-9b02" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="0c9a-d272-491c-a4a0" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -2632,7 +2632,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="5b41-a9f0-4801-9dff" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="5b41-a9f0-4801-9dff" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="d64e-e976-4668-bb95" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
         <categoryLink id="17a6-f363-4094-9a7c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
@@ -2656,7 +2656,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="fe4f-c8f2-470f-901c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="f3f0-973b-4a45-ac41" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="f3f0-973b-4a45-ac41" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="343e-5caf-4fb0-b0ac" name="Sky-Hunter Squadron" hidden="true" collective="false" import="false" targetId="6263-c696-2f2e-c105" type="selectionEntry">
@@ -2679,7 +2679,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="63ff-0a92-42ab-ae8c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="204c-7b0f-4fb9-b1b3" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="204c-7b0f-4fb9-b1b3" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="85e6-cb31-427c-a040" name="Line Sub-type:" hidden="false" targetId="6399-5c65-7833-1025" primary="false"/>
         <categoryLink id="4297-dea3-a5d5-a5b1" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
       </categoryLinks>
@@ -2704,7 +2704,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="68dd-fc0f-4fde-8adc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="74ca-dd4f-46be-8be7" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="74ca-dd4f-46be-8be7" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="3870-0bd3-b9d0-be92" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -2795,7 +2795,7 @@
       <categoryLinks>
         <categoryLink id="0d5b-be56-47af-a22e" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="2e59-1043-4719-96c4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="52fa-8c3c-49d4-a321" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="52fa-8c3c-49d4-a321" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="8c3a-9851-41a9-b7e9" name="Termite Assault Drill" hidden="true" collective="false" import="false" targetId="cb30-307a-f0d7-3b13" type="selectionEntry">
@@ -2819,7 +2819,7 @@
       <categoryLinks>
         <categoryLink id="1fef-4409-4fab-93fc" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="ca2d-245e-48b4-a1cf" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="6692-6e39-44f0-ad8e" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="6692-6e39-44f0-ad8e" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="4cf6-31fa-4a0e-b26d" name="Venerable Ancient Contemptor Dreadnought" hidden="true" collective="false" import="false" targetId="dad1-0807-e254-d498" type="selectionEntry">
@@ -2836,7 +2836,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="9261-acb5-4230-8d89" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="1a5d-cbc8-418f-91a3" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="1a5d-cbc8-418f-91a3" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="c0cb-406f-4b46-9d8d" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
       </categoryLinks>
       <entryLinks>
@@ -2859,7 +2859,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="c0b2-dd90-46c1-a2a9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="9a94-76fb-4a89-ad5d" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="9a94-76fb-4a89-ad5d" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="d120-34f2-d6dd-2c1d" name="Castellax Battle-Automata Maniple" hidden="true" collective="false" import="false" targetId="537f-846d-90e3-2526" type="selectionEntry">
@@ -2872,7 +2872,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="4847-e84a-ff6f-e6fe" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="df47-8dd6-70a5-6bcc" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="df47-8dd6-70a5-6bcc" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="8554-cfdf-52dd-c8b5" name="Domitar Battle-Automata Maniple" hidden="true" collective="false" import="false" targetId="1a1b-fa35-a6a2-ca78" type="selectionEntry">
@@ -2885,7 +2885,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="e1c9-ef0b-dbee-6b25" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="7ac1-7e26-c77a-ef62" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="7ac1-7e26-c77a-ef62" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="a906-1dca-e042-8433" name="Thanatar Siege-automata Maniple" hidden="true" collective="false" import="false" targetId="2903-fef6-e839-368b" type="selectionEntry">
@@ -2902,7 +2902,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="b9a5-4cef-3bff-2821" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="fb99-553e-dab1-becb" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="fb99-553e-dab1-becb" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="101d-673b-eb4f-d9e2" name="Vorax Battle-automata Maniple" hidden="true" collective="false" import="false" targetId="f144-1079-11ff-019d" type="selectionEntry">
@@ -2915,7 +2915,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="5a40-f559-0f9c-cea7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="856b-fba9-b0ce-8e8c" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="856b-fba9-b0ce-8e8c" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="43da-5d96-18a5-3e7a" name="Sekhmet Terminator Cabal" hidden="true" collective="false" import="false" targetId="dda2-bdd0-3ced-b427" type="selectionEntry">
@@ -2937,7 +2937,7 @@
       <categoryLinks>
         <categoryLink id="2606-d746-7f52-0386" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="6454-4a82-a8bd-af34" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
-        <categoryLink id="084a-976c-4fd9-2d0a" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="084a-976c-4fd9-2d0a" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="9459-1bbc-25cc-935f" name="Thallax Cohort" hidden="true" collective="false" import="false" targetId="25c8-3e0f-e22d-a7eb" type="selectionEntry">
@@ -2962,7 +2962,7 @@
         <constraint field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="aa14-6422-cf26-1117" type="max"/>
       </constraints>
       <categoryLinks>
-        <categoryLink id="b216-3ea3-7fc8-276f" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="b216-3ea3-7fc8-276f" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="cefe-d1eb-7654-615c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -2984,7 +2984,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="a81e-5122-d99f-96a6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="6a2d-4b5c-d2c1-d604" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="6a2d-4b5c-d2c1-d604" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="ff08-0f1b-ad0f-f01b" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -4124,7 +4124,7 @@
       <categoryLinks>
         <categoryLink id="ee57-776c-ef90-1f77" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="3066-9075-b4df-8684" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="ea5b-1965-f2b0-cd0d" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+        <categoryLink id="ea5b-1965-f2b0-cd0d" name="Heavy Sub-type:" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
         <categoryLink id="4863-5593-dedb-fb54" name="Terminators:" hidden="false" targetId="bab3-f50d-3e5f-2f78" primary="false"/>
       </categoryLinks>
       <selectionEntries>
@@ -5595,12 +5595,12 @@ Additionally, a unit that includes any models with this special rule may not be 
             </modifier>
           </modifiers>
         </entryLink>
-        <entryLink id="c505-e39e-a306-c969" name="Tartaros Command Squad (Placeholder Points)" hidden="false" collective="false" import="true" targetId="58d0-a0fd-d20b-cb1b" type="selectionEntry"/>
+        <entryLink id="c505-e39e-a306-c969" name="Command Squad, Tartaros" hidden="false" collective="false" import="true" targetId="58d0-a0fd-d20b-cb1b" type="selectionEntry"/>
         <entryLink id="d46c-418f-b9b2-b2c8" name="Command Squad" hidden="false" collective="false" import="true" targetId="0aca-632d-1642-8af9" type="selectionEntry"/>
       </entryLinks>
     </selectionEntryGroup>
   </sharedSelectionEntryGroups>
   <catalogueLinks>
-    <catalogueLink id="2f60-18fb-e6ed-8574" name="(HH V2) Legions Astartes" targetId="6393-649c-7213-a327" type="catalogue" importRootEntries="true"/>
+    <catalogueLink id="2f60-18fb-e6ed-8574" name="Legions Astartes" targetId="6393-649c-7213-a327" type="catalogue" importRootEntries="true"/>
   </catalogueLinks>
 </catalogue>

--- a/2022 - LA - Ultramarines.cat
+++ b/2022 - LA - Ultramarines.cat
@@ -14,7 +14,7 @@
         <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f435-f8a1-01a1-f153" type="max"/>
       </constraints>
       <categoryLinks>
-        <categoryLink id="9c1f-9d40-238f-fcd4" name="New CategoryLink" hidden="false" targetId="e90d-e5a8-f42d-da84" primary="true"/>
+        <categoryLink id="9c1f-9d40-238f-fcd4" name="Allegiance:" hidden="false" targetId="e90d-e5a8-f42d-da84" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="ec0b-803f-6220-45e0" name="Fulmentarus Terminator Squad" hidden="true" collective="false" import="false" targetId="7fb0-6302-d46f-029d" type="selectionEntry">
@@ -35,7 +35,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="4aee-83b8-37b5-66a7" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="4aee-83b8-37b5-66a7" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="7321-3a91-dcef-123d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -52,7 +52,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="ca0e-9ea0-9afa-adb3" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="ca0e-9ea0-9afa-adb3" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
         <categoryLink id="c1ef-40b1-7263-83a0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -70,7 +70,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="0853-84b5-6391-70b4" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="0853-84b5-6391-70b4" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="d957-5e7f-47b5-4f68" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -83,7 +83,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="a64a-afb1-07f6-2e1c" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="a64a-afb1-07f6-2e1c" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="6a17-2ae0-dd91-fce4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -96,7 +96,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="c367-a4e7-916c-f376" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="c367-a4e7-916c-f376" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="85bf-5fad-fade-3696" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -109,7 +109,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="0da5-c661-19f7-a22b" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="0da5-c661-19f7-a22b" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="72db-c9b1-2570-cf99" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="19b5-180b-0b78-cc2f" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
       </categoryLinks>
@@ -123,7 +123,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="4e41-472d-ebca-f3ce" name="New CategoryLink" hidden="false" targetId="ad5f-31db-8bc7-5c46" primary="true"/>
+        <categoryLink id="4e41-472d-ebca-f3ce" name="Primarch:" hidden="false" targetId="ad5f-31db-8bc7-5c46" primary="true"/>
         <categoryLink id="9f58-9b7f-011e-d79c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
       <entryLinks>
@@ -141,7 +141,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="5c12-7aef-b106-7159" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="5c12-7aef-b106-7159" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="3c4b-fd38-d4d8-9480" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -151,7 +151,7 @@
         <categoryLink id="d735-8a47-4b85-8d2f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_c6d4-581f-4746-bec3</comment>
         </categoryLink>
-        <categoryLink id="1f2f-6c25-43ba-9afa" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
+        <categoryLink id="1f2f-6c25-43ba-9afa" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
           <comment>template_id_2489-ee2a-45dd-b384</comment>
         </categoryLink>
       </categoryLinks>
@@ -181,7 +181,7 @@
         <categoryLink id="05a9-d0e7-4a5e-96b2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_8378-ede4-476d-b657</comment>
         </categoryLink>
-        <categoryLink id="64c7-fee6-4242-8554" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="64c7-fee6-4242-8554" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_d64f-ad19-426c-adf7</comment>
         </categoryLink>
       </categoryLinks>
@@ -207,7 +207,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="779b-35d4-421b-9b1a" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="779b-35d4-421b-9b1a" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_ac26-e639-4d53-9b8b</comment>
         </categoryLink>
         <categoryLink id="6adb-1e33-409f-900d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -218,7 +218,7 @@
         </categoryLink>
       </categoryLinks>
     </entryLink>
-    <entryLink id="7584-4ae5-fa83-7a27" name="Avenger Strike Fighter" hidden="true" collective="false" import="false" targetId="b25c-e85c-1c29-9e05" type="selectionEntry">
+    <entryLink id="7584-4ae5-fa83-7a27" name="Legion Avenger Strike Fighter" hidden="true" collective="false" import="false" targetId="b25c-e85c-1c29-9e05" type="selectionEntry">
       <comment>template_id_1064-175d-4616-9c71</comment>
       <modifiers>
         <modifier type="set" field="hidden" value="false">
@@ -240,7 +240,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="4fdc-1bc9-49a9-a69b" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="4fdc-1bc9-49a9-a69b" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_a009-a597-4b51-b228</comment>
         </categoryLink>
         <categoryLink id="8c32-21d8-4c1f-a8cd" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -273,7 +273,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="b1bb-3815-4200-af90" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="b1bb-3815-4200-af90" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_c165-3906-463a-9c73</comment>
         </categoryLink>
         <categoryLink id="3669-3534-4dcc-8d30" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -310,7 +310,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="dd3c-da69-45c7-ac50" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="dd3c-da69-45c7-ac50" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_3a22-caae-4eea-9bc5</comment>
         </categoryLink>
         <categoryLink id="3965-db97-4f40-86d9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -343,7 +343,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="c8ed-999c-4962-a546" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="c8ed-999c-4962-a546" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_251a-df5b-4bfd-ad63</comment>
         </categoryLink>
         <categoryLink id="884b-5b33-40ab-a6fb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -380,7 +380,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="f1e2-dd85-4389-ad26" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
+        <categoryLink id="f1e2-dd85-4389-ad26" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
           <comment>template_id_67c2-df43-44fc-92d1</comment>
         </categoryLink>
         <categoryLink id="221a-dff8-4ed6-9557" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -436,7 +436,7 @@
         <categoryLink id="ee5a-76c1-438c-9117" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_bd6a-0cda-4e0f-80ae</comment>
         </categoryLink>
-        <categoryLink id="09e1-4fc2-43a9-a37e" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
+        <categoryLink id="09e1-4fc2-43a9-a37e" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
           <comment>template_id_ae75-7cca-4701-9d56</comment>
         </categoryLink>
         <categoryLink id="f5a5-149a-434e-a314" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false">
@@ -471,7 +471,7 @@
         <categoryLink id="cb3e-46b8-4e75-a59d" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false">
           <comment>template_id_f51c-73d7-4f29-be1c</comment>
         </categoryLink>
-        <categoryLink id="7ba7-a587-4e41-98bb" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
+        <categoryLink id="7ba7-a587-4e41-98bb" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
           <comment>template_id_257d-78c0-4bab-ba65</comment>
         </categoryLink>
       </categoryLinks>
@@ -519,7 +519,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="d92a-5a05-40a5-8ded" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="d92a-5a05-40a5-8ded" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_f1c8-27fd-4f98-8527</comment>
         </categoryLink>
         <categoryLink id="1d4f-58bf-468a-bcbb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -548,7 +548,7 @@
         <categoryLink id="94eb-0240-48bd-8f0e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_dd44-e0a8-42a8-bdcc</comment>
         </categoryLink>
-        <categoryLink id="f46f-1bf0-41bd-9a64" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
+        <categoryLink id="f46f-1bf0-41bd-9a64" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
           <comment>template_id_c5b0-f9ae-468d-924a</comment>
         </categoryLink>
       </categoryLinks>
@@ -575,7 +575,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="4f96-451e-4fe7-ae4e" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
+        <categoryLink id="4f96-451e-4fe7-ae4e" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
           <comment>template_id_f926-27fd-4a92-97a1</comment>
         </categoryLink>
         <categoryLink id="9ca4-5a78-42c2-b708" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -607,7 +607,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="8528-fc5e-1d14-4b11" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="8528-fc5e-1d14-4b11" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
         <categoryLink id="acbc-4493-37ab-d439" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -666,7 +666,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="fa19-116c-47b6-9e54" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="fa19-116c-47b6-9e54" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_361e-fb90-4b0e-ac3d</comment>
         </categoryLink>
         <categoryLink id="b1b6-fc35-44b2-8ad3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -683,7 +683,7 @@
         <categoryLink id="835a-0c4b-4fd7-b7b8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_473b-e812-4158-9416</comment>
         </categoryLink>
-        <categoryLink id="2d90-50d1-43cd-8ec1" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
+        <categoryLink id="2d90-50d1-43cd-8ec1" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
           <comment>template_id_00a2-63ff-4698-a35b</comment>
         </categoryLink>
       </categoryLinks>
@@ -707,7 +707,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="1c81-f7ce-4848-a610" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="1c81-f7ce-4848-a610" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_2a08-4432-42ad-bfdb</comment>
         </categoryLink>
         <categoryLink id="1b16-e972-4426-a66e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -740,7 +740,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="f616-2a99-46b9-a04c" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="f616-2a99-46b9-a04c" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_f4c0-4396-4f39-a34f</comment>
         </categoryLink>
         <categoryLink id="2a0c-0a7f-49fe-9ca7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -773,7 +773,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="8146-9879-4fde-8a55" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="8146-9879-4fde-8a55" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_caf6-5548-4b89-8102</comment>
         </categoryLink>
         <categoryLink id="983d-4198-415f-949f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -833,7 +833,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="d7d6-0836-43a0-ab5c" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="d7d6-0836-43a0-ab5c" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_d53e-113f-4a40-a3d5</comment>
         </categoryLink>
         <categoryLink id="eb19-ef54-43e4-8974" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -854,7 +854,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="3e5b-6e04-43a4-9534" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="3e5b-6e04-43a4-9534" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_e6f7-a6ca-4825-bfc5</comment>
         </categoryLink>
         <categoryLink id="2862-5772-45db-b4e6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -889,7 +889,7 @@
         <categoryLink id="2cd1-73ae-4ad8-b885" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_cefb-cfd7-4dc8-99c4</comment>
         </categoryLink>
-        <categoryLink id="4251-3d0b-4422-b21a" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="4251-3d0b-4422-b21a" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_a9fd-9d16-4a5e-855c</comment>
         </categoryLink>
       </categoryLinks>
@@ -913,7 +913,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="42f1-b104-44bf-9ce5" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="42f1-b104-44bf-9ce5" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_a56d-347b-4b09-a918</comment>
         </categoryLink>
         <categoryLink id="60f6-31bb-4e75-9038" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -946,7 +946,7 @@
         <categoryLink id="e10d-9052-498b-8ff1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_9441-d79b-4720-9667</comment>
         </categoryLink>
-        <categoryLink id="3c3a-82a9-42ef-83e1" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="3c3a-82a9-42ef-83e1" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_7d7e-32d3-4692-b401</comment>
         </categoryLink>
       </categoryLinks>
@@ -976,7 +976,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="0683-47de-4499-80d8" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="0683-47de-4499-80d8" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_f65b-8958-49b3-92a5</comment>
         </categoryLink>
         <categoryLink id="bed4-381c-4d0f-9474" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1009,7 +1009,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="9dd1-e727-4346-bede" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="9dd1-e727-4346-bede" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_c6a8-22a8-4d41-b969</comment>
         </categoryLink>
         <categoryLink id="0a6f-ed22-4e49-9fde" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1072,7 +1072,7 @@
         <categoryLink id="c00e-ee33-47dd-8866" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_bc67-ce1f-4004-aeb7</comment>
         </categoryLink>
-        <categoryLink id="ecba-bff7-41ed-857d" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="ecba-bff7-41ed-857d" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_9a45-9699-4475-aeef</comment>
         </categoryLink>
       </categoryLinks>
@@ -1135,7 +1135,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="b9da-f503-4fe8-93cb" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="b9da-f503-4fe8-93cb" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_3610-c975-4d55-bdfe</comment>
         </categoryLink>
         <categoryLink id="b81a-4881-4c63-a874" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1171,7 +1171,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="4744-b6cd-479e-a1c7" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="4744-b6cd-479e-a1c7" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_f81d-9435-4f11-99c1</comment>
         </categoryLink>
         <categoryLink id="d93c-1ecb-4e7d-a550" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1207,7 +1207,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="fe3e-f422-405b-a4ae" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="fe3e-f422-405b-a4ae" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_b24f-3ae0-4cbb-b016</comment>
         </categoryLink>
         <categoryLink id="c51b-549c-49ba-9fd4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1240,7 +1240,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="4208-98e5-4d04-bb77" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="4208-98e5-4d04-bb77" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_c77f-0819-473b-a8a2</comment>
         </categoryLink>
         <categoryLink id="cff3-2b0e-4ab1-9865" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1273,7 +1273,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="128e-d9da-48fe-bd2a" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="128e-d9da-48fe-bd2a" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_0397-c837-4fea-a527</comment>
         </categoryLink>
         <categoryLink id="6ca1-d3ec-4472-aced" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1309,7 +1309,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="4e92-85a8-4a2d-bae3" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="4e92-85a8-4a2d-bae3" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_c1cf-cea4-4278-8f27</comment>
         </categoryLink>
         <categoryLink id="48c0-6bd7-440b-8d1b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1345,7 +1345,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="792d-2775-4021-a534" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="792d-2775-4021-a534" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_0c16-6841-42b2-b02d</comment>
         </categoryLink>
         <categoryLink id="cff4-3965-4fa8-a816" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1381,7 +1381,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="cb4c-aa80-4aea-9987" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="cb4c-aa80-4aea-9987" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_3632-0b5d-4622-ae33</comment>
         </categoryLink>
         <categoryLink id="9dd3-2099-49f3-9322" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1417,7 +1417,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="6616-02c9-4875-afbf" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="6616-02c9-4875-afbf" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_5ad5-8701-42cd-b2b6</comment>
         </categoryLink>
         <categoryLink id="3d66-bc48-4161-a9ce" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1484,7 +1484,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="a86b-38c3-4e72-9d82" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="a86b-38c3-4e72-9d82" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_4d7c-201f-4c99-b89a</comment>
         </categoryLink>
         <categoryLink id="da23-291a-497a-97d8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1517,7 +1517,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="d1cd-fd9f-4964-b849" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="d1cd-fd9f-4964-b849" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_4e52-ad1b-48d4-8eed</comment>
         </categoryLink>
         <categoryLink id="6a9c-c4b6-4b1c-b3a3" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false">
@@ -1531,7 +1531,7 @@
         <categoryLink id="b22a-5512-468c-8ceb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_6140-2404-46f9-bd42</comment>
         </categoryLink>
-        <categoryLink id="2bf8-8280-4657-85e0" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
+        <categoryLink id="2bf8-8280-4657-85e0" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
           <comment>template_id_1c86-fad8-46ec-a0b0</comment>
         </categoryLink>
       </categoryLinks>
@@ -1557,7 +1557,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="6c91-451c-4acf-8dc0" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
+        <categoryLink id="6c91-451c-4acf-8dc0" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
           <comment>template_id_0af1-d052-4bd7-aab6</comment>
         </categoryLink>
         <categoryLink id="1adf-13a3-4578-9ec3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1606,7 +1606,7 @@
         <categoryLink id="0055-ca71-4ca0-8415" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_4272-9b9d-4c59-95f0</comment>
         </categoryLink>
-        <categoryLink id="bf25-cc5a-40c3-a3ce" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="bf25-cc5a-40c3-a3ce" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_d85b-1ae7-40d5-9341</comment>
         </categoryLink>
       </categoryLinks>
@@ -1628,7 +1628,7 @@
         <categoryLink id="3edf-965b-4594-beb2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_ff9f-01cb-41b9-800e</comment>
         </categoryLink>
-        <categoryLink id="863a-7a22-4c23-b426" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="863a-7a22-4c23-b426" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_1315-6051-4a46-b070</comment>
         </categoryLink>
       </categoryLinks>
@@ -1636,7 +1636,7 @@
     <entryLink id="3487-5202-a7aa-81a2" name="Praetor" hidden="false" collective="false" import="false" targetId="03be-5d55-d05a-771d" type="selectionEntry">
       <comment>template_id_5798-3fc7-4d4c-ad41</comment>
       <categoryLinks>
-        <categoryLink id="aafb-6034-4199-85d2" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
+        <categoryLink id="aafb-6034-4199-85d2" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
           <comment>template_id_b084-df23-4f99-812f</comment>
         </categoryLink>
         <categoryLink id="043f-e8db-48ed-903d" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false">
@@ -1761,7 +1761,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="0143-1ded-415f-a99c" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="0143-1ded-415f-a99c" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_b822-3417-4613-be37</comment>
         </categoryLink>
         <categoryLink id="b2bc-df2c-4d11-b602" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1788,7 +1788,7 @@
         <categoryLink id="a2c1-7220-4740-a483" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_75a7-dc06-445b-b2dc</comment>
         </categoryLink>
-        <categoryLink id="c52d-86e7-4c8c-b548" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="c52d-86e7-4c8c-b548" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_e21a-c03b-4885-ac46</comment>
         </categoryLink>
       </categoryLinks>
@@ -1806,7 +1806,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="3965-e5e4-4436-8704" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
+        <categoryLink id="3965-e5e4-4436-8704" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
           <comment>template_id_f55b-7555-444b-beee</comment>
         </categoryLink>
         <categoryLink id="9126-ad86-4977-8b12" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1827,7 +1827,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="62e2-e26e-435f-81d4" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="62e2-e26e-435f-81d4" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_79fa-3370-4ae0-9e12</comment>
         </categoryLink>
         <categoryLink id="e4b5-1903-4ccf-bd36" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1853,7 +1853,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="9689-5098-4a04-906f" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="9689-5098-4a04-906f" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_8d82-3279-4481-84bb</comment>
         </categoryLink>
         <categoryLink id="be1b-7ffa-454c-be84" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1886,7 +1886,7 @@
         <categoryLink id="a640-9860-4ee3-a044" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_7010-be56-4709-b058</comment>
         </categoryLink>
-        <categoryLink id="1b62-3ec2-4fdc-8a24" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="1b62-3ec2-4fdc-8a24" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_7379-a740-47ba-a054</comment>
         </categoryLink>
       </categoryLinks>
@@ -1904,7 +1904,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="ef77-0845-49b6-bcb0" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="ef77-0845-49b6-bcb0" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_944f-7420-4982-8ea9</comment>
         </categoryLink>
         <categoryLink id="0817-2167-4cf2-87ce" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1948,7 +1948,7 @@
         <categoryLink id="b6c8-1914-4e7e-9bc3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_c6ff-0977-4c92-bb28</comment>
         </categoryLink>
-        <categoryLink id="7ca8-3da0-4e87-b3f2" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="7ca8-3da0-4e87-b3f2" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_f555-7d39-458f-84c9</comment>
         </categoryLink>
       </categoryLinks>
@@ -1978,7 +1978,7 @@
         <categoryLink id="f402-0952-4ebc-a8f5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_39e5-eda5-45d1-a643</comment>
         </categoryLink>
-        <categoryLink id="3b4c-e788-42d8-87d5" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="3b4c-e788-42d8-87d5" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_6416-21bb-4df4-9de8</comment>
         </categoryLink>
       </categoryLinks>
@@ -2008,7 +2008,7 @@
         <categoryLink id="c572-444b-4ab0-b701" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_5528-2dac-4be5-900c</comment>
         </categoryLink>
-        <categoryLink id="e21b-6c90-4a45-b75f" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="e21b-6c90-4a45-b75f" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_dc8f-d888-4585-991d</comment>
         </categoryLink>
       </categoryLinks>
@@ -2038,7 +2038,7 @@
         <categoryLink id="d7cc-b7a7-4bf3-a709" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_899e-b052-4d5b-8c18</comment>
         </categoryLink>
-        <categoryLink id="6d2b-1362-413e-910d" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="6d2b-1362-413e-910d" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_f5e9-cff6-41d2-a016</comment>
         </categoryLink>
       </categoryLinks>
@@ -2068,7 +2068,7 @@
         <categoryLink id="2358-d7af-4843-807d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_09cd-2176-40af-bba6</comment>
         </categoryLink>
-        <categoryLink id="26ce-8a41-4e9b-a667" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="26ce-8a41-4e9b-a667" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_05e6-7c63-4a35-9ba0</comment>
         </categoryLink>
       </categoryLinks>
@@ -2092,7 +2092,7 @@
         <categoryLink id="a1cc-b9f6-4590-906c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_0dfa-4004-4751-8022</comment>
         </categoryLink>
-        <categoryLink id="d65e-5d83-4e70-9aa6" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="d65e-5d83-4e70-9aa6" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_a669-0f5d-4fd3-811b</comment>
         </categoryLink>
       </categoryLinks>
@@ -2119,7 +2119,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="c884-bfda-44ac-ba79" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="c884-bfda-44ac-ba79" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_4f60-472b-45a9-ab9e</comment>
         </categoryLink>
         <categoryLink id="1b7c-5e89-4eaf-9a40" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2172,7 +2172,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="2be4-1e7f-425d-8e0a" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="2be4-1e7f-425d-8e0a" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_2008-f1c4-4285-a14f</comment>
         </categoryLink>
         <categoryLink id="69df-a7b3-4bb5-93b8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2204,7 +2204,7 @@
         <categoryLink id="7f24-41f1-4392-b23a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_9189-836c-475d-a52e</comment>
         </categoryLink>
-        <categoryLink id="ac79-7e28-43ba-8b16" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="ac79-7e28-43ba-8b16" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_e1fa-b7d8-47b0-a88a</comment>
         </categoryLink>
         <categoryLink id="f692-874b-490d-88e1" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false">
@@ -2218,7 +2218,7 @@
         <categoryLink id="1040-72f9-404f-8012" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_b1d5-fd75-4f17-bbf4</comment>
         </categoryLink>
-        <categoryLink id="2d97-534a-43a6-b34f" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="2d97-534a-43a6-b34f" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_f221-bf81-4045-849b</comment>
         </categoryLink>
       </categoryLinks>
@@ -2244,7 +2244,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="9539-2b8d-4f3a-b628" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="9539-2b8d-4f3a-b628" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_f203-bc26-421f-b79e</comment>
         </categoryLink>
         <categoryLink id="196f-36a0-4616-8053" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2258,7 +2258,7 @@
         <categoryLink id="a584-7580-4827-82f2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_51af-a137-4a1c-97a4</comment>
         </categoryLink>
-        <categoryLink id="b1ef-8bc8-4a33-9778" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
+        <categoryLink id="b1ef-8bc8-4a33-9778" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
           <comment>template_id_ec1f-c326-40a8-9d1f</comment>
         </categoryLink>
       </categoryLinks>
@@ -2310,7 +2310,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="e490-1fe8-430f-974f" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="e490-1fe8-430f-974f" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_fce3-801c-49c8-85d4</comment>
         </categoryLink>
         <categoryLink id="38f4-b195-4519-822a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2321,7 +2321,7 @@
     <entryLink id="cb9f-8965-41ef-bf1d" name="Terminator Tartaros Squad" hidden="false" collective="false" import="false" targetId="1a8e-0ded-a4dc-2b4e" type="selectionEntry">
       <comment>template_id_0848-4e03-417a-b224</comment>
       <categoryLinks>
-        <categoryLink id="314a-13fd-4a61-a4a8" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
+        <categoryLink id="314a-13fd-4a61-a4a8" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
           <comment>template_id_ac1c-b3bf-4011-918a</comment>
         </categoryLink>
         <categoryLink id="e90d-41a1-46d5-b541" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2351,7 +2351,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="c289-4cdc-44a1-b482" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="c289-4cdc-44a1-b482" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_5a04-9847-4c91-a49a</comment>
         </categoryLink>
         <categoryLink id="b88c-29d8-4659-87af" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2381,7 +2381,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="8542-878b-45fd-a13e" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="8542-878b-45fd-a13e" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_7d4f-547c-43ed-a520</comment>
         </categoryLink>
         <categoryLink id="f401-3dd6-4de2-9848" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2410,7 +2410,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="f3a9-b153-4f37-90dc" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
+        <categoryLink id="f3a9-b153-4f37-90dc" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
           <comment>template_id_28e0-91e7-4ada-9fac</comment>
         </categoryLink>
         <categoryLink id="ee33-f43b-4632-a68b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2443,7 +2443,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="a180-fd9a-4a3a-a2bb" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="a180-fd9a-4a3a-a2bb" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_e22a-c5f8-4825-a45f</comment>
         </categoryLink>
         <categoryLink id="96b4-f846-4ff6-8ed7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2460,7 +2460,7 @@
         <categoryLink id="b5f2-5b3a-452a-8814" name="Compulsory Elite:" hidden="false" targetId="bb1f-ae32-b587-c3e1" primary="false">
           <comment>template_id_7d5a-62e7-43ee-b79b</comment>
         </categoryLink>
-        <categoryLink id="4890-f7fe-4150-90b8" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
+        <categoryLink id="4890-f7fe-4150-90b8" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
           <comment>template_id_4986-9157-49f2-b670</comment>
         </categoryLink>
       </categoryLinks>
@@ -2490,7 +2490,7 @@
         <categoryLink id="0ab3-359e-42d8-8497" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_1b86-0977-4a8b-adac</comment>
         </categoryLink>
-        <categoryLink id="f026-0f7e-4237-9864" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="f026-0f7e-4237-9864" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_b449-403a-4e42-9239</comment>
         </categoryLink>
       </categoryLinks>
@@ -2550,7 +2550,7 @@
         <categoryLink id="6b56-4e4f-465e-83fb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_4f71-446f-4cff-afda</comment>
         </categoryLink>
-        <categoryLink id="b63e-5313-4eb3-a017" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="b63e-5313-4eb3-a017" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_3f44-8647-43a4-ac22</comment>
         </categoryLink>
       </categoryLinks>
@@ -2571,7 +2571,7 @@
         <categoryLink id="f956-b934-4fcc-8491" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_b6b1-886e-4194-8bcd</comment>
         </categoryLink>
-        <categoryLink id="ef91-b04b-4509-a296" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="ef91-b04b-4509-a296" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_51b5-f9c1-4587-8fc7</comment>
         </categoryLink>
       </categoryLinks>
@@ -2602,7 +2602,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="dc16-16d0-4890-a8e8" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="dc16-16d0-4890-a8e8" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="4b1e-3f1f-49cb-8343" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -2625,7 +2625,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="32cb-7077-4d54-9f38" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="2c35-def7-4c44-9b02" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="2c35-def7-4c44-9b02" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="0c9a-d272-491c-a4a0" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -2647,7 +2647,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="5b41-a9f0-4801-9dff" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="5b41-a9f0-4801-9dff" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="d64e-e976-4668-bb95" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
         <categoryLink id="17a6-f363-4094-9a7c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
@@ -2671,7 +2671,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="fe4f-c8f2-470f-901c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="f3f0-973b-4a45-ac41" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="f3f0-973b-4a45-ac41" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="232a-bd76-4595-93bd" name="Sky-Hunter Squadron" hidden="true" collective="false" import="false" targetId="6263-c696-2f2e-c105" type="selectionEntry">
@@ -2694,7 +2694,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="63ff-0a92-42ab-ae8c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="204c-7b0f-4fb9-b1b3" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="204c-7b0f-4fb9-b1b3" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="85e6-cb31-427c-a040" name="Line Sub-type:" hidden="false" targetId="6399-5c65-7833-1025" primary="false"/>
         <categoryLink id="1132-dd05-eea0-2bae" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
       </categoryLinks>
@@ -2719,7 +2719,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="68dd-fc0f-4fde-8adc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="74ca-dd4f-46be-8be7" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="74ca-dd4f-46be-8be7" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="f331-45ea-08d6-9291" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -2810,7 +2810,7 @@
       <categoryLinks>
         <categoryLink id="0d5b-be56-47af-a22e" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="2e59-1043-4719-96c4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="52fa-8c3c-49d4-a321" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="52fa-8c3c-49d4-a321" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="9b0e-33a1-418a-b4c8" name="Termite Assault Drill" hidden="true" collective="false" import="false" targetId="cb30-307a-f0d7-3b13" type="selectionEntry">
@@ -2834,7 +2834,7 @@
       <categoryLinks>
         <categoryLink id="1fef-4409-4fab-93fc" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="ca2d-245e-48b4-a1cf" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="6692-6e39-44f0-ad8e" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="6692-6e39-44f0-ad8e" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="5d85-571c-432a-b752" name="Venerable Ancient Contemptor Dreadnought" hidden="true" collective="false" import="false" targetId="dad1-0807-e254-d498" type="selectionEntry">
@@ -2851,7 +2851,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="9261-acb5-4230-8d89" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="1a5d-cbc8-418f-91a3" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="1a5d-cbc8-418f-91a3" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="c0cb-406f-4b46-9d8d" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
       </categoryLinks>
       <entryLinks>
@@ -2874,7 +2874,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="c0b2-dd90-46c1-a2a9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="9a94-76fb-4a89-ad5d" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="9a94-76fb-4a89-ad5d" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="be38-66a0-f0d3-a5ef" name="Vorax Battle-automata Maniple" hidden="true" collective="false" import="false" targetId="f144-1079-11ff-019d" type="selectionEntry">
@@ -2887,7 +2887,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="8bdf-4f19-a5a0-767f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="305b-ca91-66a5-e1bc" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="305b-ca91-66a5-e1bc" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="1212-b7c7-680c-5fcd" name="Thanatar Siege-automata Maniple" hidden="true" collective="false" import="false" targetId="2903-fef6-e839-368b" type="selectionEntry">
@@ -2904,7 +2904,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="6c9e-1b30-2a84-5232" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="1b32-423a-9f0f-0529" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="1b32-423a-9f0f-0529" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="4c59-b69b-3baf-cb37" name="Domitar Battle-Automata Maniple" hidden="true" collective="false" import="false" targetId="1a1b-fa35-a6a2-ca78" type="selectionEntry">
@@ -2917,7 +2917,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="907c-26b9-5fad-9233" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="ffe0-45b0-bb73-720b" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="ffe0-45b0-bb73-720b" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="acc5-4386-2370-4168" name="Castellax Battle-Automata Maniple" hidden="true" collective="false" import="false" targetId="537f-846d-90e3-2526" type="selectionEntry">
@@ -2930,7 +2930,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="d216-c311-cfa4-23c8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="fa74-2939-6845-fc01" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="fa74-2939-6845-fc01" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="cb06-9ca2-1e14-74b5" name="Fulmentarus Terminator Squad" hidden="true" collective="false" import="false" targetId="7fb0-6302-d46f-029d" type="selectionEntry">
@@ -2950,7 +2950,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="183c-2fd2-9d53-9507" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="0c03-bd1c-dd05-8321" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="0c03-bd1c-dd05-8321" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="c611-75bd-b9fe-4096" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -2976,7 +2976,7 @@
         <constraint field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b445-4d0e-c872-8dec" type="max"/>
       </constraints>
       <categoryLinks>
-        <categoryLink id="02cc-cc50-d230-facc" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="02cc-cc50-d230-facc" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="ebda-4b99-6483-d4f8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -3173,7 +3173,7 @@
       <categoryLinks>
         <categoryLink id="c1fb-3d4b-27f5-b426" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="2515-1c11-b0e3-ede9" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="f8fc-6ad9-18f9-52bb" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+        <categoryLink id="f8fc-6ad9-18f9-52bb" name="Heavy Sub-type:" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
         <categoryLink id="2939-9165-c065-999f" name="Line Sub-type:" hidden="false" targetId="6399-5c65-7833-1025" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
@@ -3492,7 +3492,7 @@
         </infoLink>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="18bd-fce6-63db-d58d" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+        <categoryLink id="18bd-fce6-63db-d58d" name="Heavy Sub-type:" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
         <categoryLink id="f8aa-a104-90eb-b32f" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="a5b1-bdaf-421c-1167" name="Line Sub-type:" hidden="false" targetId="6399-5c65-7833-1025" primary="false"/>
         <categoryLink id="9d2c-fdc3-3b78-373f" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
@@ -3788,7 +3788,7 @@
       <categoryLinks>
         <categoryLink id="d762-cd12-7679-e649" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="51d5-8c99-7bfa-92f8" name="Terminators:" hidden="false" targetId="bab3-f50d-3e5f-2f78" primary="false"/>
-        <categoryLink id="07ca-16ef-6bbf-515a" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+        <categoryLink id="07ca-16ef-6bbf-515a" name="Heavy Sub-type:" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
         <categoryLink id="e47f-ba3e-879c-88fd" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
       </categoryLinks>
       <selectionEntries>
@@ -4112,7 +4112,7 @@
                     <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="67fe-b30e-427e-c68a" type="max"/>
                   </constraints>
                 </entryLink>
-                <entryLink id="5807-30ee-6a96-ff20" name="Peritarch targeter" hidden="false" collective="false" import="true" targetId="35c3-a948-99df-5477" type="selectionEntry">
+                <entryLink id="5807-30ee-6a96-ff20" name="Peritarch Targeter" hidden="false" collective="false" import="true" targetId="35c3-a948-99df-5477" type="selectionEntry">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5487-6d14-9e3c-4a27" type="min"/>
                     <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="667f-3a78-f42f-4380" type="max"/>
@@ -4478,7 +4478,7 @@
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15"/>
                   </costs>
                 </entryLink>
-                <entryLink id="a887-9d78-c1e4-8ceb" name="Argean power sword" hidden="false" collective="false" import="true" targetId="013e-d478-87eb-badc" type="selectionEntry"/>
+                <entryLink id="a887-9d78-c1e4-8ceb" name="Argean Power Sword" hidden="false" collective="false" import="true" targetId="013e-d478-87eb-badc" type="selectionEntry"/>
               </entryLinks>
             </selectionEntryGroup>
             <selectionEntryGroup id="7af0-de3f-a14b-4103" name="2) Bolt Pistol Options" hidden="false" collective="false" import="true" defaultSelectionEntryId="825f-afc2-efcf-6eba">
@@ -5388,7 +5388,7 @@ Once per battle, a Warlord with this Warlord Trait may, at the start of any one 
     </selectionEntryGroup>
   </sharedSelectionEntryGroups>
   <catalogueLinks>
-    <catalogueLink id="2f60-18fb-e6ed-8574" name="(HH V2) Legions Astartes" targetId="6393-649c-7213-a327" type="catalogue" importRootEntries="true"/>
+    <catalogueLink id="2f60-18fb-e6ed-8574" name="Legions Astartes" targetId="6393-649c-7213-a327" type="catalogue" importRootEntries="true"/>
   </catalogueLinks>
   <sharedProfiles>
     <profile id="8b1d-ca41-c9a6-32bc" name="Praetorian" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName="Unit">

--- a/2022 - LA - White Scars.cat
+++ b/2022 - LA - White Scars.cat
@@ -14,7 +14,7 @@
         <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e400-7749-453c-4152" type="max"/>
       </constraints>
       <categoryLinks>
-        <categoryLink id="0a52-da7d-b209-7c15" name="New CategoryLink" hidden="false" targetId="e90d-e5a8-f42d-da84" primary="true"/>
+        <categoryLink id="0a52-da7d-b209-7c15" name="Allegiance:" hidden="false" targetId="e90d-e5a8-f42d-da84" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="2053-c79e-817a-32cb" name="Dark Sons of Death" hidden="false" collective="false" import="false" targetId="4372-ad51-04a6-97ce" type="selectionEntry">
@@ -26,14 +26,14 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="7689-dc44-a435-02ec" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="7689-dc44-a435-02ec" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="6621-bf90-3035-c248" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="ef8a-7d90-01fc-4eb4" name="Ebon Keshig Cohort" hidden="false" collective="false" import="false" targetId="eb44-e977-2ce5-b239" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="2046-6c03-bfac-0631" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="981c-8d75-2230-8fc6" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="981c-8d75-2230-8fc6" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="f531-b3bf-a683-bbe1" name="Falcon&apos;s Claws" hidden="true" collective="false" import="false" targetId="c598-7fda-13d0-7523" type="selectionEntry">
@@ -45,7 +45,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="1a18-cd46-d204-85ed" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="1a18-cd46-d204-85ed" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
         <categoryLink id="f3ec-1651-a78e-9b79" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -68,7 +68,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="98eb-50a0-d89c-664a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="90d1-acd8-eff5-467f" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="90d1-acd8-eff5-467f" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="866d-e6ce-71a2-0476" name="Kyzagan Assault Speeder Squadron" hidden="false" collective="false" import="false" targetId="e37e-09ea-50c6-2daa" type="selectionEntry">
@@ -89,7 +89,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="395e-8bb9-faa9-afd6" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="395e-8bb9-faa9-afd6" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
         <categoryLink id="bfe2-c28e-eb07-add1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -102,7 +102,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="3282-02f6-67ab-9faf" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="3282-02f6-67ab-9faf" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="f73e-34e5-fa25-642e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="9189-508b-565b-fd20" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
       </categoryLinks>
@@ -123,7 +123,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="cb05-ddea-48b7-7034" name="New CategoryLink" hidden="false" targetId="ad5f-31db-8bc7-5c46" primary="true"/>
+        <categoryLink id="cb05-ddea-48b7-7034" name="Primarch:" hidden="false" targetId="ad5f-31db-8bc7-5c46" primary="true"/>
         <categoryLink id="f969-cbdf-b170-b089" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -141,7 +141,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="a7da-28a9-5f15-d931" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="a7da-28a9-5f15-d931" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="a7ae-0458-9ffb-c783" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="a9bd-8e73-b3dc-7062" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
       </categoryLinks>
@@ -152,7 +152,7 @@
         <categoryLink id="289e-b283-498c-a825" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_c6d4-581f-4746-bec3</comment>
         </categoryLink>
-        <categoryLink id="8091-97ee-4d68-9337" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
+        <categoryLink id="8091-97ee-4d68-9337" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
           <comment>template_id_2489-ee2a-45dd-b384</comment>
         </categoryLink>
       </categoryLinks>
@@ -188,7 +188,7 @@
         <categoryLink id="5c11-39a1-4b48-a798" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_8378-ede4-476d-b657</comment>
         </categoryLink>
-        <categoryLink id="7edf-f266-46cf-95af" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="7edf-f266-46cf-95af" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_d64f-ad19-426c-adf7</comment>
         </categoryLink>
       </categoryLinks>
@@ -214,7 +214,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="c145-1f75-4ddf-acb4" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="c145-1f75-4ddf-acb4" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_ac26-e639-4d53-9b8b</comment>
         </categoryLink>
         <categoryLink id="e33a-37fa-4260-9f19" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -225,7 +225,7 @@
         </categoryLink>
       </categoryLinks>
     </entryLink>
-    <entryLink id="cc27-6737-f9b6-3c82" name="Avenger Strike Fighter" hidden="true" collective="false" import="false" targetId="b25c-e85c-1c29-9e05" type="selectionEntry">
+    <entryLink id="cc27-6737-f9b6-3c82" name="Legion Avenger Strike Fighter" hidden="true" collective="false" import="false" targetId="b25c-e85c-1c29-9e05" type="selectionEntry">
       <comment>template_id_1064-175d-4616-9c71</comment>
       <modifiers>
         <modifier type="set" field="hidden" value="false">
@@ -250,7 +250,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="fa54-84fb-42c6-8749" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="fa54-84fb-42c6-8749" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_a009-a597-4b51-b228</comment>
         </categoryLink>
         <categoryLink id="d329-b109-4bf5-91cb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -289,7 +289,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="ecf9-e1ca-407c-ad08" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="ecf9-e1ca-407c-ad08" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_c165-3906-463a-9c73</comment>
         </categoryLink>
         <categoryLink id="5d72-4ae6-460d-8a4c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -326,7 +326,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="b7db-f98e-45de-b6f1" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="b7db-f98e-45de-b6f1" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_3a22-caae-4eea-9bc5</comment>
         </categoryLink>
         <categoryLink id="1987-38c2-421a-beb5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -362,7 +362,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="c5c7-65e1-406a-92ab" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="c5c7-65e1-406a-92ab" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_251a-df5b-4bfd-ad63</comment>
         </categoryLink>
         <categoryLink id="60b2-73cf-455c-af18" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -399,7 +399,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="8998-8f1f-4754-908c" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
+        <categoryLink id="8998-8f1f-4754-908c" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
           <comment>template_id_67c2-df43-44fc-92d1</comment>
         </categoryLink>
         <categoryLink id="7b6c-6d45-42aa-8bb5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -468,7 +468,7 @@
         <categoryLink id="00d5-f71e-44b4-836f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_bd6a-0cda-4e0f-80ae</comment>
         </categoryLink>
-        <categoryLink id="1af3-daa3-4d76-bf71" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
+        <categoryLink id="1af3-daa3-4d76-bf71" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
           <comment>template_id_ae75-7cca-4701-9d56</comment>
         </categoryLink>
         <categoryLink id="a1cf-ddf6-4895-a1ea" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false">
@@ -503,7 +503,7 @@
         <categoryLink id="bbac-c683-478d-a383" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false">
           <comment>template_id_f51c-73d7-4f29-be1c</comment>
         </categoryLink>
-        <categoryLink id="1d4d-efe9-4327-8d9b" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
+        <categoryLink id="1d4d-efe9-4327-8d9b" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
           <comment>template_id_257d-78c0-4bab-ba65</comment>
         </categoryLink>
       </categoryLinks>
@@ -551,7 +551,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="9104-a0ba-49c0-b65c" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="9104-a0ba-49c0-b65c" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_f1c8-27fd-4f98-8527</comment>
         </categoryLink>
         <categoryLink id="728d-68de-44ef-b45c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -580,7 +580,7 @@
         <categoryLink id="97e5-50ac-4899-aac1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_dd44-e0a8-42a8-bdcc</comment>
         </categoryLink>
-        <categoryLink id="396b-d400-4401-acf0" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
+        <categoryLink id="396b-d400-4401-acf0" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
           <comment>template_id_c5b0-f9ae-468d-924a</comment>
         </categoryLink>
       </categoryLinks>
@@ -607,7 +607,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="e0f0-cda1-48d4-aacb" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
+        <categoryLink id="e0f0-cda1-48d4-aacb" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
           <comment>template_id_f926-27fd-4a92-97a1</comment>
         </categoryLink>
         <categoryLink id="48c7-78d6-4680-9bed" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -645,7 +645,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="a000-9429-2d21-e082" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="a000-9429-2d21-e082" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
         <categoryLink id="6866-960c-b381-646d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -710,7 +710,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="73b3-8094-446b-be54" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="73b3-8094-446b-be54" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_361e-fb90-4b0e-ac3d</comment>
         </categoryLink>
         <categoryLink id="630d-9245-4dfa-8b97" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -727,7 +727,7 @@
         <categoryLink id="d628-91d2-4bb2-9e59" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_473b-e812-4158-9416</comment>
         </categoryLink>
-        <categoryLink id="5446-1d19-4192-a135" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
+        <categoryLink id="5446-1d19-4192-a135" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
           <comment>template_id_00a2-63ff-4698-a35b</comment>
         </categoryLink>
       </categoryLinks>
@@ -754,7 +754,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="bb39-1479-492e-9300" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="bb39-1479-492e-9300" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_2a08-4432-42ad-bfdb</comment>
         </categoryLink>
         <categoryLink id="0afe-b61a-44d2-932d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -787,7 +787,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="a7bf-57a8-4c5b-ad80" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="a7bf-57a8-4c5b-ad80" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_f4c0-4396-4f39-a34f</comment>
         </categoryLink>
         <categoryLink id="ae3f-4e55-469a-abff" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -820,7 +820,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="7fbf-07c7-40ea-83c8" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="7fbf-07c7-40ea-83c8" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_caf6-5548-4b89-8102</comment>
         </categoryLink>
         <categoryLink id="7d47-ec64-4735-9146" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -883,7 +883,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="95c7-56fa-4301-ba7e" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="95c7-56fa-4301-ba7e" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_d53e-113f-4a40-a3d5</comment>
         </categoryLink>
         <categoryLink id="f05f-ed48-4df2-a563" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -911,7 +911,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="af3f-d43d-4302-8802" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="af3f-d43d-4302-8802" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_e6f7-a6ca-4825-bfc5</comment>
         </categoryLink>
         <categoryLink id="dab5-9031-481c-b813" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -944,7 +944,7 @@
         <categoryLink id="549b-07d6-4197-aa48" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_cefb-cfd7-4dc8-99c4</comment>
         </categoryLink>
-        <categoryLink id="5cef-4c60-4132-a476" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="5cef-4c60-4132-a476" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_a9fd-9d16-4a5e-855c</comment>
         </categoryLink>
       </categoryLinks>
@@ -971,7 +971,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="5934-5e3d-4f32-a811" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="5934-5e3d-4f32-a811" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_a56d-347b-4b09-a918</comment>
         </categoryLink>
         <categoryLink id="4c99-d7a9-47cf-96f7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1010,7 +1010,7 @@
         <categoryLink id="25e0-94be-4cc2-9aac" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_9441-d79b-4720-9667</comment>
         </categoryLink>
-        <categoryLink id="12f1-58c4-444f-aca8" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="12f1-58c4-444f-aca8" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_7d7e-32d3-4692-b401</comment>
         </categoryLink>
       </categoryLinks>
@@ -1046,7 +1046,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="68d8-0ec6-431e-9c02" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="68d8-0ec6-431e-9c02" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_f65b-8958-49b3-92a5</comment>
         </categoryLink>
         <categoryLink id="de1e-49ce-4f1a-a01a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1085,7 +1085,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="0cf1-1139-435f-9f71" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="0cf1-1139-435f-9f71" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_c6a8-22a8-4d41-b969</comment>
         </categoryLink>
         <categoryLink id="b50b-3d3e-4b2b-bd2a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1160,7 +1160,7 @@
         <categoryLink id="c1dd-f6fe-4dca-93a9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_bc67-ce1f-4004-aeb7</comment>
         </categoryLink>
-        <categoryLink id="b98e-e3c6-4a39-8add" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="b98e-e3c6-4a39-8add" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_9a45-9699-4475-aeef</comment>
         </categoryLink>
       </categoryLinks>
@@ -1229,7 +1229,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="e0e8-435e-495a-8e31" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="e0e8-435e-495a-8e31" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_3610-c975-4d55-bdfe</comment>
         </categoryLink>
         <categoryLink id="65d6-0611-48d7-98ef" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1265,7 +1265,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="46ba-7743-4f30-a582" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="46ba-7743-4f30-a582" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_f81d-9435-4f11-99c1</comment>
         </categoryLink>
         <categoryLink id="33d0-fd52-4377-96db" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1301,7 +1301,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="1375-edf8-438c-939e" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="1375-edf8-438c-939e" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_b24f-3ae0-4cbb-b016</comment>
         </categoryLink>
         <categoryLink id="2113-e9e4-4f5e-aeea" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1340,7 +1340,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="1949-8541-4232-bf7e" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="1949-8541-4232-bf7e" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_c77f-0819-473b-a8a2</comment>
         </categoryLink>
         <categoryLink id="87ea-dd9d-4a65-86f0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1379,7 +1379,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="22a6-d553-4837-adce" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="22a6-d553-4837-adce" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_0397-c837-4fea-a527</comment>
         </categoryLink>
         <categoryLink id="b503-34c4-4c3c-b354" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1415,7 +1415,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="3938-2aa3-41d6-b41b" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="3938-2aa3-41d6-b41b" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_c1cf-cea4-4278-8f27</comment>
         </categoryLink>
         <categoryLink id="7ee8-f9b8-4aaf-b24b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1451,7 +1451,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="7b9d-4b05-4a85-b7e4" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="7b9d-4b05-4a85-b7e4" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_0c16-6841-42b2-b02d</comment>
         </categoryLink>
         <categoryLink id="850d-efec-4383-b11d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1487,7 +1487,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="b03e-3980-4ee0-930a" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="b03e-3980-4ee0-930a" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_3632-0b5d-4622-ae33</comment>
         </categoryLink>
         <categoryLink id="a926-0682-4119-b9fc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1523,7 +1523,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="b680-8015-4cac-805f" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="b680-8015-4cac-805f" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_5ad5-8701-42cd-b2b6</comment>
         </categoryLink>
         <categoryLink id="35cc-95b9-4bdd-9022" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1596,7 +1596,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="074e-d71d-4a7c-b4d4" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="074e-d71d-4a7c-b4d4" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_4d7c-201f-4c99-b89a</comment>
         </categoryLink>
         <categoryLink id="d666-4fdf-42f5-afee" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1635,7 +1635,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="9688-a99d-4b20-b1f4" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="9688-a99d-4b20-b1f4" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_4e52-ad1b-48d4-8eed</comment>
         </categoryLink>
         <categoryLink id="2425-7f12-48be-a486" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false">
@@ -1649,7 +1649,7 @@
         <categoryLink id="7af2-d755-408f-a22f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_6140-2404-46f9-bd42</comment>
         </categoryLink>
-        <categoryLink id="a1ab-4074-4240-b781" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
+        <categoryLink id="a1ab-4074-4240-b781" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
           <comment>template_id_1c86-fad8-46ec-a0b0</comment>
         </categoryLink>
       </categoryLinks>
@@ -1675,7 +1675,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="200f-8403-4cad-878f" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
+        <categoryLink id="200f-8403-4cad-878f" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
           <comment>template_id_0af1-d052-4bd7-aab6</comment>
         </categoryLink>
         <categoryLink id="942b-92dd-49fd-9487" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1724,7 +1724,7 @@
         <categoryLink id="0e11-7ea3-4b57-b646" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_4272-9b9d-4c59-95f0</comment>
         </categoryLink>
-        <categoryLink id="86ca-2f69-431d-afaa" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="86ca-2f69-431d-afaa" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_d85b-1ae7-40d5-9341</comment>
         </categoryLink>
       </categoryLinks>
@@ -1746,7 +1746,7 @@
         <categoryLink id="b657-fecd-42af-8021" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_ff9f-01cb-41b9-800e</comment>
         </categoryLink>
-        <categoryLink id="b525-b105-4ad7-a79d" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="b525-b105-4ad7-a79d" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_1315-6051-4a46-b070</comment>
         </categoryLink>
       </categoryLinks>
@@ -1754,7 +1754,7 @@
     <entryLink id="109b-f4c1-4f21-88d9" name="Praetor" hidden="false" collective="false" import="false" targetId="03be-5d55-d05a-771d" type="selectionEntry">
       <comment>template_id_5798-3fc7-4d4c-ad41</comment>
       <categoryLinks>
-        <categoryLink id="29ed-35b6-4122-9b0b" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
+        <categoryLink id="29ed-35b6-4122-9b0b" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
           <comment>template_id_b084-df23-4f99-812f</comment>
         </categoryLink>
         <categoryLink id="ff42-a777-48f1-84d4" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false">
@@ -1888,7 +1888,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="767e-63be-41b3-a4a8" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="767e-63be-41b3-a4a8" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_b822-3417-4613-be37</comment>
         </categoryLink>
         <categoryLink id="40ac-cdc3-40fe-8fca" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1915,7 +1915,7 @@
         <categoryLink id="02eb-7629-4214-8374" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_75a7-dc06-445b-b2dc</comment>
         </categoryLink>
-        <categoryLink id="d20d-097a-4c04-8730" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="d20d-097a-4c04-8730" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_e21a-c03b-4885-ac46</comment>
         </categoryLink>
       </categoryLinks>
@@ -1933,7 +1933,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="7ded-5004-44b0-952d" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
+        <categoryLink id="7ded-5004-44b0-952d" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
           <comment>template_id_f55b-7555-444b-beee</comment>
         </categoryLink>
         <categoryLink id="b806-f9bc-4283-b3bf" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1954,7 +1954,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="d71c-4ffe-4f01-9386" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="d71c-4ffe-4f01-9386" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_79fa-3370-4ae0-9e12</comment>
         </categoryLink>
         <categoryLink id="c671-400a-4f8d-bd3d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1975,7 +1975,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="e5a4-b2c2-4a8c-aeb4" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="e5a4-b2c2-4a8c-aeb4" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_8d82-3279-4481-84bb</comment>
         </categoryLink>
         <categoryLink id="a241-ad5e-4b59-92a9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2014,7 +2014,7 @@
         <categoryLink id="4a67-5f67-4c86-8843" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_7010-be56-4709-b058</comment>
         </categoryLink>
-        <categoryLink id="91b2-abd0-4c7d-b6cd" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="91b2-abd0-4c7d-b6cd" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_7379-a740-47ba-a054</comment>
         </categoryLink>
       </categoryLinks>
@@ -2032,7 +2032,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="8359-d710-4df8-b10e" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="8359-d710-4df8-b10e" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_944f-7420-4982-8ea9</comment>
         </categoryLink>
         <categoryLink id="f65c-c7c1-4559-b9b9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2082,7 +2082,7 @@
         <categoryLink id="e791-345a-4868-859a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_c6ff-0977-4c92-bb28</comment>
         </categoryLink>
-        <categoryLink id="4caf-b886-4185-b350" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="4caf-b886-4185-b350" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_f555-7d39-458f-84c9</comment>
         </categoryLink>
       </categoryLinks>
@@ -2118,7 +2118,7 @@
         <categoryLink id="8039-0e71-4a2a-9646" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_39e5-eda5-45d1-a643</comment>
         </categoryLink>
-        <categoryLink id="38f6-48fc-47c1-9c62" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="38f6-48fc-47c1-9c62" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_6416-21bb-4df4-9de8</comment>
         </categoryLink>
       </categoryLinks>
@@ -2154,7 +2154,7 @@
         <categoryLink id="8476-2e3c-4e1d-9492" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_5528-2dac-4be5-900c</comment>
         </categoryLink>
-        <categoryLink id="2db8-abbe-45b5-8371" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="2db8-abbe-45b5-8371" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_dc8f-d888-4585-991d</comment>
         </categoryLink>
       </categoryLinks>
@@ -2190,7 +2190,7 @@
         <categoryLink id="c809-b47f-4cb8-98b6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_899e-b052-4d5b-8c18</comment>
         </categoryLink>
-        <categoryLink id="f928-d7b0-4131-b162" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="f928-d7b0-4131-b162" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_f5e9-cff6-41d2-a016</comment>
         </categoryLink>
       </categoryLinks>
@@ -2226,7 +2226,7 @@
         <categoryLink id="4c04-3837-4f2c-bcc1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_09cd-2176-40af-bba6</comment>
         </categoryLink>
-        <categoryLink id="08c3-599c-473d-884f" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="08c3-599c-473d-884f" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_05e6-7c63-4a35-9ba0</comment>
         </categoryLink>
       </categoryLinks>
@@ -2250,7 +2250,7 @@
         <categoryLink id="5afc-e0d1-4c85-944c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_0dfa-4004-4751-8022</comment>
         </categoryLink>
-        <categoryLink id="6e00-c284-49a2-84e2" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="6e00-c284-49a2-84e2" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_a669-0f5d-4fd3-811b</comment>
         </categoryLink>
       </categoryLinks>
@@ -2280,7 +2280,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="dd0c-a1f6-4597-b2f5" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="dd0c-a1f6-4597-b2f5" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_4f60-472b-45a9-ab9e</comment>
         </categoryLink>
         <categoryLink id="0605-2bf5-4d69-8da7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2336,7 +2336,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="c06b-621c-4c91-9cf1" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="c06b-621c-4c91-9cf1" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_2008-f1c4-4285-a14f</comment>
         </categoryLink>
         <categoryLink id="6077-5676-48cd-921e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2368,7 +2368,7 @@
         <categoryLink id="bf2f-cd7d-4280-9707" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_9189-836c-475d-a52e</comment>
         </categoryLink>
-        <categoryLink id="383d-0950-46ee-bf66" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="383d-0950-46ee-bf66" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_e1fa-b7d8-47b0-a88a</comment>
         </categoryLink>
         <categoryLink id="6e3f-fc98-450b-a2bb" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false">
@@ -2382,7 +2382,7 @@
         <categoryLink id="eeb0-11b6-4a53-8e78" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_b1d5-fd75-4f17-bbf4</comment>
         </categoryLink>
-        <categoryLink id="2972-221e-444f-b992" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="2972-221e-444f-b992" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_f221-bf81-4045-849b</comment>
         </categoryLink>
       </categoryLinks>
@@ -2408,7 +2408,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="7868-650e-41a5-a0ad" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="7868-650e-41a5-a0ad" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_f203-bc26-421f-b79e</comment>
         </categoryLink>
         <categoryLink id="b284-c2d4-4cb9-bd88" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2422,7 +2422,7 @@
         <categoryLink id="8e95-1e63-463e-b6d1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_51af-a137-4a1c-97a4</comment>
         </categoryLink>
-        <categoryLink id="dfbc-c2d3-4f58-acc9" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
+        <categoryLink id="dfbc-c2d3-4f58-acc9" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
           <comment>template_id_ec1f-c326-40a8-9d1f</comment>
         </categoryLink>
       </categoryLinks>
@@ -2474,7 +2474,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="028a-c3a0-47ee-ae1b" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="028a-c3a0-47ee-ae1b" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_fce3-801c-49c8-85d4</comment>
         </categoryLink>
         <categoryLink id="92e8-c290-45c9-8017" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2485,7 +2485,7 @@
     <entryLink id="8725-2b20-0868-5cb0" name="Terminator Tartaros Squad" hidden="false" collective="false" import="false" targetId="1a8e-0ded-a4dc-2b4e" type="selectionEntry">
       <comment>template_id_0848-4e03-417a-b224</comment>
       <categoryLinks>
-        <categoryLink id="39e8-ba67-4021-967b" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
+        <categoryLink id="39e8-ba67-4021-967b" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
           <comment>template_id_ac1c-b3bf-4011-918a</comment>
         </categoryLink>
         <categoryLink id="2100-9b51-4678-8930" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2518,7 +2518,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="2291-dee1-4a75-a7d1" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="2291-dee1-4a75-a7d1" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_5a04-9847-4c91-a49a</comment>
         </categoryLink>
         <categoryLink id="c7da-2d47-4bbf-82b9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2551,7 +2551,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="ed7a-10f2-488d-ab7d" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="ed7a-10f2-488d-ab7d" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_7d4f-547c-43ed-a520</comment>
         </categoryLink>
         <categoryLink id="7215-0c6d-472c-a188" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2580,7 +2580,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="2ae4-a33d-498b-8eed" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
+        <categoryLink id="2ae4-a33d-498b-8eed" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
           <comment>template_id_28e0-91e7-4ada-9fac</comment>
         </categoryLink>
         <categoryLink id="2347-6411-4685-9262" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2613,7 +2613,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="bf14-c810-4aba-bb9e" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="bf14-c810-4aba-bb9e" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_e22a-c5f8-4825-a45f</comment>
         </categoryLink>
         <categoryLink id="9062-89b8-4086-a7dd" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2630,7 +2630,7 @@
         <categoryLink id="24b1-a152-471d-805b" name="Compulsory Elite:" hidden="false" targetId="bb1f-ae32-b587-c3e1" primary="false">
           <comment>template_id_7d5a-62e7-43ee-b79b</comment>
         </categoryLink>
-        <categoryLink id="8dbb-cbed-40a9-a358" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
+        <categoryLink id="8dbb-cbed-40a9-a358" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
           <comment>template_id_4986-9157-49f2-b670</comment>
         </categoryLink>
       </categoryLinks>
@@ -2666,7 +2666,7 @@
         <categoryLink id="b99f-0a7a-4ace-8425" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_1b86-0977-4a8b-adac</comment>
         </categoryLink>
-        <categoryLink id="c305-31cb-4f65-a994" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="c305-31cb-4f65-a994" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_b449-403a-4e42-9239</comment>
         </categoryLink>
       </categoryLinks>
@@ -2734,7 +2734,7 @@
         <categoryLink id="f4c8-3a6d-4135-bb5a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_4f71-446f-4cff-afda</comment>
         </categoryLink>
-        <categoryLink id="929b-bce1-4868-a7d0" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="929b-bce1-4868-a7d0" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_3f44-8647-43a4-ac22</comment>
         </categoryLink>
       </categoryLinks>
@@ -2755,7 +2755,7 @@
         <categoryLink id="1816-4afe-469d-b749" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_b6b1-886e-4194-8bcd</comment>
         </categoryLink>
-        <categoryLink id="1021-1e8f-4d6c-b7e0" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="1021-1e8f-4d6c-b7e0" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_51b5-f9c1-4587-8fc7</comment>
         </categoryLink>
       </categoryLinks>
@@ -2786,7 +2786,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="dc16-16d0-4890-a8e8" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="dc16-16d0-4890-a8e8" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="4b1e-3f1f-49cb-8343" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -2809,7 +2809,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="32cb-7077-4d54-9f38" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="2c35-def7-4c44-9b02" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="2c35-def7-4c44-9b02" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="0c9a-d272-491c-a4a0" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -2831,7 +2831,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="5b41-a9f0-4801-9dff" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="5b41-a9f0-4801-9dff" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="d64e-e976-4668-bb95" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
         <categoryLink id="17a6-f363-4094-9a7c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
@@ -2855,7 +2855,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="fe4f-c8f2-470f-901c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="f3f0-973b-4a45-ac41" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="f3f0-973b-4a45-ac41" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="71d7-220b-4299-8719" name="Sky-Hunter Squadron" hidden="true" collective="false" import="false" targetId="6263-c696-2f2e-c105" type="selectionEntry">
@@ -2887,7 +2887,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="63ff-0a92-42ab-ae8c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="204c-7b0f-4fb9-b1b3" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="204c-7b0f-4fb9-b1b3" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="85e6-cb31-427c-a040" name="Line Sub-type:" hidden="false" targetId="6399-5c65-7833-1025" primary="false"/>
         <categoryLink id="6c98-a1d5-a715-057d" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
       </categoryLinks>
@@ -2912,7 +2912,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="68dd-fc0f-4fde-8adc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="74ca-dd4f-46be-8be7" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="74ca-dd4f-46be-8be7" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="f440-c4c9-c0d3-d456" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -3003,7 +3003,7 @@
       <categoryLinks>
         <categoryLink id="0d5b-be56-47af-a22e" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="2e59-1043-4719-96c4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="52fa-8c3c-49d4-a321" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="52fa-8c3c-49d4-a321" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="91d5-33bf-4b2c-8acc" name="Termite Assault Drill" hidden="true" collective="false" import="false" targetId="cb30-307a-f0d7-3b13" type="selectionEntry">
@@ -3027,7 +3027,7 @@
       <categoryLinks>
         <categoryLink id="1fef-4409-4fab-93fc" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="ca2d-245e-48b4-a1cf" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="6692-6e39-44f0-ad8e" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="6692-6e39-44f0-ad8e" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="c28c-0218-4755-8be1" name="Venerable Ancient Contemptor Dreadnought" hidden="true" collective="false" import="false" targetId="dad1-0807-e254-d498" type="selectionEntry">
@@ -3044,7 +3044,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="9261-acb5-4230-8d89" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="1a5d-cbc8-418f-91a3" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="1a5d-cbc8-418f-91a3" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="c0cb-406f-4b46-9d8d" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
       </categoryLinks>
       <entryLinks>
@@ -3067,7 +3067,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="c0b2-dd90-46c1-a2a9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="9a94-76fb-4a89-ad5d" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="9a94-76fb-4a89-ad5d" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="c61f-2442-cc25-9914" name="Castellax Battle-Automata Maniple" hidden="true" collective="false" import="false" targetId="537f-846d-90e3-2526" type="selectionEntry">
@@ -3080,7 +3080,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="cfd5-e994-1bea-8dcc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="2338-05be-d8fa-b004" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="2338-05be-d8fa-b004" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="1f86-94d8-04e7-83a2" name="Domitar Battle-Automata Maniple" hidden="true" collective="false" import="false" targetId="1a1b-fa35-a6a2-ca78" type="selectionEntry">
@@ -3093,7 +3093,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="2381-cffa-0a87-be5f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="9f6c-5341-8802-773d" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="9f6c-5341-8802-773d" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="8d22-d54c-5535-75a4" name="Vorax Battle-automata Maniple" hidden="true" collective="false" import="false" targetId="f144-1079-11ff-019d" type="selectionEntry">
@@ -3106,7 +3106,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="264c-ed4d-c3ea-eb27" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="2e91-4a25-9a1f-61a0" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="2e91-4a25-9a1f-61a0" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="d875-6c05-374a-fc89" name="Thanatar Siege-automata Maniple" hidden="true" collective="false" import="false" targetId="2903-fef6-e839-368b" type="selectionEntry">
@@ -3123,7 +3123,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="eab7-c572-01bd-bc56" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="885e-be27-81ed-a5b5" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="885e-be27-81ed-a5b5" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="a8a0-4286-4126-cd13" name="Ebon Keshig Cohort" hidden="true" collective="false" import="false" targetId="eb44-e977-2ce5-b239" type="selectionEntry">
@@ -3147,7 +3147,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="9fb2-b1b3-3c15-28fe" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="ebd7-76b9-2ffc-00c0" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="ebd7-76b9-2ffc-00c0" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="33d8-6696-a240-273a" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -3173,7 +3173,7 @@
         <categoryLink id="7582-e4f4-8f6d-ab0e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_ff9f-01cb-41b9-800e</comment>
         </categoryLink>
-        <categoryLink id="ed2b-3736-8e9d-7051" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="ed2b-3736-8e9d-7051" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="e803-81d6-72fc-283c" name="Line Sub-type:" hidden="false" targetId="6399-5c65-7833-1025" primary="false"/>
         <categoryLink id="4a5a-10ef-bc04-b211" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
       </categoryLinks>
@@ -3200,7 +3200,7 @@
         <categoryLink id="3606-40e7-8f34-566a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_ff9f-01cb-41b9-800e</comment>
         </categoryLink>
-        <categoryLink id="39d8-51a5-5f04-52e4" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="39d8-51a5-5f04-52e4" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="edbf-2da8-7c11-3747" name="Sky-Hunter Squadron" hidden="true" collective="false" import="false" targetId="6263-c696-2f2e-c105" type="selectionEntry">
@@ -3223,7 +3223,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="77f5-7f8b-8596-eb81" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="faa8-510f-e10d-f2a2" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="faa8-510f-e10d-f2a2" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="dadd-2ca3-6204-981b" name="Thallax Cohort" hidden="true" collective="false" import="false" targetId="25c8-3e0f-e22d-a7eb" type="selectionEntry">
@@ -3248,7 +3248,7 @@
         <constraint field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f58f-edc9-175f-1c8b" type="max"/>
       </constraints>
       <categoryLinks>
-        <categoryLink id="f749-b5f0-50f2-abdb" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="f749-b5f0-50f2-abdb" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="4648-4a07-f101-2134" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -3289,8 +3289,8 @@
       </infoLinks>
       <categoryLinks>
         <categoryLink id="4083-4f2a-5da9-39f9" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="b4a8-ec8a-7485-af38" name="Cavalry Sub-type:" hidden="false" targetId="6d79-a3e4-381f-7b0f" primary="false"/>
-        <categoryLink id="7dc2-f06d-83d7-3f15" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+        <categoryLink id="b4a8-ec8a-7485-af38" name="Cavalry Unit-type:" hidden="false" targetId="6d79-a3e4-381f-7b0f" primary="false"/>
+        <categoryLink id="7dc2-f06d-83d7-3f15" name="Heavy Sub-type:" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="c46b-3bf0-77df-39bb" name="Golden Keshig Rider" hidden="false" collective="false" import="true" type="model">
@@ -3769,8 +3769,8 @@
         <infoLink id="f543-146d-d77f-dd23" name="Hit &amp; Run" hidden="false" targetId="5986-e960-d432-affd" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="74d4-f605-7461-db43" name="Cavalry:" hidden="false" targetId="6d79-a3e4-381f-7b0f" primary="false"/>
-        <categoryLink id="ce3b-6d6a-0eca-ace7" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+        <categoryLink id="74d4-f605-7461-db43" name="Cavalry Unit-type:" hidden="false" targetId="6d79-a3e4-381f-7b0f" primary="false"/>
+        <categoryLink id="ce3b-6d6a-0eca-ace7" name="Heavy Sub-type:" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
         <categoryLink id="0b3c-e0ff-0485-b240" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="059a-9e08-d32a-bc1f" name="Deep Strike:" hidden="false" targetId="0d4f-ff28-d819-a512" primary="false"/>
       </categoryLinks>
@@ -5524,7 +5524,7 @@ May join units that include models with the Cavalry Unit Type despite the usual 
     </selectionEntryGroup>
   </sharedSelectionEntryGroups>
   <catalogueLinks>
-    <catalogueLink id="2f60-18fb-e6ed-8574" name="(HH V2) Legions Astartes" targetId="6393-649c-7213-a327" type="catalogue" importRootEntries="true"/>
+    <catalogueLink id="2f60-18fb-e6ed-8574" name="Legions Astartes" targetId="6393-649c-7213-a327" type="catalogue" importRootEntries="true"/>
     <catalogueLink id="b5fe-774b-8da-c21e" name="LI - Sisters of Silence" targetId="585a-5ac2-a233-a6a6" type="catalogue" importRootEntries="true"/>
   </catalogueLinks>
 </catalogue>

--- a/2022 - LA - Word Bearers.cat
+++ b/2022 - LA - Word Bearers.cat
@@ -33,7 +33,7 @@
         <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5ab9-5824-231d-74b3" type="max"/>
       </constraints>
       <categoryLinks>
-        <categoryLink id="52bf-cac2-d2f1-1f9a" name="New CategoryLink" hidden="false" targetId="e90d-e5a8-f42d-da84" primary="true"/>
+        <categoryLink id="52bf-cac2-d2f1-1f9a" name="Allegiance:" hidden="false" targetId="e90d-e5a8-f42d-da84" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="6414-8db6-98c1-1319" name="Zardu Layak" hidden="false" collective="false" import="false" targetId="f511-e558-6bff-6543" type="selectionEntry">
@@ -46,7 +46,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="a725-f9c9-3ca4-1df3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="3854-9b1c-75be-f251" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="3854-9b1c-75be-f251" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="7c61-d840-15bb-ea6a" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -60,7 +60,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="1fcf-b3c5-58b8-44a9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="009d-e41c-1c69-eb35" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="009d-e41c-1c69-eb35" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="929e-1f4c-fdb0-60f9" name="Lorgar" hidden="false" collective="false" import="false" targetId="9289-65f7-e452-51a5" type="selectionEntry">
@@ -73,7 +73,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="bd80-e5c5-9f6b-9c59" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="bc01-7a4b-4350-fc46" name="New CategoryLink" hidden="false" targetId="ad5f-31db-8bc7-5c46" primary="true"/>
+        <categoryLink id="bc01-7a4b-4350-fc46" name="Primarch:" hidden="false" targetId="ad5f-31db-8bc7-5c46" primary="true"/>
       </categoryLinks>
       <entryLinks>
         <entryLink id="c07d-7c24-a0ba-e25e" name="Retinue" hidden="false" collective="false" import="true" targetId="bda8-b52d-c914-4ac2" type="selectionEntryGroup">
@@ -91,7 +91,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="2fef-2b84-70db-e88a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="dc7f-c1ed-8d5f-37b1" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="dc7f-c1ed-8d5f-37b1" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="3d0d-10b5-3bbb-912b" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -105,7 +105,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="f650-e375-34c8-f203" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="3c53-062a-658c-c195" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="3c53-062a-658c-c195" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="4c0b-a7fa-7fed-aed2" name="Kor Phaeron" hidden="false" collective="false" import="false" targetId="e61d-db78-6f56-3c05" type="selectionEntry">
@@ -127,7 +127,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="82bc-9ae6-b57c-75d7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="1486-4d78-4dea-482d" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="1486-4d78-4dea-482d" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="d622-620e-8c28-3450" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -146,7 +146,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="26be-c491-05b1-9289" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="f382-d484-61fa-673f" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="f382-d484-61fa-673f" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="eb38-8626-fa8a-1c9d" name="Argel Tal" hidden="false" collective="false" import="false" targetId="6be5-394d-9d79-344b" type="selectionEntry">
@@ -169,7 +169,7 @@
         <categoryLink id="38ba-ae8c-4ff6-a453" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_c6d4-581f-4746-bec3</comment>
         </categoryLink>
-        <categoryLink id="0f2d-ffbe-4e19-9870" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
+        <categoryLink id="0f2d-ffbe-4e19-9870" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
           <comment>template_id_2489-ee2a-45dd-b384</comment>
         </categoryLink>
       </categoryLinks>
@@ -199,7 +199,7 @@
         <categoryLink id="fd68-ce28-48d6-a5fe" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_8378-ede4-476d-b657</comment>
         </categoryLink>
-        <categoryLink id="e31c-9380-478e-9404" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="e31c-9380-478e-9404" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_d64f-ad19-426c-adf7</comment>
         </categoryLink>
       </categoryLinks>
@@ -225,7 +225,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="7650-2278-40fc-b535" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="7650-2278-40fc-b535" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_ac26-e639-4d53-9b8b</comment>
         </categoryLink>
         <categoryLink id="9eca-c601-4a5f-b83e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -236,7 +236,7 @@
         </categoryLink>
       </categoryLinks>
     </entryLink>
-    <entryLink id="4a7a-7807-4b01-35d6" name="Avenger Strike Fighter" hidden="true" collective="false" import="false" targetId="b25c-e85c-1c29-9e05" type="selectionEntry">
+    <entryLink id="4a7a-7807-4b01-35d6" name="Legion Avenger Strike Fighter" hidden="true" collective="false" import="false" targetId="b25c-e85c-1c29-9e05" type="selectionEntry">
       <comment>template_id_1064-175d-4616-9c71</comment>
       <modifiers>
         <modifier type="set" field="hidden" value="false">
@@ -258,7 +258,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="5064-bf87-42ba-b7db" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="5064-bf87-42ba-b7db" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_a009-a597-4b51-b228</comment>
         </categoryLink>
         <categoryLink id="dac3-c855-4e46-84b9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -291,7 +291,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="9eb5-0502-452d-ba5d" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="9eb5-0502-452d-ba5d" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_c165-3906-463a-9c73</comment>
         </categoryLink>
         <categoryLink id="15c9-02a4-4b33-a7fa" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -328,7 +328,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="ad19-c918-4dfd-afb5" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="ad19-c918-4dfd-afb5" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_3a22-caae-4eea-9bc5</comment>
         </categoryLink>
         <categoryLink id="050d-98da-4697-9725" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -361,7 +361,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="7394-c259-4934-9bdd" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="7394-c259-4934-9bdd" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_251a-df5b-4bfd-ad63</comment>
         </categoryLink>
         <categoryLink id="9cca-6bc0-466d-9a8f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -398,7 +398,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="d9e7-3f7e-4815-875a" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
+        <categoryLink id="d9e7-3f7e-4815-875a" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
           <comment>template_id_67c2-df43-44fc-92d1</comment>
         </categoryLink>
         <categoryLink id="050a-53ee-424a-8951" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -454,7 +454,7 @@
         <categoryLink id="7a70-622e-4a34-852d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_bd6a-0cda-4e0f-80ae</comment>
         </categoryLink>
-        <categoryLink id="b71e-0ff3-4c10-8f9a" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
+        <categoryLink id="b71e-0ff3-4c10-8f9a" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
           <comment>template_id_ae75-7cca-4701-9d56</comment>
         </categoryLink>
         <categoryLink id="4b1e-f529-4c64-8293" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false">
@@ -489,7 +489,7 @@
         <categoryLink id="001a-4f5b-4e84-8bb2" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false">
           <comment>template_id_f51c-73d7-4f29-be1c</comment>
         </categoryLink>
-        <categoryLink id="2ffd-ea2b-4b13-afc7" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
+        <categoryLink id="2ffd-ea2b-4b13-afc7" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
           <comment>template_id_257d-78c0-4bab-ba65</comment>
         </categoryLink>
       </categoryLinks>
@@ -537,7 +537,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="cd71-eb72-4acc-94fb" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="cd71-eb72-4acc-94fb" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_f1c8-27fd-4f98-8527</comment>
         </categoryLink>
         <categoryLink id="0a43-5492-46ca-8d97" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -566,7 +566,7 @@
         <categoryLink id="49cd-55f6-49cc-9d3b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_dd44-e0a8-42a8-bdcc</comment>
         </categoryLink>
-        <categoryLink id="c947-bd2d-407a-8c57" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
+        <categoryLink id="c947-bd2d-407a-8c57" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
           <comment>template_id_c5b0-f9ae-468d-924a</comment>
         </categoryLink>
       </categoryLinks>
@@ -593,7 +593,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="96db-46a7-4a8b-a8fb" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
+        <categoryLink id="96db-46a7-4a8b-a8fb" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
           <comment>template_id_f926-27fd-4a92-97a1</comment>
         </categoryLink>
         <categoryLink id="e68f-8beb-4686-be3c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -625,7 +625,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="e119-c21f-7bda-82ce" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="e119-c21f-7bda-82ce" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
         <categoryLink id="c79a-4d9e-71ab-83b5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -684,7 +684,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="b778-2304-4690-ab0e" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="b778-2304-4690-ab0e" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_361e-fb90-4b0e-ac3d</comment>
         </categoryLink>
         <categoryLink id="504b-c418-46a4-bb7f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -701,7 +701,7 @@
         <categoryLink id="0688-6cf0-46a8-b09b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_473b-e812-4158-9416</comment>
         </categoryLink>
-        <categoryLink id="d8a4-e825-444f-ba36" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
+        <categoryLink id="d8a4-e825-444f-ba36" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
           <comment>template_id_00a2-63ff-4698-a35b</comment>
         </categoryLink>
       </categoryLinks>
@@ -725,7 +725,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="52ca-05e7-4752-98ef" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="52ca-05e7-4752-98ef" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_2a08-4432-42ad-bfdb</comment>
         </categoryLink>
         <categoryLink id="2f02-b32f-452d-b14f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -758,7 +758,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="07ad-ac0c-485f-9b62" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="07ad-ac0c-485f-9b62" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_f4c0-4396-4f39-a34f</comment>
         </categoryLink>
         <categoryLink id="8750-ffee-4b99-a721" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -791,7 +791,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="289d-8dcf-4ee6-98c8" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="289d-8dcf-4ee6-98c8" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_caf6-5548-4b89-8102</comment>
         </categoryLink>
         <categoryLink id="46cf-929c-4713-b219" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -851,7 +851,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="5d10-11fe-47c3-ab5b" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="5d10-11fe-47c3-ab5b" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_d53e-113f-4a40-a3d5</comment>
         </categoryLink>
         <categoryLink id="7246-027c-494e-aa45" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -872,7 +872,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="6ffe-6631-4d41-9dc1" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="6ffe-6631-4d41-9dc1" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_e6f7-a6ca-4825-bfc5</comment>
         </categoryLink>
         <categoryLink id="6238-2bd9-4b6b-85b1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -907,7 +907,7 @@
         <categoryLink id="ac5e-5ffa-4c4d-b11b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_cefb-cfd7-4dc8-99c4</comment>
         </categoryLink>
-        <categoryLink id="918b-bf23-48d9-9a39" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="918b-bf23-48d9-9a39" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_a9fd-9d16-4a5e-855c</comment>
         </categoryLink>
       </categoryLinks>
@@ -931,7 +931,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="f05e-ea51-486e-bcd6" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="f05e-ea51-486e-bcd6" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_a56d-347b-4b09-a918</comment>
         </categoryLink>
         <categoryLink id="4730-a78d-4d46-b9b1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -964,7 +964,7 @@
         <categoryLink id="2a95-7064-45ae-b5da" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_9441-d79b-4720-9667</comment>
         </categoryLink>
-        <categoryLink id="f990-d1ce-4e8c-9867" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="f990-d1ce-4e8c-9867" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_7d7e-32d3-4692-b401</comment>
         </categoryLink>
       </categoryLinks>
@@ -994,7 +994,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="2837-042d-4788-be32" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="2837-042d-4788-be32" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_f65b-8958-49b3-92a5</comment>
         </categoryLink>
         <categoryLink id="9b0e-9d66-44e3-b752" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1027,7 +1027,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="e846-96b3-4fc8-a5a0" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="e846-96b3-4fc8-a5a0" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_c6a8-22a8-4d41-b969</comment>
         </categoryLink>
         <categoryLink id="ef7f-b4cd-429e-b2c4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1090,7 +1090,7 @@
         <categoryLink id="b884-ec31-4138-9ab0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_bc67-ce1f-4004-aeb7</comment>
         </categoryLink>
-        <categoryLink id="ff12-b477-4f8c-b0d1" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="ff12-b477-4f8c-b0d1" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_9a45-9699-4475-aeef</comment>
         </categoryLink>
       </categoryLinks>
@@ -1153,7 +1153,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="c807-93f8-4309-9c4c" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="c807-93f8-4309-9c4c" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_3610-c975-4d55-bdfe</comment>
         </categoryLink>
         <categoryLink id="c2f9-e4d3-4801-9a3e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1189,7 +1189,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="c8df-3ba7-48a2-9bff" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="c8df-3ba7-48a2-9bff" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_f81d-9435-4f11-99c1</comment>
         </categoryLink>
         <categoryLink id="ff01-c3be-42d0-8be0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1225,7 +1225,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="f078-519b-4742-80b5" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="f078-519b-4742-80b5" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_b24f-3ae0-4cbb-b016</comment>
         </categoryLink>
         <categoryLink id="fdce-c0ab-4221-b24a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1258,7 +1258,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="2d23-1328-4c11-8dec" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="2d23-1328-4c11-8dec" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_c77f-0819-473b-a8a2</comment>
         </categoryLink>
         <categoryLink id="071d-6302-415d-b911" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1291,7 +1291,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="19d6-911d-423e-bd2b" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="19d6-911d-423e-bd2b" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_0397-c837-4fea-a527</comment>
         </categoryLink>
         <categoryLink id="80d1-ff4d-4247-a808" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1327,7 +1327,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="5d0c-4de3-4299-b4cd" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="5d0c-4de3-4299-b4cd" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_c1cf-cea4-4278-8f27</comment>
         </categoryLink>
         <categoryLink id="0064-9c7b-49b5-957f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1363,7 +1363,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="330f-dd39-4117-bb94" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="330f-dd39-4117-bb94" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_0c16-6841-42b2-b02d</comment>
         </categoryLink>
         <categoryLink id="c19f-a972-40d4-8815" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1399,7 +1399,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="88d0-38d6-4847-b2f9" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="88d0-38d6-4847-b2f9" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_3632-0b5d-4622-ae33</comment>
         </categoryLink>
         <categoryLink id="a7b4-c37c-4206-9a18" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1435,7 +1435,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="8328-83e9-478a-ba0d" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="8328-83e9-478a-ba0d" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_5ad5-8701-42cd-b2b6</comment>
         </categoryLink>
         <categoryLink id="d31a-6363-417f-9688" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1502,7 +1502,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="410f-552e-4584-9f4b" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="410f-552e-4584-9f4b" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_4d7c-201f-4c99-b89a</comment>
         </categoryLink>
         <categoryLink id="bc98-41d5-4056-bfff" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1535,7 +1535,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="3be3-feb5-4342-be75" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="3be3-feb5-4342-be75" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_4e52-ad1b-48d4-8eed</comment>
         </categoryLink>
         <categoryLink id="5841-9a6d-4a53-b784" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false">
@@ -1549,7 +1549,7 @@
         <categoryLink id="63e0-ab97-456a-81ca" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_6140-2404-46f9-bd42</comment>
         </categoryLink>
-        <categoryLink id="c12c-1cab-4a7d-b144" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
+        <categoryLink id="c12c-1cab-4a7d-b144" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
           <comment>template_id_1c86-fad8-46ec-a0b0</comment>
         </categoryLink>
       </categoryLinks>
@@ -1575,7 +1575,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="7f30-45d9-4739-bf3a" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
+        <categoryLink id="7f30-45d9-4739-bf3a" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
           <comment>template_id_0af1-d052-4bd7-aab6</comment>
         </categoryLink>
         <categoryLink id="5cb8-37da-4861-b341" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1624,7 +1624,7 @@
         <categoryLink id="503a-ab7b-42a8-8398" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_4272-9b9d-4c59-95f0</comment>
         </categoryLink>
-        <categoryLink id="e27a-48b5-4cb1-aedd" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="e27a-48b5-4cb1-aedd" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_d85b-1ae7-40d5-9341</comment>
         </categoryLink>
       </categoryLinks>
@@ -1646,7 +1646,7 @@
         <categoryLink id="0162-4a58-4b61-9dd6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_ff9f-01cb-41b9-800e</comment>
         </categoryLink>
-        <categoryLink id="d928-baa2-4c63-be0b" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="d928-baa2-4c63-be0b" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_1315-6051-4a46-b070</comment>
         </categoryLink>
       </categoryLinks>
@@ -1654,7 +1654,7 @@
     <entryLink id="3155-2264-5a56-7fc5" name="Praetor" hidden="false" collective="false" import="false" targetId="03be-5d55-d05a-771d" type="selectionEntry">
       <comment>template_id_5798-3fc7-4d4c-ad41</comment>
       <categoryLinks>
-        <categoryLink id="6fb1-e112-47cc-a237" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
+        <categoryLink id="6fb1-e112-47cc-a237" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
           <comment>template_id_b084-df23-4f99-812f</comment>
         </categoryLink>
         <categoryLink id="5c34-c101-45d2-854a" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false">
@@ -1779,7 +1779,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="4166-989f-4734-bb6f" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="4166-989f-4734-bb6f" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_b822-3417-4613-be37</comment>
         </categoryLink>
         <categoryLink id="5d71-3082-44f3-990c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1806,7 +1806,7 @@
         <categoryLink id="72e0-9500-4f80-bd79" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_75a7-dc06-445b-b2dc</comment>
         </categoryLink>
-        <categoryLink id="50bf-7a3f-4fda-8d6d" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="50bf-7a3f-4fda-8d6d" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_e21a-c03b-4885-ac46</comment>
         </categoryLink>
       </categoryLinks>
@@ -1824,7 +1824,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="3e5e-307e-43ed-8cae" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
+        <categoryLink id="3e5e-307e-43ed-8cae" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
           <comment>template_id_f55b-7555-444b-beee</comment>
         </categoryLink>
         <categoryLink id="d421-e162-47e0-ada3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1845,7 +1845,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="a4a7-81dd-421e-b835" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="a4a7-81dd-421e-b835" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_79fa-3370-4ae0-9e12</comment>
         </categoryLink>
         <categoryLink id="e292-df9e-40f9-a0f6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1871,7 +1871,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="34c0-7d3c-40e5-8d5a" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="34c0-7d3c-40e5-8d5a" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_8d82-3279-4481-84bb</comment>
         </categoryLink>
         <categoryLink id="6573-a566-42a1-b032" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1904,7 +1904,7 @@
         <categoryLink id="4b04-a31c-4bbd-ada1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_7010-be56-4709-b058</comment>
         </categoryLink>
-        <categoryLink id="db38-f8e5-4b5b-bd1a" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="db38-f8e5-4b5b-bd1a" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_7379-a740-47ba-a054</comment>
         </categoryLink>
       </categoryLinks>
@@ -1922,7 +1922,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="7afc-60b6-4731-b1fb" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="7afc-60b6-4731-b1fb" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_944f-7420-4982-8ea9</comment>
         </categoryLink>
         <categoryLink id="be61-ba6e-40bb-98e7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1966,7 +1966,7 @@
         <categoryLink id="e1e2-97c0-4721-9e46" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_c6ff-0977-4c92-bb28</comment>
         </categoryLink>
-        <categoryLink id="d413-732c-4937-a778" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="d413-732c-4937-a778" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_f555-7d39-458f-84c9</comment>
         </categoryLink>
       </categoryLinks>
@@ -1996,7 +1996,7 @@
         <categoryLink id="d63a-af8f-498a-98ed" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_39e5-eda5-45d1-a643</comment>
         </categoryLink>
-        <categoryLink id="aed4-42fe-420d-bcf5" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="aed4-42fe-420d-bcf5" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_6416-21bb-4df4-9de8</comment>
         </categoryLink>
       </categoryLinks>
@@ -2026,7 +2026,7 @@
         <categoryLink id="c05c-6a69-46ca-8a9e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_5528-2dac-4be5-900c</comment>
         </categoryLink>
-        <categoryLink id="fd52-3c14-4a44-95bb" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="fd52-3c14-4a44-95bb" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_dc8f-d888-4585-991d</comment>
         </categoryLink>
       </categoryLinks>
@@ -2056,7 +2056,7 @@
         <categoryLink id="87fe-4a46-4cfa-bc1b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_899e-b052-4d5b-8c18</comment>
         </categoryLink>
-        <categoryLink id="7442-d9a4-4ceb-9163" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="7442-d9a4-4ceb-9163" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_f5e9-cff6-41d2-a016</comment>
         </categoryLink>
       </categoryLinks>
@@ -2086,7 +2086,7 @@
         <categoryLink id="1816-eec5-4443-941b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_09cd-2176-40af-bba6</comment>
         </categoryLink>
-        <categoryLink id="4511-8e18-4895-a09d" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="4511-8e18-4895-a09d" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_05e6-7c63-4a35-9ba0</comment>
         </categoryLink>
       </categoryLinks>
@@ -2110,7 +2110,7 @@
         <categoryLink id="e3f5-97fd-4b10-b015" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_0dfa-4004-4751-8022</comment>
         </categoryLink>
-        <categoryLink id="ad8e-bbbc-4d15-be38" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="ad8e-bbbc-4d15-be38" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_a669-0f5d-4fd3-811b</comment>
         </categoryLink>
       </categoryLinks>
@@ -2137,7 +2137,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="b7d8-0c7b-49d8-965a" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="b7d8-0c7b-49d8-965a" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_4f60-472b-45a9-ab9e</comment>
         </categoryLink>
         <categoryLink id="bf93-d55d-4d6d-88c2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2190,7 +2190,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="9174-fe4c-495b-90ca" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="9174-fe4c-495b-90ca" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_2008-f1c4-4285-a14f</comment>
         </categoryLink>
         <categoryLink id="f627-d3d1-4330-bfff" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2222,7 +2222,7 @@
         <categoryLink id="338c-0b4b-4a7b-878e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_9189-836c-475d-a52e</comment>
         </categoryLink>
-        <categoryLink id="1dd4-bfa2-4077-aaa5" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="1dd4-bfa2-4077-aaa5" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_e1fa-b7d8-47b0-a88a</comment>
         </categoryLink>
         <categoryLink id="0c29-0d6d-4149-8bb4" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false">
@@ -2236,7 +2236,7 @@
         <categoryLink id="3560-f623-4d28-b903" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_b1d5-fd75-4f17-bbf4</comment>
         </categoryLink>
-        <categoryLink id="47a6-90d0-4221-86a4" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="47a6-90d0-4221-86a4" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_f221-bf81-4045-849b</comment>
         </categoryLink>
       </categoryLinks>
@@ -2265,7 +2265,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="fa50-1c66-43d6-8c26" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="fa50-1c66-43d6-8c26" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_f203-bc26-421f-b79e</comment>
         </categoryLink>
         <categoryLink id="ef2f-d8a9-46a9-8a52" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2279,7 +2279,7 @@
         <categoryLink id="5fbe-8d39-4341-a196" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_51af-a137-4a1c-97a4</comment>
         </categoryLink>
-        <categoryLink id="6fc0-b363-429a-9f3f" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
+        <categoryLink id="6fc0-b363-429a-9f3f" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
           <comment>template_id_ec1f-c326-40a8-9d1f</comment>
         </categoryLink>
       </categoryLinks>
@@ -2331,7 +2331,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="e805-41f9-4c03-a3d9" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="e805-41f9-4c03-a3d9" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_fce3-801c-49c8-85d4</comment>
         </categoryLink>
         <categoryLink id="529e-17eb-4dc3-abe4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2342,7 +2342,7 @@
     <entryLink id="c16a-a744-396d-f9e8" name="Terminator Tartaros Squad" hidden="false" collective="false" import="false" targetId="1a8e-0ded-a4dc-2b4e" type="selectionEntry">
       <comment>template_id_0848-4e03-417a-b224</comment>
       <categoryLinks>
-        <categoryLink id="5efd-e6bb-4584-a4a0" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
+        <categoryLink id="5efd-e6bb-4584-a4a0" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
           <comment>template_id_ac1c-b3bf-4011-918a</comment>
         </categoryLink>
         <categoryLink id="1de9-3e8f-4336-bf0a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2372,7 +2372,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="8406-ee81-48c7-b070" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="8406-ee81-48c7-b070" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_5a04-9847-4c91-a49a</comment>
         </categoryLink>
         <categoryLink id="35f7-d254-4056-bf1c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2402,7 +2402,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="d932-6acd-4191-8921" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="d932-6acd-4191-8921" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_7d4f-547c-43ed-a520</comment>
         </categoryLink>
         <categoryLink id="ec43-1ce2-4eb8-a9d1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2431,7 +2431,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="457c-55f7-4f06-8d81" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
+        <categoryLink id="457c-55f7-4f06-8d81" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
           <comment>template_id_28e0-91e7-4ada-9fac</comment>
         </categoryLink>
         <categoryLink id="d9c4-2343-4fc5-aa07" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2464,7 +2464,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="b96e-2c80-43a7-98ff" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="b96e-2c80-43a7-98ff" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_e22a-c5f8-4825-a45f</comment>
         </categoryLink>
         <categoryLink id="cba5-20cc-463e-b72b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2481,7 +2481,7 @@
         <categoryLink id="d07f-2987-4afd-b11a" name="Compulsory Elite:" hidden="false" targetId="bb1f-ae32-b587-c3e1" primary="false">
           <comment>template_id_7d5a-62e7-43ee-b79b</comment>
         </categoryLink>
-        <categoryLink id="b1a2-4419-449e-9494" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
+        <categoryLink id="b1a2-4419-449e-9494" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
           <comment>template_id_4986-9157-49f2-b670</comment>
         </categoryLink>
       </categoryLinks>
@@ -2511,7 +2511,7 @@
         <categoryLink id="1ec6-cbee-48b4-b4ff" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_1b86-0977-4a8b-adac</comment>
         </categoryLink>
-        <categoryLink id="8929-e05b-47f4-8b7a" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="8929-e05b-47f4-8b7a" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_b449-403a-4e42-9239</comment>
         </categoryLink>
       </categoryLinks>
@@ -2571,7 +2571,7 @@
         <categoryLink id="3cc7-35c7-4683-af47" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_4f71-446f-4cff-afda</comment>
         </categoryLink>
-        <categoryLink id="517d-706e-4479-84a8" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="517d-706e-4479-84a8" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_3f44-8647-43a4-ac22</comment>
         </categoryLink>
       </categoryLinks>
@@ -2591,7 +2591,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="3150-7c35-659c-1e26" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="0abe-7863-06fb-b202" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="0abe-7863-06fb-b202" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="db3a-34bf-5577-b933" name="Seeker Squad" hidden="true" collective="false" import="false" targetId="58e6-f9cc-4c46-e258" type="selectionEntry">
@@ -2610,7 +2610,7 @@
         <categoryLink id="3fac-f25b-41fa-9cd6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_b6b1-886e-4194-8bcd</comment>
         </categoryLink>
-        <categoryLink id="a67d-355e-4474-97fa" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="a67d-355e-4474-97fa" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_51b5-f9c1-4587-8fc7</comment>
         </categoryLink>
       </categoryLinks>
@@ -2641,7 +2641,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="dc16-16d0-4890-a8e8" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="dc16-16d0-4890-a8e8" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="4b1e-3f1f-49cb-8343" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -2664,7 +2664,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="32cb-7077-4d54-9f38" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="2c35-def7-4c44-9b02" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="2c35-def7-4c44-9b02" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="0c9a-d272-491c-a4a0" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -2686,7 +2686,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="5b41-a9f0-4801-9dff" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="5b41-a9f0-4801-9dff" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="d64e-e976-4668-bb95" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
         <categoryLink id="17a6-f363-4094-9a7c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
@@ -2710,7 +2710,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="fe4f-c8f2-470f-901c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="f3f0-973b-4a45-ac41" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="f3f0-973b-4a45-ac41" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="0344-d90b-4fda-9c0b" name="Sky-Hunter Squadron" hidden="true" collective="false" import="false" targetId="6263-c696-2f2e-c105" type="selectionEntry">
@@ -2733,7 +2733,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="63ff-0a92-42ab-ae8c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="204c-7b0f-4fb9-b1b3" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="204c-7b0f-4fb9-b1b3" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="85e6-cb31-427c-a040" name="Line Sub-type:" hidden="false" targetId="6399-5c65-7833-1025" primary="false"/>
         <categoryLink id="fe0b-e9e6-91cf-83e2" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
       </categoryLinks>
@@ -2758,7 +2758,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="68dd-fc0f-4fde-8adc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="74ca-dd4f-46be-8be7" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="74ca-dd4f-46be-8be7" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="fce7-883c-b7c9-a6a5" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -2849,7 +2849,7 @@
       <categoryLinks>
         <categoryLink id="0d5b-be56-47af-a22e" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="2e59-1043-4719-96c4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="52fa-8c3c-49d4-a321" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="52fa-8c3c-49d4-a321" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="d57e-5cf9-415f-84d2" name="Termite Assault Drill" hidden="true" collective="false" import="false" targetId="cb30-307a-f0d7-3b13" type="selectionEntry">
@@ -2873,7 +2873,7 @@
       <categoryLinks>
         <categoryLink id="1fef-4409-4fab-93fc" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="ca2d-245e-48b4-a1cf" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="6692-6e39-44f0-ad8e" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="6692-6e39-44f0-ad8e" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="dfcb-47c4-40c0-bc75" name="Venerable Ancient Contemptor Dreadnought" hidden="true" collective="false" import="false" targetId="dad1-0807-e254-d498" type="selectionEntry">
@@ -2890,7 +2890,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="9261-acb5-4230-8d89" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="1a5d-cbc8-418f-91a3" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="1a5d-cbc8-418f-91a3" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="c0cb-406f-4b46-9d8d" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
       </categoryLinks>
       <entryLinks>
@@ -2913,7 +2913,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="c0b2-dd90-46c1-a2a9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="9a94-76fb-4a89-ad5d" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="9a94-76fb-4a89-ad5d" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="73b6-a105-8d16-6523" name="Thanatar Siege-automata Maniple" hidden="true" collective="false" import="false" targetId="2903-fef6-e839-368b" type="selectionEntry">
@@ -2930,7 +2930,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="301c-13a7-8172-8109" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="4a79-ecf4-ecae-e362" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="4a79-ecf4-ecae-e362" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="6e07-28a6-b7d3-846f" name="Vorax Battle-automata Maniple" hidden="true" collective="false" import="false" targetId="f144-1079-11ff-019d" type="selectionEntry">
@@ -2943,7 +2943,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="d4ba-db37-2418-32e5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="3a0b-e316-c68f-ae99" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="3a0b-e316-c68f-ae99" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="9b53-d9bb-3acf-0cac" name="Domitar Battle-Automata Maniple" hidden="true" collective="false" import="false" targetId="1a1b-fa35-a6a2-ca78" type="selectionEntry">
@@ -2956,7 +2956,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="7622-4914-20e9-66b1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="ae9f-0717-b621-fd27" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="ae9f-0717-b621-fd27" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="4f2f-4dc0-058a-c249" name="Castellax Battle-Automata Maniple" hidden="true" collective="false" import="false" targetId="537f-846d-90e3-2526" type="selectionEntry">
@@ -2969,7 +2969,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="05e0-7fa1-9ea1-ccdb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="775b-fab9-1a23-d77f" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="775b-fab9-1a23-d77f" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="331e-5f84-21a9-6e3a" name="Thallax Cohort" hidden="true" collective="false" import="false" targetId="25c8-3e0f-e22d-a7eb" type="selectionEntry">
@@ -2994,7 +2994,7 @@
         <constraint field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6d9f-c3cc-8a95-ebe6" type="max"/>
       </constraints>
       <categoryLinks>
-        <categoryLink id="8fd1-008b-5565-6b77" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="8fd1-008b-5565-6b77" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="9aa2-b288-d4e8-0a62" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -3013,7 +3013,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="e3fb-21fc-f5a6-7574" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="c7c3-f51d-8b88-3b2e" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="c7c3-f51d-8b88-3b2e" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink targetId="8f42-a824-fb5f-8fea" id="3493-2023-1319-1c99" primary="false" name="Compulsory Troops:"/>
       </categoryLinks>
     </entryLink>
@@ -3070,7 +3070,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="f2fa-fed4-efd6-dc15" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="4dcf-5af4-94bc-3861" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="4dcf-5af4-94bc-3861" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="cd2f-6081-84a9-2d1b" name="Bound Daemon Regent (Lorgar/Erebus)" hidden="false" collective="false" import="false" targetId="0da5-927a-258d-8507" type="selectionEntry">
@@ -3098,7 +3098,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="12ec-4e2f-3224-c4f4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="a665-a3d6-c56e-d791" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="a665-a3d6-c56e-d791" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="c6d3-84aa-4ff4-b364" name="Bound Samus" hidden="false" collective="false" import="false" targetId="e6cf-4fa9-df0d-64c7" type="selectionEntry">
@@ -3141,7 +3141,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="66cc-0492-cc76-b233" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="da85-2463-bcba-6aaf" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="da85-2463-bcba-6aaf" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink import="false" name="Ruinstorm Daemon Beasts (Lorgar/Erebus)" hidden="false" type="selectionEntry" id="f752-d0e3-3a2b-fb8f" targetId="cca0-3900-65ca-bd5d">
@@ -3387,7 +3387,7 @@
       </infoLinks>
       <categoryLinks>
         <categoryLink id="8bb5-03cb-13d0-5b68" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="01a3-36e3-0dee-8337" name="Corrupted:" hidden="false" targetId="9055-7410-8ffd-b8e7" primary="false"/>
+        <categoryLink id="01a3-36e3-0dee-8337" name="Corrupted Sub-type:" hidden="false" targetId="9055-7410-8ffd-b8e7" primary="false"/>
         <categoryLink id="9fc7-089c-acfd-0f40" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
@@ -3992,7 +3992,7 @@ In addition, once per battle, one friendly unit composed entirely of models with
       <categoryLinks>
         <categoryLink id="768a-11a0-1cb1-d896" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="75a1-c482-1a18-e139" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="1937-18d3-3af6-806c" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+        <categoryLink id="1937-18d3-3af6-806c" name="Heavy Sub-type:" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
         <categoryLink id="fd96-34a3-5cd2-680a" name="Jump Infantry:" hidden="false" targetId="eee8-3c7c-2762-e33e" primary="false"/>
       </categoryLinks>
       <selectionEntries>
@@ -4242,9 +4242,9 @@ In addition, once per battle, one friendly unit composed entirely of models with
         </infoLink>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="384c-208d-03b6-bd42" name="Corrupted:" hidden="false" targetId="9055-7410-8ffd-b8e7" primary="false"/>
+        <categoryLink id="384c-208d-03b6-bd42" name="Corrupted Sub-type:" hidden="false" targetId="9055-7410-8ffd-b8e7" primary="false"/>
         <categoryLink id="03be-92b3-01a3-c1ff" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="e23d-5f58-c4d7-7506" name="Dreadnought:" hidden="false" targetId="4280-4963-02b5-e31d" primary="false"/>
+        <categoryLink id="e23d-5f58-c4d7-7506" name="Dreadnought Unit-type:" hidden="false" targetId="4280-4963-02b5-e31d" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="41a2-9e23-99ea-0e6d" name="Exchange Warpfire cannon for:" hidden="false" collective="false" import="true" defaultSelectionEntryId="ed3c-bdac-aec7-ab09">
@@ -4643,8 +4643,8 @@ Psychic Weapon</description>
             <constraint field="selections" scope="parent" value="2" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1ba6-097f-ac2b-b2bc" type="max"/>
           </constraints>
           <infoLinks>
-            <infoLink id="fa2b-fab1-23f2-7c45" name="Aetheric Lightning (P3P ZW)" hidden="false" targetId="3d0c-e779-247f-0332" type="profile"/>
-            <infoLink id="65c2-fadf-e952-777c" name="Breach the Veil (P3P ZW) (Move to GST)" hidden="false" targetId="8d74-fa05-de93-4f22" type="profile"/>
+            <infoLink id="fa2b-fab1-23f2-7c45" name="Aetheric Lightning" hidden="false" targetId="3d0c-e779-247f-0332" type="profile"/>
+            <infoLink id="65c2-fadf-e952-777c" name="Breach the Veil" hidden="false" targetId="8d74-fa05-de93-4f22" type="profile"/>
             <infoLink id="f36a-f00d-292e-a1f8" name="Force" hidden="false" targetId="f39e-4c3b-38e0-0050" type="rule"/>
           </infoLinks>
           <costs>
@@ -5004,7 +5004,7 @@ as the Aetheric Lightning Psychic Weapon</description>
           <infoLinks>
             <infoLink id="2134-e504-4914-b32b" name="Pinning" hidden="false" targetId="1c96-205c-59a0-3cf2" type="rule"/>
             <infoLink id="cfe9-099f-507f-59fb" name="Shell Shock (X)" hidden="false" targetId="46b7-63a1-941c-96a5" type="rule"/>
-            <infoLink id="145c-e9ea-573c-d626" name="Psychic Focus (?? Where is this?)" hidden="false" targetId="bff3-3548-b2b8-72f1" type="rule"/>
+            <infoLink id="145c-e9ea-573c-d626" name="Psychic Focus" hidden="false" targetId="bff3-3548-b2b8-72f1" type="rule"/>
             <infoLink id="7b11-f06b-2d7f-b154" name="Aetheric Lightning" hidden="false" targetId="3d0c-e779-247f-0332" type="profile"/>
             <infoLink id="5f77-9fc0-d5db-4414" name="Force" hidden="false" targetId="f39e-4c3b-38e0-0050" type="rule"/>
           </infoLinks>
@@ -6169,12 +6169,12 @@ A Warlord with this Trait modifies his Strength and Toughness by a value determi
             </modifier>
           </modifiers>
         </entryLink>
-        <entryLink id="c7ee-48e2-28ad-8039" name="Tartaros Command Squad (Placeholder Points)" hidden="false" collective="false" import="true" targetId="58d0-a0fd-d20b-cb1b" type="selectionEntry"/>
+        <entryLink id="c7ee-48e2-28ad-8039" name="Command Squad, Tartaros" hidden="false" collective="false" import="true" targetId="58d0-a0fd-d20b-cb1b" type="selectionEntry"/>
         <entryLink id="8464-3082-bdad-e73d" name="Command Squad" hidden="false" collective="false" import="true" targetId="0aca-632d-1642-8af9" type="selectionEntry"/>
       </entryLinks>
     </selectionEntryGroup>
   </sharedSelectionEntryGroups>
   <catalogueLinks>
-    <catalogueLink id="2f60-18fb-e6ed-8574" name="(HH V2) Legions Astartes" targetId="6393-649c-7213-a327" type="catalogue" importRootEntries="true"/>
+    <catalogueLink id="2f60-18fb-e6ed-8574" name="Legions Astartes" targetId="6393-649c-7213-a327" type="catalogue" importRootEntries="true"/>
   </catalogueLinks>
 </catalogue>

--- a/2022 - LA - World Eaters.cat
+++ b/2022 - LA - World Eaters.cat
@@ -10,7 +10,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="e3d0-6c05-8d56-6e01" name="New CategoryLink" hidden="false" targetId="ad5f-31db-8bc7-5c46" primary="true"/>
+        <categoryLink id="e3d0-6c05-8d56-6e01" name="Primarch:" hidden="false" targetId="ad5f-31db-8bc7-5c46" primary="true"/>
         <categoryLink id="b212-8e0c-46ce-f3b9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
       <entryLinks>
@@ -28,7 +28,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="9a45-dc53-86fd-a519" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="9a45-dc53-86fd-a519" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="3cd1-2a33-5ca2-8154" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="8c30-b077-5daf-50e3" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
       </categoryLinks>
@@ -47,7 +47,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="5380-a98e-902b-7621" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="5380-a98e-902b-7621" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="7196-76e9-d9ce-2f13" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="eaeb-08e5-5cda-7c6a" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
       </categoryLinks>
@@ -61,13 +61,13 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="08cf-e4af-ba2a-6a96" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="08cf-e4af-ba2a-6a96" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="abeb-1149-93ec-eb08" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="6fa2-aa20-9b69-1d6b" name="Rampager Squad" hidden="false" collective="false" import="false" targetId="2fb9-74a8-43b0-dd00" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="8586-4da8-8d15-4d96" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="8586-4da8-8d15-4d96" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="4ed9-df3c-d9cc-b1f2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -85,7 +85,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="c631-e91c-7b35-038d" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="c631-e91c-7b35-038d" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="8ba5-d6d8-3c2a-cf09" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="b9d3-c817-7e77-1c90" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
       </categoryLinks>
@@ -99,7 +99,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="6809-da13-d863-b286" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="6809-da13-d863-b286" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="63b2-2890-7ed2-7b00" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -116,7 +116,7 @@
         <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5acc-e6b3-83a3-10c3" type="max"/>
       </constraints>
       <categoryLinks>
-        <categoryLink id="a155-7b9c-da9f-525b" name="New CategoryLink" hidden="false" targetId="e90d-e5a8-f42d-da84" primary="true"/>
+        <categoryLink id="a155-7b9c-da9f-525b" name="Allegiance:" hidden="false" targetId="e90d-e5a8-f42d-da84" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="a3bb-0abc-4d37-1e09" name="Xiphon Interceptor" hidden="false" collective="false" import="false" targetId="596b-5478-e079-59ab" type="selectionEntry">
@@ -141,7 +141,7 @@
         <categoryLink id="9906-2748-4666-b4be" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_4f71-446f-4cff-afda</comment>
         </categoryLink>
-        <categoryLink id="fb88-a79f-4c52-b486" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="fb88-a79f-4c52-b486" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_3f44-8647-43a4-ac22</comment>
         </categoryLink>
       </categoryLinks>
@@ -204,7 +204,7 @@
         <categoryLink id="c68c-7dee-4cdd-9a38" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_1b86-0977-4a8b-adac</comment>
         </categoryLink>
-        <categoryLink id="aa40-e785-4bda-872e" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="aa40-e785-4bda-872e" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_b449-403a-4e42-9239</comment>
         </categoryLink>
       </categoryLinks>
@@ -218,7 +218,7 @@
         <categoryLink id="3bbf-e84f-44f8-a95a" name="Compulsory Elite:" hidden="false" targetId="bb1f-ae32-b587-c3e1" primary="false">
           <comment>template_id_7d5a-62e7-43ee-b79b</comment>
         </categoryLink>
-        <categoryLink id="b2fc-c7ce-4eac-8638" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
+        <categoryLink id="b2fc-c7ce-4eac-8638" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
           <comment>template_id_4986-9157-49f2-b670</comment>
         </categoryLink>
       </categoryLinks>
@@ -248,7 +248,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="968e-ddc3-44b4-b009" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="968e-ddc3-44b4-b009" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_e22a-c5f8-4825-a45f</comment>
         </categoryLink>
         <categoryLink id="1b8a-49fe-4e6f-8d4f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -277,7 +277,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="a2fd-5071-4a72-9c68" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
+        <categoryLink id="a2fd-5071-4a72-9c68" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
           <comment>template_id_28e0-91e7-4ada-9fac</comment>
         </categoryLink>
         <categoryLink id="e23d-347b-4cb2-a7eb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -307,7 +307,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="7e70-2f31-4a98-ba63" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="7e70-2f31-4a98-ba63" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_7d4f-547c-43ed-a520</comment>
         </categoryLink>
         <categoryLink id="92cb-4ea6-4d60-87df" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -337,7 +337,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="3d06-792c-4e7e-966a" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="3d06-792c-4e7e-966a" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_5a04-9847-4c91-a49a</comment>
         </categoryLink>
         <categoryLink id="b843-7a9b-4738-a702" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -348,7 +348,7 @@
     <entryLink id="22ed-bf80-0f24-060e" name="Terminator Tartaros Squad" hidden="false" collective="false" import="false" targetId="1a8e-0ded-a4dc-2b4e" type="selectionEntry">
       <comment>template_id_0848-4e03-417a-b224</comment>
       <categoryLinks>
-        <categoryLink id="795a-3e05-4e46-961b" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
+        <categoryLink id="795a-3e05-4e46-961b" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
           <comment>template_id_ac1c-b3bf-4011-918a</comment>
         </categoryLink>
         <categoryLink id="ef4b-fec9-4089-b211" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -382,7 +382,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="e160-fcdc-4231-9388" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="e160-fcdc-4231-9388" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_fce3-801c-49c8-85d4</comment>
         </categoryLink>
         <categoryLink id="06f9-73c1-4112-94a3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -417,7 +417,7 @@
         <categoryLink id="213e-80fe-48be-9ca4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_51af-a137-4a1c-97a4</comment>
         </categoryLink>
-        <categoryLink id="1123-7ffa-413e-9529" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
+        <categoryLink id="1123-7ffa-413e-9529" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
           <comment>template_id_ec1f-c326-40a8-9d1f</comment>
         </categoryLink>
       </categoryLinks>
@@ -443,7 +443,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="75ed-64c2-4675-9b83" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="75ed-64c2-4675-9b83" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_f203-bc26-421f-b79e</comment>
         </categoryLink>
         <categoryLink id="bd9d-794a-47bd-8478" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -457,7 +457,7 @@
         <categoryLink id="74bb-6d4b-4338-a21a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_b1d5-fd75-4f17-bbf4</comment>
         </categoryLink>
-        <categoryLink id="5792-0536-4799-8839" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="5792-0536-4799-8839" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_f221-bf81-4045-849b</comment>
         </categoryLink>
       </categoryLinks>
@@ -486,7 +486,7 @@
         <categoryLink id="6557-38f9-4549-8b9a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_9189-836c-475d-a52e</comment>
         </categoryLink>
-        <categoryLink id="4f8c-72c5-4c09-bbf2" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="4f8c-72c5-4c09-bbf2" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_e1fa-b7d8-47b0-a88a</comment>
         </categoryLink>
         <categoryLink id="4b23-5d46-4ef7-b4bd" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false">
@@ -518,7 +518,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="ae4b-d9e1-4f8a-a468" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="ae4b-d9e1-4f8a-a468" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_2008-f1c4-4285-a14f</comment>
         </categoryLink>
         <categoryLink id="db6b-c6db-439b-ac96" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -574,7 +574,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="29df-de3b-4c1b-8d51" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="29df-de3b-4c1b-8d51" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_4f60-472b-45a9-ab9e</comment>
         </categoryLink>
         <categoryLink id="c261-a6f6-41d7-8990" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -601,7 +601,7 @@
         <categoryLink id="d7be-ce1c-4e25-8043" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_0dfa-4004-4751-8022</comment>
         </categoryLink>
-        <categoryLink id="0c88-5989-488b-9e70" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="0c88-5989-488b-9e70" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_a669-0f5d-4fd3-811b</comment>
         </categoryLink>
       </categoryLinks>
@@ -631,7 +631,7 @@
         <categoryLink id="eb1a-b2fa-45b9-993a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_09cd-2176-40af-bba6</comment>
         </categoryLink>
-        <categoryLink id="de86-3e93-4460-a3e1" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="de86-3e93-4460-a3e1" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_05e6-7c63-4a35-9ba0</comment>
         </categoryLink>
       </categoryLinks>
@@ -661,7 +661,7 @@
         <categoryLink id="c470-596f-42f6-b736" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_899e-b052-4d5b-8c18</comment>
         </categoryLink>
-        <categoryLink id="2c37-4f6d-4ad4-acb6" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="2c37-4f6d-4ad4-acb6" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_f5e9-cff6-41d2-a016</comment>
         </categoryLink>
       </categoryLinks>
@@ -691,7 +691,7 @@
         <categoryLink id="582b-ae28-420c-8e4e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_5528-2dac-4be5-900c</comment>
         </categoryLink>
-        <categoryLink id="a2c8-3815-4aac-8edc" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="a2c8-3815-4aac-8edc" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_dc8f-d888-4585-991d</comment>
         </categoryLink>
       </categoryLinks>
@@ -721,7 +721,7 @@
         <categoryLink id="5322-11b6-48cc-980e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_39e5-eda5-45d1-a643</comment>
         </categoryLink>
-        <categoryLink id="8935-e320-463f-82ea" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="8935-e320-463f-82ea" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_6416-21bb-4df4-9de8</comment>
         </categoryLink>
       </categoryLinks>
@@ -751,7 +751,7 @@
         <categoryLink id="5ca3-1d6b-46bd-b736" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_c6ff-0977-4c92-bb28</comment>
         </categoryLink>
-        <categoryLink id="b9ee-7987-4eda-8ca9" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="b9ee-7987-4eda-8ca9" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_f555-7d39-458f-84c9</comment>
         </categoryLink>
       </categoryLinks>
@@ -780,7 +780,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="f021-5ff1-4742-b7c7" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="f021-5ff1-4742-b7c7" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_944f-7420-4982-8ea9</comment>
         </categoryLink>
         <categoryLink id="334d-83aa-4809-b7f3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -813,7 +813,7 @@
         <categoryLink id="7cc5-00d0-44d9-84a4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_7010-be56-4709-b058</comment>
         </categoryLink>
-        <categoryLink id="87d9-5924-4ba5-a78e" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="87d9-5924-4ba5-a78e" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_7379-a740-47ba-a054</comment>
         </categoryLink>
       </categoryLinks>
@@ -836,7 +836,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="cb6c-3c85-49c7-9b97" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="cb6c-3c85-49c7-9b97" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_8d82-3279-4481-84bb</comment>
         </categoryLink>
         <categoryLink id="edca-14fd-4829-9d71" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -857,7 +857,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="00ad-23dd-4764-b9da" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="00ad-23dd-4764-b9da" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_79fa-3370-4ae0-9e12</comment>
         </categoryLink>
         <categoryLink id="8c4b-954a-4cbb-a6fe" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -878,7 +878,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="aa3e-3fa4-4779-8d35" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
+        <categoryLink id="aa3e-3fa4-4779-8d35" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
           <comment>template_id_f55b-7555-444b-beee</comment>
         </categoryLink>
         <categoryLink id="16ff-840c-477d-b735" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -905,7 +905,7 @@
         <categoryLink id="40d0-28db-497a-ba03" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_75a7-dc06-445b-b2dc</comment>
         </categoryLink>
-        <categoryLink id="5f4b-2851-4f2a-b8a6" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="5f4b-2851-4f2a-b8a6" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_e21a-c03b-4885-ac46</comment>
         </categoryLink>
       </categoryLinks>
@@ -932,7 +932,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="e3af-90aa-45c5-9667" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="e3af-90aa-45c5-9667" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_b822-3417-4613-be37</comment>
         </categoryLink>
         <categoryLink id="0f57-eea8-407c-a44c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1027,7 +1027,7 @@
     <entryLink id="792c-37c2-8548-693c" name="Praetor" hidden="false" collective="false" import="false" targetId="03be-5d55-d05a-771d" type="selectionEntry">
       <comment>template_id_5798-3fc7-4d4c-ad41</comment>
       <categoryLinks>
-        <categoryLink id="2da9-bd91-411f-8ef2" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
+        <categoryLink id="2da9-bd91-411f-8ef2" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
           <comment>template_id_b084-df23-4f99-812f</comment>
         </categoryLink>
         <categoryLink id="4540-4f3c-4aa9-af32" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false">
@@ -1063,7 +1063,7 @@
         <categoryLink id="9773-b245-4fd8-8ffd" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_ff9f-01cb-41b9-800e</comment>
         </categoryLink>
-        <categoryLink id="f631-c801-47ef-a777" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="f631-c801-47ef-a777" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_1315-6051-4a46-b070</comment>
         </categoryLink>
       </categoryLinks>
@@ -1109,7 +1109,7 @@
         <categoryLink id="e051-91a0-4796-ad9b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_4272-9b9d-4c59-95f0</comment>
         </categoryLink>
-        <categoryLink id="1d46-32bc-4a57-a73a" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="1d46-32bc-4a57-a73a" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_d85b-1ae7-40d5-9341</comment>
         </categoryLink>
       </categoryLinks>
@@ -1135,7 +1135,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="c2a3-608a-4434-b984" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
+        <categoryLink id="c2a3-608a-4434-b984" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
           <comment>template_id_0af1-d052-4bd7-aab6</comment>
         </categoryLink>
         <categoryLink id="f293-e427-4966-9a29" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1149,7 +1149,7 @@
         <categoryLink id="ae87-9b89-4791-b23e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_6140-2404-46f9-bd42</comment>
         </categoryLink>
-        <categoryLink id="77ca-3e6c-499d-bedf" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
+        <categoryLink id="77ca-3e6c-499d-bedf" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
           <comment>template_id_1c86-fad8-46ec-a0b0</comment>
         </categoryLink>
       </categoryLinks>
@@ -1179,7 +1179,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="19e0-02bc-48ce-9eca" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="19e0-02bc-48ce-9eca" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_4e52-ad1b-48d4-8eed</comment>
         </categoryLink>
         <categoryLink id="3dc5-21e9-41c7-ac28" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false">
@@ -1212,7 +1212,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="064e-7dcb-41fd-8e37" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="064e-7dcb-41fd-8e37" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_4d7c-201f-4c99-b89a</comment>
         </categoryLink>
         <categoryLink id="796f-aabf-41e1-8718" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1282,7 +1282,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="1514-0d23-4455-88ab" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="1514-0d23-4455-88ab" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_5ad5-8701-42cd-b2b6</comment>
         </categoryLink>
         <categoryLink id="5e71-7ba4-426d-ba0c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1318,7 +1318,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="cff4-189a-4d4c-8d09" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="cff4-189a-4d4c-8d09" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_3632-0b5d-4622-ae33</comment>
         </categoryLink>
         <categoryLink id="5652-2a65-4c4b-bc53" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1354,7 +1354,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="a94b-321d-4e2a-a00c" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="a94b-321d-4e2a-a00c" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_0c16-6841-42b2-b02d</comment>
         </categoryLink>
         <categoryLink id="f6d6-558f-4570-98b8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1390,7 +1390,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="d85e-c762-435e-83d9" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="d85e-c762-435e-83d9" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_c1cf-cea4-4278-8f27</comment>
         </categoryLink>
         <categoryLink id="a5d5-a29e-4a2e-9b4d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1423,7 +1423,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="53c5-68ca-4672-8134" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="53c5-68ca-4672-8134" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_0397-c837-4fea-a527</comment>
         </categoryLink>
         <categoryLink id="9f31-b4db-4b7d-bc39" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1456,7 +1456,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="9f20-7932-41d5-9ef4" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="9f20-7932-41d5-9ef4" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_c77f-0819-473b-a8a2</comment>
         </categoryLink>
         <categoryLink id="54cb-af58-438d-9e32" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1492,7 +1492,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="3b5d-0be9-43ef-bada" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="3b5d-0be9-43ef-bada" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_b24f-3ae0-4cbb-b016</comment>
         </categoryLink>
         <categoryLink id="2b29-273c-4d80-bc7d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1528,7 +1528,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="5561-53a8-47bc-bc14" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="5561-53a8-47bc-bc14" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_f81d-9435-4f11-99c1</comment>
         </categoryLink>
         <categoryLink id="b017-ce01-4afb-88da" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1564,7 +1564,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="ee04-c72e-4166-9be5" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="ee04-c72e-4166-9be5" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_3610-c975-4d55-bdfe</comment>
         </categoryLink>
         <categoryLink id="5a31-125f-438c-b6a6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1632,7 +1632,7 @@
         <categoryLink id="efab-89f2-4be7-b2af" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_bc67-ce1f-4004-aeb7</comment>
         </categoryLink>
-        <categoryLink id="c6ae-4d7f-4210-86e9" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="c6ae-4d7f-4210-86e9" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_9a45-9699-4475-aeef</comment>
         </categoryLink>
       </categoryLinks>
@@ -1692,7 +1692,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="a041-b97b-4fd9-8f9b" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="a041-b97b-4fd9-8f9b" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_c6a8-22a8-4d41-b969</comment>
         </categoryLink>
         <categoryLink id="3597-e0d5-48e5-b56d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1725,7 +1725,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="c6ce-dcc7-4555-9f3f" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="c6ce-dcc7-4555-9f3f" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_f65b-8958-49b3-92a5</comment>
         </categoryLink>
         <categoryLink id="bcf0-2589-4b94-814b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1758,7 +1758,7 @@
         <categoryLink id="ce7e-39fa-4be0-b7c8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_9441-d79b-4720-9667</comment>
         </categoryLink>
-        <categoryLink id="9fc9-eb48-49a5-b33b" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="9fc9-eb48-49a5-b33b" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_7d7e-32d3-4692-b401</comment>
         </categoryLink>
       </categoryLinks>
@@ -1787,7 +1787,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="1e53-59c6-4738-91ad" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="1e53-59c6-4738-91ad" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_a56d-347b-4b09-a918</comment>
         </categoryLink>
         <categoryLink id="001b-406e-4cdd-a6bb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1822,7 +1822,7 @@
         <categoryLink id="0a96-64aa-4b6e-8427" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_cefb-cfd7-4dc8-99c4</comment>
         </categoryLink>
-        <categoryLink id="2282-7848-4b2e-be2d" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="2282-7848-4b2e-be2d" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_a9fd-9d16-4a5e-855c</comment>
         </categoryLink>
       </categoryLinks>
@@ -1840,7 +1840,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="de33-0651-4f23-832e" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="de33-0651-4f23-832e" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_e6f7-a6ca-4825-bfc5</comment>
         </categoryLink>
         <categoryLink id="44c3-fe6e-43fe-9bf3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1873,7 +1873,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="ae87-aa89-40f5-8cf0" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="ae87-aa89-40f5-8cf0" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_d53e-113f-4a40-a3d5</comment>
         </categoryLink>
         <categoryLink id="7ab3-2f7d-44ca-a438" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1933,7 +1933,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="70ed-b942-4b36-a8cc" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="70ed-b942-4b36-a8cc" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_caf6-5548-4b89-8102</comment>
         </categoryLink>
         <categoryLink id="695a-81eb-4876-b102" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1966,7 +1966,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="8b62-e13e-4011-a9c5" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="8b62-e13e-4011-a9c5" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_f4c0-4396-4f39-a34f</comment>
         </categoryLink>
         <categoryLink id="d19c-b799-4237-aab9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1998,7 +1998,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="8312-1f0d-4b26-b881" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="8312-1f0d-4b26-b881" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_2a08-4432-42ad-bfdb</comment>
         </categoryLink>
         <categoryLink id="6045-fbef-47f2-99dc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2012,7 +2012,7 @@
         <categoryLink id="aac8-c00e-423d-a6a4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_473b-e812-4158-9416</comment>
         </categoryLink>
-        <categoryLink id="d963-7041-4f06-a6b6" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
+        <categoryLink id="d963-7041-4f06-a6b6" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
           <comment>template_id_00a2-63ff-4698-a35b</comment>
         </categoryLink>
       </categoryLinks>
@@ -2038,7 +2038,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="e385-24d3-45a7-be8b" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="e385-24d3-45a7-be8b" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_361e-fb90-4b0e-ac3d</comment>
         </categoryLink>
         <categoryLink id="b011-22cf-4d2d-afed" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2107,7 +2107,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="58e5-3c23-2dda-0229" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="58e5-3c23-2dda-0229" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
         <categoryLink id="ff26-ed07-184f-756c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -2138,7 +2138,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="9040-9829-403a-90ec" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
+        <categoryLink id="9040-9829-403a-90ec" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
           <comment>template_id_f926-27fd-4a92-97a1</comment>
         </categoryLink>
         <categoryLink id="031e-6772-4981-814c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2167,7 +2167,7 @@
         <categoryLink id="1113-7c59-41fa-96c9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_dd44-e0a8-42a8-bdcc</comment>
         </categoryLink>
-        <categoryLink id="f92e-2ba6-4038-b567" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
+        <categoryLink id="f92e-2ba6-4038-b567" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
           <comment>template_id_c5b0-f9ae-468d-924a</comment>
         </categoryLink>
       </categoryLinks>
@@ -2197,7 +2197,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="b26a-b5cf-4b64-960f" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
+        <categoryLink id="b26a-b5cf-4b64-960f" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true">
           <comment>template_id_f1c8-27fd-4f98-8527</comment>
         </categoryLink>
         <categoryLink id="87eb-e154-400a-a5d7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2214,7 +2214,7 @@
         <categoryLink id="0aba-2252-4592-b75b" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false">
           <comment>template_id_f51c-73d7-4f29-be1c</comment>
         </categoryLink>
-        <categoryLink id="2a1b-aea5-4446-999f" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
+        <categoryLink id="2a1b-aea5-4446-999f" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
           <comment>template_id_257d-78c0-4bab-ba65</comment>
         </categoryLink>
       </categoryLinks>
@@ -2253,7 +2253,7 @@
         <categoryLink id="38ca-fa0b-48d9-b5a7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_bd6a-0cda-4e0f-80ae</comment>
         </categoryLink>
-        <categoryLink id="13db-b61e-414f-a209" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
+        <categoryLink id="13db-b61e-414f-a209" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
           <comment>template_id_ae75-7cca-4701-9d56</comment>
         </categoryLink>
         <categoryLink id="895a-aae5-4d58-83b4" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false">
@@ -2340,7 +2340,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="9b74-ac61-4a8f-ab2f" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
+        <categoryLink id="9b74-ac61-4a8f-ab2f" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
           <comment>template_id_67c2-df43-44fc-92d1</comment>
         </categoryLink>
         <categoryLink id="c532-e5cf-4b99-a2fa" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2370,7 +2370,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="7581-1223-4390-ab0a" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="7581-1223-4390-ab0a" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_251a-df5b-4bfd-ad63</comment>
         </categoryLink>
         <categoryLink id="3c34-6bd0-45e4-a537" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2378,7 +2378,7 @@
         </categoryLink>
       </categoryLinks>
     </entryLink>
-    <entryLink id="19a7-0534-8cf1-b0b7" name="Avenger Strike Fighter" hidden="true" collective="false" import="false" targetId="b25c-e85c-1c29-9e05" type="selectionEntry">
+    <entryLink id="19a7-0534-8cf1-b0b7" name="Legion Avenger Strike Fighter" hidden="true" collective="false" import="false" targetId="b25c-e85c-1c29-9e05" type="selectionEntry">
       <comment>template_id_1064-175d-4616-9c71</comment>
       <modifiers>
         <modifier type="set" field="hidden" value="false">
@@ -2400,7 +2400,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="9c6d-b7f1-4cc0-8f07" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
+        <categoryLink id="9c6d-b7f1-4cc0-8f07" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true">
           <comment>template_id_a009-a597-4b51-b228</comment>
         </categoryLink>
         <categoryLink id="dfab-e40a-4de8-a9f6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2433,7 +2433,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="30dd-2527-4805-b76a" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="30dd-2527-4805-b76a" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_c165-3906-463a-9c73</comment>
         </categoryLink>
         <categoryLink id="eda4-c309-4a14-8316" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2470,7 +2470,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="6f4f-cf60-4e46-b48b" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="6f4f-cf60-4e46-b48b" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_3a22-caae-4eea-9bc5</comment>
         </categoryLink>
         <categoryLink id="bc6d-80ea-40a5-9fa1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2502,7 +2502,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="a963-97b2-49a9-8b3d" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="a963-97b2-49a9-8b3d" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_ac26-e639-4d53-9b8b</comment>
         </categoryLink>
         <categoryLink id="4d2a-3b50-4aed-9c13" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -2538,7 +2538,7 @@
         <categoryLink id="a757-4468-4174-8abf" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_8378-ede4-476d-b657</comment>
         </categoryLink>
-        <categoryLink id="64b6-041c-44a4-98dc" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
+        <categoryLink id="64b6-041c-44a4-98dc" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true">
           <comment>template_id_d64f-ad19-426c-adf7</comment>
         </categoryLink>
       </categoryLinks>
@@ -2549,7 +2549,7 @@
         <categoryLink id="b3c2-86f9-45eb-8aec" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_c6d4-581f-4746-bec3</comment>
         </categoryLink>
-        <categoryLink id="2026-b0d4-4296-960b" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
+        <categoryLink id="2026-b0d4-4296-960b" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true">
           <comment>template_id_2489-ee2a-45dd-b384</comment>
         </categoryLink>
       </categoryLinks>
@@ -2570,7 +2570,7 @@
         <categoryLink id="ab84-c93c-49a2-8350" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
           <comment>template_id_b6b1-886e-4194-8bcd</comment>
         </categoryLink>
-        <categoryLink id="a6b6-9d7f-4131-8556" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
+        <categoryLink id="a6b6-9d7f-4131-8556" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_51b5-f9c1-4587-8fc7</comment>
         </categoryLink>
       </categoryLinks>
@@ -2601,7 +2601,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="dc16-16d0-4890-a8e8" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="dc16-16d0-4890-a8e8" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="4b1e-3f1f-49cb-8343" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -2624,7 +2624,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="32cb-7077-4d54-9f38" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="2c35-def7-4c44-9b02" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="2c35-def7-4c44-9b02" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="0c9a-d272-491c-a4a0" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -2646,7 +2646,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="5b41-a9f0-4801-9dff" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="5b41-a9f0-4801-9dff" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="d64e-e976-4668-bb95" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
         <categoryLink id="17a6-f363-4094-9a7c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
@@ -2670,7 +2670,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="fe4f-c8f2-470f-901c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="f3f0-973b-4a45-ac41" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="f3f0-973b-4a45-ac41" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="6d3e-2088-4b8a-b7aa" name="Sky-Hunter Squadron" hidden="true" collective="false" import="false" targetId="6263-c696-2f2e-c105" type="selectionEntry">
@@ -2693,7 +2693,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="63ff-0a92-42ab-ae8c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="204c-7b0f-4fb9-b1b3" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="204c-7b0f-4fb9-b1b3" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="85e6-cb31-427c-a040" name="Line Sub-type:" hidden="false" targetId="6399-5c65-7833-1025" primary="false"/>
         <categoryLink id="8197-2ef4-84d5-a84a" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
       </categoryLinks>
@@ -2718,7 +2718,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="68dd-fc0f-4fde-8adc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="74ca-dd4f-46be-8be7" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="74ca-dd4f-46be-8be7" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="13b5-8e68-8f6c-ede9" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -2809,7 +2809,7 @@
       <categoryLinks>
         <categoryLink id="0d5b-be56-47af-a22e" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="2e59-1043-4719-96c4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="52fa-8c3c-49d4-a321" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="52fa-8c3c-49d4-a321" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="f7af-4a1e-4570-aad5" name="Termite Assault Drill" hidden="true" collective="false" import="false" targetId="cb30-307a-f0d7-3b13" type="selectionEntry">
@@ -2833,7 +2833,7 @@
       <categoryLinks>
         <categoryLink id="1fef-4409-4fab-93fc" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="ca2d-245e-48b4-a1cf" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="6692-6e39-44f0-ad8e" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="6692-6e39-44f0-ad8e" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="7d07-ea3b-41ff-8084" name="Venerable Ancient Contemptor Dreadnought" hidden="true" collective="false" import="false" targetId="dad1-0807-e254-d498" type="selectionEntry">
@@ -2850,7 +2850,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="9261-acb5-4230-8d89" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="1a5d-cbc8-418f-91a3" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="1a5d-cbc8-418f-91a3" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="c0cb-406f-4b46-9d8d" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
       </categoryLinks>
       <entryLinks>
@@ -2873,7 +2873,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="c0b2-dd90-46c1-a2a9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="9a94-76fb-4a89-ad5d" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="9a94-76fb-4a89-ad5d" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="0103-520d-5680-bd3d" name="Castellax Battle-Automata Maniple" hidden="true" collective="false" import="false" targetId="537f-846d-90e3-2526" type="selectionEntry">
@@ -2886,7 +2886,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="064f-543e-3cbe-b5a5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="d1d6-17eb-77d9-7cc3" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="d1d6-17eb-77d9-7cc3" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="6aa7-49c9-76e9-0d27" name="Domitar Battle-Automata Maniple" hidden="true" collective="false" import="false" targetId="1a1b-fa35-a6a2-ca78" type="selectionEntry">
@@ -2899,7 +2899,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="3119-7dbf-d23d-abf7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="16b8-d689-437a-551a" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="16b8-d689-437a-551a" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="a72f-7aa4-5b79-2419" name="Thanatar Siege-automata Maniple" hidden="true" collective="false" import="false" targetId="2903-fef6-e839-368b" type="selectionEntry">
@@ -2916,7 +2916,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="2d02-dcab-832e-f9e9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="3fd9-773f-37cf-4ce2" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="3fd9-773f-37cf-4ce2" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="8883-fe70-0029-d6ca" name="Vorax Battle-automata Maniple" hidden="true" collective="false" import="false" targetId="f144-1079-11ff-019d" type="selectionEntry">
@@ -2929,7 +2929,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="43d4-d56c-e64b-c034" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="c0b4-54c8-f750-89ca" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="c0b4-54c8-f750-89ca" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="e010-6118-a240-dd12" name="Red Butchers" hidden="true" collective="false" import="false" targetId="1987-2aa5-929b-979e" type="selectionEntry">
@@ -2950,7 +2950,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="58bd-e7fc-7459-f227" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="2df6-37f6-03e8-afe2" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="2df6-37f6-03e8-afe2" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="6b01-1717-a8c4-d8df" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -2981,7 +2981,7 @@
         <constraint field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8d79-887f-d9af-b6b1" type="max"/>
       </constraints>
       <categoryLinks>
-        <categoryLink id="0d17-1b2f-b5d3-b5e7" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="0d17-1b2f-b5d3-b5e7" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="fe51-d88d-c607-9870" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -2997,7 +2997,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="c293-1a6e-3287-c8bd" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="7d74-ff42-876f-f0d0" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="7d74-ff42-876f-f0d0" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="09e5-f24c-2719-d2c4" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -3020,7 +3020,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="928b-f08c-a155-8962" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="f0dc-4c8f-c31e-9bfb" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="f0dc-4c8f-c31e-9bfb" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
       </categoryLinks>
     </entryLink>
   </entryLinks>
@@ -3714,7 +3714,7 @@
         <infoLink id="9f9a-d927-04d9-579a" name="Ravening Madmen" hidden="false" targetId="1864-f270-d462-ecb5" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="dac3-55aa-0d1b-36b7" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+        <categoryLink id="dac3-55aa-0d1b-36b7" name="Heavy Sub-type:" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
         <categoryLink id="cf1c-50e5-11f5-a5c0" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="080b-8aab-b802-323a" name="Terminators:" hidden="false" targetId="bab3-f50d-3e5f-2f78" primary="false"/>
         <categoryLink id="4259-2c1a-9160-12f3" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
@@ -3919,7 +3919,7 @@
                 </profile>
               </profiles>
               <categoryLinks>
-                <categoryLink id="3350-d90c-ee36-ecdb" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+                <categoryLink id="3350-d90c-ee36-ecdb" name="Heavy Sub-type:" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
               </categoryLinks>
               <entryLinks>
                 <entryLink id="0dba-da69-d791-9dfa" name="Pair of Lightning Claws" hidden="false" collective="false" import="true" targetId="405f-030d-0343-ade8" type="selectionEntry">
@@ -3935,7 +3935,7 @@
             </selectionEntry>
             <selectionEntry id="7916-ca80-5a20-cfbb" name="Red Butcher (Pair of Power Axes)" hidden="false" collective="false" import="true" type="model">
               <categoryLinks>
-                <categoryLink id="1a75-21e4-e926-1808" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+                <categoryLink id="1a75-21e4-e926-1808" name="Heavy Sub-type:" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
               </categoryLinks>
               <entryLinks>
                 <entryLink id="29a6-069f-4daa-a55a" name="Power Axe" hidden="false" collective="false" import="true" targetId="ef98-66ac-fcaf-c15d" type="selectionEntry">
@@ -3957,7 +3957,7 @@
             </selectionEntry>
             <selectionEntry id="f307-35b7-3b94-91a6" name="Red Butcher (Power Axe &amp; Combi-Bolter)" hidden="false" collective="false" import="true" type="model">
               <categoryLinks>
-                <categoryLink id="bdb6-5467-8aaf-75a8" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+                <categoryLink id="bdb6-5467-8aaf-75a8" name="Heavy Sub-type:" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
               </categoryLinks>
               <entryLinks>
                 <entryLink id="fa41-1e69-487d-b1ae" name="Combi-Bolter" hidden="false" collective="false" import="true" targetId="0f3d-c07c-7a7e-d534" type="selectionEntry">
@@ -5134,7 +5134,7 @@
             </modifier>
           </modifiers>
         </entryLink>
-        <entryLink id="2b36-986b-95a5-212d" name="Tartaros Command Squad (Placeholder Points)" hidden="false" collective="false" import="true" targetId="58d0-a0fd-d20b-cb1b" type="selectionEntry"/>
+        <entryLink id="2b36-986b-95a5-212d" name="Command Squad, Tartaros" hidden="false" collective="false" import="true" targetId="58d0-a0fd-d20b-cb1b" type="selectionEntry"/>
         <entryLink id="6f6c-6a79-ac41-8a7d" name="Command Squad" hidden="false" collective="false" import="true" targetId="0aca-632d-1642-8af9" type="selectionEntry"/>
       </entryLinks>
     </selectionEntryGroup>
@@ -5150,6 +5150,6 @@
     </profile>
   </sharedProfiles>
   <catalogueLinks>
-    <catalogueLink id="2f60-18fb-e6ed-8574" name="(HH V2) Legions Astartes" targetId="6393-649c-7213-a327" type="catalogue" importRootEntries="true"/>
+    <catalogueLink id="2f60-18fb-e6ed-8574" name="Legions Astartes" targetId="6393-649c-7213-a327" type="catalogue" importRootEntries="true"/>
   </catalogueLinks>
 </catalogue>

--- a/2022 - LI - Custodes.cat
+++ b/2022 - LI - Custodes.cat
@@ -21,40 +21,40 @@
         <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="890b-89ca-ea6d-213d" type="max"/>
       </constraints>
       <categoryLinks>
-        <categoryLink id="a7d7-0c14-596d-b293" name="New CategoryLink" hidden="false" targetId="e90d-e5a8-f42d-da84" primary="true"/>
+        <categoryLink id="a7d7-0c14-596d-b293" name="Allegiance:" hidden="false" targetId="e90d-e5a8-f42d-da84" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="1595-7192-9e5e-26a9" name="Constantin Valdor" hidden="false" collective="false" import="false" targetId="2e44-7b4f-37dd-05f4" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="17f6-6098-0dbf-e27c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="13c9-8366-95ab-62ab" name="New CategoryLink" hidden="false" targetId="ad5f-31db-8bc7-5c46" primary="true"/>
+        <categoryLink id="13c9-8366-95ab-62ab" name="Primarch:" hidden="false" targetId="ad5f-31db-8bc7-5c46" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="d518-801b-fe9a-03f8" name="Custodes Tribune" hidden="false" collective="false" import="false" targetId="d485-7848-0118-2dc3" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="8dc3-8d38-d807-d501" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="e66d-6558-458f-6eae" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="e66d-6558-458f-6eae" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="90af-a3d2-5caf-fb2e" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="608e-6aee-421f-3e30" name="Custodian Shield Captain" hidden="false" collective="false" import="false" targetId="bfaf-d07a-d3a5-c708" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="e312-4038-319f-8798" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="5e05-1cfb-3fab-a389" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="5e05-1cfb-3fab-a389" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="0332-ccb5-ae69-b162" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="9ccf-710a-120d-b858" name="Hetaeron Guard Squad" hidden="false" collective="false" import="false" targetId="76da-acc0-3ffb-6161" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="6c6f-d217-da4a-f3f3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="7e8a-2bdb-4800-48b9" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="7e8a-2bdb-4800-48b9" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="4ffe-afe4-30ee-9d4d" name="Compulsory Elite:" hidden="false" targetId="bb1f-ae32-b587-c3e1" primary="false"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="1fdd-ef9e-a979-0b44" name="Aquilon Terminator Squad (Placeholder)" hidden="false" collective="false" import="false" targetId="258c-214d-bc9d-35e1" type="selectionEntry">
+    <entryLink id="1fdd-ef9e-a979-0b44" name="Aquilon Terminator Squad" hidden="false" collective="false" import="false" targetId="258c-214d-bc9d-35e1" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="975d-e109-d5bd-7068" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="6f50-248f-d8e0-f877" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="6f50-248f-d8e0-f877" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="86cb-0998-7a8c-4996" name="Compulsory Elite:" hidden="false" targetId="bb1f-ae32-b587-c3e1" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -65,17 +65,17 @@
         <categoryLink id="1c3f-5c95-29b8-0549" name="Compulsory Elite:" hidden="false" targetId="bb1f-ae32-b587-c3e1" primary="false"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="da13-587f-7be9-66be" name="Custodian Guard Squad (Placeholder)" hidden="false" collective="false" import="false" targetId="7cec-fe1b-5748-7af3" type="selectionEntry">
+    <entryLink id="da13-587f-7be9-66be" name="Custodian Guard Squad" hidden="false" collective="false" import="false" targetId="7cec-fe1b-5748-7af3" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="046e-f52c-1705-678f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="29eb-c36e-75ff-003c" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="29eb-c36e-75ff-003c" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="901a-865f-b9d9-f198" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="ebd8-b84b-ff52-81da" name="Sentinel Guard Squad (Placeholder)" hidden="false" collective="false" import="false" targetId="206f-680f-4be9-6307" type="selectionEntry">
+    <entryLink id="ebd8-b84b-ff52-81da" name="Sentinel Guard Squad" hidden="false" collective="false" import="false" targetId="206f-680f-4be9-6307" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="283b-9bf8-51c2-fc3f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="2e7d-7993-769b-59e8" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="2e7d-7993-769b-59e8" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="dd75-438b-d47e-bb9d" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -89,7 +89,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="e519-9c3c-2ae3-2c19" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="8a99-7c4b-782a-8d54" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="8a99-7c4b-782a-8d54" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="65bb-7a39-4350-741e" name="Pallas Attack Speeder Squadron" hidden="false" collective="false" import="false" targetId="2ce3-4ce5-d86f-543f" type="selectionEntry">
@@ -102,19 +102,19 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="c710-2671-3cfb-8db7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="9415-2e52-7a11-d13b" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="9415-2e52-7a11-d13b" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="9fdd-741c-affb-289a" name="Custodian Venatari Squad" hidden="false" collective="false" import="false" targetId="4c7e-42e0-1c1e-5ba9" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="8d2b-5293-abf8-2065" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="4520-024b-fc8e-05ce" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="4520-024b-fc8e-05ce" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="656c-b6b9-7dcf-b89c" name="Sagittarum Guard Squad (Placeholder)" hidden="false" collective="false" import="false" targetId="8a39-6452-e075-c8d6" type="selectionEntry">
+    <entryLink id="656c-b6b9-7dcf-b89c" name="Sagittarum Guard Squad" hidden="false" collective="false" import="false" targetId="8a39-6452-e075-c8d6" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="1eab-2543-5401-8fd8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="3023-fbd5-f9ad-a69f" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="3023-fbd5-f9ad-a69f" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="689b-1084-e8c8-6e9b" name="Caladius Grav-Tank" hidden="false" collective="false" import="false" targetId="ff3b-e8ec-8623-322d" type="selectionEntry">
@@ -127,13 +127,13 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="ad5a-737c-b0ab-c723" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="42d6-e888-330f-39b2" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="42d6-e888-330f-39b2" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="0e1f-efc9-d81d-9c7e" name="Contemptor-Galatus Dreadnought" hidden="false" collective="false" import="false" targetId="cecc-da1f-9de6-2163" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="43c5-1053-74b3-054e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="085f-0c31-d88c-30f5" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="085f-0c31-d88c-30f5" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="12bb-7e2b-f4ac-9b94" name="Telemon Heavy Dreadnought" hidden="false" collective="false" import="false" targetId="4be9-470a-201e-c72a" type="selectionEntry">
@@ -146,7 +146,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="4689-f35f-ec9d-bb67" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="a43b-4f90-b009-182a" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="a43b-4f90-b009-182a" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="36ee-7fd7-accc-604e" name="Orion Assault Dropship" hidden="false" collective="false" import="false" targetId="6526-bdfb-4ebe-6e0a" type="selectionEntry">
@@ -159,7 +159,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="7fe7-71bf-70cc-f8e9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="e2f9-76b9-eb66-903d" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="e2f9-76b9-eb66-903d" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="6b3f-84ff-d24d-7c4d" name="Ares Gunship" hidden="false" collective="false" import="false" targetId="aa0c-15a3-9d4b-ac47" type="selectionEntry">
@@ -172,7 +172,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="2545-36db-5e09-10ce" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="ab0b-897d-307f-e973" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="ab0b-897d-307f-e973" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="23b7-2bb1-90a6-51b1" name="Clade Assassins (Loyalist)" hidden="false" collective="false" import="false" targetId="7363-5a05-4102-24fa" type="selectionEntry">
@@ -193,7 +193,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="7263-0192-71cc-fbd5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="0303-1608-485a-1102" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="0303-1608-485a-1102" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="d171-46d5-3e37-597f" name="Nathaniel Garro" hidden="true" collective="false" import="false" targetId="0583-258d-f0a0-2170" type="selectionEntry">
@@ -216,7 +216,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="c5ee-75f2-39a7-5a56" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
+        <categoryLink id="c5ee-75f2-39a7-5a56" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
           <comment>template_id_0af1-d052-4bd7-aab6</comment>
         </categoryLink>
         <categoryLink id="1f94-fc2c-8d76-ec9b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -244,7 +244,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="d93a-5082-8fa-129a" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
+        <categoryLink id="d93a-5082-8fa-129a" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
           <comment>template_id_28e0-91e7-4ada-9fac</comment>
         </categoryLink>
         <categoryLink id="90e1-36a9-2038-4ed2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -479,7 +479,7 @@
               </constraints>
               <entryLinks>
                 <entryLink id="5338-f912-8efa-5500" name="Guardian Spear" hidden="false" collective="false" import="true" targetId="2bb9-0525-4865-407c" type="selectionEntry"/>
-                <entryLink id="35ac-2f57-09de-f2fb" name="Pyrithire Spear" hidden="false" collective="false" import="true" targetId="4620-e360-7dd2-f908" type="selectionEntry">
+                <entryLink id="35ac-2f57-09de-f2fb" name="Pyrithite Spear" hidden="false" collective="false" import="true" targetId="4620-e360-7dd2-f908" type="selectionEntry">
                   <costs>
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15"/>
                   </costs>
@@ -1196,7 +1196,7 @@
                 <infoLink id="c661-13bf-9983-2e68" name="Custodian" hidden="false" targetId="cf1b-e0d6-ddd9-24e6" type="profile"/>
               </infoLinks>
               <entryLinks>
-                <entryLink id="1006-05c3-bf5e-6750" name="Pyrithire Spear" hidden="false" collective="false" import="true" targetId="4c16-32b1-1a7a-928b" type="selectionEntry">
+                <entryLink id="1006-05c3-bf5e-6750" name="Pyrithite Spear" hidden="false" collective="false" import="true" targetId="4c16-32b1-1a7a-928b" type="selectionEntry">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="447c-a318-b615-a277" type="min"/>
                     <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e233-96db-c99d-c0f8" type="max"/>
@@ -2485,7 +2485,7 @@
     </selectionEntry>
     <selectionEntry id="d9bd-74cb-097b-14de" name="Solarite Power Talon" hidden="false" collective="true" import="true" type="upgrade">
       <infoLinks>
-        <infoLink id="5954-4c98-4aa2-dad5" name="Solarite Power Talon (TBC)" hidden="false" targetId="2a2f-144f-f63f-2cd7" type="profile"/>
+        <infoLink id="5954-4c98-4aa2-dad5" name="Solarite Power Talon" hidden="false" targetId="2a2f-144f-f63f-2cd7" type="profile"/>
         <infoLink id="f4fd-8993-e22a-c6c9" name="Shred" hidden="false" targetId="5e7e-1628-8174-6f2c" type="rule"/>
       </infoLinks>
       <costs>
@@ -3261,7 +3261,7 @@ the Front Armour during the same Phase.�</characteristic>
           </constraints>
           <entryLinks>
             <entryLink id="e899-f823-21b2-19bd" name="Guardian Spear" hidden="false" collective="false" import="true" targetId="2bb9-0525-4865-407c" type="selectionEntry"/>
-            <entryLink id="cfbd-6ce8-45d1-31b7" name="Pyrithire Spear" hidden="false" collective="false" import="true" targetId="4620-e360-7dd2-f908" type="selectionEntry">
+            <entryLink id="cfbd-6ce8-45d1-31b7" name="Pyrithite Spear" hidden="false" collective="false" import="true" targetId="4620-e360-7dd2-f908" type="selectionEntry">
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15"/>
               </costs>
@@ -4115,7 +4115,7 @@ Lightning Blows (X) special rule, but do benefit from any other special rules po
     </profile>
   </sharedProfiles>
   <catalogueLinks>
-    <catalogueLink id="e048-9e5e-507c-5bad" name="LI - Assassins" targetId="4c88-1a81-7e53-0a67" type="catalogue" importRootEntries="true"/>
+    <catalogueLink id="e048-9e5e-507c-5bad" name="LI - Assassins and Agents" targetId="4c88-1a81-7e53-0a67" type="catalogue" importRootEntries="true"/>
     <catalogueLink id="60d6-cab6-4580-b772" name="Mech Library" targetId="3129-da35-55e0-642d" type="catalogue" importRootEntries="true"/>
   </catalogueLinks>
 </catalogue>

--- a/2022 - LI - Sisters Of Silence.cat
+++ b/2022 - LI - Sisters Of Silence.cat
@@ -73,27 +73,27 @@ In addition, the Leadership Characteristic of a model with the Anathema Unit Sub
         <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e448-ba5a-2280-ce3c" type="min"/>
       </constraints>
       <categoryLinks>
-        <categoryLink id="eada-8ff8-8101-fa97" name="New CategoryLink" hidden="false" targetId="e90d-e5a8-f42d-da84" primary="true"/>
+        <categoryLink id="eada-8ff8-8101-fa97" name="Allegiance:" hidden="false" targetId="e90d-e5a8-f42d-da84" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="e415-f03a-c52c-c52a" name="Jenetia Krole" hidden="false" collective="false" import="false" targetId="c400-14ac-853c-161f" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="dde2-5eff-fe37-5ace" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="e9cf-ef14-9c91-9e7c" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="e9cf-ef14-9c91-9e7c" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="5790-4c74-f1fe-b584" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="062f-4a1f-0e57-e22b" name="Knight Abyssal" hidden="false" collective="false" import="false" targetId="6ed4-f039-3f78-9877" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="7c31-46ed-501b-f626" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="f4e1-ab36-d875-5e64" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="f4e1-ab36-d875-5e64" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="af21-3497-0102-5a63" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="d0af-f280-4e54-65c0" name="Silent Judge" hidden="false" collective="false" import="false" targetId="9d32-1528-4e59-d1c5" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="bde0-651a-aa47-3fb7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="669c-7626-b8b2-4ccf" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="669c-7626-b8b2-4ccf" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="899e-0a82-b4af-ff21" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -107,21 +107,21 @@ In addition, the Leadership Characteristic of a model with the Anathema Unit Sub
       </modifiers>
       <categoryLinks>
         <categoryLink id="3eb4-ef93-a93c-4271" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="6da1-1119-9922-3e47" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="6da1-1119-9922-3e47" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="1f72-f5b2-41c3-cf13" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="6ccb-754e-4347-3ede" name="Knight Centura" hidden="false" collective="false" import="false" targetId="6445-e0ea-58ac-ac6c" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="6ae1-46ba-deb4-8e93" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="e426-cce5-d7c6-8a80" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="e426-cce5-d7c6-8a80" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="937e-9166-d11c-b144" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="3a57-a3dc-16d4-26d9" name="Knight Vestal Covenant" hidden="false" collective="false" import="false" targetId="7f95-0220-f031-0986" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="20a0-6e34-6609-9a14" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="0e45-0e50-8e46-3cd8" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="0e45-0e50-8e46-3cd8" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="cd35-7c55-1065-0fca" name="Clade Assassins (Loyalist)" hidden="false" collective="false" import="false" targetId="7363-5a05-4102-24fa" type="selectionEntry">
@@ -133,39 +133,39 @@ In addition, the Leadership Characteristic of a model with the Anathema Unit Sub
     <entryLink id="6864-9f7f-2c42-f856" name="Oblivion Knights" hidden="false" collective="false" import="false" targetId="a104-d140-eb76-5777" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="7a69-6a9c-50cc-badd" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="4c2a-14f2-87c7-89f7" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="4c2a-14f2-87c7-89f7" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="3618-a4ae-674b-d78a" name="Eradicator Cadre" hidden="false" collective="false" import="false" targetId="6f0b-7bd1-ea5f-936e" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="1ef2-70de-1218-a330" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="e9e5-99f1-02ce-cf35" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="e9e5-99f1-02ce-cf35" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="b4c2-8102-8847-b9fc" name="Prosecutor Cadre" hidden="false" collective="false" import="false" targetId="a2df-539a-6cc6-92a3" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="8dbb-879e-0444-08cd" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="e009-530c-88db-53dc" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
-        <categoryLink id="cc36-565b-b2d0-2cbf" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="cc36-565b-b2d0-2cbf" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="457c-5ead-f710-00bc" name="Vigilator Cadre" hidden="false" collective="false" import="false" targetId="9ab2-6d05-b388-e73d" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="a09c-69c1-1234-15e4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="4afb-a6e1-49ca-7feb" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
-        <categoryLink id="cb3e-e13b-b028-5fb3" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="cb3e-e13b-b028-5fb3" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="708c-1eb1-6145-2023" name="Pursuer Cadre" hidden="false" collective="false" import="false" targetId="db4a-57f3-f451-da91" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="a59b-a741-2a64-c857" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="a378-3781-8012-2c8d" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="a378-3781-8012-2c8d" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="04cb-ab0b-580f-22cc" name="Firebrand Cadre" hidden="false" collective="false" import="false" targetId="b739-d90c-49d7-903c" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="51f2-a681-6572-64b6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="a206-58f8-c572-d35f" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="a206-58f8-c572-d35f" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="88d3-d560-9cde-7cf8" name="Subjugator Cadre" hidden="false" collective="false" import="false" targetId="84c1-50d4-cf46-0ea2" type="selectionEntry">
@@ -178,7 +178,7 @@ In addition, the Leadership Characteristic of a model with the Anathema Unit Sub
       </modifiers>
       <categoryLinks>
         <categoryLink id="0a1f-2f7d-8b2c-11ee" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="3385-dcd1-dab5-386c" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="3385-dcd1-dab5-386c" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="a875-a695-bb4c-33ae" name="Termite Assault Drill" hidden="false" collective="false" import="false" targetId="b3bd-c23c-aca6-f883" type="selectionEntry">
@@ -191,19 +191,19 @@ In addition, the Leadership Characteristic of a model with the Anathema Unit Sub
       </modifiers>
       <categoryLinks>
         <categoryLink id="329f-35bf-067e-8ce8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="55c9-fe02-8204-e098" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="55c9-fe02-8204-e098" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="19d2-53d8-3f64-0c48" name="Sanctioner Cadre" hidden="false" collective="false" import="false" targetId="11ee-6fbc-3206-1f33" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="d6c2-127c-63bf-4bfc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="596b-39de-8064-788d" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="596b-39de-8064-788d" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="da60-fa88-c62c-2544" name="Expurgator Cadre" hidden="false" collective="false" import="false" targetId="d748-5878-98f6-b592" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="023d-18c4-d4cc-6a2d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="ef7a-8062-9395-f942" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="ef7a-8062-9395-f942" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="b86b-bd81-d5e5-624a" name="Expeditionary Navigator" hidden="true" collective="false" import="false" targetId="ce53-e40c-65b6-4d3a" type="selectionEntry">
@@ -218,7 +218,7 @@ In addition, the Leadership Characteristic of a model with the Anathema Unit Sub
       </modifiers>
       <categoryLinks>
         <categoryLink id="1a84-997c-8103-7766" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="cac5-6380-385a-6c9d" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="cac5-6380-385a-6c9d" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="e10d-2373-4517-9ec2" name="Nathaniel Garro" hidden="true" collective="false" import="false" targetId="0583-258d-f0a0-2170" type="selectionEntry">
@@ -241,7 +241,7 @@ In addition, the Leadership Characteristic of a model with the Anathema Unit Sub
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="62ae-9898-3d12-fa9f" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
+        <categoryLink id="62ae-9898-3d12-fa9f" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
           <comment>template_id_0af1-d052-4bd7-aab6</comment>
         </categoryLink>
         <categoryLink id="657c-563a-f888-8c72" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -269,7 +269,7 @@ In addition, the Leadership Characteristic of a model with the Anathema Unit Sub
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="edc3-cc1d-d244-63f0" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
+        <categoryLink id="edc3-cc1d-d244-63f0" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
           <comment>template_id_28e0-91e7-4ada-9fac</comment>
         </categoryLink>
         <categoryLink id="c301-f234-51dc-c11f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1727,7 +1727,7 @@ In addition, the Leadership Characteristic of a model with the Anathema Unit Sub
         <infoLink id="17cc-cdff-f607-79d6" name="Silent Sisterhood (X)" hidden="false" targetId="1d8d-3038-9267-6f1b" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="41d2-f0d2-14d0-fe27" name="Cavalry Sub-type:" hidden="false" targetId="6d79-a3e4-381f-7b0f" primary="false"/>
+        <categoryLink id="41d2-f0d2-14d0-fe27" name="Cavalry Unit-type:" hidden="false" targetId="6d79-a3e4-381f-7b0f" primary="false"/>
         <categoryLink id="d3d4-0f12-5244-f4e7" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
         <categoryLink id="b1a3-b5d8-3818-dd07" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
         <categoryLink id="bfe0-fc96-b80f-f1f2" name="Light Sub-type:" hidden="false" targetId="bff2-ae16-74a8-8712" primary="false"/>
@@ -5370,7 +5370,7 @@ In addition, the Leadership Characteristic of a model with the Anathema Unit Sub
         <infoLink id="6b02-b6a8-2663-228f" name="Silent Sisterhood (X)" hidden="false" targetId="1d8d-3038-9267-6f1b" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="cba8-faf1-bd05-d46a" name="Cavalry Sub-type:" hidden="false" targetId="6d79-a3e4-381f-7b0f" primary="false"/>
+        <categoryLink id="cba8-faf1-bd05-d46a" name="Cavalry Unit-type:" hidden="false" targetId="6d79-a3e4-381f-7b0f" primary="false"/>
         <categoryLink id="d29d-2c7e-9074-1379" name="Skirmish Sub-type:" hidden="false" targetId="59a4-7b61-600a-c457" primary="false"/>
         <categoryLink id="b917-710e-795f-1ea1" name="Silent Sisterhood (Chamber of Judgement)" hidden="false" targetId="b71a-371d-4401-9dc0" primary="false"/>
         <categoryLink id="87bb-2a59-f19c-aac1" name="Antigrav Sub-type" hidden="false" targetId="4303-1348-cce4-9501" primary="false"/>
@@ -6722,8 +6722,8 @@ In addition, the Leadership Characteristic of a model with the Anathema Unit Sub
       </infoLinks>
       <categoryLinks>
         <categoryLink id="4048-cdbc-7bad-778e" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
-        <categoryLink id="d29e-cf5d-77db-4913" name="Fast Vehicles" hidden="false" targetId="0ea2-efb5-b7af-226e" primary="false"/>
-        <categoryLink id="529d-3432-2c61-6c5a" name="Transport" hidden="false" targetId="7b0a-a743-a8da-3a39" primary="false"/>
+        <categoryLink id="d29e-cf5d-77db-4913" name="Fast Sub-type:" hidden="false" targetId="0ea2-efb5-b7af-226e" primary="false"/>
+        <categoryLink id="529d-3432-2c61-6c5a" name="Transport Sub-type:" hidden="false" targetId="7b0a-a743-a8da-3a39" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="e5ea-5a84-b7d2-eadd" name="1) Hull (Front) Mounted Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="1962-701d-5052-32ab">
@@ -7452,7 +7452,7 @@ In addition, the Leadership Characteristic of a model with the Anathema Unit Sub
                 <infoLink id="e08b-6dbc-a60a-cbb0" name="Raptora" hidden="false" targetId="f95e-9b9e-28c7-65e4" type="profile"/>
               </infoLinks>
               <entryLinks>
-                <entryLink id="ea2f-7c98-078c-ee68" name="Execution Blade (Placeholder)" hidden="false" collective="false" import="true" targetId="b902-5e27-e3ec-18ca" type="selectionEntry">
+                <entryLink id="ea2f-7c98-078c-ee68" name="Execution Blade" hidden="false" collective="false" import="true" targetId="b902-5e27-e3ec-18ca" type="selectionEntry">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ff39-a2a0-bcf8-746e" type="min"/>
                     <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ae77-dfab-eb18-e096" type="max"/>
@@ -7510,7 +7510,7 @@ In addition, the Leadership Characteristic of a model with the Anathema Unit Sub
                 <infoLink id="2021-092c-577a-c341" name="Raptora" hidden="false" targetId="f95e-9b9e-28c7-65e4" type="profile"/>
               </infoLinks>
               <entryLinks>
-                <entryLink id="e9c5-5198-6020-7563" name="Execution Blade (Placeholder)" hidden="false" collective="false" import="true" targetId="b902-5e27-e3ec-18ca" type="selectionEntry">
+                <entryLink id="e9c5-5198-6020-7563" name="Execution Blade" hidden="false" collective="false" import="true" targetId="b902-5e27-e3ec-18ca" type="selectionEntry">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="27d7-9bfb-e9ef-18b8" type="min"/>
                     <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b4b1-4fb3-34c3-9f00" type="max"/>
@@ -8049,7 +8049,7 @@ For example, a Sisters of Silence Detachment includes three HQ choices – two K
     </rule>
   </sharedRules>
   <catalogueLinks>
-    <catalogueLink id="e048-9e5e-507c-5baa" name="LI - Assassins" targetId="4c88-1a81-7e53-0a67" type="catalogue" importRootEntries="true"/>
+    <catalogueLink id="e048-9e5e-507c-5baa" name="LI - Assassins and Agents" targetId="4c88-1a81-7e53-0a67" type="catalogue" importRootEntries="true"/>
     <catalogueLink id="60d6-cab6-4580-b772" name="Mech Library" targetId="3129-da35-55e0-642d" type="catalogue" importRootEntries="true"/>
   </catalogueLinks>
 </catalogue>

--- a/2022 - LI - Solar Auxilia.cat
+++ b/2022 - LI - Solar Auxilia.cat
@@ -30,7 +30,7 @@
       <categoryLinks>
         <categoryLink id="6489-237d-8136-f214" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="1a8b-0e69-4574-ebb1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="b5c3-bbcb-1830-c624" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="b5c3-bbcb-1830-c624" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
       </categoryLinks>
       <entryLinks>
         <entryLink id="ba87-d770-24f2-e5f5" name="Leman Russ Strike Squadron" hidden="false" collective="false" import="true" targetId="3fce-bf1a-6369-a386" type="selectionEntry">
@@ -65,7 +65,7 @@
       <categoryLinks>
         <categoryLink id="39db-1baa-7e06-84f2" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="f761-f3d5-51c4-c323" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="e95d-9715-778b-109d" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="e95d-9715-778b-109d" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="105b-f74b-c52a-5450" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
       </categoryLinks>
       <entryLinks>
@@ -117,35 +117,35 @@
         <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2d28-dc52-f9e3-4cc8" type="min"/>
       </constraints>
       <categoryLinks>
-        <categoryLink id="cba9-ee29-fb68-4d2e" name="New CategoryLink" hidden="false" targetId="e90d-e5a8-f42d-da84" primary="true"/>
+        <categoryLink id="cba9-ee29-fb68-4d2e" name="Allegiance:" hidden="false" targetId="e90d-e5a8-f42d-da84" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="de2a-9dad-ac9f-acb8" name="Legate Marshal" hidden="false" collective="false" import="false" targetId="9dd4-325a-c1cb-fac2" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="ee17-6c7f-eaf9-3bad" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="a5a3-7a89-6ceb-869b" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
-        <categoryLink id="9f46-eeaa-6d50-4461" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="9f46-eeaa-6d50-4461" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="66e5-ccf5-813f-c285" name="Tactical Command Tercio" hidden="false" collective="false" import="false" targetId="e9d4-7207-71e0-0762" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="ae33-ec9e-6580-f355" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="f0dc-1c12-3dc1-1eb0" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
-        <categoryLink id="4b88-e690-a860-9593" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="4b88-e690-a860-9593" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="a242-53dd-ea9d-f575" name="Veletaris Tercio" hidden="false" collective="false" import="false" targetId="1905-2087-cffc-4839" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="651a-7993-8e52-2915" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="9aad-b5e8-c664-cbe2" name="Compulsory Elite:" hidden="false" targetId="bb1f-ae32-b587-c3e1" primary="false"/>
-        <categoryLink id="3c8b-25ba-7140-990f" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="3c8b-25ba-7140-990f" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="dac0-7b81-a856-9c82" name="Medicae Section" hidden="false" collective="false" import="false" targetId="f28b-5804-f1fd-c187" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="766c-e4f5-ee83-3e97" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="0dc5-c352-d1f9-1d96" name="Compulsory Elite:" hidden="false" targetId="bb1f-ae32-b587-c3e1" primary="false"/>
-        <categoryLink id="d76e-62a4-def0-c7ce" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="d76e-62a4-def0-c7ce" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="78d3-5777-ada5-f697" name="Surgeon-Primus Aevos Jovan" hidden="true" collective="false" import="false" targetId="c032-86a2-3757-80e4" type="selectionEntry">
@@ -163,14 +163,14 @@
       <categoryLinks>
         <categoryLink id="9120-2371-ecc7-e1ba" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="b045-2281-4b3c-9ddb" name="Compulsory Elite:" hidden="false" targetId="bb1f-ae32-b587-c3e1" primary="false"/>
-        <categoryLink id="f0a0-c2e9-ca37-d599" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="f0a0-c2e9-ca37-d599" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="4c93-38d3-fad6-1c39" name="Charonite Ogryn Section" hidden="false" collective="false" import="false" targetId="6728-8632-5bf2-79bb" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="5c3d-4769-4f4d-a2ce" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="e26d-7d39-db08-79e1" name="Compulsory Elite:" hidden="false" targetId="bb1f-ae32-b587-c3e1" primary="false"/>
-        <categoryLink id="d3d0-d59c-c111-0625" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="d3d0-d59c-c111-0625" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="5be2-1846-2870-ba0b" name="Veletaris Tercio" hidden="true" collective="false" import="false" targetId="1905-2087-cffc-4839" type="selectionEntry">
@@ -184,13 +184,13 @@
       <categoryLinks>
         <categoryLink id="2487-0ee0-6607-a560" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="fd02-44a6-83fa-ece7" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
-        <categoryLink id="516f-012d-99f9-8514" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="516f-012d-99f9-8514" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="67af-429c-2973-c7e3" name="Infantry Tercio" hidden="false" collective="false" import="false" targetId="e3d9-ef46-4077-e1f5" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="2d85-9cea-9317-2cfb" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
-        <categoryLink id="04c9-6447-531c-b4c8" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="04c9-6447-531c-b4c8" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="149c-7c16-c0cf-0e47" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -203,7 +203,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="5d1c-6b1e-50a0-0e6c" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="5d1c-6b1e-50a0-0e6c" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="09ec-3faf-d447-1913" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -216,7 +216,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="a369-8b1e-eb51-ac7d" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="a369-8b1e-eb51-ac7d" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="c044-20ca-8fb0-6718" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -229,7 +229,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="3ae4-de9e-f922-10aa" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="3ae4-de9e-f922-10aa" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
         <categoryLink id="916c-bc5e-04f4-8436" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -242,7 +242,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="087c-8fe0-c01a-0df1" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="087c-8fe0-c01a-0df1" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
         <categoryLink id="2bf5-fad9-222b-b6c4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -255,7 +255,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="1f07-e625-a049-e21c" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="1f07-e625-a049-e21c" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
         <categoryLink id="8c4e-43be-06fb-5ddb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -268,7 +268,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="9854-215c-ce7d-0b0d" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="9854-215c-ce7d-0b0d" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
         <categoryLink id="d267-bac1-acff-1c26" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -287,7 +287,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="9342-bc8f-a2d8-9715" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="9342-bc8f-a2d8-9715" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
         <categoryLink id="e9fe-72de-4d67-86ec" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -313,7 +313,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="cbd8-3c9e-c1be-79ce" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="cbd8-3c9e-c1be-79ce" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
         <categoryLink id="2699-4760-ffad-c7ed" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -333,7 +333,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="11f9-5738-0e51-2256" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="3159-eaff-3539-97e4" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="3159-eaff-3539-97e4" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="b543-b159-6b24-a64b" name="Stormhammer" hidden="false" collective="false" import="false" targetId="19c9-f8e8-edff-fa8e" type="selectionEntry">
@@ -345,7 +345,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="8c54-8f75-3e5d-9bb3" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="8c54-8f75-3e5d-9bb3" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
         <categoryLink id="6918-6859-f839-7288" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -359,7 +359,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="9d1a-8ece-dab6-279a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="8cf2-bf86-70aa-285d" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="8cf2-bf86-70aa-285d" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="ed96-832f-8425-e15b" name="Armoured Battery" hidden="true" collective="false" import="false" targetId="c020-7685-ddf4-a10a" type="selectionEntry">
@@ -377,7 +377,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="0165-b8a0-97f6-c517" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="4ff0-547e-22fe-2189" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="4ff0-547e-22fe-2189" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="c6aa-1923-1ee3-1647" name="Clade Assassins (Loyalist)" hidden="false" collective="false" import="false" targetId="7363-5a05-4102-24fa" type="selectionEntry">
@@ -410,7 +410,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="421a-81cb-66b6-efca" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="94ab-2ae3-84c8-5bc1" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="94ab-2ae3-84c8-5bc1" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="2991-097b-9222-04a9" name="Expeditionary Navigator" hidden="true" collective="false" import="false" targetId="ce53-e40c-65b6-4d3a" type="selectionEntry">
@@ -425,7 +425,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="4f33-9f78-6d8e-d614" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="ddf4-1ebe-f86f-4faa" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="ddf4-1ebe-f86f-4faa" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="4d72-b7f3-dd03-d376" name="Carnodon Strike Squadron" hidden="true" collective="false" import="false" targetId="2918-e98d-0ab1-811b" type="selectionEntry">
@@ -445,7 +445,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="a7e1-5382-7db4-4e74" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="4cc5-469c-bdd8-ddcc" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="4cc5-469c-bdd8-ddcc" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="7406-eba3-d659-29bb" name="Armoured Support Tercio" hidden="true" collective="false" import="false" targetId="5ac5-b201-717f-0650" type="selectionEntry">
@@ -465,7 +465,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="5630-fb87-037c-8106" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="27d8-640c-de2a-e561" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="27d8-640c-de2a-e561" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="2ac9-9f5e-1e52-cf67" name="Minotaur Battery" hidden="true" collective="false" import="false" targetId="838e-101d-5501-3261" type="selectionEntry">
@@ -485,7 +485,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="bdfa-ee6b-b665-7cd2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="57f6-80f9-7b7b-3e2c" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="57f6-80f9-7b7b-3e2c" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="8d16-96f2-97c9-11bd" name="Termite Assault Drill" hidden="true" collective="false" import="false" targetId="b4b5-9c0a-9e86-3d38" type="selectionEntry">
@@ -501,7 +501,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="ca93-921e-25c3-33da" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="90c0-fe0f-2d92-2659" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="90c0-fe0f-2d92-2659" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="c5da-1670-461b-21ab" name="Stormblade" hidden="true" collective="false" import="false" targetId="7331-a4a7-8e69-c55e" type="selectionEntry">
@@ -521,7 +521,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="a696-fc21-00e3-8812" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="66cb-a717-bf71-5bb8" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="66cb-a717-bf71-5bb8" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="cf45-ae22-f4b8-2d90" name="Baneblade" hidden="true" collective="false" import="false" targetId="1c10-5772-2e27-1e51" type="selectionEntry">
@@ -541,7 +541,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="9777-461b-c581-367a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="d294-7c3f-6264-c882" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="d294-7c3f-6264-c882" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="bad3-3892-04cf-64e2" name="Banehammer" hidden="true" collective="false" import="false" targetId="7bb3-2416-aaca-8e40" type="selectionEntry">
@@ -561,7 +561,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="61c6-ca33-5c6c-21c0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="89f7-cad5-a0a2-5529" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="89f7-cad5-a0a2-5529" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="90cc-aacc-5d72-47fd" name="Stormlord" hidden="true" collective="false" import="false" targetId="2bae-aaa9-9840-e2eb" type="selectionEntry">
@@ -581,7 +581,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="034e-354a-0283-849d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="cef8-739c-ccfe-3326" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="cef8-739c-ccfe-3326" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="c908-965a-0e07-8eda" name="Shadowsword" hidden="true" collective="false" import="false" targetId="4713-c9ee-2c57-9457" type="selectionEntry">
@@ -601,7 +601,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="a919-13c0-b14c-4f33" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="9ff3-7812-b99a-eede" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="9ff3-7812-b99a-eede" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="f77b-3ae1-c13b-bfbb" name="Stormsword" hidden="true" collective="false" import="false" targetId="3d0b-9f37-cd30-0db7" type="selectionEntry">
@@ -616,7 +616,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="3ae7-e7b0-ebb3-7572" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="8684-456f-2370-86ef" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="8684-456f-2370-86ef" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="0faa-98f3-251b-367c" name="Praetor Armoured Assault Launcher" hidden="true" collective="false" import="false" targetId="2d13-ea6e-e48d-f352" type="selectionEntry">
@@ -636,7 +636,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="fa22-3f36-d60b-3334" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="202d-dea9-0c8b-3514" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="202d-dea9-0c8b-3514" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="0d12-b48a-9082-d4ee" name="Crassus Armoured Assault Transport" hidden="true" collective="false" import="false" targetId="8cec-2913-77a0-c4e4" type="selectionEntry">
@@ -656,7 +656,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="b3f4-8c41-3ada-68f3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="8bd9-b994-7578-c112" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="8bd9-b994-7578-c112" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="868b-4946-4e3c-610b" name="Artillery Battery" hidden="true" collective="false" import="false" targetId="2f28-4a7d-bc90-589b" type="selectionEntry">
@@ -676,7 +676,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="6cf0-49c6-7388-e0cc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="02e0-513b-8a00-470c" name="New CategoryLink" hidden="false" targetId="a24f-12d8-36c1-f477" primary="true"/>
+        <categoryLink id="02e0-513b-8a00-470c" name="Fortification:" hidden="false" targetId="a24f-12d8-36c1-f477" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="0741-744f-034a-1221" name="Macharius Heavy Tank Squadron" hidden="true" collective="false" import="false" targetId="e59c-1b65-8de1-4490" type="selectionEntry">
@@ -696,7 +696,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="bebe-feb0-e8f8-09df" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="0aa1-a534-4cf1-f711" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="0aa1-a534-4cf1-f711" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="b4a3-983c-1a89-e10f" name="Cults Abominatio" hidden="false" collective="false" import="false" targetId="4a00-03d4-a850-884b" type="selectionEntry">
@@ -732,7 +732,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="d4ca-fcf2-ea64-881b" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
+        <categoryLink id="d4ca-fcf2-ea64-881b" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
           <comment>template_id_0af1-d052-4bd7-aab6</comment>
         </categoryLink>
         <categoryLink id="7ccd-b711-124b-f09f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -760,7 +760,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="857f-6317-74f4-6c1a" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
+        <categoryLink id="857f-6317-74f4-6c1a" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
           <comment>template_id_28e0-91e7-4ada-9fac</comment>
         </categoryLink>
         <categoryLink id="4dd3-ea95-7264-346e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -795,7 +795,7 @@
       </constraints>
       <categoryLinks>
         <categoryLink id="e7bd-8dd9-39fd-4e7d" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="3890-ed31-5e7e-4b77" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+        <categoryLink id="3890-ed31-5e7e-4b77" name="Heavy Sub-type:" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
         <categoryLink id="fb94-9780-7cb6-f0d9" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
       </categoryLinks>
       <selectionEntries>
@@ -7411,7 +7411,7 @@ Once assigned to a unit, the Auxilia Medicae is considered part of that unit and
                       </infoLinks>
                       <categoryLinks>
                         <categoryLink id="7cc6-7c1b-0126-7396" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-                        <categoryLink id="e5e1-0a3a-df3f-7aff" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+                        <categoryLink id="e5e1-0a3a-df3f-7aff" name="Heavy Sub-type:" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
                       </categoryLinks>
                       <selectionEntries>
                         <selectionEntry id="8965-b004-fc05-1160" name="Auxilia Gunners" hidden="false" collective="true" import="true" type="model">
@@ -8143,7 +8143,7 @@ Once assigned to a unit, the Auxilia Medicae is considered part of that unit and
     <selectionEntry id="2f8d-70ea-fbb2-53e2" name="Cyclops Demolition Section" hidden="false" collective="false" import="true" type="unit">
       <categoryLinks>
         <categoryLink id="c7a1-846f-70f4-f7dc" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="f39e-e2f9-5ada-4445" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+        <categoryLink id="f39e-e2f9-5ada-4445" name="Heavy Sub-type:" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="7248-052e-1c89-7cbf" name="Cyclops &amp; Operator" hidden="false" collective="false" import="true" type="upgrade">
@@ -9034,7 +9034,7 @@ Once assigned to a unit, the Auxilia Medicae is considered part of that unit and
       </infoLinks>
       <categoryLinks>
         <categoryLink id="f5e3-7554-5a00-ec73" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
-        <categoryLink id="39b0-c99a-a789-d3d0" name="Transport" hidden="false" targetId="7b0a-a743-a8da-3a39" primary="false"/>
+        <categoryLink id="39b0-c99a-a789-d3d0" name="Transport Sub-type:" hidden="false" targetId="7b0a-a743-a8da-3a39" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="ca07-fc4e-1a97-7c8d" name="Show Subterranean Assault rule (it&apos;s really long)" hidden="false" collective="false" import="true" type="upgrade">
@@ -9321,7 +9321,7 @@ If a Weapon Destroyed result is repaired, that weapon may not be used to attack 
                   <categoryLinks>
                     <categoryLink id="4144-f3f8-f494-3176" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
                     <categoryLink id="4d49-6dbc-f300-a436" name="Reinforced Sub-type:" hidden="false" targetId="9b0d-738c-10e4-4ec1" primary="false"/>
-                    <categoryLink id="c181-f890-47ac-0eb6" name="Slow Vehicle" hidden="false" targetId="c4a5-4def-dc2c-7ce2" primary="false"/>
+                    <categoryLink id="c181-f890-47ac-0eb6" name="Slow Sub-type:" hidden="false" targetId="c4a5-4def-dc2c-7ce2" primary="false"/>
                   </categoryLinks>
                   <selectionEntryGroups>
                     <selectionEntryGroup id="1dba-8542-2187-2bc0" name="May take:" hidden="false" collective="false" import="true">
@@ -9422,7 +9422,7 @@ If a Weapon Destroyed result is repaired, that weapon may not be used to attack 
                   <categoryLinks>
                     <categoryLink id="b522-f221-0c27-8d1d" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
                     <categoryLink id="29a7-ec16-c691-3110" name="Reinforced Sub-type:" hidden="false" targetId="9b0d-738c-10e4-4ec1" primary="false"/>
-                    <categoryLink id="a7db-4019-4daa-53ac" name="Slow Vehicle" hidden="false" targetId="c4a5-4def-dc2c-7ce2" primary="false"/>
+                    <categoryLink id="a7db-4019-4daa-53ac" name="Slow Sub-type:" hidden="false" targetId="c4a5-4def-dc2c-7ce2" primary="false"/>
                   </categoryLinks>
                   <selectionEntryGroups>
                     <selectionEntryGroup id="f368-4516-3e29-eb76" name="May take:" hidden="false" collective="false" import="true">
@@ -9553,7 +9553,7 @@ If a Weapon Destroyed result is repaired, that weapon may not be used to attack 
                   <categoryLinks>
                     <categoryLink id="d8e3-76eb-a832-de91" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
                     <categoryLink id="8c1f-3293-8b65-19c8" name="Reinforced Sub-type:" hidden="false" targetId="9b0d-738c-10e4-4ec1" primary="false"/>
-                    <categoryLink id="c87e-3820-c613-7e6f" name="Slow Vehicle" hidden="false" targetId="c4a5-4def-dc2c-7ce2" primary="false"/>
+                    <categoryLink id="c87e-3820-c613-7e6f" name="Slow Sub-type:" hidden="false" targetId="c4a5-4def-dc2c-7ce2" primary="false"/>
                   </categoryLinks>
                   <selectionEntryGroups>
                     <selectionEntryGroup id="1545-5bda-4a1b-892f" name="May take:" hidden="false" collective="false" import="true">
@@ -9620,7 +9620,7 @@ If a Weapon Destroyed result is repaired, that weapon may not be used to attack 
       <categoryLinks>
         <categoryLink id="0d9a-7bc3-a965-032a" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="ac7f-9374-c266-cd0a" name="Reinforced Sub-type:" hidden="false" targetId="9b0d-738c-10e4-4ec1" primary="false"/>
-        <categoryLink id="a3e7-0f6c-dd72-bb1e" name="Slow Vehicle" hidden="false" targetId="c4a5-4def-dc2c-7ce2" primary="false"/>
+        <categoryLink id="a3e7-0f6c-dd72-bb1e" name="Slow Sub-type:" hidden="false" targetId="c4a5-4def-dc2c-7ce2" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="98d0-88df-32dd-7e35" name="Minotaur" hidden="false" collective="false" import="true" type="model">
@@ -9707,7 +9707,7 @@ If a Weapon Destroyed result is repaired, that weapon may not be used to attack 
     <selectionEntry id="e59c-1b65-8de1-4490" name="Macharius Heavy Tank Squadron" hidden="false" collective="false" import="true" type="unit">
       <categoryLinks>
         <categoryLink id="3cf6-cfb2-9cec-19aa" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
-        <categoryLink id="0894-5a2a-e649-9e11" name="Super-heavy" hidden="false" targetId="7381-1130-ca6e-1806" primary="false"/>
+        <categoryLink id="0894-5a2a-e649-9e11" name="Super-heavy Sub-type:" hidden="false" targetId="7381-1130-ca6e-1806" primary="false"/>
         <categoryLink id="ef5d-7e4a-3f44-2c74" name="LoW &amp; Primarchs (25% Limit)" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false"/>
       </categoryLinks>
       <selectionEntries>
@@ -9870,7 +9870,7 @@ If a Weapon Destroyed result is repaired, that weapon may not be used to attack 
       <categoryLinks>
         <categoryLink id="de09-1df4-8669-471a" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="ad54-ca78-7edc-a179" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
-        <categoryLink id="69ce-1545-0115-6b4c" name="Super-heavy" hidden="false" targetId="7381-1130-ca6e-1806" primary="false"/>
+        <categoryLink id="69ce-1545-0115-6b4c" name="Super-heavy Sub-type:" hidden="false" targetId="7381-1130-ca6e-1806" primary="false"/>
         <categoryLink id="d531-f3df-e669-2625" name="LoW &amp; Primarchs (25% Limit)" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
@@ -9979,7 +9979,7 @@ If a Weapon Destroyed result is repaired, that weapon may not be used to attack 
       <categoryLinks>
         <categoryLink id="19d7-d7c4-347e-ab03" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="f144-30f4-a71a-1ae2" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
-        <categoryLink id="6efd-84a8-f464-cf15" name="Super-heavy" hidden="false" targetId="7381-1130-ca6e-1806" primary="false"/>
+        <categoryLink id="6efd-84a8-f464-cf15" name="Super-heavy Sub-type:" hidden="false" targetId="7381-1130-ca6e-1806" primary="false"/>
         <categoryLink id="f0e7-a326-6e7e-379a" name="LoW &amp; Primarchs (25% Limit)" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
@@ -10115,7 +10115,7 @@ If a Weapon Destroyed result is repaired, that weapon may not be used to attack 
       <categoryLinks>
         <categoryLink id="f58f-1579-7361-c081" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="e4ad-1c54-0ec3-d2e9" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
-        <categoryLink id="037c-b14a-bd4d-4165" name="Super-heavy" hidden="false" targetId="7381-1130-ca6e-1806" primary="false"/>
+        <categoryLink id="037c-b14a-bd4d-4165" name="Super-heavy Sub-type:" hidden="false" targetId="7381-1130-ca6e-1806" primary="false"/>
         <categoryLink id="ab12-4d4c-d43a-85ae" name="LoW &amp; Primarchs (25% Limit)" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
@@ -10233,8 +10233,8 @@ If a Weapon Destroyed result is repaired, that weapon may not be used to attack 
       <categoryLinks>
         <categoryLink id="c889-d1a9-8e16-1443" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="aed3-b3e9-451c-a98a" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
-        <categoryLink id="ec0b-0bbd-f8e9-c06a" name="Super-heavy" hidden="false" targetId="7381-1130-ca6e-1806" primary="false"/>
-        <categoryLink id="26c6-dd68-7098-6b24" name="Transport" hidden="false" targetId="7b0a-a743-a8da-3a39" primary="false"/>
+        <categoryLink id="ec0b-0bbd-f8e9-c06a" name="Super-heavy Sub-type:" hidden="false" targetId="7381-1130-ca6e-1806" primary="false"/>
+        <categoryLink id="26c6-dd68-7098-6b24" name="Transport Sub-type:" hidden="false" targetId="7b0a-a743-a8da-3a39" primary="false"/>
         <categoryLink id="a37a-866c-74a7-ff6e" name="LoW &amp; Primarchs (25% Limit)" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
@@ -10343,7 +10343,7 @@ If a Weapon Destroyed result is repaired, that weapon may not be used to attack 
       <categoryLinks>
         <categoryLink id="68fc-594f-9744-6ddc" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="4084-88dc-f96d-60c9" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
-        <categoryLink id="2f9c-4226-7b42-7315" name="Super-heavy" hidden="false" targetId="7381-1130-ca6e-1806" primary="false"/>
+        <categoryLink id="2f9c-4226-7b42-7315" name="Super-heavy Sub-type:" hidden="false" targetId="7381-1130-ca6e-1806" primary="false"/>
         <categoryLink id="73f8-ec6c-d95f-2590" name="LoW &amp; Primarchs (25% Limit)" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
@@ -10460,7 +10460,7 @@ If a Weapon Destroyed result is repaired, that weapon may not be used to attack 
       <categoryLinks>
         <categoryLink id="bc40-3790-05be-92af" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="8b0f-4a5b-5b79-4889" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
-        <categoryLink id="64f9-5968-2846-c2dd" name="Super-heavy" hidden="false" targetId="7381-1130-ca6e-1806" primary="false"/>
+        <categoryLink id="64f9-5968-2846-c2dd" name="Super-heavy Sub-type:" hidden="false" targetId="7381-1130-ca6e-1806" primary="false"/>
         <categoryLink id="430e-9dcd-57a4-c158" name="LoW &amp; Primarchs (25% Limit)" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
@@ -10589,7 +10589,7 @@ If a Weapon Destroyed result is repaired, that weapon may not be used to attack 
       <categoryLinks>
         <categoryLink id="b18b-0269-2997-701b" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
         <categoryLink id="292c-2ba6-1ffe-edf3" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
-        <categoryLink id="68b3-c9fb-8111-8174" name="Super-heavy" hidden="false" targetId="7381-1130-ca6e-1806" primary="false"/>
+        <categoryLink id="68b3-c9fb-8111-8174" name="Super-heavy Sub-type:" hidden="false" targetId="7381-1130-ca6e-1806" primary="false"/>
         <categoryLink id="ee2c-9ed9-6d30-f2f7" name="LoW &amp; Primarchs (25% Limit)" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false"/>
       </categoryLinks>
       <selectionEntries>
@@ -10688,8 +10688,8 @@ If a Weapon Destroyed result is repaired, that weapon may not be used to attack 
     </selectionEntry>
     <selectionEntry id="8cec-2913-77a0-c4e4" name="Crassus Armoured Assault Transport" hidden="false" collective="false" import="true" type="unit">
       <categoryLinks>
-        <categoryLink id="6e85-cf68-151f-a77a" name="Transport" hidden="false" targetId="7b0a-a743-a8da-3a39" primary="false"/>
-        <categoryLink id="97e6-b9cf-c1f9-798c" name="Super-heavy" hidden="false" targetId="7381-1130-ca6e-1806" primary="false"/>
+        <categoryLink id="6e85-cf68-151f-a77a" name="Transport Sub-type:" hidden="false" targetId="7b0a-a743-a8da-3a39" primary="false"/>
+        <categoryLink id="97e6-b9cf-c1f9-798c" name="Super-heavy Sub-type:" hidden="false" targetId="7381-1130-ca6e-1806" primary="false"/>
         <categoryLink id="bd8e-77b3-327b-2d75" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="5d63-23f1-06ba-ecf7" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
         <categoryLink id="3963-6e6a-dbb0-a0f5" name="LoW &amp; Primarchs (25% Limit)" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false"/>
@@ -10786,7 +10786,7 @@ If a Weapon Destroyed result is repaired, that weapon may not be used to attack 
     </selectionEntry>
     <selectionEntry id="2f28-4a7d-bc90-589b" name="Artillery Battery" hidden="false" collective="false" import="true" type="unit">
       <categoryLinks>
-        <categoryLink id="9464-ef7e-aae6-f5bf" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+        <categoryLink id="9464-ef7e-aae6-f5bf" name="Heavy Sub-type:" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
         <categoryLink id="6245-19c4-15bc-896e" name="Static Artillery" hidden="false" targetId="19f3-8727-02db-3ce5" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
@@ -11140,7 +11140,7 @@ Demo charge		- 	10	1	Melee, Armourbane (Melee), Instant Death, Brutal (2)</descr
     </rule>
   </sharedRules>
   <catalogueLinks>
-    <catalogueLink id="e048-9e5e-507c-5bac" name="LI - Assassins" targetId="4c88-1a81-7e53-0a67" type="catalogue" importRootEntries="true"/>
+    <catalogueLink id="e048-9e5e-507c-5bac" name="LI - Assassins and Agents" targetId="4c88-1a81-7e53-0a67" type="catalogue" importRootEntries="true"/>
     <catalogueLink id="60d6-cab6-4580-b772" name="Mech Library" targetId="3129-da35-55e0-642d" type="catalogue" importRootEntries="true"/>
   </catalogueLinks>
 </catalogue>

--- a/2022 - Mech Library.cat
+++ b/2022 - Mech Library.cat
@@ -1257,7 +1257,7 @@ Invulnerable Saves granted by a mag-inverter shield do not stack with other Invu
           </infoLinks>
           <categoryLinks>
             <categoryLink id="75c6-f54e-a02e-e590" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
-            <categoryLink id="e91e-b235-f4d0-bc52" name="Fast Vehicles" hidden="false" targetId="0ea2-efb5-b7af-226e" primary="false"/>
+            <categoryLink id="e91e-b235-f4d0-bc52" name="Fast Sub-type:" hidden="false" targetId="0ea2-efb5-b7af-226e" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="9421-2b5c-e5f4-6029" name="Left Arm Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="d7e1-874e-679e-bb26">
@@ -1266,7 +1266,7 @@ Invulnerable Saves granted by a mag-inverter shield do not stack with other Invu
                 <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4818-85f0-f870-8523" type="max"/>
               </constraints>
               <entryLinks>
-                <entryLink id="3575-1717-6410-e0d6" name="Twin-linked Turbo Laser-Destructor**" hidden="false" collective="false" import="true" targetId="f947-d7f1-40bd-f425" type="selectionEntry"/>
+                <entryLink id="3575-1717-6410-e0d6" name="Twin-linked Turbo Laser-Destructor" hidden="false" collective="false" import="true" targetId="f947-d7f1-40bd-f425" type="selectionEntry"/>
                 <entryLink id="d7e1-874e-679e-bb26" name="Vulcan Mega-Bolter" hidden="false" collective="false" import="true" targetId="b953-83d7-6cc1-5695" type="selectionEntry"/>
                 <entryLink id="b277-877d-220d-a685" name="Plasma Blastgun" hidden="false" collective="false" import="true" targetId="c666-29f6-42da-2e07" type="selectionEntry"/>
                 <entryLink id="bff0-1ef8-6b6f-e6a7" name="Inferno Gun" hidden="false" collective="false" import="true" targetId="aa57-fc73-86fe-217c" type="selectionEntry"/>
@@ -1278,7 +1278,7 @@ Invulnerable Saves granted by a mag-inverter shield do not stack with other Invu
                 <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0a9f-7623-0860-35fc" type="max"/>
               </constraints>
               <entryLinks>
-                <entryLink id="2c2d-1225-7f72-a9e7" name="Twin-linked Turbo Laser-Destructor**" hidden="false" collective="false" import="true" targetId="f947-d7f1-40bd-f425" type="selectionEntry"/>
+                <entryLink id="2c2d-1225-7f72-a9e7" name="Twin-linked Turbo Laser-Destructor" hidden="false" collective="false" import="true" targetId="f947-d7f1-40bd-f425" type="selectionEntry"/>
                 <entryLink id="10b6-946d-d13e-c214" name="Vulcan Mega-Bolter" hidden="false" collective="false" import="true" targetId="b953-83d7-6cc1-5695" type="selectionEntry"/>
                 <entryLink id="bc1f-f183-99db-a90b" name="Plasma Blastgun" hidden="false" collective="false" import="true" targetId="c666-29f6-42da-2e07" type="selectionEntry"/>
                 <entryLink id="7be4-7cd1-2c01-4cb4" name="Inferno Gun" hidden="false" collective="false" import="true" targetId="aa57-fc73-86fe-217c" type="selectionEntry"/>
@@ -4966,7 +4966,7 @@ Invulnerable Saves granted by a mag-inverter shield do not stack with other Invu
       <categoryLinks>
         <categoryLink id="d13c-fa11-113a-6b4b" name="Automata Unit-type:" hidden="false" targetId="d8ab-8e21-e193-63ba" primary="false"/>
         <categoryLink id="ae51-75de-b9f6-61c2" name="Cybernetica Sub-type:" hidden="false" targetId="2440-b64e-cb24-87f0" primary="false"/>
-        <categoryLink id="0f64-8711-75d2-ad9b" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+        <categoryLink id="0f64-8711-75d2-ad9b" name="Heavy Sub-type:" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="c48e-f9ea-9d9d-46aa" name="Thanatar" publicationId="bde1-6db1-163b-3b76" page="46" hidden="false" collective="false" import="true" type="model">

--- a/2022 - Mechanicum.cat
+++ b/2022 - Mechanicum.cat
@@ -18,48 +18,48 @@
         <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c3e3-faec-34a7-3b4c" type="min"/>
       </constraints>
       <categoryLinks>
-        <categoryLink id="e8be-9a28-67c2-ab93" name="New CategoryLink" hidden="false" targetId="e90d-e5a8-f42d-da84" primary="true"/>
+        <categoryLink id="e8be-9a28-67c2-ab93" name="Allegiance:" hidden="false" targetId="e90d-e5a8-f42d-da84" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="12ef-d6e7-3e43-41f7" name="Archmagos Prime" hidden="false" collective="false" import="false" targetId="d0f2-ee39-450c-39db" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="b654-9601-210e-2023" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="ed2f-e502-9c88-ef9e" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="ed2f-e502-9c88-ef9e" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="943e-3900-7eb5-e5ab" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="c24f-27c9-1759-4427" name="Archmagos Prime on Abeyant" hidden="false" collective="false" import="false" targetId="3821-7503-6139-3054" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="7fc8-bff9-1ce8-4ab5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="fec0-6e63-9264-bfd2" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="fec0-6e63-9264-bfd2" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="4592-5ca2-9c47-09ba" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="850d-b62e-8f76-b1be" name="Magos Dominus" hidden="false" collective="false" import="false" targetId="2dcd-d6c5-9f57-0084" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="5b02-7a0e-57ce-4c30" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="3984-61d8-2f84-c437" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="3984-61d8-2f84-c437" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="ce21-60e8-7612-3909" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="2f3b-dd15-7f5e-9cf7" name="Magos Dominus on Abeyant" hidden="false" collective="false" import="false" targetId="ed8b-48de-1e04-fa9d" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="071e-1aff-6f80-5a67" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="44e7-ba3a-da35-d5fc" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="44e7-ba3a-da35-d5fc" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="ae9b-7528-7813-39d2" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="140c-306c-d09d-265f" name="Calleb Decima Invictus" hidden="true" collective="false" import="false" targetId="a204-6b74-3aeb-0231" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="58b5-6803-6799-0aa9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="3d6b-6612-cc33-5f72" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="3d6b-6612-cc33-5f72" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="ae5d-99ed-bca3-5c51" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="eb03-59c6-97aa-8f6b" name="Tech-Priest Auxilia" hidden="false" collective="false" import="false" targetId="0eae-0c52-1087-a3b0" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="0e6d-0458-4a4d-ca4d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="5ba2-c0ac-fb56-e190" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="5ba2-c0ac-fb56-e190" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="d629-dd69-e689-c38a" name="Arcuitor Magisterium" hidden="false" collective="false" import="false" targetId="6f33-657c-a1b4-710e" type="selectionEntry">
@@ -72,45 +72,45 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="4833-3ad9-f086-2980" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="0c0f-9a1e-4050-56d4" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="0c0f-9a1e-4050-56d4" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="4f46-e279-a2c2-df18" name="Myrmidon Secutor Host" hidden="false" collective="false" import="false" targetId="1869-2d16-d825-04c3" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="8567-d030-d756-4c6a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="e0af-3ec1-6313-926e" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="e0af-3ec1-6313-926e" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="c06a-da74-71b7-fee1" name="Adsecularis Tech-thralls Covenant" hidden="false" collective="false" import="false" targetId="bc2c-076a-209b-f121" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="b03f-214f-f4e8-8de8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="e761-63e9-40c4-57ff" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="e761-63e9-40c4-57ff" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="9bef-dc92-297a-da86" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="123c-8d49-5eb2-8e19" name="Thallax Cohort" hidden="false" collective="false" import="false" targetId="25c8-3e0f-e22d-a7eb" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="670f-cf2a-d36d-be6e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="eb58-ed23-c958-3d96" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="eb58-ed23-c958-3d96" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="02de-e1ca-567c-d897" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="88d1-a0a6-3637-5bf8" name="Scyllax Guardian-Automata Maniple" hidden="false" collective="false" import="false" targetId="57ab-2409-6707-b967" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="6658-9df3-d4ac-70d7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="f1b8-f9a4-e1fb-c21f" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="f1b8-f9a4-e1fb-c21f" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="de1b-2a5f-b271-fd61" name="Arlatax Battle-Automata Maniple" hidden="false" collective="false" import="false" targetId="b178-7d35-136f-d305" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="b0c1-fb4e-652e-7630" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="fa0b-cfcd-a68a-1c73" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="fa0b-cfcd-a68a-1c73" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="a722-3efe-7ccb-6242" name="Ursarax Cohort" hidden="false" collective="false" import="false" targetId="0750-2aed-2d36-8a82" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="d453-d437-1236-00c0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="9ca5-73ce-baf3-ecf1" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="9ca5-73ce-baf3-ecf1" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="b790-b6dc-b904-118c" name="Vultarax Stratos-Automata Squadron" hidden="false" collective="false" import="false" targetId="0e08-6b7e-8fff-1f02" type="selectionEntry">
@@ -123,13 +123,13 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="76a8-0091-e9f9-e5e2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="ef35-36e0-2fc3-f8c7" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="ef35-36e0-2fc3-f8c7" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="6558-9557-4654-31fc" name="Myrmidon Destructor Host" hidden="false" collective="false" import="false" targetId="356f-a88b-1d13-3700" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="23e1-8fa1-49c1-1d77" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="66c0-0a59-046b-249b" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="66c0-0a59-046b-249b" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="4467-970e-236e-6118" name="Karacnos Assault Tank" hidden="false" collective="false" import="false" targetId="8920-3184-2455-1834" type="selectionEntry">
@@ -142,7 +142,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="3691-ade8-41f9-ecf2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="1e5d-4224-528c-7cba" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="1e5d-4224-528c-7cba" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="30bc-6d27-6a7b-5d02" name="Krios Squadron" hidden="false" collective="false" import="false" targetId="ce87-68e2-0134-3c84" type="selectionEntry">
@@ -155,7 +155,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="90f5-b210-0447-2356" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="4b9e-daec-dd50-1582" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="4b9e-daec-dd50-1582" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="4351-1507-2a58-b11d" name="Knight Moirax Talon" hidden="false" collective="false" import="false" targetId="c21c-3c14-2d2e-4bc0" type="selectionEntry">
@@ -168,7 +168,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="ca25-1bf8-642c-6aa4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="ff46-2a7c-d938-8c35" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="ff46-2a7c-d938-8c35" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="9ca0-8d1b-faa7-e89d" name="Mechanicum Knight Magaera" hidden="false" collective="false" import="false" targetId="b582-e53e-5e13-286c" type="selectionEntry">
@@ -181,7 +181,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="6411-f60a-4ee6-fa8a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="76b5-a3b8-07c7-eb28" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="76b5-a3b8-07c7-eb28" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
         <categoryLink targetId="2eaf-32d6-9d1d-d906" id="4ed9-cc03-f7be-875d" primary="false" name="LoW &amp; Primarchs (25% Limit)"/>
       </categoryLinks>
     </entryLink>
@@ -195,7 +195,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="9984-1655-436c-e75c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="d445-8c66-903b-de69" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="d445-8c66-903b-de69" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
         <categoryLink targetId="2eaf-32d6-9d1d-d906" id="1255-c6c-6588-fd3d" primary="false" name="LoW &amp; Primarchs (25% Limit)"/>
       </categoryLinks>
     </entryLink>
@@ -209,7 +209,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="5572-322f-3fd4-df9c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="d947-9ad4-b373-47f7" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="d947-9ad4-b373-47f7" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
         <categoryLink targetId="2eaf-32d6-9d1d-d906" id="5f98-86c6-7d9f-edd2" primary="false" name="LoW &amp; Primarchs (25% Limit)"/>
       </categoryLinks>
     </entryLink>
@@ -223,7 +223,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="ef49-9452-4d80-69a3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="58ac-b3ec-8a9d-0f89" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="58ac-b3ec-8a9d-0f89" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
         <categoryLink targetId="2eaf-32d6-9d1d-d906" id="8591-dd4-c72e-c21c" primary="false" name="LoW &amp; Primarchs (25% Limit)"/>
       </categoryLinks>
     </entryLink>
@@ -237,7 +237,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="5a23-8aaf-d1cc-9a2c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="8f5e-22b8-50e7-1004" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="8f5e-22b8-50e7-1004" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="ac39-4b53-e47f-d54c" name="Ordinatus Aktaeus" hidden="false" collective="false" import="false" targetId="89a5-fa4d-0e01-3a55" type="selectionEntry">
@@ -250,13 +250,13 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="8eee-4e6f-0d30-cbd6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="3331-9a71-e131-6128" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="3331-9a71-e131-6128" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="6a07-9580-9c41-dbc6" name="Archmagos Anacharis Scoria" hidden="true" collective="false" import="false" targetId="2185-5fd1-2e59-b467" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="1bfa-3de2-bf04-16db" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="d3aa-2699-4210-25dd" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="d3aa-2699-4210-25dd" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="2583-0dcb-f271-6960" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -270,7 +270,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="9d6b-f8e9-44a9-9974" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="b283-74d2-92e1-5d80" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="b283-74d2-92e1-5d80" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="3c04-f537-6cf1-65bc" name="Castellax Battle-Automata Maniple" hidden="false" collective="false" import="false" targetId="537f-846d-90e3-2526" type="selectionEntry">
@@ -283,26 +283,26 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="b52a-0f4e-b317-2bcd" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="12ad-c3f3-cdb7-1735" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="12ad-c3f3-cdb7-1735" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="63cb-4eca-61e7-11af" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="2394-56b3-7592-01ae" name="Domitar Battle-Automata Maniple" hidden="false" collective="false" import="false" targetId="1a1b-fa35-a6a2-ca78" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="ca4b-e16a-f7d8-fc3d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="ed71-00ef-b55e-2e50" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="ed71-00ef-b55e-2e50" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="8010-9dfe-c8dc-3561" name="Vorax Battle-automata Maniple" hidden="false" collective="false" import="false" targetId="f144-1079-11ff-019d" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="5e13-e19b-50c8-72ad" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="099a-66ab-81aa-4ac7" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="099a-66ab-81aa-4ac7" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="cb9d-dcbd-a336-3687" name="Archmagos Draykavac" hidden="false" collective="false" import="false" targetId="8b4c-01f4-f39f-7c55" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="e5b1-a8f4-deff-e3fc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="f7a4-e7ef-9bc9-80b2" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="f7a4-e7ef-9bc9-80b2" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="22c6-2c40-c433-b524" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -316,7 +316,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="22e8-b76e-e559-5ac5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="093d-3993-8774-9f21" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="093d-3993-8774-9f21" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="2e88-4d17-543b-453e" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -335,7 +335,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="ac20-54eb-277f-85ca" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="a52f-f980-0f7d-36c3" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="a52f-f980-0f7d-36c3" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
         <categoryLink id="cd51-74f1-04ca-2248" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -354,7 +354,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="19e9-28c4-f881-a0b3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="db76-cda6-0690-9f5c" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="db76-cda6-0690-9f5c" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="3ca2-40e2-1b7e-b0b3" name="Myrmidon Secutor Host" hidden="true" collective="false" import="false" targetId="1869-2d16-d825-04c3" type="selectionEntry">
@@ -367,7 +367,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="e4bc-e382-e2f4-1151" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="6609-996b-bd48-3075" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="6609-996b-bd48-3075" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
         <categoryLink id="44d3-3b8a-f672-7fb4" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -381,7 +381,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="9a3c-7e17-b013-675c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="7c96-b532-93cb-02c2" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="7c96-b532-93cb-02c2" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="46b7-2b32-94fe-5552" name="Adsecularis Tech-thralls Certus Covenant" hidden="true" collective="false" import="false" targetId="4436-7062-9be3-b233" type="selectionEntry">
@@ -458,7 +458,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="af46-73e9-95b5-ecb9" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="af46-73e9-95b5-ecb9" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
         <categoryLink id="5e30-0ad2-6f7f-6943" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -477,7 +477,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="1f73-6e2d-c3f3-f53c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="e795-e3e7-17d4-cfc3" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="e795-e3e7-17d4-cfc3" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="f092-9b7c-0ece-5f1a" name="Ordo Reductor Artillery Tank Battery" hidden="true" collective="false" import="false" targetId="6353-c4c3-d099-002e" type="selectionEntry">
@@ -495,7 +495,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="5b9e-14a0-d63d-ee8a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="2363-773b-54f6-4940" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="2363-773b-54f6-4940" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="75ab-47e9-3e7d-1fcb" name="Macrocarid Explorator" hidden="true" collective="false" import="false" targetId="bd83-b47d-1f37-1159" type="selectionEntry">
@@ -508,7 +508,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="6b3d-b497-866a-d8a0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="a12c-791f-fbf5-c999" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="a12c-791f-fbf5-c999" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="fc21-65ad-c05e-4fc9" name="Clade Assassins (Loyalist)" hidden="false" collective="false" import="false" targetId="7363-5a05-4102-24fa" type="selectionEntry">
@@ -554,7 +554,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="e561-cf41-30ee-0f9b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="f4eb-e438-533b-8318" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="f4eb-e438-533b-8318" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="2bbf-2986-1550-477f" name="Expeditionary Navigator" hidden="true" collective="false" import="false" targetId="ce53-e40c-65b6-4d3a" type="selectionEntry">
@@ -569,7 +569,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="804f-203f-b407-1c32" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="adcb-ff5b-4cd1-1ae5" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="adcb-ff5b-4cd1-1ae5" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink import="true" name="Kytan Daemon Engine" hidden="false" type="selectionEntry" id="c814-2c52-5523-5e46" targetId="b7cd-670-7027-fee8">
@@ -606,7 +606,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="655a-6d13-81f5-9625" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
+        <categoryLink id="655a-6d13-81f5-9625" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
           <comment>template_id_0af1-d052-4bd7-aab6</comment>
         </categoryLink>
         <categoryLink id="468a-6bce-e601-d96e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -634,7 +634,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="888e-5134-3f39-af46" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
+        <categoryLink id="888e-5134-3f39-af46" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
           <comment>template_id_28e0-91e7-4ada-9fac</comment>
         </categoryLink>
         <categoryLink id="88a9-9ec3-6926-cda0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -1253,7 +1253,7 @@
       <categoryLinks>
         <categoryLink id="4312-d152-9e2a-c653" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
         <categoryLink id="176d-fff6-f157-330a" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="a16c-e7f6-08fc-a357" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+        <categoryLink id="a16c-e7f6-08fc-a357" name="Heavy Sub-type:" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="0cae-ba4f-f97c-5f0f" name="May take any of the following options:" hidden="false" collective="false" import="true">
@@ -1485,7 +1485,7 @@
         <categoryLink id="7d92-0210-bdb9-cd3a" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
         <categoryLink id="8595-f4c5-ba1d-69b5" name="Monstrous Sub-type:" hidden="false" targetId="7d95-f9d1-440a-67bd" primary="false"/>
         <categoryLink id="f75f-bd69-3fb1-c37d" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="ad3f-ad1c-6a50-2d8c" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+        <categoryLink id="ad3f-ad1c-6a50-2d8c" name="Heavy Sub-type:" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="14fc-6747-0f45-1075" name="May take one of the following options:" hidden="false" collective="false" import="true">
@@ -1790,8 +1790,8 @@
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a3bd-333f-c92b-7cca" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="aaf4-a361-cb00-532c" name="Tech-Priest Auxilia (Placeholder)" hidden="false" collective="false" import="true" targetId="0eae-0c52-1087-a3b0" type="selectionEntry"/>
-            <entryLink id="28da-44a5-3785-0b1d" name="Scyllax Guardian-Automata Maniple (Placeholder)" hidden="false" collective="false" import="true" targetId="57ab-2409-6707-b967" type="selectionEntry"/>
+            <entryLink id="aaf4-a361-cb00-532c" name="Tech-Priest Auxilia" hidden="false" collective="false" import="true" targetId="0eae-0c52-1087-a3b0" type="selectionEntry"/>
+            <entryLink id="28da-44a5-3785-0b1d" name="Scyllax Guardian-Automata Maniple" hidden="false" collective="false" import="true" targetId="57ab-2409-6707-b967" type="selectionEntry"/>
           </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
@@ -2612,7 +2612,7 @@ This unit may be upgraded freely as described in their profile, though they may 
             </rule>
           </rules>
           <entryLinks>
-            <entryLink id="0c1f-26cb-e920-f719" name="12 Arlatax Battle-Automata Maniple" hidden="false" collective="false" import="true" targetId="b178-7d35-136f-d305" type="selectionEntry">
+            <entryLink id="0c1f-26cb-e920-f719" name="Arlatax Battle-Automata Maniple" hidden="false" collective="false" import="true" targetId="b178-7d35-136f-d305" type="selectionEntry">
               <constraints>
                 <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="99aa-c61f-ba38-3678" type="max"/>
               </constraints>
@@ -2632,7 +2632,7 @@ This unit may be upgraded freely as described in their profile, though they may 
     <selectionEntry id="1869-2d16-d825-04c3" name="Myrmidon Secutor Host" publicationId="bde1-6db1-163b-3b76" page="32" hidden="false" collective="false" import="true" type="unit">
       <categoryLinks>
         <categoryLink id="524b-df9c-a50f-7103" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="f7bb-798d-a14e-4915" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+        <categoryLink id="f7bb-798d-a14e-4915" name="Heavy Sub-type:" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="33d3-7ec5-ef32-38ca" name="Myrmidon Secutors" publicationId="bde1-6db1-163b-3b76" page="32" hidden="false" collective="false" import="true" type="model">
@@ -2834,7 +2834,7 @@ This unit may be upgraded freely as described in their profile, though they may 
     </selectionEntry>
     <selectionEntry id="bc2c-076a-209b-f121" name="Adsecularis Tech-thralls Covenant" publicationId="bde1-6db1-163b-3b76" page="34" hidden="false" collective="false" import="true" type="unit">
       <categoryLinks>
-        <categoryLink id="8ee7-e36b-9a79-6998" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+        <categoryLink id="8ee7-e36b-9a79-6998" name="Heavy Sub-type:" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
         <categoryLink id="2d6d-c8c5-9da8-958a" name="Line Sub-type:" hidden="false" targetId="6399-5c65-7833-1025" primary="false"/>
         <categoryLink id="09f4-c088-2ec8-fac3" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
       </categoryLinks>
@@ -2929,7 +2929,7 @@ This unit may be upgraded freely as described in their profile, though they may 
     </selectionEntry>
     <selectionEntry id="57ab-2409-6707-b967" name="Scyllax Guardian-Automata Maniple" publicationId="bde1-6db1-163b-3b76" page="36" hidden="false" collective="false" import="true" type="unit">
       <categoryLinks>
-        <categoryLink id="07b9-a447-feb6-8bfe" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+        <categoryLink id="07b9-a447-feb6-8bfe" name="Heavy Sub-type:" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
         <categoryLink id="807c-edb4-9721-da11" name="Line Sub-type:" hidden="false" targetId="6399-5c65-7833-1025" primary="false"/>
         <categoryLink id="e3b7-cbc5-ca8e-80e2" name="Automata Unit-type:" hidden="false" targetId="d8ab-8e21-e193-63ba" primary="false"/>
       </categoryLinks>
@@ -3601,7 +3601,7 @@ This unit may be upgraded freely as described in their profile, though they may 
     <selectionEntry id="356f-a88b-1d13-3700" name="Myrmidon Destructor Host" publicationId="bde1-6db1-163b-3b76" page="47" hidden="false" collective="false" import="true" type="unit">
       <categoryLinks>
         <categoryLink id="dd54-d5d1-0a67-2cc1" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="300d-bc70-c03a-6048" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+        <categoryLink id="300d-bc70-c03a-6048" name="Heavy Sub-type:" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="ef1e-ad56-2550-340f" name="Destructor Lord" publicationId="bde1-6db1-163b-3b76" page="47" hidden="false" collective="false" import="true" type="model">
@@ -3873,7 +3873,7 @@ This unit may be upgraded freely as described in their profile, though they may 
     </selectionEntry>
     <selectionEntry id="ce87-68e2-0134-3c84" name="Krios Squadron" publicationId="bde1-6db1-163b-3b76" page="49" hidden="false" collective="false" import="true" type="unit">
       <categoryLinks>
-        <categoryLink id="c4aa-2ea1-7395-2961" name="Fast Vehicles" hidden="false" targetId="0ea2-efb5-b7af-226e" primary="false"/>
+        <categoryLink id="c4aa-2ea1-7395-2961" name="Fast Sub-type:" hidden="false" targetId="0ea2-efb5-b7af-226e" primary="false"/>
         <categoryLink id="a179-577f-cd12-e576" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
       </categoryLinks>
       <selectionEntries>
@@ -4252,7 +4252,7 @@ At the beginning of each of the controlling player’s Shooting phases for the r
         <categoryLink id="35ea-4280-934d-b8e0" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
         <categoryLink id="b65c-4e4f-9056-3390" name="Monstrous Sub-type:" hidden="false" targetId="7d95-f9d1-440a-67bd" primary="false"/>
         <categoryLink id="1048-d3fc-35af-c693" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="75ce-3f3b-dc4a-ecad" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+        <categoryLink id="75ce-3f3b-dc4a-ecad" name="Heavy Sub-type:" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
         <categoryLink id="d4ac-5be1-aa59-90ad" name="Feudal Hierarchy (On Abeyant)" hidden="false" targetId="4c2b-03e9-abb7-7209" primary="false"/>
       </categoryLinks>
       <selectionEntries>
@@ -4898,7 +4898,7 @@ removed as a casualty.�</characteristic>
     </selectionEntry>
     <selectionEntry id="4436-7062-9be3-b233" name="Adsecularis Tech-thralls Certus Covenant" publicationId="3886-76e5-438f-159f" page="3" hidden="false" collective="false" import="true" type="unit">
       <categoryLinks>
-        <categoryLink id="4189-3144-1000-df23" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+        <categoryLink id="4189-3144-1000-df23" name="Heavy Sub-type:" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
         <categoryLink id="f4be-0d9a-9547-9567" name="Line Sub-type:" hidden="false" targetId="6399-5c65-7833-1025" primary="false"/>
         <categoryLink id="77ac-25a2-4098-2aaa" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
       </categoryLinks>
@@ -6670,7 +6670,7 @@ Additionally, each time Inar Satarael makes a successful Invulnable Save on a ro
   </sharedSelectionEntries>
   <catalogueLinks>
     <catalogueLink id="5f24-4626-71c3-0547" name="Mech Library" targetId="3129-da35-55e0-642d" type="catalogue" importRootEntries="true"/>
-    <catalogueLink id="e048-9e5e-507c-5bae" name="LI - Assassins" targetId="4c88-1a81-7e53-0a67" type="catalogue" importRootEntries="true"/>
+    <catalogueLink id="e048-9e5e-507c-5bae" name="LI - Assassins and Agents" targetId="4c88-1a81-7e53-0a67" type="catalogue" importRootEntries="true"/>
     <catalogueLink id="e123-456e-507c-5trc" name="Daemons - Bound Daemons" targetId="e545-295b-4cd9-f235" type="catalogue" importRootEntries="true"/>
   </catalogueLinks>
 </catalogue>

--- a/2022 - Questoris Household.cat
+++ b/2022 - Questoris Household.cat
@@ -48,13 +48,13 @@
         <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7a16-b1cb-730d-f4b6" type="min"/>
       </constraints>
       <categoryLinks>
-        <categoryLink id="af54-5227-93ca-a151" name="New CategoryLink" hidden="false" targetId="e90d-e5a8-f42d-da84" primary="true"/>
+        <categoryLink id="af54-5227-93ca-a151" name="Allegiance:" hidden="false" targetId="e90d-e5a8-f42d-da84" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="c64c-453a-329d-1662" name="Armiger Helverin Talon" hidden="false" collective="false" import="false" targetId="bd5d-61fa-d2f6-45a2" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="8834-b5ff-be64-696d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="c8a9-bc4a-19a5-7e60" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="c8a9-bc4a-19a5-7e60" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="d584-89d3-0ba5-7faa" name="Knight Questoris" hidden="false" collective="false" import="true" targetId="3706-a84c-678d-b1c6" type="selectionEntry">
@@ -76,7 +76,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="365e-b0a4-87b6-2f2a" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="365e-b0a4-87b6-2f2a" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
         <categoryLink id="e579-64c8-62ad-2e6f" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="94aa-a472-6134-9a69" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
@@ -84,7 +84,7 @@
     <entryLink id="cbd4-46bc-a375-5189" name="Armiger Warglaive Talon" hidden="false" collective="false" import="false" targetId="df92-71d6-bf1a-d62e" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="e55e-460f-c3d7-687c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="4af9-72f5-e618-a95f" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="4af9-72f5-e618-a95f" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="09eb-0791-7539-e3fe" name="Knight Lancer" hidden="false" collective="false" import="true" targetId="8312-7457-e7b6-fd9f" type="selectionEntry">
@@ -106,7 +106,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="3e12-5f5e-ac9c-4354" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="3e12-5f5e-ac9c-4354" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
         <categoryLink id="79bf-3d91-67d1-33fb" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="c291-9ee4-666e-9d10" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
@@ -130,7 +130,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="b47e-a501-6a7c-4580" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="b47e-a501-6a7c-4580" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
         <categoryLink id="83cc-eb2d-633f-e999" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="4788-cf09-0e2b-c067" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
@@ -154,7 +154,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="3d5a-ce72-e96a-7b84" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="3d5a-ce72-e96a-7b84" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
         <categoryLink id="7bef-0998-45bf-ea1c" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="33d6-a111-c3df-a379" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
@@ -178,7 +178,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="2e28-e276-031d-c76e" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="2e28-e276-031d-c76e" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
         <categoryLink id="9ada-aa9b-2414-57c2" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="5f2e-d459-05ef-47cd" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
@@ -202,7 +202,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="d0e2-884a-8ff6-1276" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="d0e2-884a-8ff6-1276" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
         <categoryLink id="039b-e62e-649e-c494" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="81cf-e91f-c836-3d51" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
@@ -226,7 +226,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="f6c1-febb-5445-a61e" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="f6c1-febb-5445-a61e" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
         <categoryLink id="aaf6-7f9a-dc73-4735" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="0c31-ab40-c943-dce6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
@@ -250,7 +250,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="081a-4cc1-02c0-4470" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="081a-4cc1-02c0-4470" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
         <categoryLink id="f903-585f-a0ec-9d17" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="8a49-22f7-ef48-8294" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
@@ -274,7 +274,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="fe46-14a5-092c-1063" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="fe46-14a5-092c-1063" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
         <categoryLink id="6233-a9df-929f-7b0c" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="9f63-749f-01c1-f860" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
@@ -289,7 +289,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="4a67-a200-71c0-1ed7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="a47d-d432-118d-bd75" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="a47d-d432-118d-bd75" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="cbc2-40d7-1ad8-6430" name="Vorax Battle-automata Maniple" hidden="true" collective="false" import="false" targetId="f144-1079-11ff-019d" type="selectionEntry">
@@ -302,13 +302,13 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="dff8-4608-5fa0-9dbd" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="4264-d41e-828b-e3e0" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="4264-d41e-828b-e3e0" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="a855-6cea-2eb6-3f9f" name="Archmagos Draykavac" hidden="false" collective="false" import="false" targetId="8b4c-01f4-f39f-7c55" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="bea2-c10e-0d10-7b82" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="5eea-7318-5183-f1e4" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="5eea-7318-5183-f1e4" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="e283-4fdf-28be-5c4c" name="Cults Abominatio" hidden="false" collective="false" import="true" targetId="4a00-03d4-a850-884b" type="selectionEntry">
@@ -328,6 +328,6 @@
   <catalogueLinks>
     <catalogueLink id="f98f-e172-8ed2-4bef" name="Mech Library" targetId="3129-da35-55e0-642d" type="catalogue" importRootEntries="true"/>
     <catalogueLink id="e123-456e-507c-5trb" name="Daemons - Bound Daemons" targetId="e545-295b-4cd9-f235" type="catalogue" importRootEntries="true"/>
-    <catalogueLink id="d37a-a16f-fc51-2b60" name="LI - Assassins" targetId="4c88-1a81-7e53-0a67" type="catalogue" importRootEntries="true"/>
+    <catalogueLink id="d37a-a16f-fc51-2b60" name="LI - Assassins and Agents" targetId="4c88-1a81-7e53-0a67" type="catalogue" importRootEntries="true"/>
   </catalogueLinks>
 </catalogue>

--- a/2022 - Titan Legions.cat
+++ b/2022 - Titan Legions.cat
@@ -51,33 +51,33 @@
         <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9b71-5246-c019-3c96" type="min"/>
       </constraints>
       <categoryLinks>
-        <categoryLink id="277b-dd85-3a29-3e6d" name="New CategoryLink" hidden="false" targetId="e90d-e5a8-f42d-da84" primary="true"/>
+        <categoryLink id="277b-dd85-3a29-3e6d" name="Allegiance:" hidden="false" targetId="e90d-e5a8-f42d-da84" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="0283-c466-47b4-de8f" name="Warlord Battle Titan" hidden="false" collective="false" import="true" targetId="d737-baca-32e7-8da6" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="53aa-f28d-38ab-c2fc" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="53aa-f28d-38ab-c2fc" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
         <categoryLink id="5e25-d5c2-8f6e-1e86" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="bdf3-6ff5-236a-cdba" name="LoW &amp; Primarchs (25% Limit)" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="d6ad-baec-87f6-e839" name="Warbringer Nemesis Titan" hidden="false" collective="false" import="true" targetId="3dd1-77d8-4289-b745" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="fcdb-3e8d-a4f7-7665" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="fcdb-3e8d-a4f7-7665" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
         <categoryLink id="203a-2c3d-872b-9cc1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="7460-3671-ebc8-97ff" name="LoW &amp; Primarchs (25% Limit)" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="61a7-4c8e-1ef8-84cc" name="Warhound Scout Titan" hidden="false" collective="false" import="true" targetId="841c-c2f5-9817-3061" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="eef0-bad3-f27a-6a02" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="eef0-bad3-f27a-6a02" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
         <categoryLink id="acf1-ae9e-a4c0-91af" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="179a-b78e-4846-e731" name="LoW &amp; Primarchs (25% Limit)" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="c8ee-7d52-39c1-17d4" name="Reaver Battle Titan" hidden="false" collective="false" import="true" targetId="2dbc-7655-bb05-ab89" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="e182-a612-dbd0-e0be" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="e182-a612-dbd0-e0be" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
         <categoryLink id="49e9-613a-ed0b-5efb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="c1c8-11dd-c376-f3f7" name="LoW &amp; Primarchs (25% Limit)" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false"/>
       </categoryLinks>
@@ -85,19 +85,19 @@
     <entryLink id="fc74-4887-4a56-b156" name="Secutarii Axiarch" hidden="false" collective="false" import="false" targetId="b08e-55fe-3e1d-913b" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="1bbb-eefa-3c7a-a644" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="38b9-d50b-cb5c-3f9d" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="38b9-d50b-cb5c-3f9d" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="08fe-a1c3-8026-bb5b" name="Secutarii Hoplite Phalanx" hidden="false" collective="false" import="false" targetId="f4cc-a854-5467-45cf" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="6a27-5000-b509-a7d7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="032c-b742-5238-a7dc" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="032c-b742-5238-a7dc" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="d42f-542d-2cba-8d45" name="Secutarii Peltast Phalanx" hidden="false" collective="false" import="false" targetId="4fc3-7259-f9b0-71cd" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="8940-f885-bcc9-b74f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="a270-c7de-cbbf-fd44" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="a270-c7de-cbbf-fd44" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="3db2-0def-e7f6-b22e" name="Clade Assassins (Loyalist)" hidden="false" collective="false" import="false" targetId="7363-5a05-4102-24fa" type="selectionEntry">
@@ -143,7 +143,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="f773-c1b7-d92f-0c22" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="8230-707a-b399-d1c3" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="8230-707a-b399-d1c3" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="da7c-b91d-9e0c-adfb" name="Expeditionary Navigator" hidden="true" collective="false" import="false" targetId="ce53-e40c-65b6-4d3a" type="selectionEntry">
@@ -158,7 +158,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="bea0-83fa-a50c-e349" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="b034-ded5-0558-06d1" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="b034-ded5-0558-06d1" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="1524-b7f8-2291-86ef" name="Nathaniel Garro" hidden="true" collective="false" import="false" targetId="0583-258d-f0a0-2170" type="selectionEntry">
@@ -181,7 +181,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="a7e1-ad77-9bef-d189" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
+        <categoryLink id="a7e1-ad77-9bef-d189" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
           <comment>template_id_0af1-d052-4bd7-aab6</comment>
         </categoryLink>
         <categoryLink id="1455-775a-a656-2cac" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -209,7 +209,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="d61e-c1f9-cd5-2031" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
+        <categoryLink id="d61e-c1f9-cd5-2031" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true">
           <comment>template_id_28e0-91e7-4ada-9fac</comment>
         </categoryLink>
         <categoryLink id="110-529c-82fe-b9d4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false">
@@ -887,6 +887,6 @@
   </sharedSelectionEntries>
   <catalogueLinks>
     <catalogueLink id="de74-d2a5-d0be-55c8" name="Mech Library" targetId="3129-da35-55e0-642d" type="catalogue" importRootEntries="true"/>
-    <catalogueLink id="e048-9e5e-507c-5baf" name="LI - Assassins" targetId="4c88-1a81-7e53-0a67" type="catalogue" importRootEntries="true"/>
+    <catalogueLink id="e048-9e5e-507c-5baf" name="LI - Assassins and Agents" targetId="4c88-1a81-7e53-0a67" type="catalogue" importRootEntries="true"/>
   </catalogueLinks>
 </catalogue>


### PR DESCRIPTION
There are two changes here. 
1. I removed (HHV2) from the start of the System name and Catalogue name for LA.
2. I updated all links in the system to have the same name on the link as the link's target.
This mostly affects categorylinks, where the editor (nr? bs? unsure?) hasn't appeared to properly update names.
It also removes the numbering from the root entry links in Daemons of the ruinstorm, but this didn't appear to matter.