### PR TITLE
Fix for Knight Dark Blessings

### DIFF
--- a/2022 - Mech Library.cat
+++ b/2022 - Mech Library.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="3129-da35-55e0-642d" name="Mech Library" revision="42" battleScribeVersion="2.03" library="true" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="67" type="catalogue">
+<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="3129-da35-55e0-642d" name="Mech Library" revision="43" battleScribeVersion="2.03" library="true" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="67" type="catalogue">
   <categoryEntries>
     <categoryEntry id="4086-0589-f010-e688" name="Titan Legion Min Troop/LoW" hidden="false"/>
     <categoryEntry id="57a1-ae47-ff1b-36e4" name="Cybertheurgist" publicationId="bde1-6db1-163b-3b76" page="92-96" hidden="false"/>
@@ -7873,36 +7873,56 @@ Preceptor: Any units of Armiger Warglaives or Armiger Helverins that have at lea
           </costs>
         </selectionEntry>
         <selectionEntry type="upgrade" import="true" name="Heedless Slaughter" hidden="false" id="4d39-37c3-366-9cbd" publicationId="44e-19f2-a369-b04e" page="7">
-          <infoLinks>
-            <infoLink id="a04f-92eb-66e1-dc45" name="Heedless Slaughter" targetId="a57e-1003-3f17-d12e" type="rule"/>
-          </infoLinks>
+          <rules>
+            <rule name="Heedless Slaughter (Dark Blessing)" hidden="false" id="a04f-92eb-66e1-dc45" publicationId="44e-19f2-a369-b04e" page="7">
+              <description>A model with this Dark Blessing gains the Character Unit Sub-type and must reduce its Weapon Skill and Ballistic Skill Characteristics by -1. In addition, for each model with this Dark Blessing, all models in a single unit made up entirely of models with the Armiger Unit Type, selected as part of the same Detachment, gain the Rage (2) special rule for no additional points cost.</description>
+            </rule>
+          </rules>
         </selectionEntry>
-        <selectionEntry type="upgrade" import="true" name="Malevolent Artifice" hidden="false" id="d6ff-d1db-10d2-9280" publicationId="44e-19f2-a369-b04e" page="8">
+        <selectionEntry type="upgrade" import="true" name="Malevolent Artifice (Dark Blessing)" hidden="false" id="d6ff-d1db-10d2-9280" publicationId="44e-19f2-a369-b04e" page="8">
+          <rules>
+            <rule name="Malevolent Artifice (Dark Blessing)" hidden="false" id="de1e-6bee-f53f-de9c" publicationId="44e-19f2-a369-b04e" page="8">
+              <description>At the end of each of the controlling player’s turns in which a model with this upgrade inflicts at least one unsaved Wound or Hull Point with a weapon with the Melee type, it gains the It Will Not Die (6+) special rule until the end of the battle. If the model already has the It Will Not Die (X) special rule, it increases the value of X by 1, up to a maximum of 4+.</description>
+            </rule>
+          </rules>
           <infoLinks>
             <infoLink name="It Will Not Die (X)" hidden="false" type="rule" id="7335-9c66-777a-d5cc" targetId="2784-d0be-a4e2-890f"/>
-            <infoLink id="de1e-6bee-f53f-de9c" name="Malevolent Artifice" targetId="c488-ac28-c303-57b" type="rule"/>
           </infoLinks>
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="50"/>
           </costs>
         </selectionEntry>
-        <selectionEntry type="upgrade" import="true" name="Encroaching Ruin" hidden="false" id="e208-5a47-5937-4f5c" publicationId="44e-19f2-a369-b04e" page="8">
+        <selectionEntry type="upgrade" import="true" name="Encroaching Ruin (Dark Blessing)" hidden="false" id="e208-5a47-5937-4f5c" publicationId="44e-19f2-a369-b04e" page="8">
+          <rules>
+            <rule name="Encroaching Ruin (Dark Blessing)" hidden="false" id="3543-23e4-4cbe-a169" publicationId="44e-19f2-a369-b04e" page="8">
+              <description>A model with this upgrade increases its Ballistic Skill Characteristic by +1 and gains the Character Unit Sub-type and Commanding Presence special rule.
+Commanding Presence: Armiger Warglaives or Armiger Helverins units that have at least one model within 6&quot; of one or more friendly models with this special rule at the start of a turn increase their Movement Characteristic by +2 until the end of that player turn.</description>
+            </rule>
+          </rules>
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="40"/>
           </costs>
-          <infoLinks>
-            <infoLink id="3543-23e4-4cbe-a169" name="Encroaching Ruin" targetId="4438-874e-901d-f86" type="rule"/>
-          </infoLinks>
         </selectionEntry>
-        <selectionEntry type="upgrade" import="true" name="Putrid Corruption" hidden="false" id="6a9-eb18-8dc5-ef1c" publicationId="44e-19f2-a369-b04e" page="8">
+        <selectionEntry type="upgrade" import="true" name="Putrid Corruption (Dark Blessing)" hidden="false" id="6a9-eb18-8dc5-ef1c" publicationId="44e-19f2-a369-b04e" page="8">
+          <rules>
+            <rule name="Putrid Corruption (Dark Blessing)" hidden="false" id="ba33-7b89-512c-7bbf" publicationId="44e-19f2-a369-b04e" page="8">
+              <description>A model with this upgrade must reduce its Movement Characteristic by -2 and gains the Unrelenting special rule.
+An Acastus Knight Porphyrion or Acastus Knight Asterius may not be given this Dark Blessing.
+Unrelenting: Each time a model with this special rule suffers an Explodes result on the Vehicle Damage chart, it loses 1 extra Hull Point instead of D3, in addition to the Hull Point it loses for the Penetrating Hit</description>
+            </rule>
+          </rules>
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="45"/>
           </costs>
-          <infoLinks>
-            <infoLink id="ba33-7b89-512c-7bbf" name="Putrid Corruption" targetId="94eb-7da4-953-529f" type="rule"/>
-          </infoLinks>
         </selectionEntry>
-        <selectionEntry type="upgrade" import="true" name="Infernal Tempest" hidden="false" id="7ad-bd12-1203-4018" publicationId="44e-19f2-a369-b04e" page="8">
+        <selectionEntry type="upgrade" import="true" name="Infernal Tempest (Dark Blessing)" hidden="false" id="7ad-bd12-1203-4018" publicationId="44e-19f2-a369-b04e" page="8">
+          <rules>
+            <rule name="Infernal Tempest (Dark Blessing)" hidden="false" id="2b0e-5f20-f672-ea98" publicationId="44e-19f2-a369-b04e" page="8">
+              <description>A model with this upgrade gains the Character and Psyker Unit Sub-types, and Infernal Rites Psychic Discipline. When making a Psychic check, a model with this upgrade always counts as having a Leadership Characteristic of 7 regardless of any modifiers or effects.
+Psychic Discipline: Infernal Rites
+A Psyker with this Discipline gains the listed Power, weapon and special rules but does not gain the Aetheric Lightning Psychic Weapon.</description>
+            </rule>
+          </rules>
           <profiles>
             <profile name="Empyreal Tempest (Psychic Weapon)" typeId="cede-0217-1b10-2a34" typeName="Psychic Weapon" hidden="false" id="d825-9702-7cd0-1fe" publicationId="44e-19f2-a369-b04e" page="8">
               <characteristics>
@@ -7920,36 +7940,43 @@ Preceptor: Any units of Armiger Warglaives or Armiger Helverins that have at lea
           </profiles>
           <infoLinks>
             <infoLink name="Psychic Focus" hidden="false" type="rule" id="acc2-537b-ff29-991e" targetId="bff3-3548-b2b8-72f1"/>
-            <infoLink id="2b0e-5f20-f672-ea98" name="Infernal Tempest" targetId="457b-86dd-cedd-ce60" type="rule"/>
           </infoLinks>
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25"/>
           </costs>
         </selectionEntry>
-        <selectionEntry type="upgrade" import="true" name="Ravenous Dissolution" hidden="false" id="6463-f70a-45df-f1f4" publicationId="44e-19f2-a369-b04e" page="9">
+        <selectionEntry type="upgrade" import="true" name="Ravenous Dissolution (Dark Blessing)" hidden="false" id="6463-f70a-45df-f1f4" publicationId="44e-19f2-a369-b04e" page="9">
+          <rules>
+            <rule name="Ravenous Dissolution (Dark Blessing)" hidden="false" id="51e9-cbc3-6e3-e1ed" publicationId="44e-19f2-a369-b04e" page="9">
+              <description>A model with this upgrade increases its Weapon Skill Characteristic by +1, and gains the Character Unit Sub-type and the Marked for Death special rule.</description>
+            </rule>
+          </rules>
           <infoLinks>
             <infoLink name="Marked For Death" hidden="false" type="rule" id="5650-a7f5-930b-465" targetId="4f41-4c04-9cd8-c5a1"/>
-            <infoLink id="51e9-cbc3-6e3-e1ed" name="Ravenous Dissolution" targetId="ef2f-faf6-8a1a-d10b" type="rule"/>
           </infoLinks>
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="50"/>
           </costs>
         </selectionEntry>
-        <selectionEntry type="upgrade" import="true" name="Rapturous Sensation" hidden="false" id="68f-18b3-d00b-5caf" publicationId="44e-19f2-a369-b04e" page="9">
+        <selectionEntry type="upgrade" import="true" name="Rapturous Sensation (Dark Blessing)" hidden="false" id="68f-18b3-d00b-5caf" publicationId="44e-19f2-a369-b04e" page="9">
+          <rules>
+            <rule name="Rapturous Sensation (Dark Blessing)" hidden="false" id="3afb-89b0-1dae-96fa" publicationId="44e-19f2-a369-b04e" page="9">
+              <description>No enemy unit that has one or more models within 8&quot; of a model with this Dark Blessing may have a Reaction declared for it in any Phase unless that unit’s controlling player first passes a Leadership test for the unit that they wish to declare a Reaction for. If the Test is passed then a Reaction may be declared and resolved as normal. If the Test is failed then that unit may not have any Reactions declared for it in the current player turn, but the controlling player does not lose a point of their Reaction Allotment.</description>
+            </rule>
+          </rules>
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="65"/>
           </costs>
-          <infoLinks>
-            <infoLink id="3afb-89b0-1dae-96fa" name="Rapturous Sensation" targetId="1bf8-cca9-299a-6c5a" type="rule"/>
-          </infoLinks>
         </selectionEntry>
-        <selectionEntry type="upgrade" import="true" name="Formless Distortion" hidden="false" id="b4c8-641b-5139-1acd" publicationId="44e-19f2-a369-b04e" page="9">
+        <selectionEntry type="upgrade" import="true" name="Formless Distortion (Dark Blessing)" hidden="false" id="b4c8-641b-5139-1acd" publicationId="44e-19f2-a369-b04e" page="9">
+          <rules>
+            <rule name="Formless Distortion (Dark Blessing)" hidden="false" id="7e74-972a-b0f5-2c58" publicationId="44e-19f2-a369-b04e" page="9">
+              <description>A model with this upgrade increases its Weapon Skill Characteristic by +1 and gains the Character Unit Sub-type. In addition, it may exchange a single weapon with the Melee type to an Ionic Lash.</description>
+            </rule>
+          </rules>
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="45"/>
           </costs>
-          <infoLinks>
-            <infoLink id="7e74-972a-b0f5-2c58" name="Formless Distortion" targetId="3546-bb80-a1d7-7d1d" type="rule"/>
-          </infoLinks>
         </selectionEntry>
       </selectionEntries>
       <modifiers>


### PR DESCRIPTION


## Fixed Units

Knight dark blessings are no longer replaced by aetheric dominions. I also added (Dark Blessing) to the end of each name.

### Related Issues

* closes #3140


