### PR TITLE
Change Centurion to a model. Close #3133

### DIFF
--- a/2022 - Imperialis Militia.cat
+++ b/2022 - Imperialis Militia.cat
@@ -6226,14 +6226,14 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
             </profile>
           </profiles>
           <selectionEntryGroups>
-            <selectionEntryGroup id="c6e5-4fad-33b8-b356" name="1) Pintle-Mounted Weapon:" hidden="false" collective="false" import="true">
+            <selectionEntryGroup id="c6e5-4fad-33b8-b356" name="1) Pintle Mounted Weapon:" hidden="false" collective="false" import="true">
               <constraints>
                 <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5a2f-f018-ee29-493c" type="max"/>
               </constraints>
               <entryLinks>
                 <entryLink id="dc9f-e5df-72da-03be" name="Heavy Stubber" hidden="false" collective="false" import="true" targetId="f227-a61a-3215-932b" type="selectionEntry">
                   <modifiers>
-                    <modifier type="set" field="name" value="Pintle-mounted Heavy Stubber"/>
+                    <modifier type="set" field="name" value="Pintle Mounted Heavy Stubber"/>
                   </modifiers>
                   <costs>
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5"/>
@@ -6241,7 +6241,7 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
                 </entryLink>
                 <entryLink id="4566-e936-c60a-990f" name="Grenade Launcher" hidden="false" collective="false" import="true" targetId="e0f3-3743-a9d0-f5f1" type="selectionEntry">
                   <modifiers>
-                    <modifier type="set" field="name" value="Pintle-mounted Grenade Launcher"/>
+                    <modifier type="set" field="name" value="Pintle Mounted Grenade Launcher"/>
                   </modifiers>
                   <costs>
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5"/>
@@ -6300,9 +6300,9 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
                 </entryLink>
               </entryLinks>
             </selectionEntryGroup>
-            <selectionEntryGroup name="3) Additional Pintle-mounted Heavy Stubber(s)" hidden="false" id="4e2f-805c-4917-5310">
+            <selectionEntryGroup name="3) Additional Pintle Mounted Heavy Stubber(s)" hidden="false" id="4e2f-805c-4917-5310">
               <selectionEntries>
-                <selectionEntry type="upgrade" import="true" name="Additional Pintle-mounted Heavy Stubber" hidden="false" id="64f1-91c1-a87a-39f6">
+                <selectionEntry type="upgrade" import="true" name="Additional Pintle Mounted Heavy Stubber" hidden="false" id="64f1-91c1-a87a-39f6">
                   <costs>
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5"/>
                   </costs>
@@ -8016,14 +8016,14 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="94e8-97c0-4e49-bcd7" name="4) May take one of the following Pintle-mounted weapon:" hidden="false" collective="false" import="true">
+        <selectionEntryGroup id="94e8-97c0-4e49-bcd7" name="4) May take one of the following Pintle Mounted weapon:" hidden="false" collective="false" import="true">
           <constraints>
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="03ab-65db-2f2f-6d69" type="max"/>
           </constraints>
           <entryLinks>
             <entryLink id="971b-5dd7-1219-2f99" name="Heavy Stubber" hidden="false" collective="false" import="true" targetId="f227-a61a-3215-932b" type="selectionEntry">
               <modifiers>
-                <modifier type="set" field="name" value="Pintle-mounted Heavy Stubber"/>
+                <modifier type="set" field="name" value="Pintle Mounted Heavy Stubber"/>
               </modifiers>
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5"/>
@@ -8031,7 +8031,7 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
             </entryLink>
             <entryLink id="a2dc-cfdc-6585-7cac" name="Multi-Laser" hidden="false" collective="false" import="true" targetId="003b-af4b-0094-f5c3" type="selectionEntry">
               <modifiers>
-                <modifier type="set" field="name" value="Pintle-mounted Multi-Laser"/>
+                <modifier type="set" field="name" value="Pintle Mounted Multi-Laser"/>
               </modifiers>
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10"/>
@@ -8039,7 +8039,7 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
             </entryLink>
             <entryLink id="d148-83d7-d3e2-7a62" name="Heavy Flamer" hidden="false" collective="false" import="true" targetId="5507-b432-3b4c-df12" type="selectionEntry">
               <modifiers>
-                <modifier type="set" field="name" value="Pintle-mounted Heavy Flamer"/>
+                <modifier type="set" field="name" value="Pintle Mounted Heavy Flamer"/>
               </modifiers>
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5"/>
@@ -8146,7 +8146,7 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="bf8e-21cc-7032-9267" name="2) May take one of the following Pintle-mounted weapons:" hidden="false" collective="false" import="true">
+        <selectionEntryGroup id="bf8e-21cc-7032-9267" name="2) May take one of the following Pintle Mounted weapons:" hidden="false" collective="false" import="true">
           <constraints>
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="af9a-5a33-0e8a-0130" type="max"/>
           </constraints>
@@ -10272,7 +10272,7 @@ equal to the number of Militia Gunners in the unit when making a Shooting Attack
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
-        <selectionEntryGroup id="71ec-212b-7e89-38a6" name="1) Pintle-mounted Weaponry" hidden="false" collective="false" import="true" defaultSelectionEntryId="0d98-e8a6-156a-9843">
+        <selectionEntryGroup id="71ec-212b-7e89-38a6" name="1) Pintle Mounted Weaponry" hidden="false" collective="false" import="true" defaultSelectionEntryId="0d98-e8a6-156a-9843">
           <constraints>
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8d3d-730c-7f22-da33" type="min"/>
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6efb-1884-88da-b125" type="max"/>
@@ -10731,7 +10731,7 @@ equal to the number of Militia Gunners in the unit when making a Shooting Attack
         </entryLink>
         <entryLink import="true" name="Mauler Bolt Cannon" hidden="false" type="selectionEntry" id="ad6d-f7e0-11d-abe6" targetId="7478-2c29-dfc4-f4cf">
           <modifiers>
-            <modifier type="set" value="Pintle-mounted Mauler Bolt Cannon" field="name"/>
+            <modifier type="set" value="Pintle Mounted Mauler Bolt Cannon" field="name"/>
           </modifiers>
           <constraints>
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ee9d-4b59-f848-b65e" type="max"/>

--- a/2022 - LA - Word Bearers.cat
+++ b/2022 - LA - Word Bearers.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="1df7-bbbc-b70e-6a3f" name="LA -  XVII: Word Bearers" revision="33" battleScribeVersion="2.03" authorName="UrsinePatriarch" authorContact="BSData Developers Discord" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="67" type="catalogue">
+<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="1df7-bbbc-b70e-6a3f" name="LA -  XVII: Word Bearers" revision="34" battleScribeVersion="2.03" authorName="UrsinePatriarch" authorContact="BSData Developers Discord" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="67" type="catalogue">
   <categoryEntries>
     <categoryEntry id="821c-0c83-5ed0-ff6b" name="Harbinger of Chaos Restriction" hidden="false">
       <modifiers>
@@ -5516,7 +5516,6 @@ as the Aetheric Lightning Psychic Weapon</description>
         <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="485d-b71b-a3bb-43be" type="max"/>
       </constraints>
       <infoLinks>
-        <infoLink id="ccbb-3d0c-f08c-9a45" name="Blind" hidden="false" targetId="d836-747d-07d6-2b63" type="rule"/>
         <infoLink id="f5dc-234e-5457-109e" name="Boltspitter" targetId="f5db-b3b0-4d9b-11b5" type="profile"/>
       </infoLinks>
       <costs>

--- a/2022 - LI - Sisters Of Silence.cat
+++ b/2022 - LI - Sisters Of Silence.cat
@@ -6326,7 +6326,7 @@ In addition, the Leadership Characteristic of a model with the Anathema Unit Sub
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
-        <selectionEntryGroup id="7eb8-14e5-2dca-a4ea" name="1) Pintle-mounted Weaponry" hidden="false" collective="false" import="true" defaultSelectionEntryId="e340-2c37-b27d-9193">
+        <selectionEntryGroup id="7eb8-14e5-2dca-a4ea" name="1) Pintle Mounted Weaponry" hidden="false" collective="false" import="true" defaultSelectionEntryId="e340-2c37-b27d-9193">
           <constraints>
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="09e1-f324-aa40-6703" type="min"/>
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2d26-e3d1-689a-e6f0" type="max"/>

--- a/2022 - LI - Solar Auxilia.cat
+++ b/2022 - LI - Solar Auxilia.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="6af7-3fee-5bc1-7533" name="LI - Solar Auxilia" revision="27" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="70" type="catalogue">
+<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="6af7-3fee-5bc1-7533" name="LI - Solar Auxilia" revision="28" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="70" type="catalogue">
   <categoryEntries>
     <categoryEntry id="19f3-8727-02db-3ce5" name="Static Artillery" hidden="false">
       <rules>
@@ -9734,21 +9734,6 @@ If a Weapon Destroyed result is repaired, that weapon may not be used to attack 
             <categoryLink id="47e4-9cd8-d66e-2c84" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
-            <selectionEntryGroup id="f63b-b35f-38f5-9de2" name="1) Main Cannon" hidden="false" collective="false" import="true" defaultSelectionEntryId="4530-f4f8-699a-99d9">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9134-b9c9-0e73-b6d6" type="min"/>
-                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e8ee-9cd6-40ed-7035" type="max"/>
-              </constraints>
-              <entryLinks>
-                <entryLink import="true" name="Macharius Battlecannon" hidden="false" type="selectionEntry" id="ebee-7977-565a-7934" targetId="88d5-d893-4635-8331"/>
-                <entryLink import="true" name="Macharius Vanquisher Cannon" hidden="false" type="selectionEntry" id="9756-cb7d-6f36-2a9b" targetId="8cd-670f-9284-a723"/>
-                <entryLink import="true" name="Macharius Rotary Bolt Cannon" hidden="false" type="selectionEntry" id="8752-ea7-cd09-22cc" targetId="7d8e-670f-dcd8-2e86">
-                  <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20"/>
-                  </costs>
-                </entryLink>
-              </entryLinks>
-            </selectionEntryGroup>
             <selectionEntryGroup id="1293-cf52-b3db-1611" name="2) Pintle mounted Weapon:" hidden="false" collective="false" import="true">
               <constraints>
                 <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="48f0-cb45-2199-2980" type="max"/>
@@ -9849,6 +9834,31 @@ If a Weapon Destroyed result is repaired, that weapon may not be used to attack 
       <costs>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20"/>
       </costs>
+      <selectionEntryGroups>
+        <selectionEntryGroup name="1) Main Cannon" hidden="false" id="f63b-b35f-38f5-9de2" collective="false" import="true" defaultSelectionEntryId="4530-f4f8-699a-99d9">
+          <constraints>
+            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="9134-b9c9-0e73-b6d6" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="e8ee-9cd6-40ed-7035" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+          </constraints>
+          <entryLinks>
+            <entryLink import="true" name="Macharius Battlecannon" hidden="false" id="ebee-7977-565a-7934" type="selectionEntry" targetId="88d5-d893-4635-8331"/>
+            <entryLink import="true" name="Macharius Vanquisher Cannon" hidden="false" id="dd61-f29a-d366-afe4" type="selectionEntry" targetId="8cd-670f-9284-a723"/>
+            <entryLink import="true" name="Macharius Rotary Bolt Cannon" hidden="false" id="5ff9-62a-827e-f6f5" type="selectionEntry" targetId="7d8e-670f-dcd8-2e86">
+              <costs>
+                <cost name="Pts" hidden="false" id="3d73-4a2b-79d7-bbcf" typeId="d2ee-04cb-5f8a-2642" value="20"/>
+              </costs>
+              <modifiers>
+                <modifier type="increment" value="20" field="d2ee-04cb-5f8a-2642">
+                  <conditions>
+                    <condition type="atLeast" value="2" field="selections" scope="parent" childId="83fd-3959-0a1c-1815" shared="true"/>
+                  </conditions>
+                  <comment>Assumes max 2 tanks per unit</comment>
+                </modifier>
+              </modifiers>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
     </selectionEntry>
     <selectionEntry id="7331-a4a7-8e69-c55e" name="Stormblade" hidden="false" collective="false" import="true" type="unit">
       <profiles>

--- a/2022 - LI - Solar Auxilia.cat
+++ b/2022 - LI - Solar Auxilia.cat
@@ -6406,7 +6406,7 @@ Once assigned to a unit, the Auxilia Medicae is considered part of that unit and
                         </profile>
                       </profiles>
                       <selectionEntryGroups>
-                        <selectionEntryGroup id="ee42-bf4b-adb4-4674" name="2) May take one of the following Pintle-mounted weapons:" hidden="false" collective="false" import="true">
+                        <selectionEntryGroup id="ee42-bf4b-adb4-4674" name="2) May take one of the following Pintle Mounted weapons:" hidden="false" collective="false" import="true">
                           <constraints>
                             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="efb1-416b-8eb6-9064" type="max"/>
                           </constraints>
@@ -6656,7 +6656,7 @@ Once assigned to a unit, the Auxilia Medicae is considered part of that unit and
                             <entryLink id="f1d9-af31-6569-cedb" name="Heavy Bolter" hidden="false" collective="false" import="true" targetId="07fd-c24a-9235-4206" type="selectionEntry"/>
                           </entryLinks>
                         </selectionEntryGroup>
-                        <selectionEntryGroup id="272b-e004-c076-c09b" name="2) May take one of the following Pintle-mounted weapons:" hidden="false" collective="false" import="true">
+                        <selectionEntryGroup id="272b-e004-c076-c09b" name="2) May take one of the following Pintle Mounted weapons:" hidden="false" collective="false" import="true">
                           <constraints>
                             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="47fc-bee6-b218-4cc4" type="max"/>
                           </constraints>
@@ -7804,14 +7804,14 @@ Once assigned to a unit, the Auxilia Medicae is considered part of that unit and
                 </entryLink>
               </entryLinks>
             </selectionEntryGroup>
-            <selectionEntryGroup id="5c1f-785f-f0e6-d22f" name="4) May take one of the following Pintle-mounted weapon:" hidden="false" collective="false" import="true">
+            <selectionEntryGroup id="5c1f-785f-f0e6-d22f" name="4) May take one of the following Pintle Mounted weapon:" hidden="false" collective="false" import="true">
               <constraints>
                 <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="932e-6b81-cf24-56c1" type="max"/>
               </constraints>
               <entryLinks>
                 <entryLink id="b1d4-6356-484a-9f43" name="Heavy Stubber" hidden="false" collective="false" import="true" targetId="f227-a61a-3215-932b" type="selectionEntry">
                   <modifiers>
-                    <modifier type="set" field="name" value="Pintle-mounted Heavy Stubber"/>
+                    <modifier type="set" field="name" value="Pintle Mounted Heavy Stubber"/>
                   </modifiers>
                   <costs>
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5"/>
@@ -7819,7 +7819,7 @@ Once assigned to a unit, the Auxilia Medicae is considered part of that unit and
                 </entryLink>
                 <entryLink id="69e6-3124-b43d-9655" name="Multi-Laser" hidden="false" collective="false" import="true" targetId="003b-af4b-0094-f5c3" type="selectionEntry">
                   <modifiers>
-                    <modifier type="set" field="name" value="Pintle-mounted Multi-Laser"/>
+                    <modifier type="set" field="name" value="Pintle Mounted Multi-Laser"/>
                   </modifiers>
                   <costs>
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10"/>
@@ -7827,7 +7827,7 @@ Once assigned to a unit, the Auxilia Medicae is considered part of that unit and
                 </entryLink>
                 <entryLink id="96df-c981-85d9-116e" name="Heavy Flamer" hidden="false" collective="false" import="true" targetId="5507-b432-3b4c-df12" type="selectionEntry">
                   <modifiers>
-                    <modifier type="set" field="name" value="Pintle-mounted Heavy Flamer"/>
+                    <modifier type="set" field="name" value="Pintle Mounted Heavy Flamer"/>
                   </modifiers>
                   <costs>
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5"/>
@@ -8067,7 +8067,7 @@ Once assigned to a unit, the Auxilia Medicae is considered part of that unit and
                 </entryLink>
               </entryLinks>
             </selectionEntryGroup>
-            <selectionEntryGroup id="8984-e2a1-07e6-2040" name="2) May take one of the following Pintle-mounted weapons:" hidden="false" collective="false" import="true">
+            <selectionEntryGroup id="8984-e2a1-07e6-2040" name="2) May take one of the following Pintle Mounted weapons:" hidden="false" collective="false" import="true">
               <constraints>
                 <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="db7e-e0d0-e487-3681" type="max"/>
               </constraints>
@@ -8408,7 +8408,7 @@ Once assigned to a unit, the Auxilia Medicae is considered part of that unit and
                 </entryLink>
               </entryLinks>
             </selectionEntryGroup>
-            <selectionEntryGroup id="3a22-e046-21ea-7c4a" name="3) May take one of the following Pintle-mounted weapons:" hidden="false" collective="false" import="true">
+            <selectionEntryGroup id="3a22-e046-21ea-7c4a" name="3) May take one of the following Pintle Mounted weapons:" hidden="false" collective="false" import="true">
               <constraints>
                 <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a8b3-0e73-b2bf-34f9" type="max"/>
               </constraints>
@@ -8719,7 +8719,7 @@ Once assigned to a unit, the Auxilia Medicae is considered part of that unit and
                 </entryLink>
               </entryLinks>
             </selectionEntryGroup>
-            <selectionEntryGroup id="10a3-ecae-4c1b-9a7c" name="Any Solar Auxilia Carnodon may take one Pintle-mounted weapon:" hidden="false" collective="false" import="true">
+            <selectionEntryGroup id="10a3-ecae-4c1b-9a7c" name="Any Solar Auxilia Carnodon may take one Pintle Mounted weapon:" hidden="false" collective="false" import="true">
               <constraints>
                 <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cb11-68be-decd-bf44" type="max"/>
               </constraints>
@@ -9048,7 +9048,7 @@ Once assigned to a unit, the Auxilia Medicae is considered part of that unit and
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
-        <selectionEntryGroup id="9b74-d258-64a2-979b" name="1) Pintle-mounted Weaponry" hidden="false" collective="false" import="true" defaultSelectionEntryId="c03a-d321-ea4f-ae23">
+        <selectionEntryGroup id="9b74-d258-64a2-979b" name="1) Pintle Mounted Weaponry" hidden="false" collective="false" import="true" defaultSelectionEntryId="c03a-d321-ea4f-ae23">
           <constraints>
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="758e-4a01-ec1a-3e82" type="min"/>
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dfc5-7c44-e0eb-ac21" type="max"/>
@@ -9430,7 +9430,7 @@ If a Weapon Destroyed result is repaired, that weapon may not be used to attack 
                       <entryLinks>
                         <entryLink id="c6ba-d780-08cc-4de8" name="Multi-Laser" hidden="false" collective="false" import="true" targetId="003b-af4b-0094-f5c3" type="selectionEntry">
                           <modifiers>
-                            <modifier type="set" field="name" value="Pintle-mounted Multi-Laser"/>
+                            <modifier type="set" field="name" value="Pintle Mounted Multi-Laser"/>
                           </modifiers>
                           <costs>
                             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10"/>
@@ -9438,7 +9438,7 @@ If a Weapon Destroyed result is repaired, that weapon may not be used to attack 
                         </entryLink>
                         <entryLink id="cb4c-9e8a-8469-b896" name="Heavy Stubber" hidden="false" collective="false" import="true" targetId="f227-a61a-3215-932b" type="selectionEntry">
                           <modifiers>
-                            <modifier type="set" field="name" value="Pintle-mounted Heavy Stubber"/>
+                            <modifier type="set" field="name" value="Pintle Mounted Heavy Stubber"/>
                           </modifiers>
                           <costs>
                             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5"/>
@@ -9446,7 +9446,7 @@ If a Weapon Destroyed result is repaired, that weapon may not be used to attack 
                         </entryLink>
                         <entryLink id="1f84-ab5b-023d-e4e9" name="Heavy Flamer" hidden="false" collective="false" import="true" targetId="5507-b432-3b4c-df12" type="selectionEntry">
                           <modifiers>
-                            <modifier type="set" field="name" value="Pintle-mounted Heavy Flamer"/>
+                            <modifier type="set" field="name" value="Pintle Mounted Heavy Flamer"/>
                           </modifiers>
                           <costs>
                             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5"/>

--- a/2022 - Mechanicum.cat
+++ b/2022 - Mechanicum.cat
@@ -5046,7 +5046,7 @@ removed as a casualty.�</characteristic>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
-        <selectionEntryGroup id="3faf-3f56-5953-7640" name="1) Pintle-mounted Weaponry" hidden="false" collective="false" import="true" defaultSelectionEntryId="3851-d4dd-b108-37c8">
+        <selectionEntryGroup id="3faf-3f56-5953-7640" name="1) Pintle Mounted Weaponry" hidden="false" collective="false" import="true" defaultSelectionEntryId="3851-d4dd-b108-37c8">
           <constraints>
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bec2-2f2f-d285-3db3" type="min"/>
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="18b4-877b-1a7e-356a" type="max"/>


### PR DESCRIPTION
We should be more consistent about unit -> model.
Centurion was a model with a model in it. Now it's a unit with a model in it.
I also changed a bunch of vehicles which were just models to be units. 
