### PR TITLE
Changed Sun Killers status from Legacy to Exemplary in Alpha Legion Rewards of Treachery

### DIFF
--- a/2022 - LA - Alpha Legion.cat
+++ b/2022 - LA - Alpha Legion.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="9c06-1c61-d01d-8445" name="LA - XX: Alpha Legion" revision="48" battleScribeVersion="2.03" authorName="Alphalas" authorContact="BSData Developers Discord" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="70" type="catalogue">
+<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="9c06-1c61-d01d-8445" name="LA - XX: Alpha Legion" revision="49" battleScribeVersion="2.03" authorName="Alphalas" authorContact="BSData Developers Discord" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="70" type="catalogue">
   <categoryEntries>
     <categoryEntry id="2275-5253-2421-7383" name="Rewards of Trechery" hidden="false">
       <modifiers>
@@ -420,7 +420,7 @@
             <conditionGroup type="and">
               <conditions>
                 <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dfd9-5b77-cd3b-c998" type="greaterThan"/>
-                <condition field="selections" scope="roster" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8d56-d960-0687-7fee" type="greaterThan"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
@@ -7436,7 +7436,7 @@ A weapon with this special rule may not be used to make Shooting Attacks as part
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="dfd9-5b77-cd3b-c998" name="Sun Killer Squad (Legacy)" hidden="false" collective="false" import="true" type="upgrade">
+        <selectionEntry id="dfd9-5b77-cd3b-c998" name="Sun Killer Squad (Exemplary)" hidden="false" collective="false" import="true" type="upgrade">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>

--- a/2022 - LA - Emperor's Children.cat
+++ b/2022 - LA - Emperor's Children.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="72ba-61c2-37ad-c785" name="LA -   III: Emperor&apos;s Children" revision="36" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="67" type="catalogue">
+<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="72ba-61c2-37ad-c785" name="LA -   III: Emperor&apos;s Children" revision="37" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="67" type="catalogue">
   <entryLinks>
     <entryLink id="a119-3943-4b8b-b651" name="Captain Lucius" hidden="true" collective="false" import="false" targetId="0707-1e4b-27da-9cd4" type="selectionEntry">
       <modifiers>
@@ -129,7 +129,7 @@
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8d56-d960-0687-7fee" type="greaterThan"/>
           </conditions>
         </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">


### PR DESCRIPTION
## Fixed Units
Alpha Legion Rewards of Treachery - Sun Killers

## Test Case
Setup:
 - Create Alpha Legion Crusade Force
 - Select 'III: Emperor's Children' from Rewards of Treachery
 - Select 'Sun Killer Squad (Exemplary)' from Rewards of Treachery
 - Scroll down to Heavy Support choices

Tests
 - Click 'Expanded Army List Profiles'
Test 1:
 - Toggle 'Exemplary Units Off'
 - Toggle 'Legacy Units Off'
 - Expected Result: 'Sun Killer Squad' is not a listed Heavy Support Choice

Test 2:
 - Toggle 'Exmplary Units On'
 - Toggle 'Legacy Units Off'
 - Expected Result: 'Sun Killer Squad' is a listed Heavy Support Choice

Test 3:
 - Toggle 'Exmplary Units Off'
 - Toggle 'Legacy Units On'
 - Expected Result: 'Sun Killer Squad' is not a listed Heavy Support Choice

Test 4:
 - Toggle 'Exmplary Units On'
 - Toggle 'Legacy Units On'
 - Expected Result: 'Sun Killer Squad' is a listed Heavy Support Choice