### PR TITLE
Set types onto models based on their profiles

### DIFF
--- a/2022 - Daemons - Bound Daemons.cat
+++ b/2022 - Daemons - Bound Daemons.cat
@@ -395,6 +395,10 @@ The End and the Death – When fighting in a Challenge, successful Invulnerable 
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="45"/>
           </costs>
+          <categoryLinks>
+            <categoryLink targetId="e699-d9cd-e68e-46d9" id="d711-9e00-4e7b-9608" name="Daemon" primary="false"/>
+            <categoryLink targetId="40f3-05e8-5ddc-636a" id="7c92-d8f4-4b19-82f0" name="Bound" primary="false"/>
+          </categoryLinks>
         </selectionEntry>
         <selectionEntry id="6979-74bc-2519-6bba" name="Bound Daemon Regent" hidden="false" collective="false" import="true" type="model">
           <constraints>
@@ -446,6 +450,8 @@ The End and the Death – When fighting in a Challenge, successful Invulnerable 
           </infoLinks>
           <categoryLinks>
             <categoryLink id="025b-4963-b934-8aed" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
+            <categoryLink targetId="e699-d9cd-e68e-46d9" id="ca8c-6f37-492f-b6a1" name="Daemon" primary="false"/>
+            <categoryLink targetId="40f3-05e8-5ddc-636a" id="9cb8-36af-4518-8cfb" name="Bound" primary="false"/>
           </categoryLinks>
           <selectionEntries>
             <selectionEntry id="afba-e14e-6344-820f" name="Regent Blade" publicationId="cb13-da24-e6da-75b3" page="17" hidden="false" collective="true" import="true" type="upgrade">
@@ -723,6 +729,10 @@ During a Reaction made in any Phase, a player may not choose to activate a model
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="40"/>
           </costs>
+          <categoryLinks>
+            <categoryLink targetId="e699-d9cd-e68e-46d9" id="46e8-6d6e-42fe-acdb" name="Daemon" primary="false"/>
+            <categoryLink targetId="40f3-05e8-5ddc-636a" id="776a-d8e9-4e56-8a41" name="Bound" primary="false"/>
+          </categoryLinks>
         </selectionEntry>
       </selectionEntries>
       <entryLinks>

--- a/2022 - Daemons - Bound Daemons.cat
+++ b/2022 - Daemons - Bound Daemons.cat
@@ -211,8 +211,8 @@
       <categoryLinks>
         <categoryLink id="1552-27b9-87a1-ed75" name="Bound Sub-type" hidden="false" targetId="40f3-05e8-5ddc-636a" primary="false"/>
         <categoryLink id="1ae3-f371-c157-ce13" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
-        <categoryLink id="2708-3188-198a-16d4" name="Monstrous Sub-type:" hidden="false" targetId="7d95-f9d1-440a-67bd" primary="false"/>
-        <categoryLink id="70ea-80de-49b7-e853" name="Daemon Unit-type:" hidden="false" targetId="e699-d9cd-e68e-46d9" primary="false"/>
+        <categoryLink id="2708-3188-198a-16d4" name="Monstrous Sub-type" hidden="false" targetId="7d95-f9d1-440a-67bd" primary="false"/>
+        <categoryLink id="70ea-80de-49b7-e853" name="Daemon Unit Type" hidden="false" targetId="e699-d9cd-e68e-46d9" primary="false"/>
         <categoryLink targetId="c42-1919-c37e-51f0" id="fb9b-20c9-2af-7ec2" primary="false" name="Encroaching Ruin"/>
       </categoryLinks>
       <selectionEntries>
@@ -300,7 +300,7 @@ The End and the Death – When fighting in a Challenge, successful Invulnerable 
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="ffef-0edc-ccde-7d6e" name="Daemon Unit-type:" hidden="false" targetId="e699-d9cd-e68e-46d9" primary="false"/>
+        <categoryLink id="ffef-0edc-ccde-7d6e" name="Daemon Unit Type" hidden="false" targetId="e699-d9cd-e68e-46d9" primary="false"/>
         <categoryLink id="1a54-e769-f5c2-8ce8" name="Bound Sub-type" hidden="false" targetId="40f3-05e8-5ddc-636a" primary="false"/>
       </categoryLinks>
       <selectionEntries>
@@ -562,7 +562,7 @@ The End and the Death – When fighting in a Challenge, successful Invulnerable 
         <categoryLink id="4a52-aa7c-e37c-8188" name="Bound Sub-type" hidden="false" targetId="40f3-05e8-5ddc-636a" primary="false"/>
         <categoryLink id="eec0-d409-3404-e87f" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
         <categoryLink id="115c-e4d6-487b-8949" name="Gargantuan Unit Sub-type" hidden="false" targetId="f479-3c81-1e42-1b3a" primary="false"/>
-        <categoryLink id="2f54-04ee-8fd1-bd98" name="Daemon Unit-type:" hidden="false" targetId="e699-d9cd-e68e-46d9" primary="false"/>
+        <categoryLink id="2f54-04ee-8fd1-bd98" name="Daemon Unit Type" hidden="false" targetId="e699-d9cd-e68e-46d9" primary="false"/>
         <categoryLink targetId="f074-f60a-9aa6-c52a" id="f24d-a7b1-3895-ef11" primary="false" name="Heedless Slaughter"/>
       </categoryLinks>
       <selectionEntries>
@@ -669,7 +669,7 @@ During a Reaction made in any Phase, a player may not choose to activate a model
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="6e4a-c4d0-ec9e-672c" name="Daemon Unit-type:" hidden="false" targetId="e699-d9cd-e68e-46d9" primary="false"/>
+        <categoryLink id="6e4a-c4d0-ec9e-672c" name="Daemon Unit Type" hidden="false" targetId="e699-d9cd-e68e-46d9" primary="false"/>
         <categoryLink id="286f-7739-46ee-5ba2" name="Bound Sub-type" hidden="false" targetId="40f3-05e8-5ddc-636a" primary="false"/>
       </categoryLinks>
       <selectionEntries>

--- a/2022 - Daemons - Bound Daemons.cat
+++ b/2022 - Daemons - Bound Daemons.cat
@@ -396,8 +396,8 @@ The End and the Death – When fighting in a Challenge, successful Invulnerable 
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="45"/>
           </costs>
           <categoryLinks>
-            <categoryLink targetId="e699-d9cd-e68e-46d9" id="d711-9e00-4e7b-9608" name="Daemon" primary="false"/>
-            <categoryLink targetId="40f3-05e8-5ddc-636a" id="7c92-d8f4-4b19-82f0" name="Bound" primary="false"/>
+            <categoryLink targetId="e699-d9cd-e68e-46d9" id="d711-9e00-4e7b-9608" name="Daemon Unit Type" primary="false"/>
+            <categoryLink targetId="40f3-05e8-5ddc-636a" id="7c92-d8f4-4b19-82f0" name="Bound Sub-type" primary="false"/>
           </categoryLinks>
         </selectionEntry>
         <selectionEntry id="6979-74bc-2519-6bba" name="Bound Daemon Regent" hidden="false" collective="false" import="true" type="model">
@@ -450,8 +450,8 @@ The End and the Death – When fighting in a Challenge, successful Invulnerable 
           </infoLinks>
           <categoryLinks>
             <categoryLink id="025b-4963-b934-8aed" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
-            <categoryLink targetId="e699-d9cd-e68e-46d9" id="ca8c-6f37-492f-b6a1" name="Daemon" primary="false"/>
-            <categoryLink targetId="40f3-05e8-5ddc-636a" id="9cb8-36af-4518-8cfb" name="Bound" primary="false"/>
+            <categoryLink targetId="e699-d9cd-e68e-46d9" id="ca8c-6f37-492f-b6a1" name="Daemon Unit Type" primary="false"/>
+            <categoryLink targetId="40f3-05e8-5ddc-636a" id="9cb8-36af-4518-8cfb" name="Bound Sub-type" primary="false"/>
           </categoryLinks>
           <selectionEntries>
             <selectionEntry id="afba-e14e-6344-820f" name="Regent Blade" publicationId="cb13-da24-e6da-75b3" page="17" hidden="false" collective="true" import="true" type="upgrade">
@@ -730,8 +730,8 @@ During a Reaction made in any Phase, a player may not choose to activate a model
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="40"/>
           </costs>
           <categoryLinks>
-            <categoryLink targetId="e699-d9cd-e68e-46d9" id="46e8-6d6e-42fe-acdb" name="Daemon" primary="false"/>
-            <categoryLink targetId="40f3-05e8-5ddc-636a" id="776a-d8e9-4e56-8a41" name="Bound" primary="false"/>
+            <categoryLink targetId="e699-d9cd-e68e-46d9" id="46e8-6d6e-42fe-acdb" name="Daemon Unit Type" primary="false"/>
+            <categoryLink targetId="40f3-05e8-5ddc-636a" id="776a-d8e9-4e56-8a41" name="Bound Sub-type" primary="false"/>
           </categoryLinks>
         </selectionEntry>
       </selectionEntries>

--- a/2022 - Daemons - Daemons of the Ruinstorm.cat
+++ b/2022 - Daemons - Daemons of the Ruinstorm.cat
@@ -172,9 +172,9 @@
         <entryLink import="true" name="Warlord Traits (Ruinstorm Daemons)" hidden="false" type="selectionEntryGroup" id="2a1-8be4-17b-75ca" targetId="2f76-74c1-d329-d3ab"/>
       </entryLinks>
       <categoryLinks>
-        <categoryLink targetId="e699-d9cd-e68e-46d9" id="65b8-a251-c47a-d600" primary="false" name="Daemon Unit-type:"/>
+        <categoryLink targetId="e699-d9cd-e68e-46d9" id="65b8-a251-c47a-d600" primary="false" name="Daemon Unit Type"/>
         <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="ca77-e05c-8eea-841b" primary="false" name="Character"/>
-        <categoryLink targetId="7d95-f9d1-440a-67bd" id="3264-7be5-e979-a356" primary="false" name="Monstrous Sub-type:"/>
+        <categoryLink targetId="7d95-f9d1-440a-67bd" id="3264-7be5-e979-a356" primary="false" name="Monstrous Sub-type"/>
       </categoryLinks>
       <infoLinks>
         <infoLink id="cf0d-80f5-9ec0-dfba" name="Traitor" hidden="false" targetId="eff2-8b0e-21da-2f0d" type="rule"/>
@@ -330,7 +330,7 @@
         <entryLink import="true" name="Warlord Traits (Ruinstorm Daemons)" hidden="false" type="selectionEntryGroup" id="f5c1-536d-3f92-a419" targetId="2f76-74c1-d329-d3ab"/>
       </entryLinks>
       <categoryLinks>
-        <categoryLink targetId="e699-d9cd-e68e-46d9" id="ea69-c0e0-5be1-9568" primary="false" name="Daemon Unit-type:"/>
+        <categoryLink targetId="e699-d9cd-e68e-46d9" id="ea69-c0e0-5be1-9568" primary="false" name="Daemon Unit Type"/>
         <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="5946-8140-a4ef-4ce0" primary="false" name="Character"/>
       </categoryLinks>
       <infoLinks>
@@ -592,7 +592,7 @@
         <entryLink import="true" name="The Ætheric Dominion (Unit)" hidden="false" type="selectionEntryGroup" id="5d3d-4561-ca3-1b5a" targetId="caad-e621-38e5-cb5f"/>
       </entryLinks>
       <categoryLinks>
-        <categoryLink targetId="e699-d9cd-e68e-46d9" id="e2f3-8a17-7b35-4909" primary="false" name="Daemon Unit-type:"/>
+        <categoryLink targetId="e699-d9cd-e68e-46d9" id="e2f3-8a17-7b35-4909" primary="false" name="Daemon Unit Type"/>
       </categoryLinks>
       <modifiers>
         <modifier type="add" field="category" value="9231-183c-b97b-63f9">
@@ -648,7 +648,7 @@
         <entryLink import="true" name="The Ætheric Dominion (Unit)" hidden="false" type="selectionEntryGroup" id="b5cc-4b7f-66f9-183f" targetId="caad-e621-38e5-cb5f"/>
       </entryLinks>
       <categoryLinks>
-        <categoryLink targetId="e699-d9cd-e68e-46d9" id="eddf-34f6-417f-401a" primary="false" name="Daemon Unit-type:"/>
+        <categoryLink targetId="e699-d9cd-e68e-46d9" id="eddf-34f6-417f-401a" primary="false" name="Daemon Unit Type"/>
       </categoryLinks>
       <infoLinks>
         <infoLink id="2191-ca7d-4b7-721b" name="Traitor" hidden="false" targetId="eff2-8b0e-21da-2f0d" type="rule"/>
@@ -718,7 +718,7 @@
         </entryLink>
       </entryLinks>
       <categoryLinks>
-        <categoryLink targetId="e699-d9cd-e68e-46d9" id="b0a9-42b3-be57-e685" primary="false" name="Daemon Unit-type:"/>
+        <categoryLink targetId="e699-d9cd-e68e-46d9" id="b0a9-42b3-be57-e685" primary="false" name="Daemon Unit Type"/>
       </categoryLinks>
       <infoLinks>
         <infoLink id="7e13-ac0e-f455-aed7" name="Bulky (X)" hidden="false" targetId="676c-7b75-4b6f-9405" type="rule">
@@ -901,8 +901,8 @@
         <entryLink import="true" name="The Ætheric Dominion (Unit)" hidden="false" type="selectionEntryGroup" id="984b-1653-1706-eaf" targetId="caad-e621-38e5-cb5f"/>
       </entryLinks>
       <categoryLinks>
-        <categoryLink targetId="e699-d9cd-e68e-46d9" id="83d4-7ef0-2bce-18cb" primary="false" name="Daemon Unit-type:"/>
-        <categoryLink targetId="6399-5c65-7833-1025" id="7bf1-d30-86a3-e2e5" primary="false" name="Line Sub-type:"/>
+        <categoryLink targetId="e699-d9cd-e68e-46d9" id="83d4-7ef0-2bce-18cb" primary="false" name="Daemon Unit Type"/>
+        <categoryLink targetId="6399-5c65-7833-1025" id="7bf1-d30-86a3-e2e5" primary="false" name="Line Sub-type"/>
       </categoryLinks>
       <infoLinks>
         <infoLink id="669f-718b-897c-7898" name="Traitor" hidden="false" targetId="eff2-8b0e-21da-2f0d" type="rule"/>
@@ -998,9 +998,9 @@
         <entryLink import="true" name="The Ætheric Dominion (Unit)" hidden="false" type="selectionEntryGroup" id="8b54-9c7b-7706-f5fb" targetId="caad-e621-38e5-cb5f"/>
       </entryLinks>
       <categoryLinks>
-        <categoryLink targetId="e699-d9cd-e68e-46d9" id="7e4d-5d59-2dfb-7bc" primary="false" name="Daemon Unit-type:"/>
-        <categoryLink targetId="6399-5c65-7833-1025" id="3401-3a7f-8da3-70a3" primary="false" name="Line Sub-type:"/>
-        <categoryLink targetId="59a4-7b61-600a-c457" id="8383-cf65-5d5-bd9c" primary="false" name="Skirmish Sub-type:"/>
+        <categoryLink targetId="e699-d9cd-e68e-46d9" id="7e4d-5d59-2dfb-7bc" primary="false" name="Daemon Unit Type"/>
+        <categoryLink targetId="6399-5c65-7833-1025" id="3401-3a7f-8da3-70a3" primary="false" name="Line Sub-type"/>
+        <categoryLink targetId="59a4-7b61-600a-c457" id="8383-cf65-5d5-bd9c" primary="false" name="Skirmish Sub-type"/>
       </categoryLinks>
       <infoLinks>
         <infoLink id="66cd-5d7d-91d-c58b" name="Traitor" hidden="false" targetId="eff2-8b0e-21da-2f0d" type="rule"/>
@@ -1076,7 +1076,7 @@
         <entryLink import="true" name="The Ætheric Dominion (Unit)" hidden="false" type="selectionEntryGroup" id="9090-c089-e5b6-db5" targetId="caad-e621-38e5-cb5f"/>
       </entryLinks>
       <categoryLinks>
-        <categoryLink targetId="e699-d9cd-e68e-46d9" id="9407-be20-96bd-e31" primary="false" name="Daemon Unit-type:"/>
+        <categoryLink targetId="e699-d9cd-e68e-46d9" id="9407-be20-96bd-e31" primary="false" name="Daemon Unit Type"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup name="Weapons" hidden="false" id="a8a4-643c-91b2-9d35" defaultSelectionEntryId="833-36e7-dd0a-72da">
@@ -1172,7 +1172,7 @@
         </entryLink>
       </entryLinks>
       <categoryLinks>
-        <categoryLink targetId="e699-d9cd-e68e-46d9" id="d862-dddd-f482-b0f6" primary="false" name="Daemon Unit-type:"/>
+        <categoryLink targetId="e699-d9cd-e68e-46d9" id="d862-dddd-f482-b0f6" primary="false" name="Daemon Unit Type"/>
       </categoryLinks>
       <infoLinks>
         <infoLink id="6f8e-cea2-fc33-c648" name="Æthereal Invulnerability (X)" hidden="false" targetId="e05e-ed23-64fb-a535" type="rule">
@@ -1273,8 +1273,8 @@
         </entryLink>
       </entryLinks>
       <categoryLinks>
-        <categoryLink targetId="e699-d9cd-e68e-46d9" id="d6-76f8-1463-2952" primary="false" name="Daemon Unit-type:"/>
-        <categoryLink targetId="7d95-f9d1-440a-67bd" id="4719-2060-9c0d-a8d8" primary="false" name="Monstrous Sub-type:"/>
+        <categoryLink targetId="e699-d9cd-e68e-46d9" id="d6-76f8-1463-2952" primary="false" name="Daemon Unit Type"/>
+        <categoryLink targetId="7d95-f9d1-440a-67bd" id="4719-2060-9c0d-a8d8" primary="false" name="Monstrous Sub-type"/>
       </categoryLinks>
       <infoLinks>
         <infoLink id="2704-6b9-50c6-8f8b" name="Æthereal Invulnerability (X)" hidden="false" targetId="e05e-ed23-64fb-a535" type="rule">
@@ -1347,8 +1347,8 @@
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="350"/>
       </costs>
       <categoryLinks>
-        <categoryLink targetId="e699-d9cd-e68e-46d9" id="f3be-b32f-20de-fb96" primary="false" name="Daemon Unit-type:"/>
-        <categoryLink targetId="7d95-f9d1-440a-67bd" id="3ea5-69b1-2640-3032" primary="false" name="Monstrous Sub-type:"/>
+        <categoryLink targetId="e699-d9cd-e68e-46d9" id="f3be-b32f-20de-fb96" primary="false" name="Daemon Unit Type"/>
+        <categoryLink targetId="7d95-f9d1-440a-67bd" id="3ea5-69b1-2640-3032" primary="false" name="Monstrous Sub-type"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup name="Weapon" hidden="false" id="d09c-34b9-8314-e1f8" defaultSelectionEntryId="ff27-27e9-267d-c874">
@@ -1576,7 +1576,7 @@
       </selectionEntryGroups>
       <categoryLinks>
         <categoryLink targetId="f479-3c81-1e42-1b3a" id="f700-11cc-5bb0-f049" primary="false" name="Gargantuan Unit Sub-type"/>
-        <categoryLink targetId="e699-d9cd-e68e-46d9" id="4a97-7f8b-9739-2baa" primary="false" name="Daemon Unit-type:"/>
+        <categoryLink targetId="e699-d9cd-e68e-46d9" id="4a97-7f8b-9739-2baa" primary="false" name="Daemon Unit Type"/>
       </categoryLinks>
       <modifiers>
         <modifier type="add" field="category" value="9231-183c-b97b-63f9">
@@ -1769,7 +1769,7 @@ If Sanguinius is removed as a casualty while fighting in a Challenge against Ka&
         </entryLink>
       </entryLinks>
       <categoryLinks>
-        <categoryLink targetId="e699-d9cd-e68e-46d9" id="2fba-d3f5-73dc-6901" primary="false" name="Daemon Unit-type:"/>
+        <categoryLink targetId="e699-d9cd-e68e-46d9" id="2fba-d3f5-73dc-6901" primary="false" name="Daemon Unit Type"/>
         <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="229b-1036-97f1-c680" primary="false" name="Character"/>
         <categoryLink targetId="f479-3c81-1e42-1b3a" id="b5b0-93f6-52d7-dbfc" primary="false" name="Gargantuan Unit Sub-type"/>
         <categoryLink targetId="aa94-5c65-d1f1-46a4" id="f567-1f17-8a16-1bd8" primary="false" name="Unique Sub-type"/>
@@ -1920,9 +1920,9 @@ Lord of Decay – All units with the Daemon Unit Type and the Ætheric Dominion 
         <constraint field="selections" scope="roster" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1c7-68b2-ae8d-4797" type="max"/>
       </constraints>
       <categoryLinks>
-        <categoryLink targetId="e699-d9cd-e68e-46d9" id="1915-2b8c-aef3-7163" primary="false" name="Daemon Unit-type:"/>
+        <categoryLink targetId="e699-d9cd-e68e-46d9" id="1915-2b8c-aef3-7163" primary="false" name="Daemon Unit Type"/>
         <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="db6f-e26e-15d0-5b64" primary="false" name="Character"/>
-        <categoryLink targetId="7d95-f9d1-440a-67bd" id="daf3-f6ec-94e2-caba" primary="false" name="Monstrous Sub-type:"/>
+        <categoryLink targetId="7d95-f9d1-440a-67bd" id="daf3-f6ec-94e2-caba" primary="false" name="Monstrous Sub-type"/>
         <categoryLink targetId="6e0c-29ba-a445-8321" id="7820-ede7-3e9b-980b" primary="false" name="Psyker:"/>
         <categoryLink targetId="aa94-5c65-d1f1-46a4" id="4940-9ca9-42dc-4dd" primary="false" name="Unique Sub-type"/>
         <categoryLink targetId="8cf6-d802-d054-6a86" id="27cc-3292-92d0-2aaf" primary="false" name="Putrid Corruption"/>
@@ -2102,9 +2102,9 @@ The End and the Death – When fighting in a Challenge, successful Invulnerable 
         </rule>
       </rules>
       <categoryLinks>
-        <categoryLink targetId="e699-d9cd-e68e-46d9" id="5934-3b97-488b-6ee5" primary="false" name="Daemon Unit-type:"/>
+        <categoryLink targetId="e699-d9cd-e68e-46d9" id="5934-3b97-488b-6ee5" primary="false" name="Daemon Unit Type"/>
         <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="9b69-a182-b19d-3b00" primary="false" name="Character"/>
-        <categoryLink targetId="7d95-f9d1-440a-67bd" id="a1b-c3a9-26cc-8d9a" primary="false" name="Monstrous Sub-type:"/>
+        <categoryLink targetId="7d95-f9d1-440a-67bd" id="a1b-c3a9-26cc-8d9a" primary="false" name="Monstrous Sub-type"/>
         <categoryLink targetId="aa94-5c65-d1f1-46a4" id="5d4e-5442-b05a-85d" primary="false" name="Unique Sub-type"/>
         <categoryLink targetId="c42-1919-c37e-51f0" id="2f4d-bee8-d427-5d97" primary="false" name="Encroaching Ruin"/>
       </categoryLinks>

--- a/2022 - Daemons - Daemons of the Ruinstorm.cat
+++ b/2022 - Daemons - Daemons of the Ruinstorm.cat
@@ -156,6 +156,11 @@
               </modifiers>
             </profile>
           </profiles>
+          <categoryLinks>
+            <categoryLink targetId="e699-d9cd-e68e-46d9" id="c75d-cc84-4f8f-91b7" name="Daemon" primary="false"/>
+            <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="f366-260f-4815-b01d" name="Character" primary="false"/>
+            <categoryLink targetId="7d95-f9d1-440a-67bd" id="4729-9aff-48a8-b0ff" name="Monstrous" primary="false"/>
+          </categoryLinks>
         </selectionEntry>
       </selectionEntries>
       <costs>
@@ -304,6 +309,10 @@
               </modifiers>
             </profile>
           </profiles>
+          <categoryLinks>
+            <categoryLink targetId="e699-d9cd-e68e-46d9" id="df2c-3c89-475f-a078" name="Daemon" primary="false"/>
+            <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="f12d-a1e4-4ba4-aee2" name="Character" primary="false"/>
+          </categoryLinks>
         </selectionEntry>
       </selectionEntries>
       <costs>
@@ -438,6 +447,7 @@
           </profiles>
           <categoryLinks>
             <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="9846-2d44-5af6-49b7" primary="false" name="Character"/>
+            <categoryLink targetId="e699-d9cd-e68e-46d9" id="e1fd-163c-4e37-8164" name="Daemon" primary="false"/>
           </categoryLinks>
           <infoLinks>
             <infoLink id="562c-a180-1968-72ab" name="Æthereal Invulnerability (X)" hidden="false" targetId="e05e-ed23-64fb-a535" type="rule">
@@ -570,6 +580,9 @@
               </entryLinks>
             </selectionEntryGroup>
           </selectionEntryGroups>
+          <categoryLinks>
+            <categoryLink targetId="e699-d9cd-e68e-46d9" id="c1f3-ac66-41ed-8304" name="Daemon" primary="false"/>
+          </categoryLinks>
         </selectionEntry>
       </selectionEntries>
       <costs>
@@ -623,6 +636,9 @@
               </modifiers>
             </profile>
           </profiles>
+          <categoryLinks>
+            <categoryLink targetId="e699-d9cd-e68e-46d9" id="4b32-5023-4ef3-bad3" name="Daemon" primary="false"/>
+          </categoryLinks>
         </selectionEntry>
       </selectionEntries>
       <costs>
@@ -773,6 +789,9 @@
               <modifiers>
                 <modifier type="decrement" value="3" field="e343-4e07-35a4-9ab"/>
               </modifiers>
+              <categoryLinks>
+                <categoryLink targetId="e699-d9cd-e68e-46d9" id="bf28-d2d0-4185-9f31" name="Daemon" primary="false"/>
+              </categoryLinks>
             </selectionEntry>
             <selectionEntry type="model" import="true" name="Daemon Beast w/ Immaterial Flame" hidden="false" id="5828-5d74-9c9b-edc5" publicationId="8775-88f5-cfdd-24f6" page="10">
               <costs>
@@ -816,6 +835,9 @@
                   </constraints>
                 </entryLink>
               </entryLinks>
+              <categoryLinks>
+                <categoryLink targetId="e699-d9cd-e68e-46d9" id="9520-afe4-45b9-822d" name="Daemon" primary="false"/>
+              </categoryLinks>
             </selectionEntry>
           </selectionEntries>
           <constraints>
@@ -866,6 +888,10 @@
               </modifiers>
             </profile>
           </profiles>
+          <categoryLinks>
+            <categoryLink targetId="e699-d9cd-e68e-46d9" id="90e7-f681-4b31-bad7" name="Daemon" primary="false"/>
+            <categoryLink targetId="6399-5c65-7833-1025" id="1460-27e8-499e-8488" name="Line" primary="false"/>
+          </categoryLinks>
         </selectionEntry>
       </selectionEntries>
       <costs>
@@ -958,6 +984,11 @@
               </modifiers>
             </profile>
           </profiles>
+          <categoryLinks>
+            <categoryLink targetId="e699-d9cd-e68e-46d9" id="296c-5750-4797-8849" name="Daemon" primary="false"/>
+            <categoryLink targetId="6399-5c65-7833-1025" id="5117-229f-4e4b-9d10" name="Line" primary="false"/>
+            <categoryLink targetId="59a4-7b61-600a-c457" id="17da-3c9d-454c-8c01" name="Skirmish" primary="false"/>
+          </categoryLinks>
         </selectionEntry>
       </selectionEntries>
       <costs>
@@ -1033,6 +1064,9 @@
               </modifiers>
             </profile>
           </profiles>
+          <categoryLinks>
+            <categoryLink targetId="e699-d9cd-e68e-46d9" id="3f19-20e7-4450-badd" name="Daemon" primary="false"/>
+          </categoryLinks>
         </selectionEntry>
       </selectionEntries>
       <costs>
@@ -1121,6 +1155,9 @@
               </modifiers>
             </profile>
           </profiles>
+          <categoryLinks>
+            <categoryLink targetId="e699-d9cd-e68e-46d9" id="192c-3067-4751-8c8a" name="Daemon" primary="false"/>
+          </categoryLinks>
         </selectionEntry>
       </selectionEntries>
       <costs>
@@ -1217,6 +1254,10 @@
               </modifiers>
             </profile>
           </profiles>
+          <categoryLinks>
+            <categoryLink targetId="e699-d9cd-e68e-46d9" id="7ca2-ecec-440a-b9fc" name="Daemon" primary="false"/>
+            <categoryLink targetId="7d95-f9d1-440a-67bd" id="3cae-b86c-4395-a3d6" name="Monstrous" primary="false"/>
+          </categoryLinks>
         </selectionEntry>
       </selectionEntries>
       <costs>
@@ -1296,6 +1337,10 @@
             <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="63c-704a-32c3-2279"/>
             <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="44c9-7d0c-3914-76fa"/>
           </constraints>
+          <categoryLinks>
+            <categoryLink targetId="e699-d9cd-e68e-46d9" id="c715-e5b8-4d68-8e7b" name="Daemon" primary="false"/>
+            <categoryLink targetId="7d95-f9d1-440a-67bd" id="a797-6dc9-4343-a422" name="Monstrous" primary="false"/>
+          </categoryLinks>
         </selectionEntry>
       </selectionEntries>
       <costs>
@@ -1434,6 +1479,10 @@
             <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="6f71-46db-a004-16fb"/>
             <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="c0-232e-ef53-a68f"/>
           </constraints>
+          <categoryLinks>
+            <categoryLink targetId="e699-d9cd-e68e-46d9" id="794f-5d11-4d31-8378" name="Daemon" primary="false"/>
+            <categoryLink targetId="f479-3c81-1e42-1b3a" id="390d-0f39-4a2f-8d01" name="Gargantuan" primary="false"/>
+          </categoryLinks>
         </selectionEntry>
       </selectionEntries>
       <costs>
@@ -1561,6 +1610,13 @@
             <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="9c30-be9e-1d4c-d9b7"/>
             <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="24a0-92b9-2299-b235"/>
           </constraints>
+          <categoryLinks>
+            <categoryLink targetId="e699-d9cd-e68e-46d9" id="0b73-2e58-4df4-ba67" name="Daemon" primary="false"/>
+            <categoryLink targetId="40f3-05e8-5ddc-636a" id="e4d3-276d-44de-a989" name="Bound" primary="false"/>
+            <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="4ed8-8d0c-4551-920b" name="Character" primary="false"/>
+            <categoryLink targetId="f479-3c81-1e42-1b3a" id="da7c-602d-4e7d-9d56" name="Gargantuan" primary="false"/>
+            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="cdd4-71f1-40f8-bb47" name="Unique" primary="false"/>
+          </categoryLinks>
         </selectionEntry>
         <selectionEntry id="c53f-316f-bec8-ff33" name="Warlord Trait: Skull Keeper" publicationId="cb13-da24-e6da-75b3" page="19" hidden="false" collective="false" import="true" type="upgrade">
           <modifiers>
@@ -1744,6 +1800,14 @@ If Sanguinius is removed as a casualty while fighting in a Challenge against Ka&
             <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="b221-26cf-b220-adfd"/>
             <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="e268-ae52-e7ea-564c"/>
           </constraints>
+          <categoryLinks>
+            <categoryLink targetId="e699-d9cd-e68e-46d9" id="ecdd-6a91-4027-935c" name="Daemon" primary="false"/>
+            <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="6d79-c727-4974-83cd" name="Character" primary="false"/>
+            <categoryLink targetId="7d95-f9d1-440a-67bd" id="8971-494c-48b0-8f70" name="Monstrous" primary="false"/>
+            <categoryLink targetId="6e0c-29ba-a445-8321" id="f205-b9a0-4094-87b9" name="Psyker" primary="false"/>
+            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="9110-73b5-40a2-841b" name="Unique" primary="false"/>
+            <categoryLink targetId="9231-183c-b97b-63f9" id="63bc-f02a-430b-b955" name="Heavy" primary="false"/>
+          </categoryLinks>
         </selectionEntry>
         <selectionEntry id="401-d57-6162-f869" name="Warlord Trait: Lord of Decay" hidden="false" collective="false" import="true" type="upgrade">
           <modifiers>
@@ -1895,6 +1959,12 @@ Lord of Decay – All units with the Daemon Unit Type and the Ætheric Dominion 
             <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="df42-4d51-ed0a-eaae"/>
             <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="fc22-d5ee-6541-657b"/>
           </constraints>
+          <categoryLinks>
+            <categoryLink targetId="e699-d9cd-e68e-46d9" id="7dee-b6ca-43f3-9d0e" name="Daemon" primary="false"/>
+            <categoryLink targetId="7d95-f9d1-440a-67bd" id="bf74-28a7-4e30-8e1c" name="Monstrous" primary="false"/>
+            <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="fb16-0921-403e-bc11" name="Character" primary="false"/>
+            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="c8c3-0a2a-4b6b-9e2a" name="Unique" primary="false"/>
+          </categoryLinks>
         </selectionEntry>
         <selectionEntry id="4e0b-56a7-1e28-3b3c" name="Blades of Samus" hidden="false" collective="false" import="true" type="upgrade" publicationId="8775-88f5-cfdd-24f6" page="21">
           <constraints>

--- a/2022 - Daemons - Daemons of the Ruinstorm.cat
+++ b/2022 - Daemons - Daemons of the Ruinstorm.cat
@@ -157,9 +157,9 @@
             </profile>
           </profiles>
           <categoryLinks>
-            <categoryLink targetId="e699-d9cd-e68e-46d9" id="c75d-cc84-4f8f-91b7" name="Daemon" primary="false"/>
+            <categoryLink targetId="e699-d9cd-e68e-46d9" id="c75d-cc84-4f8f-91b7" name="Daemon Unit Type" primary="false"/>
             <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="f366-260f-4815-b01d" name="Character" primary="false"/>
-            <categoryLink targetId="7d95-f9d1-440a-67bd" id="4729-9aff-48a8-b0ff" name="Monstrous" primary="false"/>
+            <categoryLink targetId="7d95-f9d1-440a-67bd" id="4729-9aff-48a8-b0ff" name="Monstrous Sub-type" primary="false"/>
           </categoryLinks>
         </selectionEntry>
       </selectionEntries>
@@ -310,7 +310,7 @@
             </profile>
           </profiles>
           <categoryLinks>
-            <categoryLink targetId="e699-d9cd-e68e-46d9" id="df2c-3c89-475f-a078" name="Daemon" primary="false"/>
+            <categoryLink targetId="e699-d9cd-e68e-46d9" id="df2c-3c89-475f-a078" name="Daemon Unit Type" primary="false"/>
             <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="f12d-a1e4-4ba4-aee2" name="Character" primary="false"/>
           </categoryLinks>
         </selectionEntry>
@@ -447,7 +447,7 @@
           </profiles>
           <categoryLinks>
             <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="9846-2d44-5af6-49b7" primary="false" name="Character"/>
-            <categoryLink targetId="e699-d9cd-e68e-46d9" id="e1fd-163c-4e37-8164" name="Daemon" primary="false"/>
+            <categoryLink targetId="e699-d9cd-e68e-46d9" id="e1fd-163c-4e37-8164" name="Daemon Unit Type" primary="false"/>
           </categoryLinks>
           <infoLinks>
             <infoLink id="562c-a180-1968-72ab" name="Æthereal Invulnerability (X)" hidden="false" targetId="e05e-ed23-64fb-a535" type="rule">
@@ -581,7 +581,7 @@
             </selectionEntryGroup>
           </selectionEntryGroups>
           <categoryLinks>
-            <categoryLink targetId="e699-d9cd-e68e-46d9" id="c1f3-ac66-41ed-8304" name="Daemon" primary="false"/>
+            <categoryLink targetId="e699-d9cd-e68e-46d9" id="c1f3-ac66-41ed-8304" name="Daemon Unit Type" primary="false"/>
           </categoryLinks>
         </selectionEntry>
       </selectionEntries>
@@ -637,7 +637,7 @@
             </profile>
           </profiles>
           <categoryLinks>
-            <categoryLink targetId="e699-d9cd-e68e-46d9" id="4b32-5023-4ef3-bad3" name="Daemon" primary="false"/>
+            <categoryLink targetId="e699-d9cd-e68e-46d9" id="4b32-5023-4ef3-bad3" name="Daemon Unit Type" primary="false"/>
           </categoryLinks>
         </selectionEntry>
       </selectionEntries>
@@ -790,7 +790,7 @@
                 <modifier type="decrement" value="3" field="e343-4e07-35a4-9ab"/>
               </modifiers>
               <categoryLinks>
-                <categoryLink targetId="e699-d9cd-e68e-46d9" id="bf28-d2d0-4185-9f31" name="Daemon" primary="false"/>
+                <categoryLink targetId="e699-d9cd-e68e-46d9" id="bf28-d2d0-4185-9f31" name="Daemon Unit Type" primary="false"/>
               </categoryLinks>
             </selectionEntry>
             <selectionEntry type="model" import="true" name="Daemon Beast w/ Immaterial Flame" hidden="false" id="5828-5d74-9c9b-edc5" publicationId="8775-88f5-cfdd-24f6" page="10">
@@ -836,7 +836,7 @@
                 </entryLink>
               </entryLinks>
               <categoryLinks>
-                <categoryLink targetId="e699-d9cd-e68e-46d9" id="9520-afe4-45b9-822d" name="Daemon" primary="false"/>
+                <categoryLink targetId="e699-d9cd-e68e-46d9" id="9520-afe4-45b9-822d" name="Daemon Unit Type" primary="false"/>
               </categoryLinks>
             </selectionEntry>
           </selectionEntries>
@@ -889,8 +889,8 @@
             </profile>
           </profiles>
           <categoryLinks>
-            <categoryLink targetId="e699-d9cd-e68e-46d9" id="90e7-f681-4b31-bad7" name="Daemon" primary="false"/>
-            <categoryLink targetId="6399-5c65-7833-1025" id="1460-27e8-499e-8488" name="Line" primary="false"/>
+            <categoryLink targetId="e699-d9cd-e68e-46d9" id="90e7-f681-4b31-bad7" name="Daemon Unit Type" primary="false"/>
+            <categoryLink targetId="6399-5c65-7833-1025" id="1460-27e8-499e-8488" name="Line Sub-type" primary="false"/>
           </categoryLinks>
         </selectionEntry>
       </selectionEntries>
@@ -985,9 +985,9 @@
             </profile>
           </profiles>
           <categoryLinks>
-            <categoryLink targetId="e699-d9cd-e68e-46d9" id="296c-5750-4797-8849" name="Daemon" primary="false"/>
-            <categoryLink targetId="6399-5c65-7833-1025" id="5117-229f-4e4b-9d10" name="Line" primary="false"/>
-            <categoryLink targetId="59a4-7b61-600a-c457" id="17da-3c9d-454c-8c01" name="Skirmish" primary="false"/>
+            <categoryLink targetId="e699-d9cd-e68e-46d9" id="296c-5750-4797-8849" name="Daemon Unit Type" primary="false"/>
+            <categoryLink targetId="6399-5c65-7833-1025" id="5117-229f-4e4b-9d10" name="Line Sub-type" primary="false"/>
+            <categoryLink targetId="59a4-7b61-600a-c457" id="17da-3c9d-454c-8c01" name="Skirmish Sub-type" primary="false"/>
           </categoryLinks>
         </selectionEntry>
       </selectionEntries>
@@ -1065,7 +1065,7 @@
             </profile>
           </profiles>
           <categoryLinks>
-            <categoryLink targetId="e699-d9cd-e68e-46d9" id="3f19-20e7-4450-badd" name="Daemon" primary="false"/>
+            <categoryLink targetId="e699-d9cd-e68e-46d9" id="3f19-20e7-4450-badd" name="Daemon Unit Type" primary="false"/>
           </categoryLinks>
         </selectionEntry>
       </selectionEntries>
@@ -1156,7 +1156,7 @@
             </profile>
           </profiles>
           <categoryLinks>
-            <categoryLink targetId="e699-d9cd-e68e-46d9" id="192c-3067-4751-8c8a" name="Daemon" primary="false"/>
+            <categoryLink targetId="e699-d9cd-e68e-46d9" id="192c-3067-4751-8c8a" name="Daemon Unit Type" primary="false"/>
           </categoryLinks>
         </selectionEntry>
       </selectionEntries>
@@ -1255,8 +1255,8 @@
             </profile>
           </profiles>
           <categoryLinks>
-            <categoryLink targetId="e699-d9cd-e68e-46d9" id="7ca2-ecec-440a-b9fc" name="Daemon" primary="false"/>
-            <categoryLink targetId="7d95-f9d1-440a-67bd" id="3cae-b86c-4395-a3d6" name="Monstrous" primary="false"/>
+            <categoryLink targetId="e699-d9cd-e68e-46d9" id="7ca2-ecec-440a-b9fc" name="Daemon Unit Type" primary="false"/>
+            <categoryLink targetId="7d95-f9d1-440a-67bd" id="3cae-b86c-4395-a3d6" name="Monstrous Sub-type" primary="false"/>
           </categoryLinks>
         </selectionEntry>
       </selectionEntries>
@@ -1338,8 +1338,8 @@
             <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="44c9-7d0c-3914-76fa"/>
           </constraints>
           <categoryLinks>
-            <categoryLink targetId="e699-d9cd-e68e-46d9" id="c715-e5b8-4d68-8e7b" name="Daemon" primary="false"/>
-            <categoryLink targetId="7d95-f9d1-440a-67bd" id="a797-6dc9-4343-a422" name="Monstrous" primary="false"/>
+            <categoryLink targetId="e699-d9cd-e68e-46d9" id="c715-e5b8-4d68-8e7b" name="Daemon Unit Type" primary="false"/>
+            <categoryLink targetId="7d95-f9d1-440a-67bd" id="a797-6dc9-4343-a422" name="Monstrous Sub-type" primary="false"/>
           </categoryLinks>
         </selectionEntry>
       </selectionEntries>
@@ -1480,8 +1480,8 @@
             <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="c0-232e-ef53-a68f"/>
           </constraints>
           <categoryLinks>
-            <categoryLink targetId="e699-d9cd-e68e-46d9" id="794f-5d11-4d31-8378" name="Daemon" primary="false"/>
-            <categoryLink targetId="f479-3c81-1e42-1b3a" id="390d-0f39-4a2f-8d01" name="Gargantuan" primary="false"/>
+            <categoryLink targetId="e699-d9cd-e68e-46d9" id="794f-5d11-4d31-8378" name="Daemon Unit Type" primary="false"/>
+            <categoryLink targetId="f479-3c81-1e42-1b3a" id="390d-0f39-4a2f-8d01" name="Gargantuan Unit Sub-type" primary="false"/>
           </categoryLinks>
         </selectionEntry>
       </selectionEntries>
@@ -1611,11 +1611,11 @@
             <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="24a0-92b9-2299-b235"/>
           </constraints>
           <categoryLinks>
-            <categoryLink targetId="e699-d9cd-e68e-46d9" id="0b73-2e58-4df4-ba67" name="Daemon" primary="false"/>
-            <categoryLink targetId="40f3-05e8-5ddc-636a" id="e4d3-276d-44de-a989" name="Bound" primary="false"/>
+            <categoryLink targetId="e699-d9cd-e68e-46d9" id="0b73-2e58-4df4-ba67" name="Daemon Unit Type" primary="false"/>
+            <categoryLink targetId="40f3-05e8-5ddc-636a" id="e4d3-276d-44de-a989" name="Bound Sub-type" primary="false"/>
             <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="4ed8-8d0c-4551-920b" name="Character" primary="false"/>
-            <categoryLink targetId="f479-3c81-1e42-1b3a" id="da7c-602d-4e7d-9d56" name="Gargantuan" primary="false"/>
-            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="cdd4-71f1-40f8-bb47" name="Unique" primary="false"/>
+            <categoryLink targetId="f479-3c81-1e42-1b3a" id="da7c-602d-4e7d-9d56" name="Gargantuan Unit Sub-type" primary="false"/>
+            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="cdd4-71f1-40f8-bb47" name="Unique Sub-type" primary="false"/>
           </categoryLinks>
         </selectionEntry>
         <selectionEntry id="c53f-316f-bec8-ff33" name="Warlord Trait: Skull Keeper" publicationId="cb13-da24-e6da-75b3" page="19" hidden="false" collective="false" import="true" type="upgrade">
@@ -1801,12 +1801,12 @@ If Sanguinius is removed as a casualty while fighting in a Challenge against Ka&
             <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="e268-ae52-e7ea-564c"/>
           </constraints>
           <categoryLinks>
-            <categoryLink targetId="e699-d9cd-e68e-46d9" id="ecdd-6a91-4027-935c" name="Daemon" primary="false"/>
+            <categoryLink targetId="e699-d9cd-e68e-46d9" id="ecdd-6a91-4027-935c" name="Daemon Unit Type" primary="false"/>
             <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="6d79-c727-4974-83cd" name="Character" primary="false"/>
-            <categoryLink targetId="7d95-f9d1-440a-67bd" id="8971-494c-48b0-8f70" name="Monstrous" primary="false"/>
-            <categoryLink targetId="6e0c-29ba-a445-8321" id="f205-b9a0-4094-87b9" name="Psyker" primary="false"/>
-            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="9110-73b5-40a2-841b" name="Unique" primary="false"/>
-            <categoryLink targetId="9231-183c-b97b-63f9" id="63bc-f02a-430b-b955" name="Heavy" primary="false"/>
+            <categoryLink targetId="7d95-f9d1-440a-67bd" id="8971-494c-48b0-8f70" name="Monstrous Sub-type" primary="false"/>
+            <categoryLink targetId="6e0c-29ba-a445-8321" id="f205-b9a0-4094-87b9" name="Psyker:" primary="false"/>
+            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="9110-73b5-40a2-841b" name="Unique Sub-type" primary="false"/>
+            <categoryLink targetId="9231-183c-b97b-63f9" id="63bc-f02a-430b-b955" name="Heavy Sub-type" primary="false"/>
           </categoryLinks>
         </selectionEntry>
         <selectionEntry id="401-d57-6162-f869" name="Warlord Trait: Lord of Decay" hidden="false" collective="false" import="true" type="upgrade">
@@ -1960,10 +1960,10 @@ Lord of Decay – All units with the Daemon Unit Type and the Ætheric Dominion 
             <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="fc22-d5ee-6541-657b"/>
           </constraints>
           <categoryLinks>
-            <categoryLink targetId="e699-d9cd-e68e-46d9" id="7dee-b6ca-43f3-9d0e" name="Daemon" primary="false"/>
-            <categoryLink targetId="7d95-f9d1-440a-67bd" id="bf74-28a7-4e30-8e1c" name="Monstrous" primary="false"/>
+            <categoryLink targetId="e699-d9cd-e68e-46d9" id="7dee-b6ca-43f3-9d0e" name="Daemon Unit Type" primary="false"/>
+            <categoryLink targetId="7d95-f9d1-440a-67bd" id="bf74-28a7-4e30-8e1c" name="Monstrous Sub-type" primary="false"/>
             <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="fb16-0921-403e-bc11" name="Character" primary="false"/>
-            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="c8c3-0a2a-4b6b-9e2a" name="Unique" primary="false"/>
+            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="c8c3-0a2a-4b6b-9e2a" name="Unique Sub-type" primary="false"/>
           </categoryLinks>
         </selectionEntry>
         <selectionEntry id="4e0b-56a7-1e28-3b3c" name="Blades of Samus" hidden="false" collective="false" import="true" type="upgrade" publicationId="8775-88f5-cfdd-24f6" page="21">

--- a/2022 - Horus Heresy.gst
+++ b/2022 - Horus Heresy.gst
@@ -1639,7 +1639,7 @@ If a Skimmer is Immobilised or Wrecked, its base is removed, if possible. If thi
             <constraint field="selections" scope="force" value="2" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8810-8109-85db-93e4" type="min"/>
           </constraints>
         </categoryLink>
-        <categoryLink id="2545-86dd-f928-73f3" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false">
+        <categoryLink id="2545-86dd-f928-73f3" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false">
           <infoLinks>
             <infoLink name="Stubborn" hidden="false" type="rule" id="986d-7ecf-f212-2602" targetId="7989-1f2c-a43d-82ae">
               <modifiers>
@@ -1885,7 +1885,7 @@ If a Skimmer is Immobilised or Wrecked, its base is removed, if possible. If thi
             <constraint field="selections" scope="force" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3965-7b5b-1e0b-d284" type="min"/>
           </constraints>
         </categoryLink>
-        <categoryLink id="13d3-d01e-f52f-e687" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="13d3-d01e-f52f-e687" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="c1eb-5ad0-5c14-b414" name="Clanfolk Cavalry (Troops)" hidden="false" targetId="d029-ac65-0ade-0c32" primary="false">
           <constraints>
             <constraint field="selections" scope="force" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b40d-bc3b-2e1b-1243" type="max"/>
@@ -2128,7 +2128,7 @@ If a Skimmer is Immobilised or Wrecked, its base is removed, if possible. If thi
             <constraint field="selections" scope="force" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f56f-a2c5-0423-bca7" type="min"/>
           </constraints>
         </categoryLink>
-        <categoryLink id="3dbc-6e8f-de3e-52ae" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="3dbc-6e8f-de3e-52ae" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="9bbe-d889-072c-1258" name="LoW &amp; Primarchs (25% Limit)" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false">
           <modifiers>
             <modifier type="increment" field="11cb-d547-c07c-da25" value="1">
@@ -6482,9 +6482,6 @@ Fire Point (Front 4)</characteristic>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="55"/>
           </costs>
           <categoryLinks/>
-          <comment>!BSC Errors from 20240328-1346
-Could not find type or subtype &apos;Fortificaion&apos;
-Could not find type or subtype &apos;Building)&apos;</comment>
         </selectionEntry>
       </selectionEntries>
       <costs>
@@ -6523,9 +6520,6 @@ Hull Mounted (Rear) Heavy Bolter</characteristic>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="85"/>
           </costs>
           <categoryLinks/>
-          <comment>!BSC Errors from 20240328-1346
-Could not find type or subtype &apos;Fortificaion&apos;
-Could not find type or subtype &apos;Building)&apos;</comment>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
@@ -6605,11 +6599,6 @@ Four single Blast Shields</characteristic>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="35"/>
           </costs>
           <categoryLinks/>
-          <comment>!BSC Errors from 20240328-1346
-Could not find type or subtype &apos;Fortication&apos;
-Could not find type or subtype &apos;Barricade)
-Four double Blast Shields
-Four single Blast Shield&apos;</comment>
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
@@ -8651,10 +8640,8 @@ Hull Mounted (Rear) Heavy Bolter</characteristic>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="75"/>
           </costs>
           <categoryLinks>
-            <categoryLink targetId="3eeb-b4b8-3d85-245a" id="43c1-7dc4-4f66-b763" name="Emplacement" primary="false"/>
+            <categoryLink targetId="3eeb-b4b8-3d85-245a" id="43c1-7dc4-4f66-b763" name="Emplacement Sub-type" primary="false"/>
           </categoryLinks>
-          <comment>!BSC Errors from 20240328-1346
-Could not find type or subtype &apos;Fortificaion&apos;</comment>
         </selectionEntry>
       </selectionEntries>
       <costs>
@@ -8878,10 +8865,8 @@ Hull Mounted (Rear) Mounted Twin-linked Heavy Bolter or Heavy Flamers</character
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
           </costs>
           <categoryLinks>
-            <categoryLink targetId="3eeb-b4b8-3d85-245a" id="076b-78d8-46ba-a6ed" name="Emplacement" primary="false"/>
+            <categoryLink targetId="3eeb-b4b8-3d85-245a" id="076b-78d8-46ba-a6ed" name="Emplacement Sub-type" primary="false"/>
           </categoryLinks>
-          <comment>!BSC Errors from 20240328-1346
-Could not find type or subtype &apos;Fortificaion&apos;</comment>
         </selectionEntry>
         <selectionEntry id="1332-1487-ac2c-3921" name="Bunker Annex" hidden="false" collective="false" import="true" type="model">
           <constraints>
@@ -8937,10 +8922,8 @@ Could not find type or subtype &apos;Fortificaion&apos;</comment>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
           </costs>
           <categoryLinks>
-            <categoryLink targetId="9f1e-fbf0-3032-32fe" id="8af4-11d7-46c2-b6c4" name="Building" primary="false"/>
+            <categoryLink targetId="9f1e-fbf0-3032-32fe" id="8af4-11d7-46c2-b6c4" name="Building Sub-type" primary="false"/>
           </categoryLinks>
-          <comment>!BSC Errors from 20240328-1346
-Could not find type or subtype &apos;Fortificaion&apos;</comment>
         </selectionEntry>
       </selectionEntries>
       <costs>

--- a/2022 - Horus Heresy.gst
+++ b/2022 - Horus Heresy.gst
@@ -1314,6 +1314,28 @@ Reactions:
     <categoryEntry name="Forge Remnants - Militia Krios Squadron" hidden="false" id="dfbc-8edd-e14f-fd80"/>
     <categoryEntry name="Primus Medicae" hidden="false" id="b81a-8f4a-ff50-ef99"/>
     <categoryEntry name="Tech-Priest Auxilia" hidden="true" id="86dd-51d8-3669-68ca"/>
+    <categoryEntry name="Skimmer" hidden="false" id="6a28-17c5-8117-d99c">
+      <rules>
+        <rule name="Skimmers" hidden="false" id="c874-2cbd-3ad9-4f1f" publicationId="e77a-823a-da94-16b9" page="214">
+          <description>Skimmers have flying bases under their hull. However, distances are still measured to and from the Skimmer’s hull, with the exception of the Vehicle’s weapons, which all work as normal. The base of a Skimmer is effectively ignored, except for when the Skimmer is being Charged or Rammed, in which case, models may move into contact with the Vehicle’s hull, its base or both.
+Skimmers can move over friendly and enemy models, but they cannot end their move on top of either. Skimmers can move over all terrain, ignoring all penalties for Difficult Terrain and Dangerous Terrain tests. However, if a moving Skimmer starts or ends its move in Difficult Terrain or Dangerous Terrain, it must take a Dangerous Terrain test. A Skimmer can even end its move over Impassable Terrain if it is possible to actually place the model on top of it, but if it does so it must take a Dangerous Terrain test. If a Skimmer is forced to end its move over friendly or enemy models, move the Skimmer the minimum distance so that no models are left underneath it.
+If a Skimmer is Immobilised or Wrecked, its base is removed, if possible. If this is not possible (the base might have been glued in place, for example), then leave the base in place. Note that it is not otherwise permitted to remove the flying base, as Skimmers cannot land in battle conditions.</description>
+        </rule>
+      </rules>
+    </categoryEntry>
+    <categoryEntry name="Guardian Unit Sub-type" hidden="false" id="8745-b21e-8576-7c30" publicationId="bde1-6db1-163b-3b76" page="91">
+      <rules>
+        <rule name="Guardian Unit Sub-type" hidden="false" id="48af-72a8-159e-9cfe" publicationId="bde1-6db1-163b-3b76" page="91">
+          <description>The following rules apply to all models with the Guardian Unit Sub-type:
+• Units including models with the Guardian Unit Sub-type may Embark freely upon models with the Transport Unit Sub-type and within Buildings and Fortifications as if they had the Infantry Type, even if their Unit Type would normally restrict this.
+• Units including models with the Guardian Unit Sub-type may be joined by friendly models with the Character Unit Sub-type or Independent Character special rule, and when they are joined in this manner may make Reactions, even if their Unit Type would normally restrict this.
+• If a unit contains any models with the Guardian Unit Sub-type as well as one or more models with the Character Unit Sub-type, any Wounds which would be allocated to the Character (even those caused by the Precision Strikes (X) or Sniper special rules) may instead be allocated to a model with the Guardian Unit Sub-type first.
+• Unless they are joined by a friendly Character, all models with the Guardian Unit Sub-type suffer the following provisions:
+- Reduce their Movement Characteristic by -2 and may not Run. 
+- Reduce their Initiative Characteristic to 1.</description>
+        </rule>
+      </rules>
+    </categoryEntry>
   </categoryEntries>
   <forceEntries>
     <forceEntry id="d926-652f-8436-30ce" name="1. Crusade Force Organisation Chart" hidden="false">

--- a/2022 - Horus Heresy.gst
+++ b/2022 - Horus Heresy.gst
@@ -6455,6 +6455,10 @@ Fire Point (Front 4)</characteristic>
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="55"/>
           </costs>
+          <categoryLinks/>
+          <comment>!BSC Errors from 20240328-1346
+Could not find type or subtype &apos;Fortificaion&apos;
+Could not find type or subtype &apos;Building)&apos;</comment>
         </selectionEntry>
       </selectionEntries>
       <costs>
@@ -6492,6 +6496,10 @@ Hull Mounted (Rear) Heavy Bolter</characteristic>
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="85"/>
           </costs>
+          <categoryLinks/>
+          <comment>!BSC Errors from 20240328-1346
+Could not find type or subtype &apos;Fortificaion&apos;
+Could not find type or subtype &apos;Building)&apos;</comment>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
@@ -6570,6 +6578,12 @@ Four single Blast Shields</characteristic>
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="35"/>
           </costs>
+          <categoryLinks/>
+          <comment>!BSC Errors from 20240328-1346
+Could not find type or subtype &apos;Fortication&apos;
+Could not find type or subtype &apos;Barricade)
+Four double Blast Shields
+Four single Blast Shield&apos;</comment>
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
@@ -8610,6 +8624,11 @@ Hull Mounted (Rear) Heavy Bolter</characteristic>
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="75"/>
           </costs>
+          <categoryLinks>
+            <categoryLink targetId="3eeb-b4b8-3d85-245a" id="43c1-7dc4-4f66-b763" name="Emplacement" primary="false"/>
+          </categoryLinks>
+          <comment>!BSC Errors from 20240328-1346
+Could not find type or subtype &apos;Fortificaion&apos;</comment>
         </selectionEntry>
       </selectionEntries>
       <costs>
@@ -8832,6 +8851,11 @@ Hull Mounted (Rear) Mounted Twin-linked Heavy Bolter or Heavy Flamers</character
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
           </costs>
+          <categoryLinks>
+            <categoryLink targetId="3eeb-b4b8-3d85-245a" id="076b-78d8-46ba-a6ed" name="Emplacement" primary="false"/>
+          </categoryLinks>
+          <comment>!BSC Errors from 20240328-1346
+Could not find type or subtype &apos;Fortificaion&apos;</comment>
         </selectionEntry>
         <selectionEntry id="1332-1487-ac2c-3921" name="Bunker Annex" hidden="false" collective="false" import="true" type="model">
           <constraints>
@@ -8886,6 +8910,11 @@ Hull Mounted (Rear) Mounted Twin-linked Heavy Bolter or Heavy Flamers</character
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
           </costs>
+          <categoryLinks>
+            <categoryLink targetId="9f1e-fbf0-3032-32fe" id="8af4-11d7-46c2-b6c4" name="Building" primary="false"/>
+          </categoryLinks>
+          <comment>!BSC Errors from 20240328-1346
+Could not find type or subtype &apos;Fortificaion&apos;</comment>
         </selectionEntry>
       </selectionEntries>
       <costs>

--- a/2022 - Horus Heresy.gst
+++ b/2022 - Horus Heresy.gst
@@ -260,7 +260,7 @@ During Reactions made in any Phase, a unit equipped with Jump PAcks may not acti
         </rule>
         <rule name="Infantry Unit Type" hidden="false" id="ed36-77cb-5da7-3298" publicationId="e77a-823a-da94-16b9" page="195">
           <alias>Infantry</alias>
-          <description>An Infantry unit may only include or be joined by models of the Infantry or Primarch Unit Type, unless a special rule states otherwise.</description>
+          <description>An Infantry unit may only include or be joined by models of the Infantry or Primarch Unit Type, unless a special rule states otherwise.</description>
         </rule>
       </rules>
       <infoLinks>
@@ -6459,6 +6459,7 @@ Fire Point (Front 4)</characteristic>
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="55"/>
           </costs>
+          <categoryLinks/>
           <comment>!BSC Errors from 20240328-1346
 Could not find type or subtype &apos;Fortificaion&apos;
 Could not find type or subtype &apos;Building)&apos;</comment>
@@ -6499,6 +6500,7 @@ Hull Mounted (Rear) Heavy Bolter</characteristic>
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="85"/>
           </costs>
+          <categoryLinks/>
           <comment>!BSC Errors from 20240328-1346
 Could not find type or subtype &apos;Fortificaion&apos;
 Could not find type or subtype &apos;Building)&apos;</comment>
@@ -6580,6 +6582,7 @@ Four single Blast Shields</characteristic>
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="35"/>
           </costs>
+          <categoryLinks/>
           <comment>!BSC Errors from 20240328-1346
 Could not find type or subtype &apos;Fortication&apos;
 Could not find type or subtype &apos;Barricade)

--- a/2022 - Horus Heresy.gst
+++ b/2022 - Horus Heresy.gst
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<gameSystem xmlns="http://www.battlescribe.net/schema/gameSystemSchema" id="28d4-bd2e-4858-ece6" name="Horus Heresy (2022)" revision="102" battleScribeVersion="2.03" type="gameSystem">
+<gameSystem xmlns="http://www.battlescribe.net/schema/gameSystemSchema" id="28d4-bd2e-4858-ece6" name="Horus Heresy (2022)" revision="103" battleScribeVersion="2.03" type="gameSystem">
   <publications>
     <publication name="Github" hidden="false" id="e2a4-ac85-1bef-22f5" publisherUrl="https://github.com/BSData/horus-heresy" shortName="BSData/horus-heresy"/>
     <publication id="e77a-823a-da94-16b9" name="Warhammer: The Horus Heresy - Age of Darkness Rulebook" shortName="Main Rules" publicationDate="June 2022"/>
@@ -233,7 +233,7 @@ During Reactions made in any Phase, a unit equipped with Jump PAcks may not acti
         </infoLink>
       </infoLinks>
     </categoryEntry>
-    <categoryEntry id="8b4f-bfe2-ce7b-f1b1" name="Infantry:" hidden="false">
+    <categoryEntry id="8b4f-bfe2-ce7b-f1b1" name="Infantry Unit Type" hidden="false">
       <modifiers>
         <modifier type="increment" field="9658-3768-cea2-6062" value="1">
           <repeats>
@@ -257,6 +257,10 @@ During Reactions made in any Phase, a unit equipped with Jump PAcks may not acti
             </modifier>
           </modifiers>
           <description>All models with both the Infantry Unit Type and the Legiones Astartes (Salamanders) in a Detachment using this Rite of War ignore all modifiers to their Leadership when making Pinning tests.</description>
+        </rule>
+        <rule name="Infantry Unit Type" hidden="false" id="ed36-77cb-5da7-3298" publicationId="e77a-823a-da94-16b9" page="195">
+          <alias>Infantry</alias>
+          <description>An Infantry unit may only include or be joined by models of the Infantry or Primarch Unit Type, unless a special rule states otherwise.</description>
         </rule>
       </rules>
       <infoLinks>
@@ -367,7 +371,7 @@ During Reactions made in any Phase, a unit equipped with Jump PAcks may not acti
         </infoLink>
       </infoLinks>
     </categoryEntry>
-    <categoryEntry id="6d79-a3e4-381f-7b0f" name="Cavalry Unit-type:" hidden="false">
+    <categoryEntry id="6d79-a3e4-381f-7b0f" name="Cavalry Unit Type" hidden="false">
       <modifiers>
         <modifier type="increment" field="1b62-2f0a-dffc-cb7b" value="1">
           <conditionGroups>
@@ -495,7 +499,7 @@ During Reactions made in any Phase, a unit equipped with Jump PAcks may not acti
     </categoryEntry>
     <categoryEntry id="23eb-0b9e-0857-e965" name="Vehicle Unit:" hidden="false"/>
     <categoryEntry id="bab3-f50d-3e5f-2f78" name="Terminators:" hidden="false"/>
-    <categoryEntry id="d8ab-8e21-e193-63ba" name="Automata Unit-type:" publicationId="e77a-823a-da94-16b9" page="195" hidden="false">
+    <categoryEntry id="d8ab-8e21-e193-63ba" name="Automata Unit Type" publicationId="e77a-823a-da94-16b9" page="195" hidden="false">
       <rules>
         <rule id="d9e0-baf4-66cb-24cc" name="Automata Unit-type" publicationId="e77a-823a-da94-16b9" page="195" hidden="false">
           <description>• All Automata models have the Fearless special rule.
@@ -509,7 +513,7 @@ During Reactions made in any Phase, a unit equipped with Jump PAcks may not acti
       </infoLinks>
     </categoryEntry>
     <categoryEntry id="4171-e276-e90d-b8e5" name="Legion Consularis:" hidden="false"/>
-    <categoryEntry id="59a4-7b61-600a-c457" name="Skirmish Sub-type:" hidden="false">
+    <categoryEntry id="59a4-7b61-600a-c457" name="Skirmish Sub-type" hidden="false">
       <rules>
         <rule id="e02b-5fd3-aa3b-4fc4" name="Skirmish Sub-type" publicationId="817a-6288-e016-7469" page="95" hidden="false">
           <description>• A unit that includes only models with the Skirmish Sub-type has a unit coherency range of 3&quot; rather than 2&quot;
@@ -517,7 +521,7 @@ During Reactions made in any Phase, a unit equipped with Jump PAcks may not acti
         </rule>
       </rules>
     </categoryEntry>
-    <categoryEntry id="d5df-57ac-8f3c-097b" name="Bombard Sub-type:" hidden="false">
+    <categoryEntry id="d5df-57ac-8f3c-097b" name="Bombard Sub-type" hidden="false">
       <modifiers>
         <modifier type="set" field="b5db-1b13-81a9-66fe" value="0">
           <conditionGroups>
@@ -540,7 +544,7 @@ During Reactions made in any Phase, a unit equipped with Jump PAcks may not acti
         </rule>
       </rules>
     </categoryEntry>
-    <categoryEntry id="9b0d-738c-10e4-4ec1" name="Reinforced Sub-type:" hidden="false">
+    <categoryEntry id="9b0d-738c-10e4-4ec1" name="Reinforced Sub-type" hidden="false">
       <rules>
         <rule id="dbac-669b-298c-868e" name="Reinforced Sub-type" publicationId="817a-6288-e016-7469" page="95" hidden="false">
           <description>• A model with the Reinforced Sub-type ignores the effects of any Crew Shaken result on the Vehicle Damage table
@@ -558,7 +562,7 @@ During Reactions made in any Phase, a unit equipped with Jump PAcks may not acti
     <categoryEntry id="030f-3801-4f54-e7f8" name="Compulsory Heavy Support:" hidden="false"/>
     <categoryEntry id="0a04-abac-c606-2d48" name="Compulsory Lord of War:" hidden="false"/>
     <categoryEntry id="1b67-8d3b-283a-1488" name="Compulsory Fortification:" hidden="false"/>
-    <categoryEntry id="9231-183c-b97b-63f9" name="Heavy Sub-type:" hidden="false">
+    <categoryEntry id="9231-183c-b97b-63f9" name="Heavy Sub-type" hidden="false">
       <modifiers>
         <modifier type="set" field="fd31-bf22-2243-ccc7" value="0">
           <conditionGroups>
@@ -582,7 +586,7 @@ During Reactions made in any Phase, a unit equipped with Jump PAcks may not acti
       </rules>
     </categoryEntry>
     <categoryEntry id="6e0c-29ba-a445-8321" name="Psyker:" hidden="false"/>
-    <categoryEntry id="9055-7410-8ffd-b8e7" name="Corrupted Sub-type:" hidden="false">
+    <categoryEntry id="9055-7410-8ffd-b8e7" name="Corrupted Sub-type" hidden="false">
       <rules>
         <rule id="e441-d934-fee5-990b" name="Corrupted Sub-type" publicationId="e77a-823a-da94-16b9" page="307" hidden="false">
           <description>• Models with the Corrupted Unit Sub-type gain the Fear (1) special rule.
@@ -599,7 +603,7 @@ During Reactions made in any Phase, a unit equipped with Jump PAcks may not acti
         </infoLink>
       </infoLinks>
     </categoryEntry>
-    <categoryEntry id="4280-4963-02b5-e31d" name="Dreadnought Unit-type:" hidden="false">
+    <categoryEntry id="4280-4963-02b5-e31d" name="Dreadnought Unit Type" hidden="false">
       <constraints>
         <constraint field="selections" scope="force" value="-1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a524-3855-be3c-a633" type="max"/>
       </constraints>
@@ -649,7 +653,7 @@ During Reactions made in any Phase, a unit equipped with Jump PAcks may not acti
         <infoLink id="155a-8fd2-5d2a-2bd3" name="Deep Strike" hidden="false" targetId="f1e1-986f-c783-ca9e" type="rule"/>
       </infoLinks>
     </categoryEntry>
-    <categoryEntry id="7d95-f9d1-440a-67bd" name="Monstrous Sub-type:" hidden="false">
+    <categoryEntry id="7d95-f9d1-440a-67bd" name="Monstrous Sub-type" hidden="false">
       <rules>
         <rule id="3322-e589-ba33-b1b7" name="Monstrous Sub-type" publicationId="e77a-823a-da94-16b9" page="197" hidden="false">
           <description>• A unit that includes any models with the Monstrous sub-type cannot be Pinned.
@@ -671,7 +675,7 @@ During Reactions made in any Phase, a unit equipped with Jump PAcks may not acti
         </infoLink>
       </infoLinks>
     </categoryEntry>
-    <categoryEntry id="e699-d9cd-e68e-46d9" name="Daemon Unit-type:" hidden="false">
+    <categoryEntry id="e699-d9cd-e68e-46d9" name="Daemon Unit Type" hidden="false">
       <rules>
         <rule id="df15-2b9e-8437-3295" name="Daemon Unit-type" hidden="false">
           <description>• All Daemon models have their Strength and Toughness modified by a value determined by the current Game Turn: +1 on Game Turns 1 &amp; 2, +/-0 on Game Turns 3 &amp; 4, -1 on Game Turns 5 &amp; 6, and -2 on Game Turns 7+.
@@ -706,14 +710,14 @@ During any Reaction that allows a unit equipped entirely with Jet PAcks to move,
         </infoLink>
       </infoLinks>
     </categoryEntry>
-    <categoryEntry id="6399-5c65-7833-1025" name="Line Sub-type:" hidden="false">
+    <categoryEntry id="6399-5c65-7833-1025" name="Line Sub-type" hidden="false">
       <rules>
         <rule id="bc1e-9c95-f971-cd7b" name="Line Sub-type" publicationId="e77a-823a-da94-16b9" page="196" hidden="false">
           <description>• A unit that includes at least one model with the Line sub-type counts as both a Scoring and Denial unit.</description>
         </rule>
       </rules>
     </categoryEntry>
-    <categoryEntry id="6f99-c178-6f9d-fb63" name="Artillery Sub-type:" hidden="false">
+    <categoryEntry id="6f99-c178-6f9d-fb63" name="Artillery Sub-type" hidden="false">
       <modifiers>
         <modifier type="set" field="0ae6-51c0-d028-a03a" value="0">
           <conditionGroups>
@@ -738,7 +742,7 @@ A unit that includes one or more models with the Artillery sub-type may not make
         </rule>
       </rules>
     </categoryEntry>
-    <categoryEntry id="bff2-ae16-74a8-8712" name="Light Sub-type:" hidden="false">
+    <categoryEntry id="bff2-ae16-74a8-8712" name="Light Sub-type" hidden="false">
       <rules>
         <rule id="3ec9-276f-e19f-e639" name="Light Sub-type" publicationId="e77a-823a-da94-16b9" page="197" hidden="false">
           <description>• A unit that includes only models with the Light sub-type gains a +1 modifier to its Initiative when determining how far that unit may Run (this bonus stacks with other bonuses to Run distance, such as the Fleet (X) special rule) and when moving as part of a Reaction.
@@ -902,10 +906,10 @@ Conversely, if an Independent Character joins a unit after that unit has been th
         <constraint type="min" value="0" field="selections" scope="force" shared="true" id="d132-946e-6aac-db7" includeChildSelections="true"/>
       </constraints>
     </categoryEntry>
-    <categoryEntry id="2440-b64e-cb24-87f0" name="Cybernetica Sub-type:" publicationId="bde1-6db1-163b-3b76" page="90" hidden="false">
+    <categoryEntry id="2440-b64e-cb24-87f0" name="Cybernetica Sub-type" publicationId="bde1-6db1-163b-3b76" page="90" hidden="false">
       <rules>
-        <rule id="ad70-0b7c-539c-3e16" name="Cybernetica Sub-type:" publicationId="bde1-6db1-163b-3b76" page="90" hidden="false">
-          <description>The following rules apply to all models with the Cybernetica Unit Sub-type:
+        <rule id="ad70-0b7c-539c-3e16" name="Cybernetica Sub-type" publicationId="bde1-6db1-163b-3b76" page="90" hidden="false">
+          <description>The following rules apply to all models with the Cybernetica Unit Sub-type
 • Models with the Cybernetica Unit Sub-type are subject to the Programmed Behaviour provision. During both the controlling player’s Shooting phase and the Charge sub-phase, an Automata unit must attempt a Shooting Attack and/or Charge if there is an enemy unit within range, and must target the closest enemy unit possible that is within its line of sight and is a valid target for a Shooting Attack or Charge. If two or more targets are equally close then the controlling player chooses which will be the target of a Shooting Attack or Charge.
 • A model with the Cybernetica Unit Sub-type may fire all weapons they are equipped with in each Shooting Attack they make, including as part of a Reaction where eligible (this rule on its own does not allow units to make Reactions if they would otherwise be prevented from doing so).
 • Models with the Cybernetica Unit Sub-type may fire Heavy and Ordnance weapons and count as Stationary even if they moved in the preceding Movement phase, and may declare Charges as normal regardless of any Shooting Attacks made in the same turn.
@@ -913,7 +917,7 @@ Conversely, if an Independent Character joins a unit after that unit has been th
         </rule>
       </rules>
     </categoryEntry>
-    <categoryEntry id="0ea2-efb5-b7af-226e" name="Fast Sub-type:" hidden="false">
+    <categoryEntry id="0ea2-efb5-b7af-226e" name="Fast Sub-type" hidden="false">
       <rules>
         <rule id="2cbf-c1a1-844a-6456" name="Fast Vehicles" hidden="false">
           <description>When a Fast Vehicle moves, other than to pivot in place, it is always considered to have moved at Combat Speed regardless of how many inches it moves, unless it chooses to move Flat-out.
@@ -958,9 +962,9 @@ In addition, when a Fast Vehicle moves, it may choose to move at Flat-out:</desc
       </constraints>
     </categoryEntry>
     <categoryEntry id="d82b-1980-74f8-5dac" name="Allied Detachment" hidden="false"/>
-    <categoryEntry id="d615-c0e4-6d17-107e" name="Assassin Sub-Type" publicationId="15a4-fc68-502d-48a9" page="128" hidden="false">
+    <categoryEntry id="d615-c0e4-6d17-107e" name="Assassin Sub-type" publicationId="15a4-fc68-502d-48a9" page="128" hidden="false">
       <rules>
-        <rule id="9522-1b3d-f849-fd60" name="Assassin Sub-Type" publicationId="15a4-fc68-502d-48a9" page="128" hidden="false">
+        <rule id="9522-1b3d-f849-fd60" name="Assassin Sub-type" publicationId="15a4-fc68-502d-48a9" page="128" hidden="false">
           <description>• Models with the Assassin Sub-type ignore all movement penalties when moving or Charging through terrain of any kind and automatically pass all Dangerous Terrain tests they are called upon to make.
 • Models with the Independant Character special rule may not join a unit composed only of models with the Assassin Sub-type.
 • Models with the Assassin Sub-type may not Embark on any model with the Transport Sub-type.
@@ -998,7 +1002,7 @@ In addition, when a Fast Vehicle moves, it may choose to move at Flat-out:</desc
       </constraints>
     </categoryEntry>
     <categoryEntry id="11f2-472f-c1d1-9ae9" name="Legiones Astartes" hidden="false"/>
-    <categoryEntry id="0faa-1bab-2901-4330" name="Automated Artillery Sub-Type" publicationId="15a4-fc68-502d-48a9" page="128" hidden="false">
+    <categoryEntry id="0faa-1bab-2901-4330" name="Automated Artillery Sub-type" publicationId="15a4-fc68-502d-48a9" page="128" hidden="false">
       <modifiers>
         <modifier type="set" field="98cf-aba1-feac-7081" value="0">
           <conditionGroups>
@@ -1014,17 +1018,17 @@ In addition, when a Fast Vehicle moves, it may choose to move at Flat-out:</desc
         <constraint field="selections" scope="force" value="-1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="98cf-aba1-feac-7081" type="max"/>
       </constraints>
       <rules>
-        <rule id="013d-6065-1cfc-77e5" name="Automated Artillery Sub-Type" publicationId="15a4-fc68-502d-48a9" page="128" hidden="false">
+        <rule id="013d-6065-1cfc-77e5" name="Automated Artillery Sub-type" publicationId="15a4-fc68-502d-48a9" page="128" hidden="false">
           <description>• A unit that includes one or more models with the Automated Artillery Sub-type may not Run, declare or otherwise make Charge moves, or make Reactions. 
 • A unit that includes one or more models with the Automated Artillery Sub-type may not make Sweeping Advances and if targeted by a Sweeping Advance automatically fails without rolling any dice and is destroyed.
 • A unit that includes one or more models with this Unit Sub-type may never hold or deny an Objective.</description>
         </rule>
       </rules>
     </categoryEntry>
-    <categoryEntry id="7f9b-c5ed-7edb-02dc" name="Lumbering Sub-type:" hidden="false"/>
-    <categoryEntry id="4e84-2d57-4986-2b23" name="Flyer Sub-type:" hidden="false"/>
-    <categoryEntry id="7b0a-a743-a8da-3a39" name="Transport Sub-type:" hidden="false"/>
-    <categoryEntry id="7381-1130-ca6e-1806" name="Super-heavy Sub-type:" hidden="false">
+    <categoryEntry id="7f9b-c5ed-7edb-02dc" name="Lumbering Sub-type" hidden="false"/>
+    <categoryEntry id="4e84-2d57-4986-2b23" name="Flyer Sub-type" hidden="false"/>
+    <categoryEntry id="7b0a-a743-a8da-3a39" name="Transport Sub-type" hidden="false"/>
+    <categoryEntry id="7381-1130-ca6e-1806" name="Super-heavy Sub-type" hidden="false">
       <modifiers>
         <modifier type="set" field="b17b-8b75-59f6-6442" value="0">
           <conditionGroups>
@@ -1041,7 +1045,7 @@ In addition, when a Fast Vehicle moves, it may choose to move at Flat-out:</desc
         <constraint field="selections" scope="force" value="-1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b17b-8b75-59f6-6442" type="max"/>
       </constraints>
     </categoryEntry>
-    <categoryEntry id="c4a5-4def-dc2c-7ce2" name="Slow Sub-type:" hidden="false">
+    <categoryEntry id="c4a5-4def-dc2c-7ce2" name="Slow Sub-type" hidden="false">
       <modifiers>
         <modifier type="set" field="6098-fe90-8855-def8" value="0">
           <conditionGroups>
@@ -1133,7 +1137,7 @@ Brace - The Reacting unit must make a Morale check. If the Check is failed, the 
     <categoryEntry id="40f3-05e8-5ddc-636a" name="Bound Sub-type" publicationId="cb13-da24-e6da-75b3" page="11" hidden="false">
       <rules>
         <rule id="7c3e-e5ca-7af9-e051" name="Bound Sub-type" publicationId="cb13-da24-e6da-75b3" page="11" hidden="false">
-          <description>The following rules apply to all models with the Bound Sub-type:
+          <description>The following rules apply to all models with the Bound Sub-type
 • Models with the Bound Sub-type do not modify their Strength and Toughness values according to the current Game Turn as detailed in the Daemon Unit Type.
 • While there are no models from the same army with both the Psyker Unit Sub-type and the Independent Character special rule on the battlefield or Embarked upon a unit with the Transport Sub-type that is on the battlefield, models with the Bound Sub-type suffer a penalty of -1 to their Strength and Toughness characteristics to a minimum value of 1.
 • During deployment, in order for units entirely composed of models with the Bound Sub-type to be deployed on the battlefield, a model from the same army with the Psyker Unit Sub-type and the Independent Character special rule which is already deployed (or Embarked upon a unit with the Transport Sub-type which is already deployed) must make a Psychic check for each such unit, one at a time. For each successful Check a single unit containing models with the Bound Sub-type may be deployed as normal, but once a Psychic check is failed, that and all further units containing models with the Bound Sub-type must be placed in Reserves. The controlling player may choose not to make a Psychic check for any unit containing models with the Bound Sub-type, instead placing it directly into reserves and allowing Psychic checks to be made to deploy any further units containing models with the Bound Sub-type. Note that failing a Psychic check in this manner does not inflict Perils of the Warp.
@@ -6455,7 +6459,6 @@ Fire Point (Front 4)</characteristic>
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="55"/>
           </costs>
-          <categoryLinks/>
           <comment>!BSC Errors from 20240328-1346
 Could not find type or subtype &apos;Fortificaion&apos;
 Could not find type or subtype &apos;Building)&apos;</comment>
@@ -6496,7 +6499,6 @@ Hull Mounted (Rear) Heavy Bolter</characteristic>
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="85"/>
           </costs>
-          <categoryLinks/>
           <comment>!BSC Errors from 20240328-1346
 Could not find type or subtype &apos;Fortificaion&apos;
 Could not find type or subtype &apos;Building)&apos;</comment>
@@ -6578,7 +6580,6 @@ Four single Blast Shields</characteristic>
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="35"/>
           </costs>
-          <categoryLinks/>
           <comment>!BSC Errors from 20240328-1346
 Could not find type or subtype &apos;Fortication&apos;
 Could not find type or subtype &apos;Barricade)
@@ -7428,7 +7429,7 @@ A unit that makes a Shooting Attack as part of a Scornful Fire Reaction may not 
 In addition, a model with the Paragon of Metal special rule may not be targeted or affected by any Cybertheurgic Power or any Weapon with the Data-djinn special rule, either friendly or enemy.</description>
         </rule>
         <rule id="aa64-ebfc-e457-1e0d" name="Paragon Unit Sub-type" publicationId="bde1-6db1-163b-3b76" page="91" hidden="false">
-          <description>The following rules apply to all models with the Paragon Unit Sub-type:
+          <description>The following rules apply to all models with the Paragon Unit Sub-type
 • Models with the Paragon Unit Sub-type are not affected by special rules that negatively modify their Characteristics (other than Wounds or Hull Points).
 • A model with the Paragon Unit Sub-type may fire all weapons they are equipped with in each Shooting Attack they make, including as part of a Reaction.
 • Models with the Paragon Unit Sub-type may fire Heavy and Ordnance weapons and count as Stationary even if they moved in the preceding Movement phase, and may declare Charges as normal regardless of any Shooting Attacks made in the same turn.
@@ -15379,7 +15380,7 @@ Maxima :When destroyed, a model with this special rule resolves Hits caused by C
       <description>A unit that includes any models with this special rule must make a Shooting Attack targeting the enemy unit which has the closest model in line of sight to any model in the attacking unit in the controlling player’s Shooting phase.</description>
     </rule>
     <rule id="c036-66e2-4e07-c2b8" name="Automated Artillery Sub-type" publicationId="e77a-823a-da94-16b9" page="16" hidden="false">
-      <description>The following rules apply to all models with the Automated Artillery Sub-type:
+      <description>The following rules apply to all models with the Automated Artillery Sub-type
 
 • A unit that includes one or more models with the Automated Artillery Sub-type may not Run, declare or otherwise make Charge moves, and may only make the Interceptor Advanced Reaction.
 • A unit that includes one or more models with the Automated Artillery Sub-type may not make Sweeping Advances and if targeted by a Sweeping Advance automatically fails without rolling any dice and is destroyed.

--- a/2022 - Imperialis Militia.cat
+++ b/2022 - Imperialis Militia.cat
@@ -839,6 +839,7 @@ Unless noted, the effects of any rules featured in the Provenance’s descriptio
             <categoryLink id="a65e-9023-2e84-4f5a" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
             <categoryLink id="b2c0-61dc-f06d-7596" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
             <categoryLink id="17a7-7777-5452-6e01" name="Militia Unit Sub-type" hidden="false" targetId="66b2-c457-4d5e-8041" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="2490-1700-47ab-ad1d" name="Infantry" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="88ce-c3b7-b1c1-0055" name="1.1) Weapon (Exchange Laspistol/Autopistol)" hidden="false" collective="false" import="true" defaultSelectionEntryId="352c-a5d1-de12-bf4b">
@@ -1833,6 +1834,8 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
           </infoLinks>
           <categoryLinks>
             <categoryLink id="af33-2130-a0d9-77c4" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="dc46-dacc-4b4c-bb8c" name="Infantry" primary="false"/>
+            <categoryLink targetId="66b2-c457-4d5e-8041" id="67d8-2ea7-472d-9310" name="Militia" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="fd7f-e242-cb21-f6a9" name="2) Armour" hidden="false" collective="false" import="true" defaultSelectionEntryId="2b69-4950-7578-7994">
@@ -2187,6 +2190,8 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
           </infoLinks>
           <categoryLinks>
             <categoryLink id="e545-8eba-ce63-490f" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="df3c-8d24-4d38-98f8" name="Infantry" primary="false"/>
+            <categoryLink targetId="66b2-c457-4d5e-8041" id="f049-cf32-45bd-a2e6" name="Militia" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="69e3-c3f4-1c6e-efa1" name="1.1) Weapon (Exchange Laspistol/Autopistol)" hidden="false" collective="false" import="true" defaultSelectionEntryId="78ea-a056-d291-2a8b">
@@ -2736,6 +2741,10 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="8"/>
           </costs>
+          <categoryLinks>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="2d74-1fc2-43ec-963d" name="Infantry" primary="false"/>
+            <categoryLink targetId="66b2-c457-4d5e-8041" id="5888-613a-4d53-bbf8" name="Militia" primary="false"/>
+          </categoryLinks>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
@@ -2999,6 +3008,9 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
                   </infoLinks>
                   <categoryLinks>
                     <categoryLink id="16d5-56a2-4e6a-6abb" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
+                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="2454-5688-4c1b-b81b" name="Infantry" primary="false"/>
+                    <categoryLink targetId="66b2-c457-4d5e-8041" id="0f82-f1d0-4eb7-ab08" name="Militia" primary="false"/>
+                    <categoryLink targetId="6399-5c65-7833-1025" id="8c6e-1277-419d-aef4" name="Line" primary="false"/>
                   </categoryLinks>
                   <entryLinks>
                     <entryLink id="7ed5-d306-8605-373b" name="Flak Armour" hidden="false" collective="false" import="true" targetId="0251-8365-9efb-61a7" type="selectionEntry">
@@ -3090,6 +3102,11 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
                   <costs>
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
                   </costs>
+                  <categoryLinks>
+                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="187d-ece9-438b-add5" name="Infantry" primary="false"/>
+                    <categoryLink targetId="66b2-c457-4d5e-8041" id="c4fa-d92f-4259-9e0b" name="Militia" primary="false"/>
+                    <categoryLink targetId="6399-5c65-7833-1025" id="10cf-eb33-4535-9dd4" name="Line" primary="false"/>
+                  </categoryLinks>
                 </selectionEntry>
               </selectionEntries>
               <selectionEntryGroups>
@@ -3819,6 +3836,8 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
                   </infoLinks>
                   <categoryLinks>
                     <categoryLink id="ee2d-b515-e075-bb85" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
+                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="76b1-ea36-4edb-9d67" name="Infantry" primary="false"/>
+                    <categoryLink targetId="66b2-c457-4d5e-8041" id="d2eb-79f9-46da-b744" name="Militia" primary="false"/>
                   </categoryLinks>
                   <selectionEntryGroups>
                     <selectionEntryGroup id="19a9-19de-d6eb-8de4" name="The Sergeant may exchange their Lasgun for the following" hidden="false" collective="false" import="true" defaultSelectionEntryId="8d59-a1c1-7098-05a6">
@@ -4063,6 +4082,10 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
                   <costs>
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2"/>
                   </costs>
+                  <categoryLinks>
+                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="c4b8-00f0-4e20-9a28" name="Infantry" primary="false"/>
+                    <categoryLink targetId="66b2-c457-4d5e-8041" id="16b9-cacc-42e6-970e" name="Militia" primary="false"/>
+                  </categoryLinks>
                 </selectionEntry>
               </selectionEntries>
               <selectionEntryGroups>
@@ -4712,6 +4735,11 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="6"/>
           </costs>
+          <categoryLinks>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="7883-dea0-4862-a768" name="Infantry" primary="false"/>
+            <categoryLink targetId="66b2-c457-4d5e-8041" id="4cd3-4939-467d-a975" name="Militia" primary="false"/>
+            <categoryLink targetId="6399-5c65-7833-1025" id="ef26-6ae6-4cd8-932e" name="Line" primary="false"/>
+          </categoryLinks>
         </selectionEntry>
         <selectionEntry id="5d42-ca93-dc35-8745" name="1) Grenadier Sergeant" hidden="false" collective="false" import="true" type="model">
           <constraints>
@@ -4797,6 +4825,9 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
           </infoLinks>
           <categoryLinks>
             <categoryLink id="a707-2515-52c5-cf6c" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="f893-c3ab-46bd-a85c" name="Infantry" primary="false"/>
+            <categoryLink targetId="66b2-c457-4d5e-8041" id="76c7-2f63-4f60-a98d" name="Militia" primary="false"/>
+            <categoryLink targetId="6399-5c65-7833-1025" id="2fe2-0880-407f-8a08" name="Line" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="3326-bba2-05f6-175a" name="1.1) Weapons (Laspistol/Autopistol)" hidden="false" collective="false" import="true" defaultSelectionEntryId="1465-584d-ddc3-50de">
@@ -5208,6 +5239,11 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20"/>
               </costs>
+              <categoryLinks>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="5537-0c68-4499-972c" name="Infantry" primary="false"/>
+                <categoryLink targetId="9231-183c-b97b-63f9" id="868b-2ec9-4231-a6e0" name="Heavy" primary="false"/>
+                <categoryLink targetId="66b2-c457-4d5e-8041" id="2a09-7ca6-43fa-879a" name="Militia" primary="false"/>
+              </categoryLinks>
             </selectionEntry>
             <selectionEntry id="9643-3e33-55ed-e9f1" name="Militia Fire Team w/ Autocannon" hidden="false" collective="false" import="true" type="model">
               <constraints>
@@ -5247,6 +5283,11 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20"/>
               </costs>
+              <categoryLinks>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="2b1f-3565-4790-861f" name="Infantry" primary="false"/>
+                <categoryLink targetId="9231-183c-b97b-63f9" id="95c8-b9f1-4ebd-93fe" name="Heavy" primary="false"/>
+                <categoryLink targetId="66b2-c457-4d5e-8041" id="ba52-9558-49bd-b8ac" name="Militia" primary="false"/>
+              </categoryLinks>
             </selectionEntry>
             <selectionEntry id="5ff1-5b17-ca8b-0676" name="Militia Fire Team w/ Heavy Stubber" hidden="false" collective="false" import="true" type="model">
               <constraints>
@@ -5330,6 +5371,11 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20"/>
               </costs>
+              <categoryLinks>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="5a1d-95f6-4db4-8836" name="Infantry" primary="false"/>
+                <categoryLink targetId="9231-183c-b97b-63f9" id="5dcb-25b5-487b-9ebc" name="Heavy" primary="false"/>
+                <categoryLink targetId="66b2-c457-4d5e-8041" id="eb2f-8d44-4b2d-9e59" name="Militia" primary="false"/>
+              </categoryLinks>
             </selectionEntry>
             <selectionEntry id="ffb6-7ae4-9f04-7c7d" name="Militia Fire Team w/ Missile Launcher Frag/Krak" hidden="false" collective="false" import="true" type="model">
               <constraints>
@@ -5365,6 +5411,11 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20"/>
               </costs>
+              <categoryLinks>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="53cf-4e7c-4b0f-b16e" name="Infantry" primary="false"/>
+                <categoryLink targetId="9231-183c-b97b-63f9" id="3dc5-e564-4ef9-a4d5" name="Heavy" primary="false"/>
+                <categoryLink targetId="66b2-c457-4d5e-8041" id="d5c5-5d8f-44f3-8425" name="Militia" primary="false"/>
+              </categoryLinks>
             </selectionEntry>
             <selectionEntry id="237e-5215-928f-a38f" name="Militia Fire Team w/ Mortar" hidden="false" collective="false" import="true" type="model">
               <constraints>
@@ -5402,6 +5453,11 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20"/>
               </costs>
+              <categoryLinks>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="6849-022b-4f86-a5dc" name="Infantry" primary="false"/>
+                <categoryLink targetId="9231-183c-b97b-63f9" id="1212-8194-4301-a810" name="Heavy" primary="false"/>
+                <categoryLink targetId="66b2-c457-4d5e-8041" id="6f7d-c4dd-45b1-8de0" name="Militia" primary="false"/>
+              </categoryLinks>
             </selectionEntry>
             <selectionEntry id="e5fc-9d18-110f-569b" name="Militia Fire Team w/ Multilaser" hidden="false" collective="false" import="true" type="model">
               <constraints>
@@ -5436,6 +5492,11 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20"/>
               </costs>
+              <categoryLinks>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="7d70-7d41-41d5-963e" name="Infantry" primary="false"/>
+                <categoryLink targetId="9231-183c-b97b-63f9" id="45ad-fe95-48c7-985a" name="Heavy" primary="false"/>
+                <categoryLink targetId="66b2-c457-4d5e-8041" id="150c-1f22-47ce-8335" name="Militia" primary="false"/>
+              </categoryLinks>
             </selectionEntry>
             <selectionEntry id="0170-77fa-0994-bbe7" name="Militia Fire Team w/ Heavy Bolter" hidden="false" collective="false" import="true" type="model">
               <constraints>
@@ -5465,6 +5526,11 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20"/>
               </costs>
+              <categoryLinks>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="7758-9588-4f1e-9fd7" name="Infantry" primary="false"/>
+                <categoryLink targetId="9231-183c-b97b-63f9" id="d928-1eac-4c4d-90b5" name="Heavy" primary="false"/>
+                <categoryLink targetId="66b2-c457-4d5e-8041" id="b2b2-2c94-439e-bc1c" name="Militia" primary="false"/>
+              </categoryLinks>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
@@ -5616,6 +5682,11 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5"/>
           </costs>
+          <categoryLinks>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="b33e-d51f-4da5-b29d" name="Infantry" primary="false"/>
+            <categoryLink targetId="66b2-c457-4d5e-8041" id="ee74-71a4-4846-8a2c" name="Militia" primary="false"/>
+            <categoryLink targetId="bff2-ae16-74a8-8712" id="20d5-00e8-4d40-9d8e" name="Light" primary="false"/>
+          </categoryLinks>
         </selectionEntry>
         <selectionEntry id="73bd-73fb-8c08-283b" name="Scout Sergeant" hidden="false" collective="false" import="true" type="model">
           <constraints>
@@ -5696,6 +5767,9 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
           </infoLinks>
           <categoryLinks>
             <categoryLink id="ae89-1a96-9894-da38" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="4ea9-82e2-4394-936b" name="Infantry" primary="false"/>
+            <categoryLink targetId="66b2-c457-4d5e-8041" id="9f81-b7f4-4619-ade9" name="Militia" primary="false"/>
+            <categoryLink targetId="bff2-ae16-74a8-8712" id="d5b1-ff57-4159-8820" name="Light" primary="false"/>
           </categoryLinks>
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
@@ -6052,6 +6126,11 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="40"/>
               </costs>
+              <categoryLinks>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="298a-0b27-4850-9852" name="Infantry" primary="false"/>
+                <categoryLink targetId="9231-183c-b97b-63f9" id="cc2f-af5d-4690-8887" name="Heavy" primary="false"/>
+                <categoryLink targetId="66b2-c457-4d5e-8041" id="3b4b-3e9c-4821-af75" name="Militia" primary="false"/>
+              </categoryLinks>
             </selectionEntry>
             <selectionEntry id="5ea0-e933-72fe-17a5" name="Militia Field Gun w/ Kalliope Mortar" hidden="false" collective="false" import="true" type="model">
               <constraints>
@@ -6091,6 +6170,11 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="40"/>
               </costs>
+              <categoryLinks>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="61d5-868d-4e3a-90ab" name="Infantry" primary="false"/>
+                <categoryLink targetId="9231-183c-b97b-63f9" id="38f4-3543-4be4-940a" name="Heavy" primary="false"/>
+                <categoryLink targetId="66b2-c457-4d5e-8041" id="3fba-9099-4a95-a1c1" name="Militia" primary="false"/>
+              </categoryLinks>
             </selectionEntry>
             <selectionEntry id="1568-3730-cce3-342a" name="Militia Field Gun w/ Thunderblast Cannon" hidden="false" collective="false" import="true" type="model">
               <constraints>
@@ -6125,6 +6209,11 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="40"/>
               </costs>
+              <categoryLinks>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="602d-2f20-45bb-9d9e" name="Infantry" primary="false"/>
+                <categoryLink targetId="9231-183c-b97b-63f9" id="9c68-3362-410d-98df" name="Heavy" primary="false"/>
+                <categoryLink targetId="66b2-c457-4d5e-8041" id="25f2-a1be-476a-b49e" name="Militia" primary="false"/>
+              </categoryLinks>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
@@ -6342,6 +6431,11 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="40"/>
           </costs>
+          <categoryLinks>
+            <categoryLink targetId="e2b6-b770-784c-9e95" id="78bb-d201-4c77-adfc" name="Vehicle" primary="false"/>
+            <categoryLink targetId="cdaa-645b-fda7-8556" id="45fa-49f1-44c7-96f3" name="Third-line" primary="false"/>
+            <categoryLink targetId="7b0a-a743-a8da-3a39" id="d3e3-9d7d-40f1-aa75" name="Transport" primary="false"/>
+          </categoryLinks>
         </selectionEntry>
       </selectionEntries>
       <costs>
@@ -6523,6 +6617,9 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
           </infoLinks>
           <categoryLinks>
             <categoryLink id="1f88-1a48-9e6f-578e" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
+            <categoryLink targetId="6d79-a3e4-381f-7b0f" id="81f9-8d40-48cb-aaae" name="Cavalry" primary="false"/>
+            <categoryLink targetId="bff2-ae16-74a8-8712" id="f59e-7339-45d1-b8ce" name="Light" primary="false"/>
+            <categoryLink targetId="66b2-c457-4d5e-8041" id="e8f5-365b-4a5c-8438" name="Militia" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="adaf-346a-a591-f44c" name="1.1) Weapon (Exchange Laspistol/Autopistol)" hidden="false" collective="false" import="true" defaultSelectionEntryId="f52f-9556-369c-6cb5">
@@ -6774,6 +6871,11 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="8"/>
               </costs>
+              <categoryLinks>
+                <categoryLink targetId="6d79-a3e4-381f-7b0f" id="6edc-06e4-4c7d-8124" name="Cavalry" primary="false"/>
+                <categoryLink targetId="bff2-ae16-74a8-8712" id="130b-2e5b-4ce1-8e76" name="Light" primary="false"/>
+                <categoryLink targetId="66b2-c457-4d5e-8041" id="46d2-b475-463f-9ecb" name="Militia" primary="false"/>
+              </categoryLinks>
             </selectionEntry>
             <selectionEntry id="688b-7dee-f649-d1ec" name="Outrider w/ Autopistol" hidden="false" collective="false" import="true" type="model">
               <constraints>
@@ -6859,6 +6961,11 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="8"/>
               </costs>
+              <categoryLinks>
+                <categoryLink targetId="6d79-a3e4-381f-7b0f" id="735c-1356-4d20-b71c" name="Cavalry" primary="false"/>
+                <categoryLink targetId="bff2-ae16-74a8-8712" id="3cab-f9fd-4fdd-afd1" name="Light" primary="false"/>
+                <categoryLink targetId="66b2-c457-4d5e-8041" id="f91e-8dd5-45a4-9546" name="Militia" primary="false"/>
+              </categoryLinks>
             </selectionEntry>
             <selectionEntry id="a956-492e-0dcd-0191" name="Outrider w/ Laspistol &amp; Chainaxe" hidden="false" collective="false" import="true" type="model">
               <modifiers>
@@ -6901,6 +7008,11 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="8"/>
               </costs>
+              <categoryLinks>
+                <categoryLink targetId="6d79-a3e4-381f-7b0f" id="e4ad-0d11-4df1-a453" name="Cavalry" primary="false"/>
+                <categoryLink targetId="bff2-ae16-74a8-8712" id="7b3b-7c7e-4405-af14" name="Light" primary="false"/>
+                <categoryLink targetId="66b2-c457-4d5e-8041" id="cb16-531d-4113-a127" name="Militia" primary="false"/>
+              </categoryLinks>
             </selectionEntry>
             <selectionEntry id="2c47-a35f-14c2-c8c9" name="Outrider w/ Autopistol &amp; Chainaxe" hidden="false" collective="false" import="true" type="model">
               <modifiers>
@@ -6943,6 +7055,11 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="8"/>
               </costs>
+              <categoryLinks>
+                <categoryLink targetId="6d79-a3e4-381f-7b0f" id="6889-bdbc-45d4-9d8f" name="Cavalry" primary="false"/>
+                <categoryLink targetId="bff2-ae16-74a8-8712" id="1c97-5658-4310-8eda" name="Light" primary="false"/>
+                <categoryLink targetId="66b2-c457-4d5e-8041" id="12d7-b3f2-44c9-9d80" name="Militia" primary="false"/>
+              </categoryLinks>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
@@ -7263,6 +7380,11 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="8"/>
               </costs>
+              <categoryLinks>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="b4fc-b544-4e3c-b7a6" name="Infantry" primary="false"/>
+                <categoryLink targetId="66b2-c457-4d5e-8041" id="bf00-1592-48f8-b030" name="Militia" primary="false"/>
+                <categoryLink targetId="59a4-7b61-600a-c457" id="75db-0f24-431a-9a5f" name="Skirmish" primary="false"/>
+              </categoryLinks>
             </selectionEntry>
             <selectionEntry id="fcc4-81ff-34ab-4fda" name="Handler w/ Autopistol" hidden="false" collective="false" import="true" type="model">
               <constraints>
@@ -7347,6 +7469,11 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="8"/>
               </costs>
+              <categoryLinks>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="f838-57ef-4763-bbff" name="Infantry" primary="false"/>
+                <categoryLink targetId="66b2-c457-4d5e-8041" id="0082-f9cb-4705-9748" name="Militia" primary="false"/>
+                <categoryLink targetId="59a4-7b61-600a-c457" id="b5cc-4d26-4231-b12b" name="Skirmish" primary="false"/>
+              </categoryLinks>
             </selectionEntry>
             <selectionEntry id="0aad-ede5-6b66-7ee4" name="Handler w/ Auitopistol &amp; Chainaxe" hidden="false" collective="false" import="true" type="model">
               <modifiers>
@@ -7388,6 +7515,11 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="8"/>
               </costs>
+              <categoryLinks>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="d8d3-a1e0-425d-aeac" name="Infantry" primary="false"/>
+                <categoryLink targetId="66b2-c457-4d5e-8041" id="ceb7-95da-4ab3-bfc8" name="Militia" primary="false"/>
+                <categoryLink targetId="59a4-7b61-600a-c457" id="152c-c64b-4fd5-a945" name="Skirmish" primary="false"/>
+              </categoryLinks>
             </selectionEntry>
             <selectionEntry id="7c34-c649-ca22-2b7f" name="Handler w/ Laspistol &amp; Chainaxe" hidden="false" collective="false" import="true" type="model">
               <modifiers>
@@ -7429,6 +7561,11 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="8"/>
               </costs>
+              <categoryLinks>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="c9d8-1024-4e55-a722" name="Infantry" primary="false"/>
+                <categoryLink targetId="66b2-c457-4d5e-8041" id="c85e-7a30-43a0-816a" name="Militia" primary="false"/>
+                <categoryLink targetId="59a4-7b61-600a-c457" id="216f-20a7-4f71-bae5" name="Skirmish" primary="false"/>
+              </categoryLinks>
             </selectionEntry>
           </selectionEntries>
           <entryLinks>
@@ -7485,6 +7622,12 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="60"/>
           </costs>
+          <categoryLinks>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="b86e-0b1e-454a-88c8" name="Infantry" primary="false"/>
+            <categoryLink targetId="66b2-c457-4d5e-8041" id="c68e-7bf0-44c1-8355" name="Militia" primary="false"/>
+            <categoryLink targetId="59a4-7b61-600a-c457" id="2084-071b-4e73-836f" name="Skirmish" primary="false"/>
+            <categoryLink targetId="e929-a5c3-451c-6f19" id="de39-9b3c-4fb5-8cfa" name="Mechanised" primary="false"/>
+          </categoryLinks>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
@@ -9134,6 +9277,9 @@ equal to the number of Militia Gunners in the unit when making a Shooting Attack
           </infoLinks>
           <categoryLinks>
             <categoryLink id="a0a9-c12b-1625-4ec7" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="f179-1124-4e47-b88b" name="Infantry" primary="false"/>
+            <categoryLink targetId="66b2-c457-4d5e-8041" id="1a1d-b7fd-406e-8c89" name="Militia" primary="false"/>
+            <categoryLink targetId="7d95-f9d1-440a-67bd" id="875c-1b3f-45d8-acc8" name="Monstrous" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="f9ea-2ef5-5010-de5e" name="2.1) Additional Boss Weapons" hidden="false" collective="false" import="true">
@@ -9495,6 +9641,11 @@ equal to the number of Militia Gunners in the unit when making a Shooting Attack
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="30"/>
               </costs>
+              <categoryLinks>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="64de-b078-4463-8433" name="Infantry" primary="false"/>
+                <categoryLink targetId="66b2-c457-4d5e-8041" id="710d-077a-4973-9999" name="Militia" primary="false"/>
+                <categoryLink targetId="7d95-f9d1-440a-67bd" id="78fc-4d53-42fb-84cc" name="Monstrous" primary="false"/>
+              </categoryLinks>
             </selectionEntry>
             <selectionEntry id="4a39-aeb5-4a66-98bb" name="Ogryn Brute w/ Chainaxe (Feral Warriors)" hidden="false" collective="false" import="true" type="model">
               <modifiers>
@@ -9540,6 +9691,11 @@ equal to the number of Militia Gunners in the unit when making a Shooting Attack
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="30"/>
               </costs>
+              <categoryLinks>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="a5fe-867f-4aa3-a6ab" name="Infantry" primary="false"/>
+                <categoryLink targetId="66b2-c457-4d5e-8041" id="8bce-024a-4987-8fb4" name="Militia" primary="false"/>
+                <categoryLink targetId="7d95-f9d1-440a-67bd" id="f48f-639e-4003-bff2" name="Monstrous" primary="false"/>
+              </categoryLinks>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
@@ -9721,6 +9877,8 @@ equal to the number of Militia Gunners in the unit when making a Shooting Attack
             <categoryLink id="4e78-0ff4-26e7-83e9" name="Psyker:" hidden="false" targetId="6e0c-29ba-a445-8321" primary="false"/>
             <categoryLink id="5f46-7822-9f6f-a14e" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
             <categoryLink id="727f-cca5-1477-bc63" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="d2af-db7b-430c-895e" name="Infantry" primary="false"/>
+            <categoryLink targetId="66b2-c457-4d5e-8041" id="ac00-a756-4d5d-bf96" name="Militia" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="3cb4-223e-8975-0221" name="1.1) Weapon (Exchange Laspistol/Autopistol)" hidden="false" collective="false" import="true" defaultSelectionEntryId="0e67-9cb1-83c4-c885">
@@ -9935,6 +10093,10 @@ equal to the number of Militia Gunners in the unit when making a Shooting Attack
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5"/>
           </costs>
+          <categoryLinks>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="f572-1263-4b03-9290" name="Infantry" primary="false"/>
+            <categoryLink targetId="66b2-c457-4d5e-8041" id="1ec7-b7c7-4713-a54d" name="Militia" primary="false"/>
+          </categoryLinks>
         </selectionEntry>
       </selectionEntries>
       <entryLinks>

--- a/2022 - Imperialis Militia.cat
+++ b/2022 - Imperialis Militia.cat
@@ -2925,7 +2925,7 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
               </infoLinks>
               <categoryLinks>
                 <categoryLink id="d4b9-04fc-2a82-3985" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-                <categoryLink id="e4d4-1648-6a6d-b470" name="Line Sub-type:" hidden="false" targetId="6399-5c65-7833-1025" primary="false"/>
+                <categoryLink id="e4d4-1648-6a6d-b470" name="Line Sub-type" hidden="false" targetId="6399-5c65-7833-1025" primary="false"/>
                 <categoryLink name="SA or IM Unit" hidden="false" id="77b2-9e7b-f60f-5e2c" targetId="4aca-2849-7f41-0200" primary="false"/>
               </categoryLinks>
               <selectionEntries>
@@ -4412,7 +4412,7 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
       <categoryLinks>
         <categoryLink id="1fbc-3ade-2ce2-689f" name="Militia Unit Sub-type" hidden="false" targetId="66b2-c457-4d5e-8041" primary="false"/>
         <categoryLink id="aff5-69b6-f98b-f576" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="4164-318f-e397-bd37" name="Line Sub-type:" hidden="false" targetId="6399-5c65-7833-1025" primary="false"/>
+        <categoryLink id="4164-318f-e397-bd37" name="Line Sub-type" hidden="false" targetId="6399-5c65-7833-1025" primary="false"/>
         <categoryLink name="SA or IM Unit" hidden="false" id="c5be-208d-4e36-5f45" targetId="4aca-2849-7f41-0200" primary="false"/>
       </categoryLinks>
       <selectionEntries>
@@ -5206,7 +5206,7 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
       </infoLinks>
       <categoryLinks>
         <categoryLink id="544a-d5de-ad24-ccf1" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="ff5e-7826-a07c-580b" name="Heavy Sub-type:" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+        <categoryLink id="ff5e-7826-a07c-580b" name="Heavy Sub-type" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
         <categoryLink id="757a-017f-0c23-8007" name="Militia Unit Sub-type" hidden="false" targetId="66b2-c457-4d5e-8041" primary="false"/>
         <categoryLink name="SA or IM Unit" hidden="false" id="e0c9-5208-41a0-6e1" targetId="4aca-2849-7f41-0200" primary="false"/>
       </categoryLinks>
@@ -5620,7 +5620,7 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
       <categoryLinks>
         <categoryLink id="f8bf-e373-7088-1dca" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="2dff-278b-2bbe-fe45" name="Militia Unit Sub-type" hidden="false" targetId="66b2-c457-4d5e-8041" primary="false"/>
-        <categoryLink id="36e0-ac5f-3884-fb95" name="Light Sub-type:" hidden="false" targetId="bff2-ae16-74a8-8712" primary="false"/>
+        <categoryLink id="36e0-ac5f-3884-fb95" name="Light Sub-type" hidden="false" targetId="bff2-ae16-74a8-8712" primary="false"/>
         <categoryLink name="SA or IM Unit" hidden="false" id="3fe0-25b6-794c-a207" targetId="4aca-2849-7f41-0200" primary="false"/>
       </categoryLinks>
       <selectionEntries>
@@ -6012,7 +6012,7 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
       </infoLinks>
       <categoryLinks>
         <categoryLink id="c0a5-6e17-90e1-9b34" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="c254-7761-dbf3-9329" name="Heavy Sub-type:" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+        <categoryLink id="c254-7761-dbf3-9329" name="Heavy Sub-type" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
         <categoryLink id="6748-d0c8-4f36-f942" name="Militia Unit Sub-type" hidden="false" targetId="66b2-c457-4d5e-8041" primary="false"/>
         <categoryLink name="SA or IM Unit" hidden="false" id="1287-bd1c-809-f3e3" targetId="4aca-2849-7f41-0200" primary="false"/>
       </categoryLinks>
@@ -6255,10 +6255,10 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
       <categoryLinks>
         <categoryLink id="0ace-71e9-c37d-d555" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
         <categoryLink id="9603-bd5c-cf78-30ed" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
-        <categoryLink id="33fe-f72a-041d-ddd2" name="Flyer Sub-type:" hidden="false" targetId="4e84-2d57-4986-2b23" primary="false"/>
+        <categoryLink id="33fe-f72a-041d-ddd2" name="Flyer Sub-type" hidden="false" targetId="4e84-2d57-4986-2b23" primary="false"/>
         <categoryLink id="e852-57ce-e2db-911c" name="Third-line Unit Sub-type" hidden="false" targetId="cdaa-645b-fda7-8556" primary="false"/>
         <categoryLink id="4bb3-644e-118d-c736" name="Hover Sub-type" hidden="false" targetId="3a7a-8bb7-b0d3-e2e7" primary="false"/>
-        <categoryLink id="acc1-0031-76ac-84ab" name="Transport Sub-type:" hidden="false" targetId="7b0a-a743-a8da-3a39" primary="false"/>
+        <categoryLink id="acc1-0031-76ac-84ab" name="Transport Sub-type" hidden="false" targetId="7b0a-a743-a8da-3a39" primary="false"/>
         <categoryLink name="SA or IM Unit" hidden="false" id="9b40-74d9-6a23-2fda" targetId="4aca-2849-7f41-0200" primary="false"/>
       </categoryLinks>
       <entryLinks>
@@ -6278,7 +6278,7 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
         <categoryLink id="54c5-857f-e188-35c3" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
         <categoryLink id="a1bc-76d4-5059-c0db" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="49e5-4cf4-a446-8180" name="Third-line Unit Sub-type" hidden="false" targetId="cdaa-645b-fda7-8556" primary="false"/>
-        <categoryLink id="eab8-e7a4-908b-ef18" name="Transport Sub-type:" hidden="false" targetId="7b0a-a743-a8da-3a39" primary="false"/>
+        <categoryLink id="eab8-e7a4-908b-ef18" name="Transport Sub-type" hidden="false" targetId="7b0a-a743-a8da-3a39" primary="false"/>
         <categoryLink name="SA or IM Unit" hidden="false" id="75c5-8698-a50c-92a7" targetId="4aca-2849-7f41-0200" primary="false"/>
       </categoryLinks>
       <selectionEntries>
@@ -6521,8 +6521,8 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
         <infoLink name="Scout" hidden="false" type="rule" id="6170-5e26-1ebf-ec4" targetId="aacf-9a7e-982d-b793"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="6a6e-34c6-73fb-264d" name="Cavalry Unit-type:" hidden="false" targetId="6d79-a3e4-381f-7b0f" primary="false"/>
-        <categoryLink id="7893-6300-4c6a-c56d" name="Light Sub-type:" hidden="false" targetId="bff2-ae16-74a8-8712" primary="false"/>
+        <categoryLink id="6a6e-34c6-73fb-264d" name="Cavalry Unit Type" hidden="false" targetId="6d79-a3e4-381f-7b0f" primary="false"/>
+        <categoryLink id="7893-6300-4c6a-c56d" name="Light Sub-type" hidden="false" targetId="bff2-ae16-74a8-8712" primary="false"/>
         <categoryLink id="82a5-2fe3-a1b8-fda6" name="Militia Unit Sub-type" hidden="false" targetId="66b2-c457-4d5e-8041" primary="false"/>
         <categoryLink name="SA or IM Unit" hidden="false" id="1792-f720-e57-a0d" targetId="4aca-2849-7f41-0200" primary="false"/>
       </categoryLinks>
@@ -7584,7 +7584,7 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
       <categoryLinks>
         <categoryLink id="8ddc-34ec-2e49-d605" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="3fe5-3a52-1b7a-a0fe" name="Militia Unit Sub-type" hidden="false" targetId="66b2-c457-4d5e-8041" primary="false"/>
-        <categoryLink id="e3af-708b-9fd8-2a73" name="Skirmish Sub-type:" hidden="false" targetId="59a4-7b61-600a-c457" primary="false"/>
+        <categoryLink id="e3af-708b-9fd8-2a73" name="Skirmish Sub-type" hidden="false" targetId="59a4-7b61-600a-c457" primary="false"/>
         <categoryLink id="5ff9-4b72-6315-ff20" name="Mechanised Unit Sub-type" hidden="false" targetId="e929-a5c3-451c-6f19" primary="false"/>
         <categoryLink name="SA or IM Unit" hidden="false" id="b992-e902-7e12-3a5b" targetId="4aca-2849-7f41-0200" primary="false"/>
       </categoryLinks>
@@ -7726,7 +7726,7 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
       <categoryLinks>
         <categoryLink id="ac47-05ee-1ca8-0518" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
         <categoryLink id="4420-1f38-8c6d-f131" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
-        <categoryLink id="6c04-9c6e-15b6-c272" name="Flyer Sub-type:" hidden="false" targetId="4e84-2d57-4986-2b23" primary="false"/>
+        <categoryLink id="6c04-9c6e-15b6-c272" name="Flyer Sub-type" hidden="false" targetId="4e84-2d57-4986-2b23" primary="false"/>
         <categoryLink id="a6fc-88e9-1faa-9bac" name="Third-line Unit Sub-type" hidden="false" targetId="cdaa-645b-fda7-8556" primary="false"/>
         <categoryLink id="f9b7-8399-25f9-360a" name="Deep Strike:" hidden="false" targetId="0d4f-ff28-d819-a512" primary="false"/>
         <categoryLink name="SA or IM Unit" hidden="false" id="bfcd-9340-8465-b8f7" targetId="4aca-2849-7f41-0200" primary="false"/>
@@ -8078,7 +8078,7 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
         <categoryLink id="c8e8-f90f-b0b0-d692" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
         <categoryLink id="43fa-85ec-2bdb-1889" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="c98c-1e49-f597-b96b" name="Third-line Unit Sub-type" hidden="false" targetId="cdaa-645b-fda7-8556" primary="false"/>
-        <categoryLink id="1dd4-afa1-484c-6dc2" name="Reinforced Sub-type:" hidden="false" targetId="9b0d-738c-10e4-4ec1" primary="false"/>
+        <categoryLink id="1dd4-afa1-484c-6dc2" name="Reinforced Sub-type" hidden="false" targetId="9b0d-738c-10e4-4ec1" primary="false"/>
         <categoryLink name="SA or IM Unit" hidden="false" id="6fd7-ced4-3f66-597b" targetId="4aca-2849-7f41-0200" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
@@ -8441,8 +8441,8 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
                 </profile>
               </profiles>
               <categoryLinks>
-                <categoryLink id="b1dd-86aa-1c7a-ec38" name="Artillery Sub-type:" hidden="false" targetId="6f99-c178-6f9d-fb63" primary="false"/>
-                <categoryLink id="144f-3d8d-5a77-0ef0" name="Heavy Sub-type:" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+                <categoryLink id="b1dd-86aa-1c7a-ec38" name="Artillery Sub-type" hidden="false" targetId="6f99-c178-6f9d-fb63" primary="false"/>
+                <categoryLink id="144f-3d8d-5a77-0ef0" name="Heavy Sub-type" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
                 <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="8d85-3a58-4ba7-66fa" primary="false" name="Infantry:"/>
               </categoryLinks>
               <selectionEntries>
@@ -8498,8 +8498,8 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
                 </profile>
               </profiles>
               <categoryLinks>
-                <categoryLink id="fc24-4a7a-d3d4-d5ee" name="Heavy Sub-type:" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
-                <categoryLink id="b8f5-f67b-e34f-462b" name="Artillery Sub-type:" hidden="false" targetId="6f99-c178-6f9d-fb63" primary="false"/>
+                <categoryLink id="fc24-4a7a-d3d4-d5ee" name="Heavy Sub-type" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+                <categoryLink id="b8f5-f67b-e34f-462b" name="Artillery Sub-type" hidden="false" targetId="6f99-c178-6f9d-fb63" primary="false"/>
                 <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="56c3-c63f-7684-21ef" primary="false" name="Infantry:"/>
               </categoryLinks>
               <selectionEntries>
@@ -8602,7 +8602,7 @@ equal to the number of Militia Gunners in the unit when making a Shooting Attack
               </rules>
               <categoryLinks>
                 <categoryLink id="205d-689e-ae32-670d" name="Militia Unit Sub-type" hidden="false" targetId="66b2-c457-4d5e-8041" primary="false"/>
-                <categoryLink id="b11f-461d-e0e7-15c1" name="Heavy Sub-type:" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+                <categoryLink id="b11f-461d-e0e7-15c1" name="Heavy Sub-type" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
                 <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="b171-2484-94bd-12b9" primary="false" name="Infantry:"/>
               </categoryLinks>
               <entryLinks>
@@ -8633,7 +8633,7 @@ equal to the number of Militia Gunners in the unit when making a Shooting Attack
               </infoLinks>
               <categoryLinks>
                 <categoryLink id="1ece-126f-876a-b249" name="Militia Unit Sub-type" hidden="false" targetId="66b2-c457-4d5e-8041" primary="false"/>
-                <categoryLink id="14a3-f6e4-e6b7-ea9d" name="Heavy Sub-type:" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+                <categoryLink id="14a3-f6e4-e6b7-ea9d" name="Heavy Sub-type" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
                 <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="48ec-fd1d-f4f2-1fcb" primary="false" name="Infantry:"/>
               </categoryLinks>
               <entryLinks>
@@ -8687,8 +8687,8 @@ equal to the number of Militia Gunners in the unit when making a Shooting Attack
         <categoryLink id="e408-1baf-a063-61e8" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
         <categoryLink id="17fc-4904-ff79-3782" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="158d-a30c-05cd-368e" name="Third-line Unit Sub-type" hidden="false" targetId="cdaa-645b-fda7-8556" primary="false"/>
-        <categoryLink id="737a-12d4-20d5-1af0" name="Super-heavy Sub-type:" hidden="false" targetId="7381-1130-ca6e-1806" primary="false"/>
-        <categoryLink id="84a5-947e-9aed-8888" name="Transport Sub-type:" hidden="false" targetId="7b0a-a743-a8da-3a39" primary="false"/>
+        <categoryLink id="737a-12d4-20d5-1af0" name="Super-heavy Sub-type" hidden="false" targetId="7381-1130-ca6e-1806" primary="false"/>
+        <categoryLink id="84a5-947e-9aed-8888" name="Transport Sub-type" hidden="false" targetId="7b0a-a743-a8da-3a39" primary="false"/>
         <categoryLink name="SA or IM Unit" hidden="false" id="7afb-1364-565a-c26d" targetId="4aca-2849-7f41-0200" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
@@ -8878,7 +8878,7 @@ equal to the number of Militia Gunners in the unit when making a Shooting Attack
         <categoryLink id="8b3a-e67c-3c16-ad31" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
         <categoryLink id="2803-8cb8-f7ab-2a8d" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="c175-e0ae-2646-b5cb" name="Third-line Unit Sub-type" hidden="false" targetId="cdaa-645b-fda7-8556" primary="false"/>
-        <categoryLink id="0585-8e7f-9c94-b9c1" name="Super-heavy Sub-type:" hidden="false" targetId="7381-1130-ca6e-1806" primary="false"/>
+        <categoryLink id="0585-8e7f-9c94-b9c1" name="Super-heavy Sub-type" hidden="false" targetId="7381-1130-ca6e-1806" primary="false"/>
         <categoryLink name="SA or IM Unit" hidden="false" id="c15b-5d3c-3e3c-9eda" targetId="4aca-2849-7f41-0200" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
@@ -9176,7 +9176,7 @@ equal to the number of Militia Gunners in the unit when making a Shooting Attack
       <categoryLinks>
         <categoryLink id="6d7a-960f-c4f1-b63c" name="Militia Unit Sub-type" hidden="false" targetId="66b2-c457-4d5e-8041" primary="false"/>
         <categoryLink id="3c09-768c-40e7-c705" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="5794-7adf-a300-a5af" name="Monstrous Sub-type:" hidden="false" targetId="7d95-f9d1-440a-67bd" primary="false"/>
+        <categoryLink id="5794-7adf-a300-a5af" name="Monstrous Sub-type" hidden="false" targetId="7d95-f9d1-440a-67bd" primary="false"/>
         <categoryLink name="SA or IM Unit" hidden="false" id="b12f-3fcc-db31-a848" targetId="4aca-2849-7f41-0200" primary="false"/>
       </categoryLinks>
       <selectionEntries>
@@ -10274,7 +10274,7 @@ equal to the number of Militia Gunners in the unit when making a Shooting Attack
       </infoLinks>
       <categoryLinks>
         <categoryLink id="4918-c7ed-dc9c-9b19" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
-        <categoryLink id="c9e7-211b-aed2-e105" name="Transport Sub-type:" hidden="false" targetId="7b0a-a743-a8da-3a39" primary="false"/>
+        <categoryLink id="c9e7-211b-aed2-e105" name="Transport Sub-type" hidden="false" targetId="7b0a-a743-a8da-3a39" primary="false"/>
         <categoryLink id="900b-8b06-0d05-270c" name="Third-line Unit Sub-type" hidden="false" targetId="cdaa-645b-fda7-8556" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
@@ -10404,7 +10404,7 @@ equal to the number of Militia Gunners in the unit when making a Shooting Attack
       </infoLinks>
       <categoryLinks>
         <categoryLink id="1ecd-2a6c-27b9-810f" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
-        <categoryLink id="d9cd-7fdd-c92e-72a0" name="Transport Sub-type:" hidden="false" targetId="7b0a-a743-a8da-3a39" primary="false"/>
+        <categoryLink id="d9cd-7fdd-c92e-72a0" name="Transport Sub-type" hidden="false" targetId="7b0a-a743-a8da-3a39" primary="false"/>
         <categoryLink id="fbd3-e774-82ad-e0b6" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="7e5e-549a-a03f-7676" name="Third-line Unit Sub-type" hidden="false" targetId="cdaa-645b-fda7-8556" primary="false"/>
       </categoryLinks>
@@ -10496,8 +10496,8 @@ equal to the number of Militia Gunners in the unit when making a Shooting Attack
       </infoLinks>
       <categoryLinks>
         <categoryLink id="8ee0-acf9-570d-0500" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
-        <categoryLink id="f3b5-bda5-3ce5-7572" name="Transport Sub-type:" hidden="false" targetId="7b0a-a743-a8da-3a39" primary="false"/>
-        <categoryLink id="436f-5f63-850c-4d1d" name="Reinforced Sub-type:" hidden="false" targetId="9b0d-738c-10e4-4ec1" primary="false"/>
+        <categoryLink id="f3b5-bda5-3ce5-7572" name="Transport Sub-type" hidden="false" targetId="7b0a-a743-a8da-3a39" primary="false"/>
+        <categoryLink id="436f-5f63-850c-4d1d" name="Reinforced Sub-type" hidden="false" targetId="9b0d-738c-10e4-4ec1" primary="false"/>
         <categoryLink id="f647-1a00-45dc-f45a" name="Third-line Unit Sub-type" hidden="false" targetId="cdaa-645b-fda7-8556" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
@@ -10647,7 +10647,7 @@ equal to the number of Militia Gunners in the unit when making a Shooting Attack
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="b4c2-b70f-6697-8a3e" name="Daemon Unit-type:" hidden="false" targetId="e699-d9cd-e68e-46d9" primary="false"/>
+        <categoryLink id="b4c2-b70f-6697-8a3e" name="Daemon Unit Type" hidden="false" targetId="e699-d9cd-e68e-46d9" primary="false"/>
         <categoryLink id="7a15-dc82-ffcd-db05" name="Bound Sub-type" hidden="false" targetId="40f3-05e8-5ddc-636a" primary="false"/>
       </categoryLinks>
       <entryLinks>
@@ -10663,7 +10663,7 @@ equal to the number of Militia Gunners in the unit when making a Shooting Attack
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20"/>
       </costs>
       <categoryLinks>
-        <categoryLink targetId="e699-d9cd-e68e-46d9" id="6f3e-1b0d-2d9a-3239" primary="false" name="Daemon Unit-type:"/>
+        <categoryLink targetId="e699-d9cd-e68e-46d9" id="6f3e-1b0d-2d9a-3239" primary="false" name="Daemon Unit Type"/>
       </categoryLinks>
       <entryLinks>
         <entryLink import="true" name="Daemon Beasts" hidden="false" type="selectionEntryGroup" id="5da4-94c9-b360-31a1" targetId="8d09-1913-b79f-5c35"/>
@@ -10713,7 +10713,7 @@ equal to the number of Militia Gunners in the unit when making a Shooting Attack
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15"/>
       </costs>
       <categoryLinks>
-        <categoryLink targetId="e699-d9cd-e68e-46d9" id="9cc7-3a82-55c3-ca1b" primary="false" name="Daemon Unit-type:"/>
+        <categoryLink targetId="e699-d9cd-e68e-46d9" id="9cc7-3a82-55c3-ca1b" primary="false" name="Daemon Unit Type"/>
       </categoryLinks>
       <entryLinks>
         <entryLink import="true" name="Daemon Brute" hidden="false" type="selectionEntry" id="8838-1f4d-99ad-c5a6" targetId="e3e-4f46-2300-a35"/>
@@ -10775,7 +10775,7 @@ equal to the number of Militia Gunners in the unit when making a Shooting Attack
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5"/>
       </costs>
       <categoryLinks>
-        <categoryLink targetId="e699-d9cd-e68e-46d9" id="4c49-865a-fc97-7c58" primary="false" name="Daemon Unit-type:"/>
+        <categoryLink targetId="e699-d9cd-e68e-46d9" id="4c49-865a-fc97-7c58" primary="false" name="Daemon Unit Type"/>
       </categoryLinks>
       <infoLinks>
         <infoLink id="48c7-6e7a-dca2-a2b7" name="Hammer of Wrath (X)" hidden="false" targetId="aec0-c3aa-1e4e-1779" type="rule">
@@ -10808,7 +10808,7 @@ equal to the number of Militia Gunners in the unit when making a Shooting Attack
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20"/>
       </costs>
       <categoryLinks>
-        <categoryLink targetId="e699-d9cd-e68e-46d9" id="f504-44e8-e7f5-54d3" primary="false" name="Daemon Unit-type:"/>
+        <categoryLink targetId="e699-d9cd-e68e-46d9" id="f504-44e8-e7f5-54d3" primary="false" name="Daemon Unit Type"/>
       </categoryLinks>
       <entryLinks>
         <entryLink import="true" name="The Ætheric Dominion (Unit)" hidden="false" type="selectionEntryGroup" id="1a90-ab1a-5dff-166a" targetId="caad-e621-38e5-cb5f"/>

--- a/2022 - Imperialis Militia.cat
+++ b/2022 - Imperialis Militia.cat
@@ -839,7 +839,7 @@ Unless noted, the effects of any rules featured in the Provenance’s descriptio
             <categoryLink id="a65e-9023-2e84-4f5a" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
             <categoryLink id="b2c0-61dc-f06d-7596" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
             <categoryLink id="17a7-7777-5452-6e01" name="Militia Unit Sub-type" hidden="false" targetId="66b2-c457-4d5e-8041" primary="false"/>
-            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="2490-1700-47ab-ad1d" name="Infantry" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="2490-1700-47ab-ad1d" name="Infantry Unit Type" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="88ce-c3b7-b1c1-0055" name="1.1) Weapon (Exchange Laspistol/Autopistol)" hidden="false" collective="false" import="true" defaultSelectionEntryId="352c-a5d1-de12-bf4b">
@@ -1329,7 +1329,7 @@ Unless noted, the effects of any rules featured in the Provenance’s descriptio
               <categoryLinks>
                 <categoryLink id="5823-9c18-2b4e-9d43" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
                 <categoryLink name="Militia Unit Sub-type" hidden="false" id="9736-fba1-c521-9ceb" targetId="66b2-c457-4d5e-8041" primary="false"/>
-                <categoryLink name="Infantry:" hidden="false" id="90ef-9684-8b3f-7d39" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+                <categoryLink name="Infantry Unit Type" hidden="false" id="90ef-9684-8b3f-7d39" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
               </categoryLinks>
               <entryLinks>
                 <entryLink id="955b-1e05-cf72-9a92" name="Close Combat Weapon" hidden="false" collective="false" import="true" targetId="19ab-4d64-f6a7-9f81" type="selectionEntry">
@@ -1439,7 +1439,7 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
               <categoryLinks>
                 <categoryLink id="7b26-d5dc-0ec4-484c" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
                 <categoryLink name="Militia Unit Sub-type" hidden="false" id="3edb-c0f8-6037-cf39" targetId="66b2-c457-4d5e-8041" primary="false"/>
-                <categoryLink name="Infantry:" hidden="false" id="43b3-6289-e7ed-fb61" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+                <categoryLink name="Infantry Unit Type" hidden="false" id="43b3-6289-e7ed-fb61" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
               </categoryLinks>
               <selectionEntries>
                 <selectionEntry id="f6f0-311a-6151-aa45" name="Auto-medicus" hidden="false" collective="true" import="true" type="upgrade">
@@ -1514,7 +1514,7 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
               <categoryLinks>
                 <categoryLink id="b9ab-6033-8791-a60b" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
                 <categoryLink name="Militia Unit Sub-type" hidden="false" id="736f-413f-ea14-91a3" targetId="66b2-c457-4d5e-8041" primary="false"/>
-                <categoryLink name="Infantry:" hidden="false" id="13b6-9ca6-97b5-57cb" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+                <categoryLink name="Infantry Unit Type" hidden="false" id="13b6-9ca6-97b5-57cb" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
               </categoryLinks>
               <selectionEntries>
                 <selectionEntry id="57cc-881a-0952-532b" name="Auto-medicus" hidden="false" collective="true" import="true" type="upgrade">
@@ -1579,7 +1579,7 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
               <categoryLinks>
                 <categoryLink id="f315-1696-b72a-d1c3" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
                 <categoryLink name="Militia Unit Sub-type" hidden="false" id="3d07-4fc9-791b-6e17" targetId="66b2-c457-4d5e-8041" primary="false"/>
-                <categoryLink name="Infantry:" hidden="false" id="8e52-6c34-82fd-a242" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+                <categoryLink name="Infantry Unit Type" hidden="false" id="8e52-6c34-82fd-a242" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
               </categoryLinks>
               <selectionEntries>
                 <selectionEntry id="0f20-73fb-c3e4-83ec" name="Auto-medicus" hidden="false" collective="true" import="true" type="upgrade">
@@ -1834,8 +1834,8 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
           </infoLinks>
           <categoryLinks>
             <categoryLink id="af33-2130-a0d9-77c4" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
-            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="dc46-dacc-4b4c-bb8c" name="Infantry" primary="false"/>
-            <categoryLink targetId="66b2-c457-4d5e-8041" id="67d8-2ea7-472d-9310" name="Militia" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="dc46-dacc-4b4c-bb8c" name="Infantry Unit Type" primary="false"/>
+            <categoryLink targetId="66b2-c457-4d5e-8041" id="67d8-2ea7-472d-9310" name="Militia Unit Sub-type" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="fd7f-e242-cb21-f6a9" name="2) Armour" hidden="false" collective="false" import="true" defaultSelectionEntryId="2b69-4950-7578-7994">
@@ -2096,7 +2096,7 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
         </infoLink>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="8fac-77b4-81d8-0791" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="8fac-77b4-81d8-0791" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="09dc-31fa-f001-168b" name="Militia Unit Sub-type" hidden="false" targetId="66b2-c457-4d5e-8041" primary="false"/>
         <categoryLink name="SA or IM Unit" hidden="false" id="628e-9fb-ce89-7f7" targetId="4aca-2849-7f41-0200" primary="false"/>
       </categoryLinks>
@@ -2190,8 +2190,8 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
           </infoLinks>
           <categoryLinks>
             <categoryLink id="e545-8eba-ce63-490f" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
-            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="df3c-8d24-4d38-98f8" name="Infantry" primary="false"/>
-            <categoryLink targetId="66b2-c457-4d5e-8041" id="f049-cf32-45bd-a2e6" name="Militia" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="df3c-8d24-4d38-98f8" name="Infantry Unit Type" primary="false"/>
+            <categoryLink targetId="66b2-c457-4d5e-8041" id="f049-cf32-45bd-a2e6" name="Militia Unit Sub-type" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="69e3-c3f4-1c6e-efa1" name="1.1) Weapon (Exchange Laspistol/Autopistol)" hidden="false" collective="false" import="true" defaultSelectionEntryId="78ea-a056-d291-2a8b">
@@ -2742,8 +2742,8 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="8"/>
           </costs>
           <categoryLinks>
-            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="2d74-1fc2-43ec-963d" name="Infantry" primary="false"/>
-            <categoryLink targetId="66b2-c457-4d5e-8041" id="5888-613a-4d53-bbf8" name="Militia" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="2d74-1fc2-43ec-963d" name="Infantry Unit Type" primary="false"/>
+            <categoryLink targetId="66b2-c457-4d5e-8041" id="5888-613a-4d53-bbf8" name="Militia Unit Sub-type" primary="false"/>
           </categoryLinks>
         </selectionEntry>
       </selectionEntries>
@@ -2924,7 +2924,7 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
                 </infoLink>
               </infoLinks>
               <categoryLinks>
-                <categoryLink id="d4b9-04fc-2a82-3985" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+                <categoryLink id="d4b9-04fc-2a82-3985" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
                 <categoryLink id="e4d4-1648-6a6d-b470" name="Line Sub-type" hidden="false" targetId="6399-5c65-7833-1025" primary="false"/>
                 <categoryLink name="SA or IM Unit" hidden="false" id="77b2-9e7b-f60f-5e2c" targetId="4aca-2849-7f41-0200" primary="false"/>
               </categoryLinks>
@@ -3008,9 +3008,9 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
                   </infoLinks>
                   <categoryLinks>
                     <categoryLink id="16d5-56a2-4e6a-6abb" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
-                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="2454-5688-4c1b-b81b" name="Infantry" primary="false"/>
-                    <categoryLink targetId="66b2-c457-4d5e-8041" id="0f82-f1d0-4eb7-ab08" name="Militia" primary="false"/>
-                    <categoryLink targetId="6399-5c65-7833-1025" id="8c6e-1277-419d-aef4" name="Line" primary="false"/>
+                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="2454-5688-4c1b-b81b" name="Infantry Unit Type" primary="false"/>
+                    <categoryLink targetId="66b2-c457-4d5e-8041" id="0f82-f1d0-4eb7-ab08" name="Militia Unit Sub-type" primary="false"/>
+                    <categoryLink targetId="6399-5c65-7833-1025" id="8c6e-1277-419d-aef4" name="Line Sub-type" primary="false"/>
                   </categoryLinks>
                   <entryLinks>
                     <entryLink id="7ed5-d306-8605-373b" name="Flak Armour" hidden="false" collective="false" import="true" targetId="0251-8365-9efb-61a7" type="selectionEntry">
@@ -3103,9 +3103,9 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
                   </costs>
                   <categoryLinks>
-                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="187d-ece9-438b-add5" name="Infantry" primary="false"/>
-                    <categoryLink targetId="66b2-c457-4d5e-8041" id="c4fa-d92f-4259-9e0b" name="Militia" primary="false"/>
-                    <categoryLink targetId="6399-5c65-7833-1025" id="10cf-eb33-4535-9dd4" name="Line" primary="false"/>
+                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="187d-ece9-438b-add5" name="Infantry Unit Type" primary="false"/>
+                    <categoryLink targetId="66b2-c457-4d5e-8041" id="c4fa-d92f-4259-9e0b" name="Militia Unit Sub-type" primary="false"/>
+                    <categoryLink targetId="6399-5c65-7833-1025" id="10cf-eb33-4535-9dd4" name="Line Sub-type" primary="false"/>
                   </categoryLinks>
                 </selectionEntry>
               </selectionEntries>
@@ -3748,7 +3748,7 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
                 </infoLink>
               </infoLinks>
               <categoryLinks>
-                <categoryLink id="7623-1857-a4d2-3139" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+                <categoryLink id="7623-1857-a4d2-3139" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
                 <categoryLink name="SA or IM Unit" hidden="false" id="ea3a-9217-36ff-6119" targetId="4aca-2849-7f41-0200" primary="false"/>
               </categoryLinks>
               <selectionEntries>
@@ -3836,8 +3836,8 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
                   </infoLinks>
                   <categoryLinks>
                     <categoryLink id="ee2d-b515-e075-bb85" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
-                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="76b1-ea36-4edb-9d67" name="Infantry" primary="false"/>
-                    <categoryLink targetId="66b2-c457-4d5e-8041" id="d2eb-79f9-46da-b744" name="Militia" primary="false"/>
+                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="76b1-ea36-4edb-9d67" name="Infantry Unit Type" primary="false"/>
+                    <categoryLink targetId="66b2-c457-4d5e-8041" id="d2eb-79f9-46da-b744" name="Militia Unit Sub-type" primary="false"/>
                   </categoryLinks>
                   <selectionEntryGroups>
                     <selectionEntryGroup id="19a9-19de-d6eb-8de4" name="The Sergeant may exchange their Lasgun for the following" hidden="false" collective="false" import="true" defaultSelectionEntryId="8d59-a1c1-7098-05a6">
@@ -4083,8 +4083,8 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2"/>
                   </costs>
                   <categoryLinks>
-                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="c4b8-00f0-4e20-9a28" name="Infantry" primary="false"/>
-                    <categoryLink targetId="66b2-c457-4d5e-8041" id="16b9-cacc-42e6-970e" name="Militia" primary="false"/>
+                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="c4b8-00f0-4e20-9a28" name="Infantry Unit Type" primary="false"/>
+                    <categoryLink targetId="66b2-c457-4d5e-8041" id="16b9-cacc-42e6-970e" name="Militia Unit Sub-type" primary="false"/>
                   </categoryLinks>
                 </selectionEntry>
               </selectionEntries>
@@ -4411,7 +4411,7 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
       </infoLinks>
       <categoryLinks>
         <categoryLink id="1fbc-3ade-2ce2-689f" name="Militia Unit Sub-type" hidden="false" targetId="66b2-c457-4d5e-8041" primary="false"/>
-        <categoryLink id="aff5-69b6-f98b-f576" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="aff5-69b6-f98b-f576" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="4164-318f-e397-bd37" name="Line Sub-type" hidden="false" targetId="6399-5c65-7833-1025" primary="false"/>
         <categoryLink name="SA or IM Unit" hidden="false" id="c5be-208d-4e36-5f45" targetId="4aca-2849-7f41-0200" primary="false"/>
       </categoryLinks>
@@ -4736,9 +4736,9 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="6"/>
           </costs>
           <categoryLinks>
-            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="7883-dea0-4862-a768" name="Infantry" primary="false"/>
-            <categoryLink targetId="66b2-c457-4d5e-8041" id="4cd3-4939-467d-a975" name="Militia" primary="false"/>
-            <categoryLink targetId="6399-5c65-7833-1025" id="ef26-6ae6-4cd8-932e" name="Line" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="7883-dea0-4862-a768" name="Infantry Unit Type" primary="false"/>
+            <categoryLink targetId="66b2-c457-4d5e-8041" id="4cd3-4939-467d-a975" name="Militia Unit Sub-type" primary="false"/>
+            <categoryLink targetId="6399-5c65-7833-1025" id="ef26-6ae6-4cd8-932e" name="Line Sub-type" primary="false"/>
           </categoryLinks>
         </selectionEntry>
         <selectionEntry id="5d42-ca93-dc35-8745" name="1) Grenadier Sergeant" hidden="false" collective="false" import="true" type="model">
@@ -4825,9 +4825,9 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
           </infoLinks>
           <categoryLinks>
             <categoryLink id="a707-2515-52c5-cf6c" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
-            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="f893-c3ab-46bd-a85c" name="Infantry" primary="false"/>
-            <categoryLink targetId="66b2-c457-4d5e-8041" id="76c7-2f63-4f60-a98d" name="Militia" primary="false"/>
-            <categoryLink targetId="6399-5c65-7833-1025" id="2fe2-0880-407f-8a08" name="Line" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="f893-c3ab-46bd-a85c" name="Infantry Unit Type" primary="false"/>
+            <categoryLink targetId="66b2-c457-4d5e-8041" id="76c7-2f63-4f60-a98d" name="Militia Unit Sub-type" primary="false"/>
+            <categoryLink targetId="6399-5c65-7833-1025" id="2fe2-0880-407f-8a08" name="Line Sub-type" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="3326-bba2-05f6-175a" name="1.1) Weapons (Laspistol/Autopistol)" hidden="false" collective="false" import="true" defaultSelectionEntryId="1465-584d-ddc3-50de">
@@ -5205,7 +5205,7 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
         </infoLink>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="544a-d5de-ad24-ccf1" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="544a-d5de-ad24-ccf1" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="ff5e-7826-a07c-580b" name="Heavy Sub-type" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
         <categoryLink id="757a-017f-0c23-8007" name="Militia Unit Sub-type" hidden="false" targetId="66b2-c457-4d5e-8041" primary="false"/>
         <categoryLink name="SA or IM Unit" hidden="false" id="e0c9-5208-41a0-6e1" targetId="4aca-2849-7f41-0200" primary="false"/>
@@ -5240,9 +5240,9 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20"/>
               </costs>
               <categoryLinks>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="5537-0c68-4499-972c" name="Infantry" primary="false"/>
-                <categoryLink targetId="9231-183c-b97b-63f9" id="868b-2ec9-4231-a6e0" name="Heavy" primary="false"/>
-                <categoryLink targetId="66b2-c457-4d5e-8041" id="2a09-7ca6-43fa-879a" name="Militia" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="5537-0c68-4499-972c" name="Infantry Unit Type" primary="false"/>
+                <categoryLink targetId="9231-183c-b97b-63f9" id="868b-2ec9-4231-a6e0" name="Heavy Sub-type" primary="false"/>
+                <categoryLink targetId="66b2-c457-4d5e-8041" id="2a09-7ca6-43fa-879a" name="Militia Unit Sub-type" primary="false"/>
               </categoryLinks>
             </selectionEntry>
             <selectionEntry id="9643-3e33-55ed-e9f1" name="Militia Fire Team w/ Autocannon" hidden="false" collective="false" import="true" type="model">
@@ -5284,9 +5284,9 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20"/>
               </costs>
               <categoryLinks>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="2b1f-3565-4790-861f" name="Infantry" primary="false"/>
-                <categoryLink targetId="9231-183c-b97b-63f9" id="95c8-b9f1-4ebd-93fe" name="Heavy" primary="false"/>
-                <categoryLink targetId="66b2-c457-4d5e-8041" id="ba52-9558-49bd-b8ac" name="Militia" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="2b1f-3565-4790-861f" name="Infantry Unit Type" primary="false"/>
+                <categoryLink targetId="9231-183c-b97b-63f9" id="95c8-b9f1-4ebd-93fe" name="Heavy Sub-type" primary="false"/>
+                <categoryLink targetId="66b2-c457-4d5e-8041" id="ba52-9558-49bd-b8ac" name="Militia Unit Sub-type" primary="false"/>
               </categoryLinks>
             </selectionEntry>
             <selectionEntry id="5ff1-5b17-ca8b-0676" name="Militia Fire Team w/ Heavy Stubber" hidden="false" collective="false" import="true" type="model">
@@ -5372,9 +5372,9 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20"/>
               </costs>
               <categoryLinks>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="5a1d-95f6-4db4-8836" name="Infantry" primary="false"/>
-                <categoryLink targetId="9231-183c-b97b-63f9" id="5dcb-25b5-487b-9ebc" name="Heavy" primary="false"/>
-                <categoryLink targetId="66b2-c457-4d5e-8041" id="eb2f-8d44-4b2d-9e59" name="Militia" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="5a1d-95f6-4db4-8836" name="Infantry Unit Type" primary="false"/>
+                <categoryLink targetId="9231-183c-b97b-63f9" id="5dcb-25b5-487b-9ebc" name="Heavy Sub-type" primary="false"/>
+                <categoryLink targetId="66b2-c457-4d5e-8041" id="eb2f-8d44-4b2d-9e59" name="Militia Unit Sub-type" primary="false"/>
               </categoryLinks>
             </selectionEntry>
             <selectionEntry id="ffb6-7ae4-9f04-7c7d" name="Militia Fire Team w/ Missile Launcher Frag/Krak" hidden="false" collective="false" import="true" type="model">
@@ -5412,9 +5412,9 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20"/>
               </costs>
               <categoryLinks>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="53cf-4e7c-4b0f-b16e" name="Infantry" primary="false"/>
-                <categoryLink targetId="9231-183c-b97b-63f9" id="3dc5-e564-4ef9-a4d5" name="Heavy" primary="false"/>
-                <categoryLink targetId="66b2-c457-4d5e-8041" id="d5c5-5d8f-44f3-8425" name="Militia" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="53cf-4e7c-4b0f-b16e" name="Infantry Unit Type" primary="false"/>
+                <categoryLink targetId="9231-183c-b97b-63f9" id="3dc5-e564-4ef9-a4d5" name="Heavy Sub-type" primary="false"/>
+                <categoryLink targetId="66b2-c457-4d5e-8041" id="d5c5-5d8f-44f3-8425" name="Militia Unit Sub-type" primary="false"/>
               </categoryLinks>
             </selectionEntry>
             <selectionEntry id="237e-5215-928f-a38f" name="Militia Fire Team w/ Mortar" hidden="false" collective="false" import="true" type="model">
@@ -5454,9 +5454,9 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20"/>
               </costs>
               <categoryLinks>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="6849-022b-4f86-a5dc" name="Infantry" primary="false"/>
-                <categoryLink targetId="9231-183c-b97b-63f9" id="1212-8194-4301-a810" name="Heavy" primary="false"/>
-                <categoryLink targetId="66b2-c457-4d5e-8041" id="6f7d-c4dd-45b1-8de0" name="Militia" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="6849-022b-4f86-a5dc" name="Infantry Unit Type" primary="false"/>
+                <categoryLink targetId="9231-183c-b97b-63f9" id="1212-8194-4301-a810" name="Heavy Sub-type" primary="false"/>
+                <categoryLink targetId="66b2-c457-4d5e-8041" id="6f7d-c4dd-45b1-8de0" name="Militia Unit Sub-type" primary="false"/>
               </categoryLinks>
             </selectionEntry>
             <selectionEntry id="e5fc-9d18-110f-569b" name="Militia Fire Team w/ Multilaser" hidden="false" collective="false" import="true" type="model">
@@ -5493,9 +5493,9 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20"/>
               </costs>
               <categoryLinks>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="7d70-7d41-41d5-963e" name="Infantry" primary="false"/>
-                <categoryLink targetId="9231-183c-b97b-63f9" id="45ad-fe95-48c7-985a" name="Heavy" primary="false"/>
-                <categoryLink targetId="66b2-c457-4d5e-8041" id="150c-1f22-47ce-8335" name="Militia" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="7d70-7d41-41d5-963e" name="Infantry Unit Type" primary="false"/>
+                <categoryLink targetId="9231-183c-b97b-63f9" id="45ad-fe95-48c7-985a" name="Heavy Sub-type" primary="false"/>
+                <categoryLink targetId="66b2-c457-4d5e-8041" id="150c-1f22-47ce-8335" name="Militia Unit Sub-type" primary="false"/>
               </categoryLinks>
             </selectionEntry>
             <selectionEntry id="0170-77fa-0994-bbe7" name="Militia Fire Team w/ Heavy Bolter" hidden="false" collective="false" import="true" type="model">
@@ -5527,9 +5527,9 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20"/>
               </costs>
               <categoryLinks>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="7758-9588-4f1e-9fd7" name="Infantry" primary="false"/>
-                <categoryLink targetId="9231-183c-b97b-63f9" id="d928-1eac-4c4d-90b5" name="Heavy" primary="false"/>
-                <categoryLink targetId="66b2-c457-4d5e-8041" id="b2b2-2c94-439e-bc1c" name="Militia" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="7758-9588-4f1e-9fd7" name="Infantry Unit Type" primary="false"/>
+                <categoryLink targetId="9231-183c-b97b-63f9" id="d928-1eac-4c4d-90b5" name="Heavy Sub-type" primary="false"/>
+                <categoryLink targetId="66b2-c457-4d5e-8041" id="b2b2-2c94-439e-bc1c" name="Militia Unit Sub-type" primary="false"/>
               </categoryLinks>
             </selectionEntry>
           </selectionEntries>
@@ -5618,7 +5618,7 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
         </infoLink>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="f8bf-e373-7088-1dca" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="f8bf-e373-7088-1dca" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="2dff-278b-2bbe-fe45" name="Militia Unit Sub-type" hidden="false" targetId="66b2-c457-4d5e-8041" primary="false"/>
         <categoryLink id="36e0-ac5f-3884-fb95" name="Light Sub-type" hidden="false" targetId="bff2-ae16-74a8-8712" primary="false"/>
         <categoryLink name="SA or IM Unit" hidden="false" id="3fe0-25b6-794c-a207" targetId="4aca-2849-7f41-0200" primary="false"/>
@@ -5683,9 +5683,9 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5"/>
           </costs>
           <categoryLinks>
-            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="b33e-d51f-4da5-b29d" name="Infantry" primary="false"/>
-            <categoryLink targetId="66b2-c457-4d5e-8041" id="ee74-71a4-4846-8a2c" name="Militia" primary="false"/>
-            <categoryLink targetId="bff2-ae16-74a8-8712" id="20d5-00e8-4d40-9d8e" name="Light" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="b33e-d51f-4da5-b29d" name="Infantry Unit Type" primary="false"/>
+            <categoryLink targetId="66b2-c457-4d5e-8041" id="ee74-71a4-4846-8a2c" name="Militia Unit Sub-type" primary="false"/>
+            <categoryLink targetId="bff2-ae16-74a8-8712" id="20d5-00e8-4d40-9d8e" name="Light Sub-type" primary="false"/>
           </categoryLinks>
         </selectionEntry>
         <selectionEntry id="73bd-73fb-8c08-283b" name="Scout Sergeant" hidden="false" collective="false" import="true" type="model">
@@ -5767,9 +5767,9 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
           </infoLinks>
           <categoryLinks>
             <categoryLink id="ae89-1a96-9894-da38" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
-            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="4ea9-82e2-4394-936b" name="Infantry" primary="false"/>
-            <categoryLink targetId="66b2-c457-4d5e-8041" id="9f81-b7f4-4619-ade9" name="Militia" primary="false"/>
-            <categoryLink targetId="bff2-ae16-74a8-8712" id="d5b1-ff57-4159-8820" name="Light" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="4ea9-82e2-4394-936b" name="Infantry Unit Type" primary="false"/>
+            <categoryLink targetId="66b2-c457-4d5e-8041" id="9f81-b7f4-4619-ade9" name="Militia Unit Sub-type" primary="false"/>
+            <categoryLink targetId="bff2-ae16-74a8-8712" id="d5b1-ff57-4159-8820" name="Light Sub-type" primary="false"/>
           </categoryLinks>
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
@@ -6011,7 +6011,7 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
         </infoLink>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="c0a5-6e17-90e1-9b34" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="c0a5-6e17-90e1-9b34" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="c254-7761-dbf3-9329" name="Heavy Sub-type" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
         <categoryLink id="6748-d0c8-4f36-f942" name="Militia Unit Sub-type" hidden="false" targetId="66b2-c457-4d5e-8041" primary="false"/>
         <categoryLink name="SA or IM Unit" hidden="false" id="1287-bd1c-809-f3e3" targetId="4aca-2849-7f41-0200" primary="false"/>
@@ -6127,9 +6127,9 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="40"/>
               </costs>
               <categoryLinks>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="298a-0b27-4850-9852" name="Infantry" primary="false"/>
-                <categoryLink targetId="9231-183c-b97b-63f9" id="cc2f-af5d-4690-8887" name="Heavy" primary="false"/>
-                <categoryLink targetId="66b2-c457-4d5e-8041" id="3b4b-3e9c-4821-af75" name="Militia" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="298a-0b27-4850-9852" name="Infantry Unit Type" primary="false"/>
+                <categoryLink targetId="9231-183c-b97b-63f9" id="cc2f-af5d-4690-8887" name="Heavy Sub-type" primary="false"/>
+                <categoryLink targetId="66b2-c457-4d5e-8041" id="3b4b-3e9c-4821-af75" name="Militia Unit Sub-type" primary="false"/>
               </categoryLinks>
             </selectionEntry>
             <selectionEntry id="5ea0-e933-72fe-17a5" name="Militia Field Gun w/ Kalliope Mortar" hidden="false" collective="false" import="true" type="model">
@@ -6171,9 +6171,9 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="40"/>
               </costs>
               <categoryLinks>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="61d5-868d-4e3a-90ab" name="Infantry" primary="false"/>
-                <categoryLink targetId="9231-183c-b97b-63f9" id="38f4-3543-4be4-940a" name="Heavy" primary="false"/>
-                <categoryLink targetId="66b2-c457-4d5e-8041" id="3fba-9099-4a95-a1c1" name="Militia" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="61d5-868d-4e3a-90ab" name="Infantry Unit Type" primary="false"/>
+                <categoryLink targetId="9231-183c-b97b-63f9" id="38f4-3543-4be4-940a" name="Heavy Sub-type" primary="false"/>
+                <categoryLink targetId="66b2-c457-4d5e-8041" id="3fba-9099-4a95-a1c1" name="Militia Unit Sub-type" primary="false"/>
               </categoryLinks>
             </selectionEntry>
             <selectionEntry id="1568-3730-cce3-342a" name="Militia Field Gun w/ Thunderblast Cannon" hidden="false" collective="false" import="true" type="model">
@@ -6210,9 +6210,9 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="40"/>
               </costs>
               <categoryLinks>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="602d-2f20-45bb-9d9e" name="Infantry" primary="false"/>
-                <categoryLink targetId="9231-183c-b97b-63f9" id="9c68-3362-410d-98df" name="Heavy" primary="false"/>
-                <categoryLink targetId="66b2-c457-4d5e-8041" id="25f2-a1be-476a-b49e" name="Militia" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="602d-2f20-45bb-9d9e" name="Infantry Unit Type" primary="false"/>
+                <categoryLink targetId="9231-183c-b97b-63f9" id="9c68-3362-410d-98df" name="Heavy Sub-type" primary="false"/>
+                <categoryLink targetId="66b2-c457-4d5e-8041" id="25f2-a1be-476a-b49e" name="Militia Unit Sub-type" primary="false"/>
               </categoryLinks>
             </selectionEntry>
           </selectionEntries>
@@ -6432,9 +6432,9 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="40"/>
           </costs>
           <categoryLinks>
-            <categoryLink targetId="e2b6-b770-784c-9e95" id="78bb-d201-4c77-adfc" name="Vehicle" primary="false"/>
-            <categoryLink targetId="cdaa-645b-fda7-8556" id="45fa-49f1-44c7-96f3" name="Third-line" primary="false"/>
-            <categoryLink targetId="7b0a-a743-a8da-3a39" id="d3e3-9d7d-40f1-aa75" name="Transport" primary="false"/>
+            <categoryLink targetId="e2b6-b770-784c-9e95" id="78bb-d201-4c77-adfc" name="Vehicle:" primary="false"/>
+            <categoryLink targetId="cdaa-645b-fda7-8556" id="45fa-49f1-44c7-96f3" name="Third-line Unit Sub-type" primary="false"/>
+            <categoryLink targetId="7b0a-a743-a8da-3a39" id="d3e3-9d7d-40f1-aa75" name="Transport Sub-type" primary="false"/>
           </categoryLinks>
         </selectionEntry>
       </selectionEntries>
@@ -6617,9 +6617,9 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
           </infoLinks>
           <categoryLinks>
             <categoryLink id="1f88-1a48-9e6f-578e" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
-            <categoryLink targetId="6d79-a3e4-381f-7b0f" id="81f9-8d40-48cb-aaae" name="Cavalry" primary="false"/>
-            <categoryLink targetId="bff2-ae16-74a8-8712" id="f59e-7339-45d1-b8ce" name="Light" primary="false"/>
-            <categoryLink targetId="66b2-c457-4d5e-8041" id="e8f5-365b-4a5c-8438" name="Militia" primary="false"/>
+            <categoryLink targetId="6d79-a3e4-381f-7b0f" id="81f9-8d40-48cb-aaae" name="Cavalry Unit Type" primary="false"/>
+            <categoryLink targetId="bff2-ae16-74a8-8712" id="f59e-7339-45d1-b8ce" name="Light Sub-type" primary="false"/>
+            <categoryLink targetId="66b2-c457-4d5e-8041" id="e8f5-365b-4a5c-8438" name="Militia Unit Sub-type" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="adaf-346a-a591-f44c" name="1.1) Weapon (Exchange Laspistol/Autopistol)" hidden="false" collective="false" import="true" defaultSelectionEntryId="f52f-9556-369c-6cb5">
@@ -6872,9 +6872,9 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="8"/>
               </costs>
               <categoryLinks>
-                <categoryLink targetId="6d79-a3e4-381f-7b0f" id="6edc-06e4-4c7d-8124" name="Cavalry" primary="false"/>
-                <categoryLink targetId="bff2-ae16-74a8-8712" id="130b-2e5b-4ce1-8e76" name="Light" primary="false"/>
-                <categoryLink targetId="66b2-c457-4d5e-8041" id="46d2-b475-463f-9ecb" name="Militia" primary="false"/>
+                <categoryLink targetId="6d79-a3e4-381f-7b0f" id="6edc-06e4-4c7d-8124" name="Cavalry Unit Type" primary="false"/>
+                <categoryLink targetId="bff2-ae16-74a8-8712" id="130b-2e5b-4ce1-8e76" name="Light Sub-type" primary="false"/>
+                <categoryLink targetId="66b2-c457-4d5e-8041" id="46d2-b475-463f-9ecb" name="Militia Unit Sub-type" primary="false"/>
               </categoryLinks>
             </selectionEntry>
             <selectionEntry id="688b-7dee-f649-d1ec" name="Outrider w/ Autopistol" hidden="false" collective="false" import="true" type="model">
@@ -6962,9 +6962,9 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="8"/>
               </costs>
               <categoryLinks>
-                <categoryLink targetId="6d79-a3e4-381f-7b0f" id="735c-1356-4d20-b71c" name="Cavalry" primary="false"/>
-                <categoryLink targetId="bff2-ae16-74a8-8712" id="3cab-f9fd-4fdd-afd1" name="Light" primary="false"/>
-                <categoryLink targetId="66b2-c457-4d5e-8041" id="f91e-8dd5-45a4-9546" name="Militia" primary="false"/>
+                <categoryLink targetId="6d79-a3e4-381f-7b0f" id="735c-1356-4d20-b71c" name="Cavalry Unit Type" primary="false"/>
+                <categoryLink targetId="bff2-ae16-74a8-8712" id="3cab-f9fd-4fdd-afd1" name="Light Sub-type" primary="false"/>
+                <categoryLink targetId="66b2-c457-4d5e-8041" id="f91e-8dd5-45a4-9546" name="Militia Unit Sub-type" primary="false"/>
               </categoryLinks>
             </selectionEntry>
             <selectionEntry id="a956-492e-0dcd-0191" name="Outrider w/ Laspistol &amp; Chainaxe" hidden="false" collective="false" import="true" type="model">
@@ -7009,9 +7009,9 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="8"/>
               </costs>
               <categoryLinks>
-                <categoryLink targetId="6d79-a3e4-381f-7b0f" id="e4ad-0d11-4df1-a453" name="Cavalry" primary="false"/>
-                <categoryLink targetId="bff2-ae16-74a8-8712" id="7b3b-7c7e-4405-af14" name="Light" primary="false"/>
-                <categoryLink targetId="66b2-c457-4d5e-8041" id="cb16-531d-4113-a127" name="Militia" primary="false"/>
+                <categoryLink targetId="6d79-a3e4-381f-7b0f" id="e4ad-0d11-4df1-a453" name="Cavalry Unit Type" primary="false"/>
+                <categoryLink targetId="bff2-ae16-74a8-8712" id="7b3b-7c7e-4405-af14" name="Light Sub-type" primary="false"/>
+                <categoryLink targetId="66b2-c457-4d5e-8041" id="cb16-531d-4113-a127" name="Militia Unit Sub-type" primary="false"/>
               </categoryLinks>
             </selectionEntry>
             <selectionEntry id="2c47-a35f-14c2-c8c9" name="Outrider w/ Autopistol &amp; Chainaxe" hidden="false" collective="false" import="true" type="model">
@@ -7056,9 +7056,9 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="8"/>
               </costs>
               <categoryLinks>
-                <categoryLink targetId="6d79-a3e4-381f-7b0f" id="6889-bdbc-45d4-9d8f" name="Cavalry" primary="false"/>
-                <categoryLink targetId="bff2-ae16-74a8-8712" id="1c97-5658-4310-8eda" name="Light" primary="false"/>
-                <categoryLink targetId="66b2-c457-4d5e-8041" id="12d7-b3f2-44c9-9d80" name="Militia" primary="false"/>
+                <categoryLink targetId="6d79-a3e4-381f-7b0f" id="6889-bdbc-45d4-9d8f" name="Cavalry Unit Type" primary="false"/>
+                <categoryLink targetId="bff2-ae16-74a8-8712" id="1c97-5658-4310-8eda" name="Light Sub-type" primary="false"/>
+                <categoryLink targetId="66b2-c457-4d5e-8041" id="12d7-b3f2-44c9-9d80" name="Militia Unit Sub-type" primary="false"/>
               </categoryLinks>
             </selectionEntry>
           </selectionEntries>
@@ -7381,9 +7381,9 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="8"/>
               </costs>
               <categoryLinks>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="b4fc-b544-4e3c-b7a6" name="Infantry" primary="false"/>
-                <categoryLink targetId="66b2-c457-4d5e-8041" id="bf00-1592-48f8-b030" name="Militia" primary="false"/>
-                <categoryLink targetId="59a4-7b61-600a-c457" id="75db-0f24-431a-9a5f" name="Skirmish" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="b4fc-b544-4e3c-b7a6" name="Infantry Unit Type" primary="false"/>
+                <categoryLink targetId="66b2-c457-4d5e-8041" id="bf00-1592-48f8-b030" name="Militia Unit Sub-type" primary="false"/>
+                <categoryLink targetId="59a4-7b61-600a-c457" id="75db-0f24-431a-9a5f" name="Skirmish Sub-type" primary="false"/>
               </categoryLinks>
             </selectionEntry>
             <selectionEntry id="fcc4-81ff-34ab-4fda" name="Handler w/ Autopistol" hidden="false" collective="false" import="true" type="model">
@@ -7470,9 +7470,9 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="8"/>
               </costs>
               <categoryLinks>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="f838-57ef-4763-bbff" name="Infantry" primary="false"/>
-                <categoryLink targetId="66b2-c457-4d5e-8041" id="0082-f9cb-4705-9748" name="Militia" primary="false"/>
-                <categoryLink targetId="59a4-7b61-600a-c457" id="b5cc-4d26-4231-b12b" name="Skirmish" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="f838-57ef-4763-bbff" name="Infantry Unit Type" primary="false"/>
+                <categoryLink targetId="66b2-c457-4d5e-8041" id="0082-f9cb-4705-9748" name="Militia Unit Sub-type" primary="false"/>
+                <categoryLink targetId="59a4-7b61-600a-c457" id="b5cc-4d26-4231-b12b" name="Skirmish Sub-type" primary="false"/>
               </categoryLinks>
             </selectionEntry>
             <selectionEntry id="0aad-ede5-6b66-7ee4" name="Handler w/ Auitopistol &amp; Chainaxe" hidden="false" collective="false" import="true" type="model">
@@ -7516,9 +7516,9 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="8"/>
               </costs>
               <categoryLinks>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="d8d3-a1e0-425d-aeac" name="Infantry" primary="false"/>
-                <categoryLink targetId="66b2-c457-4d5e-8041" id="ceb7-95da-4ab3-bfc8" name="Militia" primary="false"/>
-                <categoryLink targetId="59a4-7b61-600a-c457" id="152c-c64b-4fd5-a945" name="Skirmish" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="d8d3-a1e0-425d-aeac" name="Infantry Unit Type" primary="false"/>
+                <categoryLink targetId="66b2-c457-4d5e-8041" id="ceb7-95da-4ab3-bfc8" name="Militia Unit Sub-type" primary="false"/>
+                <categoryLink targetId="59a4-7b61-600a-c457" id="152c-c64b-4fd5-a945" name="Skirmish Sub-type" primary="false"/>
               </categoryLinks>
             </selectionEntry>
             <selectionEntry id="7c34-c649-ca22-2b7f" name="Handler w/ Laspistol &amp; Chainaxe" hidden="false" collective="false" import="true" type="model">
@@ -7562,9 +7562,9 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="8"/>
               </costs>
               <categoryLinks>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="c9d8-1024-4e55-a722" name="Infantry" primary="false"/>
-                <categoryLink targetId="66b2-c457-4d5e-8041" id="c85e-7a30-43a0-816a" name="Militia" primary="false"/>
-                <categoryLink targetId="59a4-7b61-600a-c457" id="216f-20a7-4f71-bae5" name="Skirmish" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="c9d8-1024-4e55-a722" name="Infantry Unit Type" primary="false"/>
+                <categoryLink targetId="66b2-c457-4d5e-8041" id="c85e-7a30-43a0-816a" name="Militia Unit Sub-type" primary="false"/>
+                <categoryLink targetId="59a4-7b61-600a-c457" id="216f-20a7-4f71-bae5" name="Skirmish Sub-type" primary="false"/>
               </categoryLinks>
             </selectionEntry>
           </selectionEntries>
@@ -7582,7 +7582,7 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
     </selectionEntry>
     <selectionEntry id="987d-3f99-2c52-3da4" name="IM - Sentinel Squadron" publicationId="48c2-d023-0069-001a" hidden="false" collective="false" import="true" type="unit">
       <categoryLinks>
-        <categoryLink id="8ddc-34ec-2e49-d605" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="8ddc-34ec-2e49-d605" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="3fe5-3a52-1b7a-a0fe" name="Militia Unit Sub-type" hidden="false" targetId="66b2-c457-4d5e-8041" primary="false"/>
         <categoryLink id="e3af-708b-9fd8-2a73" name="Skirmish Sub-type" hidden="false" targetId="59a4-7b61-600a-c457" primary="false"/>
         <categoryLink id="5ff9-4b72-6315-ff20" name="Mechanised Unit Sub-type" hidden="false" targetId="e929-a5c3-451c-6f19" primary="false"/>
@@ -7623,10 +7623,10 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="60"/>
           </costs>
           <categoryLinks>
-            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="b86e-0b1e-454a-88c8" name="Infantry" primary="false"/>
-            <categoryLink targetId="66b2-c457-4d5e-8041" id="c68e-7bf0-44c1-8355" name="Militia" primary="false"/>
-            <categoryLink targetId="59a4-7b61-600a-c457" id="2084-071b-4e73-836f" name="Skirmish" primary="false"/>
-            <categoryLink targetId="e929-a5c3-451c-6f19" id="de39-9b3c-4fb5-8cfa" name="Mechanised" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="b86e-0b1e-454a-88c8" name="Infantry Unit Type" primary="false"/>
+            <categoryLink targetId="66b2-c457-4d5e-8041" id="c68e-7bf0-44c1-8355" name="Militia Unit Sub-type" primary="false"/>
+            <categoryLink targetId="59a4-7b61-600a-c457" id="2084-071b-4e73-836f" name="Skirmish Sub-type" primary="false"/>
+            <categoryLink targetId="e929-a5c3-451c-6f19" id="de39-9b3c-4fb5-8cfa" name="Mechanised Unit Sub-type" primary="false"/>
           </categoryLinks>
         </selectionEntry>
       </selectionEntries>
@@ -8443,7 +8443,7 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
               <categoryLinks>
                 <categoryLink id="b1dd-86aa-1c7a-ec38" name="Artillery Sub-type" hidden="false" targetId="6f99-c178-6f9d-fb63" primary="false"/>
                 <categoryLink id="144f-3d8d-5a77-0ef0" name="Heavy Sub-type" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="8d85-3a58-4ba7-66fa" primary="false" name="Infantry:"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="8d85-3a58-4ba7-66fa" primary="false" name="Infantry Unit Type"/>
               </categoryLinks>
               <selectionEntries>
                 <selectionEntry id="d168-dd0e-70a6-9d34" name="Earthshaker cannon" publicationId="d0df-7166-5cd3-89fd" page="25" hidden="false" collective="true" import="true" type="upgrade">
@@ -8500,7 +8500,7 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
               <categoryLinks>
                 <categoryLink id="fc24-4a7a-d3d4-d5ee" name="Heavy Sub-type" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
                 <categoryLink id="b8f5-f67b-e34f-462b" name="Artillery Sub-type" hidden="false" targetId="6f99-c178-6f9d-fb63" primary="false"/>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="56c3-c63f-7684-21ef" primary="false" name="Infantry:"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="56c3-c63f-7684-21ef" primary="false" name="Infantry Unit Type"/>
               </categoryLinks>
               <selectionEntries>
                 <selectionEntry id="cd2d-75a6-629e-8433" name="Medusa Mortar" publicationId="d0df-7166-5cd3-89fd" page="26" hidden="false" collective="true" import="true" type="upgrade">
@@ -8603,7 +8603,7 @@ equal to the number of Militia Gunners in the unit when making a Shooting Attack
               <categoryLinks>
                 <categoryLink id="205d-689e-ae32-670d" name="Militia Unit Sub-type" hidden="false" targetId="66b2-c457-4d5e-8041" primary="false"/>
                 <categoryLink id="b11f-461d-e0e7-15c1" name="Heavy Sub-type" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="b171-2484-94bd-12b9" primary="false" name="Infantry:"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="b171-2484-94bd-12b9" primary="false" name="Infantry Unit Type"/>
               </categoryLinks>
               <entryLinks>
                 <entryLink id="3147-3e49-5b5d-16b8" name="Flak Armour" hidden="false" collective="false" import="true" targetId="0251-8365-9efb-61a7" type="selectionEntry">
@@ -8634,7 +8634,7 @@ equal to the number of Militia Gunners in the unit when making a Shooting Attack
               <categoryLinks>
                 <categoryLink id="1ece-126f-876a-b249" name="Militia Unit Sub-type" hidden="false" targetId="66b2-c457-4d5e-8041" primary="false"/>
                 <categoryLink id="14a3-f6e4-e6b7-ea9d" name="Heavy Sub-type" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="48ec-fd1d-f4f2-1fcb" primary="false" name="Infantry:"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="48ec-fd1d-f4f2-1fcb" primary="false" name="Infantry Unit Type"/>
               </categoryLinks>
               <entryLinks>
                 <entryLink id="eb82-a07d-6e79-4c22" name="Flak Armour" hidden="false" collective="false" import="true" targetId="0251-8365-9efb-61a7" type="selectionEntry">
@@ -9175,7 +9175,7 @@ equal to the number of Militia Gunners in the unit when making a Shooting Attack
       </infoLinks>
       <categoryLinks>
         <categoryLink id="6d7a-960f-c4f1-b63c" name="Militia Unit Sub-type" hidden="false" targetId="66b2-c457-4d5e-8041" primary="false"/>
-        <categoryLink id="3c09-768c-40e7-c705" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="3c09-768c-40e7-c705" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="5794-7adf-a300-a5af" name="Monstrous Sub-type" hidden="false" targetId="7d95-f9d1-440a-67bd" primary="false"/>
         <categoryLink name="SA or IM Unit" hidden="false" id="b12f-3fcc-db31-a848" targetId="4aca-2849-7f41-0200" primary="false"/>
       </categoryLinks>
@@ -9277,9 +9277,9 @@ equal to the number of Militia Gunners in the unit when making a Shooting Attack
           </infoLinks>
           <categoryLinks>
             <categoryLink id="a0a9-c12b-1625-4ec7" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
-            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="f179-1124-4e47-b88b" name="Infantry" primary="false"/>
-            <categoryLink targetId="66b2-c457-4d5e-8041" id="1a1d-b7fd-406e-8c89" name="Militia" primary="false"/>
-            <categoryLink targetId="7d95-f9d1-440a-67bd" id="875c-1b3f-45d8-acc8" name="Monstrous" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="f179-1124-4e47-b88b" name="Infantry Unit Type" primary="false"/>
+            <categoryLink targetId="66b2-c457-4d5e-8041" id="1a1d-b7fd-406e-8c89" name="Militia Unit Sub-type" primary="false"/>
+            <categoryLink targetId="7d95-f9d1-440a-67bd" id="875c-1b3f-45d8-acc8" name="Monstrous Sub-type" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="f9ea-2ef5-5010-de5e" name="2.1) Additional Boss Weapons" hidden="false" collective="false" import="true">
@@ -9642,9 +9642,9 @@ equal to the number of Militia Gunners in the unit when making a Shooting Attack
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="30"/>
               </costs>
               <categoryLinks>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="64de-b078-4463-8433" name="Infantry" primary="false"/>
-                <categoryLink targetId="66b2-c457-4d5e-8041" id="710d-077a-4973-9999" name="Militia" primary="false"/>
-                <categoryLink targetId="7d95-f9d1-440a-67bd" id="78fc-4d53-42fb-84cc" name="Monstrous" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="64de-b078-4463-8433" name="Infantry Unit Type" primary="false"/>
+                <categoryLink targetId="66b2-c457-4d5e-8041" id="710d-077a-4973-9999" name="Militia Unit Sub-type" primary="false"/>
+                <categoryLink targetId="7d95-f9d1-440a-67bd" id="78fc-4d53-42fb-84cc" name="Monstrous Sub-type" primary="false"/>
               </categoryLinks>
             </selectionEntry>
             <selectionEntry id="4a39-aeb5-4a66-98bb" name="Ogryn Brute w/ Chainaxe (Feral Warriors)" hidden="false" collective="false" import="true" type="model">
@@ -9692,9 +9692,9 @@ equal to the number of Militia Gunners in the unit when making a Shooting Attack
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="30"/>
               </costs>
               <categoryLinks>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="a5fe-867f-4aa3-a6ab" name="Infantry" primary="false"/>
-                <categoryLink targetId="66b2-c457-4d5e-8041" id="8bce-024a-4987-8fb4" name="Militia" primary="false"/>
-                <categoryLink targetId="7d95-f9d1-440a-67bd" id="f48f-639e-4003-bff2" name="Monstrous" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="a5fe-867f-4aa3-a6ab" name="Infantry Unit Type" primary="false"/>
+                <categoryLink targetId="66b2-c457-4d5e-8041" id="8bce-024a-4987-8fb4" name="Militia Unit Sub-type" primary="false"/>
+                <categoryLink targetId="7d95-f9d1-440a-67bd" id="f48f-639e-4003-bff2" name="Monstrous Sub-type" primary="false"/>
               </categoryLinks>
             </selectionEntry>
           </selectionEntries>
@@ -9779,7 +9779,7 @@ equal to the number of Militia Gunners in the unit when making a Shooting Attack
         </infoLink>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="0ef8-f125-9af9-0dc9" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="0ef8-f125-9af9-0dc9" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="10ff-f629-cfc2-fbf6" name="Militia Unit Sub-type" hidden="false" targetId="66b2-c457-4d5e-8041" primary="false"/>
         <categoryLink name="SA or IM Unit" hidden="false" id="f88-f818-34d-1595" targetId="4aca-2849-7f41-0200" primary="false"/>
       </categoryLinks>
@@ -9877,8 +9877,8 @@ equal to the number of Militia Gunners in the unit when making a Shooting Attack
             <categoryLink id="4e78-0ff4-26e7-83e9" name="Psyker:" hidden="false" targetId="6e0c-29ba-a445-8321" primary="false"/>
             <categoryLink id="5f46-7822-9f6f-a14e" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
             <categoryLink id="727f-cca5-1477-bc63" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
-            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="d2af-db7b-430c-895e" name="Infantry" primary="false"/>
-            <categoryLink targetId="66b2-c457-4d5e-8041" id="ac00-a756-4d5d-bf96" name="Militia" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="d2af-db7b-430c-895e" name="Infantry Unit Type" primary="false"/>
+            <categoryLink targetId="66b2-c457-4d5e-8041" id="ac00-a756-4d5d-bf96" name="Militia Unit Sub-type" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="3cb4-223e-8975-0221" name="1.1) Weapon (Exchange Laspistol/Autopistol)" hidden="false" collective="false" import="true" defaultSelectionEntryId="0e67-9cb1-83c4-c885">
@@ -10094,8 +10094,8 @@ equal to the number of Militia Gunners in the unit when making a Shooting Attack
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5"/>
           </costs>
           <categoryLinks>
-            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="f572-1263-4b03-9290" name="Infantry" primary="false"/>
-            <categoryLink targetId="66b2-c457-4d5e-8041" id="1ec7-b7c7-4713-a54d" name="Militia" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="f572-1263-4b03-9290" name="Infantry Unit Type" primary="false"/>
+            <categoryLink targetId="66b2-c457-4d5e-8041" id="1ec7-b7c7-4713-a54d" name="Militia Unit Sub-type" primary="false"/>
           </categoryLinks>
         </selectionEntry>
       </selectionEntries>

--- a/2022 - LA - Alpha Legion.cat
+++ b/2022 - LA - Alpha Legion.cat
@@ -4520,7 +4520,7 @@
       <categoryLinks>
         <categoryLink id="63ff-0a92-42ab-ae8c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="204c-7b0f-4fb9-b1b3" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="85e6-cb31-427c-a040" name="Line Sub-type:" hidden="false" targetId="6399-5c65-7833-1025" primary="false"/>
+        <categoryLink id="85e6-cb31-427c-a040" name="Line Sub-type" hidden="false" targetId="6399-5c65-7833-1025" primary="false"/>
         <categoryLink id="2ddb-e541-8186-a9d2" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -5383,9 +5383,9 @@
       </infoLinks>
       <categoryLinks>
         <categoryLink id="86bf-d7af-033d-7bc5" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="38f4-15f0-cef1-6eed" name="Heavy Sub-type:" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+        <categoryLink id="38f4-15f0-cef1-6eed" name="Heavy Sub-type" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
         <categoryLink id="d9d8-ed91-7e24-1a00" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="9c8d-bff7-f814-f674" name="Line Sub-type:" hidden="false" targetId="6399-5c65-7833-1025" primary="false"/>
+        <categoryLink id="9c8d-bff7-f814-f674" name="Line Sub-type" hidden="false" targetId="6399-5c65-7833-1025" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="215d-b8b6-0c32-188b" name="Harrower" publicationId="09c5-eeae-f398-b653" page="338" hidden="false" collective="false" import="true" type="model">
@@ -5740,7 +5740,7 @@
       <categoryLinks>
         <categoryLink id="53f7-5d61-294f-9b80" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="bb2c-c74f-2106-5acc" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="fd9e-233c-7003-2c13" name="Light Sub-type:" hidden="false" targetId="bff2-ae16-74a8-8712" primary="false"/>
+        <categoryLink id="fd9e-233c-7003-2c13" name="Light Sub-type" hidden="false" targetId="bff2-ae16-74a8-8712" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="fc1f-0089-4c16-d538" name="The Instrument" publicationId="09c5-eeae-f398-b653" page="341" hidden="false" collective="false" import="true" type="upgrade">
@@ -5907,7 +5907,7 @@
       </infoLinks>
       <categoryLinks>
         <categoryLink id="a10b-7811-b811-52e6" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="0374-00b9-d878-2d9b" name="Skirmish Sub-type:" hidden="false" targetId="59a4-7b61-600a-c457" primary="false"/>
+        <categoryLink id="0374-00b9-d878-2d9b" name="Skirmish Sub-type" hidden="false" targetId="59a4-7b61-600a-c457" primary="false"/>
         <categoryLink id="924c-38c1-a729-0f0b" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
       </categoryLinks>
       <selectionEntries>
@@ -5935,7 +5935,7 @@
           </profiles>
           <categoryLinks>
             <categoryLink id="579c-b98b-7d1e-9128" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-            <categoryLink id="2832-eaa8-d1e5-3410" name="Skirmish Sub-type:" hidden="false" targetId="59a4-7b61-600a-c457" primary="false"/>
+            <categoryLink id="2832-eaa8-d1e5-3410" name="Skirmish Sub-type" hidden="false" targetId="59a4-7b61-600a-c457" primary="false"/>
             <categoryLink id="cc85-e37a-ac25-6e25" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
@@ -6870,7 +6870,7 @@
       </infoLinks>
       <categoryLinks>
         <categoryLink id="40a2-3aee-6f87-faa4" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="e1a7-f617-5d42-6eb5" name="Skirmish Sub-type:" hidden="false" targetId="59a4-7b61-600a-c457" primary="false"/>
+        <categoryLink id="e1a7-f617-5d42-6eb5" name="Skirmish Sub-type" hidden="false" targetId="59a4-7b61-600a-c457" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="34d4-c455-f2aa-3df8" name="1) Effrit Principal" hidden="false" collective="false" import="true" type="model">

--- a/2022 - LA - Alpha Legion.cat
+++ b/2022 - LA - Alpha Legion.cat
@@ -5412,6 +5412,9 @@
           </profiles>
           <categoryLinks>
             <categoryLink id="d584-40d1-2dbf-3d6f" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="f6ab-ad8f-47be-8916" name="Infantry" primary="false"/>
+            <categoryLink targetId="9231-183c-b97b-63f9" id="77e0-da79-4b97-8078" name="Heavy" primary="false"/>
+            <categoryLink targetId="6399-5c65-7833-1025" id="8de8-bf7f-49d9-944f" name="Line" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="e762-1d80-a5ba-2417" name="CCW" hidden="false" collective="false" import="true" defaultSelectionEntryId="acfe-034f-af46-0f75">
@@ -5505,6 +5508,11 @@
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="65"/>
               </costs>
+              <categoryLinks>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="a8bc-3858-4193-ae87" name="Infantry" primary="false"/>
+                <categoryLink targetId="9231-183c-b97b-63f9" id="d8f8-84d7-45d3-98fb" name="Heavy" primary="false"/>
+                <categoryLink targetId="6399-5c65-7833-1025" id="198d-d9c8-49dd-b511" name="Line" primary="false"/>
+              </categoryLinks>
             </selectionEntry>
             <selectionEntry id="b604-cadf-ca1e-33e1" name="Lernaean w/Heavy Weapon" publicationId="09c5-eeae-f398-b653" page="338" hidden="false" collective="false" import="true" type="model">
               <modifiers>
@@ -5572,6 +5580,11 @@
               <infoLinks>
                 <infoLink id="7128-a135-2eaa-1ccd" name="Lernaean" targetId="53a7-baaf-f2b1-790b" type="profile"/>
               </infoLinks>
+              <categoryLinks>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="1be8-64f8-4a63-b329" name="Infantry" primary="false"/>
+                <categoryLink targetId="9231-183c-b97b-63f9" id="5753-6970-4438-b62a" name="Heavy" primary="false"/>
+                <categoryLink targetId="6399-5c65-7833-1025" id="d62e-49dd-401f-94ef" name="Line" primary="false"/>
+              </categoryLinks>
             </selectionEntry>
             <selectionEntry id="65fe-767b-3b47-ef53" name="Lernaean w/Power Fist" publicationId="09c5-eeae-f398-b653" page="338" hidden="false" collective="false" import="true" type="model">
               <entryLinks>
@@ -5594,6 +5607,11 @@
               <infoLinks>
                 <infoLink id="ab07-b8bc-0975-cd97" name="Lernaean" targetId="53a7-baaf-f2b1-790b" type="profile"/>
               </infoLinks>
+              <categoryLinks>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="6b67-3623-45de-9d42" name="Infantry" primary="false"/>
+                <categoryLink targetId="9231-183c-b97b-63f9" id="23ad-bf77-4033-8569" name="Heavy" primary="false"/>
+                <categoryLink targetId="6399-5c65-7833-1025" id="df4c-69bd-4333-9d8e" name="Line" primary="false"/>
+              </categoryLinks>
             </selectionEntry>
             <selectionEntry id="ee69-d749-7ec4-a20e" name="Lernaean w/Power Axe" publicationId="09c5-eeae-f398-b653" page="338" hidden="false" collective="false" import="true" type="model">
               <entryLinks>
@@ -5616,6 +5634,11 @@
               <infoLinks>
                 <infoLink id="81a9-964d-7e99-feeb" name="Lernaean" targetId="53a7-baaf-f2b1-790b" type="profile"/>
               </infoLinks>
+              <categoryLinks>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="f1fa-a17e-4cf2-a53d" name="Infantry" primary="false"/>
+                <categoryLink targetId="9231-183c-b97b-63f9" id="fa62-5bf8-44b9-a989" name="Heavy" primary="false"/>
+                <categoryLink targetId="6399-5c65-7833-1025" id="806c-40a9-41a5-8678" name="Line" primary="false"/>
+              </categoryLinks>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
@@ -5775,6 +5798,9 @@
           </constraints>
           <categoryLinks>
             <categoryLink targetId="4f07-3d45-4f28-a0c6" id="8c2a-c938-6f22-9dfd" primary="false" name="Independent Character"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="a650-2a89-4858-a8f9" name="Infantry" primary="false"/>
+            <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="3ce1-136a-4b82-99ce" name="Character" primary="false"/>
+            <categoryLink targetId="bff2-ae16-74a8-8712" id="f0b2-88dc-4ded-a79a" name="Light" primary="false"/>
           </categoryLinks>
           <profiles>
             <profile id="793c-d4f-2bbc-92fb" name="Exodus" publicationId="09c5-eeae-f398-b653" page="340" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName="Unit">
@@ -6464,6 +6490,9 @@
           </constraints>
           <categoryLinks>
             <categoryLink targetId="4f07-3d45-4f28-a0c6" id="ec3c-8298-3752-eda8" primary="false" name="Independent Character"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="b3c8-83b1-42f0-936c" name="Infantry" primary="false"/>
+            <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="0c8a-f5a5-4871-8b7d" name="Character" primary="false"/>
+            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="a62c-7334-4202-9f25" name="Unique" primary="false"/>
           </categoryLinks>
           <profiles>
             <profile id="6cf5-8af4-87b2-cb82" name="Armillus Dynat" publicationId="09c5-eeae-f398-b653" page="342" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName="Unit">
@@ -6654,6 +6683,8 @@
           </constraints>
           <categoryLinks>
             <categoryLink targetId="4f07-3d45-4f28-a0c6" id="2259-38ca-b345-49fd" primary="false" name="Independent Character"/>
+            <categoryLink targetId="ad5f-31db-8bc7-5c46" id="7e27-3e84-48f4-b5bb" name="Primarch" primary="false"/>
+            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="4187-92c2-4921-8959" name="Unique" primary="false"/>
           </categoryLinks>
           <profiles>
             <profile id="e93f-b0d8-6af1-f4e3" name="Alpharius" publicationId="09c5-eeae-f398-b653" page="336" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName="Unit">
@@ -6754,6 +6785,9 @@
           </constraints>
           <categoryLinks>
             <categoryLink targetId="4f07-3d45-4f28-a0c6" id="ffaf-9870-881d-1c72" primary="false" name="Independent Character"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="e02b-7b3a-4550-a8b7" name="Infantry" primary="false"/>
+            <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="2300-7786-4879-9500" name="Character" primary="false"/>
+            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="e7f9-b220-40ce-97b4" name="Unique" primary="false"/>
           </categoryLinks>
           <profiles>
             <profile id="5ded-9dea-c7f3-8922" name="Autilon Skorr" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName="Unit">
@@ -6863,6 +6897,8 @@
           </profiles>
           <categoryLinks>
             <categoryLink id="ebd6-70a1-85a5-e521" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="c9cc-f2b3-45c4-9f59" name="Infantry" primary="false"/>
+            <categoryLink targetId="59a4-7b61-600a-c457" id="42be-4038-4bff-9ad7" name="Skirmish" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="48cd-2f68-9815-7ae2" name="1) Ranged Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="5f05-3b22-1e72-bd9c">
@@ -6994,6 +7030,10 @@ A weapon with this special rule may not be used to make Shooting Attacks as part
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="21"/>
               </costs>
+              <categoryLinks>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="da2e-5b23-4dd2-9494" name="Infantry" primary="false"/>
+                <categoryLink targetId="59a4-7b61-600a-c457" id="f051-d5e0-48a6-ad56" name="Skirmish" primary="false"/>
+              </categoryLinks>
             </selectionEntry>
             <selectionEntry id="323c-2596-b3f5-b22d" name="Effrit Disruptors w/ Nemesis Bolter" hidden="false" collective="false" import="true" type="model">
               <constraints>
@@ -7013,6 +7053,10 @@ A weapon with this special rule may not be used to make Shooting Attacks as part
               <infoLinks>
                 <infoLink id="32d3-da3e-1e40-533c" name="Effrit Disruptors" targetId="4836-eb33-24cc-bbe4" type="profile"/>
               </infoLinks>
+              <categoryLinks>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="fe74-aad3-4203-815f" name="Infantry" primary="false"/>
+                <categoryLink targetId="59a4-7b61-600a-c457" id="f982-e817-4174-85aa" name="Skirmish" primary="false"/>
+              </categoryLinks>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>

--- a/2022 - LA - Alpha Legion.cat
+++ b/2022 - LA - Alpha Legion.cat
@@ -5382,7 +5382,7 @@
         <infoLink id="fc9c-7a9f-0979-474a" name="Stubborn" hidden="false" targetId="7989-1f2c-a43d-82ae" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="86bf-d7af-033d-7bc5" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="86bf-d7af-033d-7bc5" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="38f4-15f0-cef1-6eed" name="Heavy Sub-type" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
         <categoryLink id="d9d8-ed91-7e24-1a00" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="9c8d-bff7-f814-f674" name="Line Sub-type" hidden="false" targetId="6399-5c65-7833-1025" primary="false"/>
@@ -5412,9 +5412,9 @@
           </profiles>
           <categoryLinks>
             <categoryLink id="d584-40d1-2dbf-3d6f" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
-            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="f6ab-ad8f-47be-8916" name="Infantry" primary="false"/>
-            <categoryLink targetId="9231-183c-b97b-63f9" id="77e0-da79-4b97-8078" name="Heavy" primary="false"/>
-            <categoryLink targetId="6399-5c65-7833-1025" id="8de8-bf7f-49d9-944f" name="Line" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="f6ab-ad8f-47be-8916" name="Infantry Unit Type" primary="false"/>
+            <categoryLink targetId="9231-183c-b97b-63f9" id="77e0-da79-4b97-8078" name="Heavy Sub-type" primary="false"/>
+            <categoryLink targetId="6399-5c65-7833-1025" id="8de8-bf7f-49d9-944f" name="Line Sub-type" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="e762-1d80-a5ba-2417" name="CCW" hidden="false" collective="false" import="true" defaultSelectionEntryId="acfe-034f-af46-0f75">
@@ -5509,9 +5509,9 @@
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="65"/>
               </costs>
               <categoryLinks>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="a8bc-3858-4193-ae87" name="Infantry" primary="false"/>
-                <categoryLink targetId="9231-183c-b97b-63f9" id="d8f8-84d7-45d3-98fb" name="Heavy" primary="false"/>
-                <categoryLink targetId="6399-5c65-7833-1025" id="198d-d9c8-49dd-b511" name="Line" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="a8bc-3858-4193-ae87" name="Infantry Unit Type" primary="false"/>
+                <categoryLink targetId="9231-183c-b97b-63f9" id="d8f8-84d7-45d3-98fb" name="Heavy Sub-type" primary="false"/>
+                <categoryLink targetId="6399-5c65-7833-1025" id="198d-d9c8-49dd-b511" name="Line Sub-type" primary="false"/>
               </categoryLinks>
             </selectionEntry>
             <selectionEntry id="b604-cadf-ca1e-33e1" name="Lernaean w/Heavy Weapon" publicationId="09c5-eeae-f398-b653" page="338" hidden="false" collective="false" import="true" type="model">
@@ -5581,9 +5581,9 @@
                 <infoLink id="7128-a135-2eaa-1ccd" name="Lernaean" targetId="53a7-baaf-f2b1-790b" type="profile"/>
               </infoLinks>
               <categoryLinks>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="1be8-64f8-4a63-b329" name="Infantry" primary="false"/>
-                <categoryLink targetId="9231-183c-b97b-63f9" id="5753-6970-4438-b62a" name="Heavy" primary="false"/>
-                <categoryLink targetId="6399-5c65-7833-1025" id="d62e-49dd-401f-94ef" name="Line" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="1be8-64f8-4a63-b329" name="Infantry Unit Type" primary="false"/>
+                <categoryLink targetId="9231-183c-b97b-63f9" id="5753-6970-4438-b62a" name="Heavy Sub-type" primary="false"/>
+                <categoryLink targetId="6399-5c65-7833-1025" id="d62e-49dd-401f-94ef" name="Line Sub-type" primary="false"/>
               </categoryLinks>
             </selectionEntry>
             <selectionEntry id="65fe-767b-3b47-ef53" name="Lernaean w/Power Fist" publicationId="09c5-eeae-f398-b653" page="338" hidden="false" collective="false" import="true" type="model">
@@ -5608,9 +5608,9 @@
                 <infoLink id="ab07-b8bc-0975-cd97" name="Lernaean" targetId="53a7-baaf-f2b1-790b" type="profile"/>
               </infoLinks>
               <categoryLinks>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="6b67-3623-45de-9d42" name="Infantry" primary="false"/>
-                <categoryLink targetId="9231-183c-b97b-63f9" id="23ad-bf77-4033-8569" name="Heavy" primary="false"/>
-                <categoryLink targetId="6399-5c65-7833-1025" id="df4c-69bd-4333-9d8e" name="Line" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="6b67-3623-45de-9d42" name="Infantry Unit Type" primary="false"/>
+                <categoryLink targetId="9231-183c-b97b-63f9" id="23ad-bf77-4033-8569" name="Heavy Sub-type" primary="false"/>
+                <categoryLink targetId="6399-5c65-7833-1025" id="df4c-69bd-4333-9d8e" name="Line Sub-type" primary="false"/>
               </categoryLinks>
             </selectionEntry>
             <selectionEntry id="ee69-d749-7ec4-a20e" name="Lernaean w/Power Axe" publicationId="09c5-eeae-f398-b653" page="338" hidden="false" collective="false" import="true" type="model">
@@ -5635,9 +5635,9 @@
                 <infoLink id="81a9-964d-7e99-feeb" name="Lernaean" targetId="53a7-baaf-f2b1-790b" type="profile"/>
               </infoLinks>
               <categoryLinks>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="f1fa-a17e-4cf2-a53d" name="Infantry" primary="false"/>
-                <categoryLink targetId="9231-183c-b97b-63f9" id="fa62-5bf8-44b9-a989" name="Heavy" primary="false"/>
-                <categoryLink targetId="6399-5c65-7833-1025" id="806c-40a9-41a5-8678" name="Line" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="f1fa-a17e-4cf2-a53d" name="Infantry Unit Type" primary="false"/>
+                <categoryLink targetId="9231-183c-b97b-63f9" id="fa62-5bf8-44b9-a989" name="Heavy Sub-type" primary="false"/>
+                <categoryLink targetId="6399-5c65-7833-1025" id="806c-40a9-41a5-8678" name="Line Sub-type" primary="false"/>
               </categoryLinks>
             </selectionEntry>
           </selectionEntries>
@@ -5738,7 +5738,7 @@
         </infoLink>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="53f7-5d61-294f-9b80" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="53f7-5d61-294f-9b80" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="bb2c-c74f-2106-5acc" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="fd9e-233c-7003-2c13" name="Light Sub-type" hidden="false" targetId="bff2-ae16-74a8-8712" primary="false"/>
       </categoryLinks>
@@ -5798,9 +5798,9 @@
           </constraints>
           <categoryLinks>
             <categoryLink targetId="4f07-3d45-4f28-a0c6" id="8c2a-c938-6f22-9dfd" primary="false" name="Independent Character"/>
-            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="a650-2a89-4858-a8f9" name="Infantry" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="a650-2a89-4858-a8f9" name="Infantry Unit Type" primary="false"/>
             <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="3ce1-136a-4b82-99ce" name="Character" primary="false"/>
-            <categoryLink targetId="bff2-ae16-74a8-8712" id="f0b2-88dc-4ded-a79a" name="Light" primary="false"/>
+            <categoryLink targetId="bff2-ae16-74a8-8712" id="f0b2-88dc-4ded-a79a" name="Light Sub-type" primary="false"/>
           </categoryLinks>
           <profiles>
             <profile id="793c-d4f-2bbc-92fb" name="Exodus" publicationId="09c5-eeae-f398-b653" page="340" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName="Unit">
@@ -5906,7 +5906,7 @@
         <infoLink id="4ec2-a1a0-d7a2-73cd" name="Scout" hidden="false" targetId="aacf-9a7e-982d-b793" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="a10b-7811-b811-52e6" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="a10b-7811-b811-52e6" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="0374-00b9-d878-2d9b" name="Skirmish Sub-type" hidden="false" targetId="59a4-7b61-600a-c457" primary="false"/>
         <categoryLink id="924c-38c1-a729-0f0b" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
       </categoryLinks>
@@ -5934,7 +5934,7 @@
             </profile>
           </profiles>
           <categoryLinks>
-            <categoryLink id="579c-b98b-7d1e-9128" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+            <categoryLink id="579c-b98b-7d1e-9128" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
             <categoryLink id="2832-eaa8-d1e5-3410" name="Skirmish Sub-type" hidden="false" targetId="59a4-7b61-600a-c457" primary="false"/>
             <categoryLink id="cc85-e37a-ac25-6e25" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
           </categoryLinks>
@@ -6439,7 +6439,7 @@
         </infoLink>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="0162-1ffa-9d07-6d83" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="0162-1ffa-9d07-6d83" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="abbd-7422-7468-daf9" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
       </categoryLinks>
       <selectionEntries>
@@ -6490,9 +6490,9 @@
           </constraints>
           <categoryLinks>
             <categoryLink targetId="4f07-3d45-4f28-a0c6" id="ec3c-8298-3752-eda8" primary="false" name="Independent Character"/>
-            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="b3c8-83b1-42f0-936c" name="Infantry" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="b3c8-83b1-42f0-936c" name="Infantry Unit Type" primary="false"/>
             <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="0c8a-f5a5-4871-8b7d" name="Character" primary="false"/>
-            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="a62c-7334-4202-9f25" name="Unique" primary="false"/>
+            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="a62c-7334-4202-9f25" name="Unique Sub-type" primary="false"/>
           </categoryLinks>
           <profiles>
             <profile id="6cf5-8af4-87b2-cb82" name="Armillus Dynat" publicationId="09c5-eeae-f398-b653" page="342" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName="Unit">
@@ -6683,8 +6683,8 @@
           </constraints>
           <categoryLinks>
             <categoryLink targetId="4f07-3d45-4f28-a0c6" id="2259-38ca-b345-49fd" primary="false" name="Independent Character"/>
-            <categoryLink targetId="ad5f-31db-8bc7-5c46" id="7e27-3e84-48f4-b5bb" name="Primarch" primary="false"/>
-            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="4187-92c2-4921-8959" name="Unique" primary="false"/>
+            <categoryLink targetId="ad5f-31db-8bc7-5c46" id="7e27-3e84-48f4-b5bb" name="Primarch:" primary="false"/>
+            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="4187-92c2-4921-8959" name="Unique Sub-type" primary="false"/>
           </categoryLinks>
           <profiles>
             <profile id="e93f-b0d8-6af1-f4e3" name="Alpharius" publicationId="09c5-eeae-f398-b653" page="336" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName="Unit">
@@ -6785,9 +6785,9 @@
           </constraints>
           <categoryLinks>
             <categoryLink targetId="4f07-3d45-4f28-a0c6" id="ffaf-9870-881d-1c72" primary="false" name="Independent Character"/>
-            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="e02b-7b3a-4550-a8b7" name="Infantry" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="e02b-7b3a-4550-a8b7" name="Infantry Unit Type" primary="false"/>
             <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="2300-7786-4879-9500" name="Character" primary="false"/>
-            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="e7f9-b220-40ce-97b4" name="Unique" primary="false"/>
+            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="e7f9-b220-40ce-97b4" name="Unique Sub-type" primary="false"/>
           </categoryLinks>
           <profiles>
             <profile id="5ded-9dea-c7f3-8922" name="Autilon Skorr" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName="Unit">
@@ -6869,7 +6869,7 @@
         <infoLink id="0134-67e7-91b9-cc1c" name="Scout" hidden="false" targetId="aacf-9a7e-982d-b793" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="40a2-3aee-6f87-faa4" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="40a2-3aee-6f87-faa4" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="e1a7-f617-5d42-6eb5" name="Skirmish Sub-type" hidden="false" targetId="59a4-7b61-600a-c457" primary="false"/>
       </categoryLinks>
       <selectionEntries>
@@ -6897,8 +6897,8 @@
           </profiles>
           <categoryLinks>
             <categoryLink id="ebd6-70a1-85a5-e521" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
-            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="c9cc-f2b3-45c4-9f59" name="Infantry" primary="false"/>
-            <categoryLink targetId="59a4-7b61-600a-c457" id="42be-4038-4bff-9ad7" name="Skirmish" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="c9cc-f2b3-45c4-9f59" name="Infantry Unit Type" primary="false"/>
+            <categoryLink targetId="59a4-7b61-600a-c457" id="42be-4038-4bff-9ad7" name="Skirmish Sub-type" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="48cd-2f68-9815-7ae2" name="1) Ranged Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="5f05-3b22-1e72-bd9c">
@@ -7031,8 +7031,8 @@ A weapon with this special rule may not be used to make Shooting Attacks as part
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="21"/>
               </costs>
               <categoryLinks>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="da2e-5b23-4dd2-9494" name="Infantry" primary="false"/>
-                <categoryLink targetId="59a4-7b61-600a-c457" id="f051-d5e0-48a6-ad56" name="Skirmish" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="da2e-5b23-4dd2-9494" name="Infantry Unit Type" primary="false"/>
+                <categoryLink targetId="59a4-7b61-600a-c457" id="f051-d5e0-48a6-ad56" name="Skirmish Sub-type" primary="false"/>
               </categoryLinks>
             </selectionEntry>
             <selectionEntry id="323c-2596-b3f5-b22d" name="Effrit Disruptors w/ Nemesis Bolter" hidden="false" collective="false" import="true" type="model">
@@ -7054,8 +7054,8 @@ A weapon with this special rule may not be used to make Shooting Attacks as part
                 <infoLink id="32d3-da3e-1e40-533c" name="Effrit Disruptors" targetId="4836-eb33-24cc-bbe4" type="profile"/>
               </infoLinks>
               <categoryLinks>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="fe74-aad3-4203-815f" name="Infantry" primary="false"/>
-                <categoryLink targetId="59a4-7b61-600a-c457" id="f982-e817-4174-85aa" name="Skirmish" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="fe74-aad3-4203-815f" name="Infantry Unit Type" primary="false"/>
+                <categoryLink targetId="59a4-7b61-600a-c457" id="f982-e817-4174-85aa" name="Skirmish Sub-type" primary="false"/>
               </categoryLinks>
             </selectionEntry>
           </selectionEntries>

--- a/2022 - LA - Blood Angels.cat
+++ b/2022 - LA - Blood Angels.cat
@@ -2639,7 +2639,7 @@
         <categoryLink id="b43f-eff3-4984-aaae" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true">
           <comment>template_id_204c-7b0f-4fb9-b1b3</comment>
         </categoryLink>
-        <categoryLink id="0dee-430e-458e-a030" name="Line Sub-type:" hidden="false" targetId="6399-5c65-7833-1025" primary="false">
+        <categoryLink id="0dee-430e-458e-a030" name="Line Sub-type" hidden="false" targetId="6399-5c65-7833-1025" primary="false">
           <comment>template_id_85e6-cb31-427c-a040</comment>
         </categoryLink>
         <categoryLink id="63f7-4b34-0502-f667" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
@@ -3476,7 +3476,7 @@ Sanguinius may still Run on a turn when his wings have been activated. When maki
       </infoLinks>
       <categoryLinks>
         <categoryLink id="21ac-518e-b688-7692" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="5bf7-7060-f4e9-3862" name="Heavy Sub-type:" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+        <categoryLink id="5bf7-7060-f4e9-3862" name="Heavy Sub-type" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
         <categoryLink id="38d1-09b6-7e6d-9833" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
       </categoryLinks>
       <selectionEntries>
@@ -3504,7 +3504,7 @@ Sanguinius may still Run on a turn when his wings have been activated. When maki
           </profiles>
           <categoryLinks>
             <categoryLink id="f69b-2b54-8d15-5c73" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
-            <categoryLink id="c012-908d-abb8-1f88" name="Heavy Sub-type:" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+            <categoryLink id="c012-908d-abb8-1f88" name="Heavy Sub-type" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
             <categoryLink id="310b-bcb8-52f5-55e7" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
@@ -3992,7 +3992,7 @@ Sanguinius may still Run on a turn when his wings have been activated. When maki
         <infoLink id="9387-662d-f57c-6b3b" name="Legiones Astartes (Blood Angels)" hidden="false" targetId="b0d1-ccab-8708-500f" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="22af-8bdb-ac49-af08" name="Dreadnought Unit-type:" hidden="false" targetId="4280-4963-02b5-e31d" primary="false"/>
+        <categoryLink id="22af-8bdb-ac49-af08" name="Dreadnought Unit Type" hidden="false" targetId="4280-4963-02b5-e31d" primary="false"/>
         <categoryLink id="8f2a-d33d-1b36-8cb0" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
       </categoryLinks>
       <selectionEntries>
@@ -4851,7 +4851,7 @@ A unit selected in this manner is considered a &apos;Retinue Squad? The Retinue 
       <categoryLinks>
         <categoryLink id="54b5-51ed-7e8b-f3fb" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="42e7-a248-5756-01f9" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="feb6-58bf-657f-310e" name="Heavy Sub-type:" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+        <categoryLink id="feb6-58bf-657f-310e" name="Heavy Sub-type" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
         <categoryLink id="7bd8-4f22-3143-1abc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
       <selectionEntries>
@@ -4878,7 +4878,7 @@ A unit selected in this manner is considered a &apos;Retinue Squad? The Retinue 
             </profile>
           </profiles>
           <categoryLinks>
-            <categoryLink id="c36e-bb39-8df0-74e2" name="Heavy Sub-type:" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+            <categoryLink id="c36e-bb39-8df0-74e2" name="Heavy Sub-type" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
             <categoryLink id="b4d7-4ed5-a971-32a5" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
             <categoryLink id="191b-abdd-c10c-0657" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
             <categoryLink id="3f8c-7a78-380b-d895" name="Jump Infantry:" hidden="false" targetId="eee8-3c7c-2762-e33e" primary="false"/>

--- a/2022 - LA - Blood Angels.cat
+++ b/2022 - LA - Blood Angels.cat
@@ -3123,6 +3123,8 @@ Sanguinius may still Run on a turn when his wings have been activated. When maki
         <selectionEntry type="model" import="true" name="Sanguinius" hidden="false" id="c604-746e-d68b-3541">
           <categoryLinks>
             <categoryLink targetId="4f07-3d45-4f28-a0c6" id="2bb1-2477-683f-3f11" primary="false" name="Independent Character"/>
+            <categoryLink targetId="ad5f-31db-8bc7-5c46" id="d97c-b448-4ada-821f" name="Primarch" primary="false"/>
+            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="d67f-21f8-4894-8786" name="Unique" primary="false"/>
           </categoryLinks>
           <constraints>
             <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="72a-7632-dc99-3a6c"/>
@@ -3377,6 +3379,9 @@ Sanguinius may still Run on a turn when his wings have been activated. When maki
         <selectionEntry type="model" import="true" name="Judicar Aster Crohne" hidden="false" id="d82c-e354-14fd-a65b">
           <categoryLinks>
             <categoryLink targetId="4f07-3d45-4f28-a0c6" id="628b-d37d-d649-36b9" primary="false" name="Independent Character"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="735f-7f19-42ae-9edf" name="Infantry" primary="false"/>
+            <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="85b3-39f2-4147-8b8c" name="Character" primary="false"/>
+            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="669b-224a-4382-bb88" name="Unique" primary="false"/>
           </categoryLinks>
           <constraints>
             <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="72a-7632-dc99-3a6c"/>
@@ -4167,6 +4172,9 @@ Rite of War must use the Deep Strike option and must be assigned to a Deep Strik
         <selectionEntry type="model" import="true" name="Chapter Master Raldoron" hidden="false" id="b0e6-842b-c38e-7605">
           <categoryLinks>
             <categoryLink targetId="4f07-3d45-4f28-a0c6" id="2bc6-6378-27a2-c9b4" primary="false" name="Independent Character"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="5d9f-e775-475e-9935" name="Infantry" primary="false"/>
+            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="bd0a-5c5c-4793-9090" name="Unique" primary="false"/>
+            <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="c84b-af9b-483e-a4fb" name="Character" primary="false"/>
           </categoryLinks>
           <constraints>
             <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="72a-7632-dc99-3a6c"/>
@@ -4734,6 +4742,9 @@ The Paragon of Restoration gives Dominion Zephon the Feel No Pain (5+) special r
         <selectionEntry type="model" import="true" name="Dominion Zephon" hidden="false" id="85cd-89c1-5853-ee5a">
           <categoryLinks>
             <categoryLink targetId="4f07-3d45-4f28-a0c6" id="fe39-c065-88c4-288c" primary="false" name="Independent Character"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="087e-1c46-4db6-b1f8" name="Infantry" primary="false"/>
+            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="2ee0-cf6e-4d97-aabb" name="Unique" primary="false"/>
+            <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="020e-7835-4388-bcf0" name="Character" primary="false"/>
           </categoryLinks>
           <constraints>
             <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="72a-7632-dc99-3a6c"/>
@@ -5264,6 +5275,10 @@ A unit selected in this manner is considered a &apos;Retinue Squad? The Retinue 
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20"/>
           </costs>
+          <categoryLinks>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="2672-56d4-4b03-a033" name="Infantry" primary="false"/>
+            <categoryLink targetId="9231-183c-b97b-63f9" id="2252-3a3f-480c-8a82" name="Heavy" primary="false"/>
+          </categoryLinks>
         </selectionEntry>
         <selectionEntry id="7bb9-6f7e-d482-34df" name="The entire unit may take meltabombs" hidden="false" collective="false" import="true" type="upgrade">
           <modifiers>
@@ -5827,6 +5842,9 @@ A unit selected in this manner is considered a &apos;Retinue Squad? The Retinue 
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="40"/>
           </costs>
+          <categoryLinks>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="ef18-4e2d-4d96-97e8" name="Infantry" primary="false"/>
+          </categoryLinks>
         </selectionEntry>
       </selectionEntries>
       <entryLinks>

--- a/2022 - LA - Blood Angels.cat
+++ b/2022 - LA - Blood Angels.cat
@@ -3123,8 +3123,8 @@ Sanguinius may still Run on a turn when his wings have been activated. When maki
         <selectionEntry type="model" import="true" name="Sanguinius" hidden="false" id="c604-746e-d68b-3541">
           <categoryLinks>
             <categoryLink targetId="4f07-3d45-4f28-a0c6" id="2bb1-2477-683f-3f11" primary="false" name="Independent Character"/>
-            <categoryLink targetId="ad5f-31db-8bc7-5c46" id="d97c-b448-4ada-821f" name="Primarch" primary="false"/>
-            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="d67f-21f8-4894-8786" name="Unique" primary="false"/>
+            <categoryLink targetId="ad5f-31db-8bc7-5c46" id="d97c-b448-4ada-821f" name="Primarch:" primary="false"/>
+            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="d67f-21f8-4894-8786" name="Unique Sub-type" primary="false"/>
           </categoryLinks>
           <constraints>
             <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="72a-7632-dc99-3a6c"/>
@@ -3341,7 +3341,7 @@ Sanguinius may still Run on a turn when his wings have been activated. When maki
         <infoLink id="c3f1-c79c-87d2-f4eb" name="Bitter Duty" hidden="false" targetId="d1b8-31da-c53c-4fe2" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="9443-2cc4-be17-c3d0" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="9443-2cc4-be17-c3d0" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="e910-b4f4-561a-a680" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
       </categoryLinks>
       <selectionEntries>
@@ -3379,9 +3379,9 @@ Sanguinius may still Run on a turn when his wings have been activated. When maki
         <selectionEntry type="model" import="true" name="Judicar Aster Crohne" hidden="false" id="d82c-e354-14fd-a65b">
           <categoryLinks>
             <categoryLink targetId="4f07-3d45-4f28-a0c6" id="628b-d37d-d649-36b9" primary="false" name="Independent Character"/>
-            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="735f-7f19-42ae-9edf" name="Infantry" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="735f-7f19-42ae-9edf" name="Infantry Unit Type" primary="false"/>
             <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="85b3-39f2-4147-8b8c" name="Character" primary="false"/>
-            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="669b-224a-4382-bb88" name="Unique" primary="false"/>
+            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="669b-224a-4382-bb88" name="Unique Sub-type" primary="false"/>
           </categoryLinks>
           <constraints>
             <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="72a-7632-dc99-3a6c"/>
@@ -3475,7 +3475,7 @@ Sanguinius may still Run on a turn when his wings have been activated. When maki
         <infoLink id="3441-b4f8-20cc-e523" name="Deep Strike" hidden="false" targetId="f1e1-986f-c783-ca9e" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="21ac-518e-b688-7692" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="21ac-518e-b688-7692" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="5bf7-7060-f4e9-3862" name="Heavy Sub-type" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
         <categoryLink id="38d1-09b6-7e6d-9833" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
       </categoryLinks>
@@ -3505,7 +3505,7 @@ Sanguinius may still Run on a turn when his wings have been activated. When maki
           <categoryLinks>
             <categoryLink id="f69b-2b54-8d15-5c73" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
             <categoryLink id="c012-908d-abb8-1f88" name="Heavy Sub-type" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
-            <categoryLink id="310b-bcb8-52f5-55e7" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+            <categoryLink id="310b-bcb8-52f5-55e7" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="59c2-658e-99fa-9d85" name="Arms" hidden="false" collective="false" import="true" defaultSelectionEntryId="6e37-c972-f6a5-cff0">
@@ -4137,7 +4137,7 @@ Rite of War must use the Deep Strike option and must be assigned to a Deep Strik
         </infoLink>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="9b24-0f3e-79a4-f40d" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="9b24-0f3e-79a4-f40d" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="774a-cc6b-d207-692e" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
       </categoryLinks>
       <selectionEntries>
@@ -4172,8 +4172,8 @@ Rite of War must use the Deep Strike option and must be assigned to a Deep Strik
         <selectionEntry type="model" import="true" name="Chapter Master Raldoron" hidden="false" id="b0e6-842b-c38e-7605">
           <categoryLinks>
             <categoryLink targetId="4f07-3d45-4f28-a0c6" id="2bc6-6378-27a2-c9b4" primary="false" name="Independent Character"/>
-            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="5d9f-e775-475e-9935" name="Infantry" primary="false"/>
-            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="bd0a-5c5c-4793-9090" name="Unique" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="5d9f-e775-475e-9935" name="Infantry Unit Type" primary="false"/>
+            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="bd0a-5c5c-4793-9090" name="Unique Sub-type" primary="false"/>
             <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="c84b-af9b-483e-a4fb" name="Character" primary="false"/>
           </categoryLinks>
           <constraints>
@@ -4683,7 +4683,7 @@ The Paragon of Restoration gives Dominion Zephon the Feel No Pain (5+) special r
         <infoLink id="6544-cea9-9c06-ba7c" name="Bitter Duty" hidden="false" targetId="d1b8-31da-c53c-4fe2" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="feba-d345-0dbc-faa9" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="feba-d345-0dbc-faa9" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="8059-18d2-a192-f6bd" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="9f7b-e6db-ff1f-ad62" name="Jump Infantry:" hidden="false" targetId="eee8-3c7c-2762-e33e" primary="false"/>
       </categoryLinks>
@@ -4742,8 +4742,8 @@ The Paragon of Restoration gives Dominion Zephon the Feel No Pain (5+) special r
         <selectionEntry type="model" import="true" name="Dominion Zephon" hidden="false" id="85cd-89c1-5853-ee5a">
           <categoryLinks>
             <categoryLink targetId="4f07-3d45-4f28-a0c6" id="fe39-c065-88c4-288c" primary="false" name="Independent Character"/>
-            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="087e-1c46-4db6-b1f8" name="Infantry" primary="false"/>
-            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="2ee0-cf6e-4d97-aabb" name="Unique" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="087e-1c46-4db6-b1f8" name="Infantry Unit Type" primary="false"/>
+            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="2ee0-cf6e-4d97-aabb" name="Unique Sub-type" primary="false"/>
             <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="020e-7835-4388-bcf0" name="Character" primary="false"/>
           </categoryLinks>
           <constraints>
@@ -4849,7 +4849,7 @@ A unit selected in this manner is considered a &apos;Retinue Squad? The Retinue 
         </infoLink>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="54b5-51ed-7e8b-f3fb" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="54b5-51ed-7e8b-f3fb" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="42e7-a248-5756-01f9" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="feb6-58bf-657f-310e" name="Heavy Sub-type" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
         <categoryLink id="7bd8-4f22-3143-1abc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
@@ -4879,7 +4879,7 @@ A unit selected in this manner is considered a &apos;Retinue Squad? The Retinue 
           </profiles>
           <categoryLinks>
             <categoryLink id="c36e-bb39-8df0-74e2" name="Heavy Sub-type" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
-            <categoryLink id="b4d7-4ed5-a971-32a5" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+            <categoryLink id="b4d7-4ed5-a971-32a5" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
             <categoryLink id="191b-abdd-c10c-0657" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
             <categoryLink id="3f8c-7a78-380b-d895" name="Jump Infantry:" hidden="false" targetId="eee8-3c7c-2762-e33e" primary="false"/>
           </categoryLinks>
@@ -5276,8 +5276,8 @@ A unit selected in this manner is considered a &apos;Retinue Squad? The Retinue 
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20"/>
           </costs>
           <categoryLinks>
-            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="2672-56d4-4b03-a033" name="Infantry" primary="false"/>
-            <categoryLink targetId="9231-183c-b97b-63f9" id="2252-3a3f-480c-8a82" name="Heavy" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="2672-56d4-4b03-a033" name="Infantry Unit Type" primary="false"/>
+            <categoryLink targetId="9231-183c-b97b-63f9" id="2252-3a3f-480c-8a82" name="Heavy Sub-type" primary="false"/>
           </categoryLinks>
         </selectionEntry>
         <selectionEntry id="7bb9-6f7e-d482-34df" name="The entire unit may take meltabombs" hidden="false" collective="false" import="true" type="upgrade">
@@ -5323,7 +5323,7 @@ A unit selected in this manner is considered a &apos;Retinue Squad? The Retinue 
         </infoLink>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="ea81-014b-635d-47bb" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="ea81-014b-635d-47bb" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="8925-58cb-6e34-0c0c" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="680f-d029-6ed2-3bf6" name="Jump Infantry:" hidden="false" targetId="eee8-3c7c-2762-e33e" primary="false"/>
       </categoryLinks>
@@ -5352,7 +5352,7 @@ A unit selected in this manner is considered a &apos;Retinue Squad? The Retinue 
           </profiles>
           <categoryLinks>
             <categoryLink id="7e67-d421-30d9-0127" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
-            <categoryLink id="6b93-ada7-2d5d-09a7" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+            <categoryLink id="6b93-ada7-2d5d-09a7" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="2683-ff01-5aff-0bf9" name="May replace Falling-star Pattern Spear with:" hidden="false" collective="false" import="true" defaultSelectionEntryId="8973-aea3-2fcf-5ac6">
@@ -5740,7 +5740,7 @@ A unit selected in this manner is considered a &apos;Retinue Squad? The Retinue 
         <constraint field="selections" scope="roster" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b30c-fe0f-bf5c-f932" type="max"/>
       </constraints>
       <categoryLinks>
-        <categoryLink id="eaab-f392-0f3e-d833" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="eaab-f392-0f3e-d833" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="aa35-71f4-8032-20b1" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
       </categoryLinks>
       <selectionEntries>
@@ -5843,7 +5843,7 @@ A unit selected in this manner is considered a &apos;Retinue Squad? The Retinue 
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="40"/>
           </costs>
           <categoryLinks>
-            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="ef18-4e2d-4d96-97e8" name="Infantry" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="ef18-4e2d-4d96-97e8" name="Infantry Unit Type" primary="false"/>
           </categoryLinks>
         </selectionEntry>
       </selectionEntries>

--- a/2022 - LA - Dark Angels.cat
+++ b/2022 - LA - Dark Angels.cat
@@ -3495,7 +3495,7 @@ Could not find type or subtype &apos;Dreadwing&apos;</comment>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="6efd-8f1a-fc43-564f" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="41dc-2f36-d265-13b9" name="Heavy Sub-type:" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+        <categoryLink id="41dc-2f36-d265-13b9" name="Heavy Sub-type" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
         <categoryLink id="4a74-0b7b-e4f1-ac5d" name="Cybertheurgist" hidden="false" targetId="57a1-ae47-ff1b-36e4" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
@@ -4185,7 +4185,7 @@ Could not find type or subtype &apos;Firewing&apos;</comment>
       </constraints>
       <categoryLinks>
         <categoryLink id="02a1-f083-b1fa-673a" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="ef49-f8a7-3bda-0fba" name="Heavy Sub-type:" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+        <categoryLink id="ef49-f8a7-3bda-0fba" name="Heavy Sub-type" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
         <categoryLink id="2dec-96ad-9237-42f0" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="21de-4e57-9f08-b389" name="Terminators:" hidden="false" targetId="bab3-f50d-3e5f-2f78" primary="false"/>
       </categoryLinks>
@@ -4357,7 +4357,7 @@ Could not find type or subtype &apos;Deathwing&apos;</comment>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="359e-1590-1dcc-33d3" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="c379-1039-7f09-252d" name="Heavy Sub-type:" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+        <categoryLink id="c379-1039-7f09-252d" name="Heavy Sub-type" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
         <categoryLink id="94ed-ef24-43f7-ea1e" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
       </categoryLinks>
       <selectionEntries>
@@ -4698,7 +4698,7 @@ Could not find type or subtype &apos;Deathwing&apos;</comment>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="5ae3-be22-48b5-7f36" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="9a31-0a49-48f9-57ca" name="Heavy Sub-type:" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+        <categoryLink id="9a31-0a49-48f9-57ca" name="Heavy Sub-type" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
         <categoryLink id="ca24-0dcb-67f2-0a38" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
       </categoryLinks>
       <selectionEntries>
@@ -5167,7 +5167,7 @@ Could not find type or subtype &apos;Deathwing&apos;</comment>
         <categoryLink id="2601-e1ee-e7fc-4791" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="ee1c-afee-f2c8-3259" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="2687-f1d9-6b82-5dc4" name="Terminators:" hidden="false" targetId="bab3-f50d-3e5f-2f78" primary="false"/>
-        <categoryLink id="ffb0-fffb-d657-d8f2" name="Heavy Sub-type:" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+        <categoryLink id="ffb0-fffb-d657-d8f2" name="Heavy Sub-type" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="3f28-07ff-77b7-bd25" name="Regalia of the Shattered Sceptre" hidden="false" collective="false" import="true" type="upgrade">
@@ -5763,7 +5763,7 @@ Could not find type or subtype &apos;Deathwing&apos;</comment>
         <categoryLink id="e21c-04da-da7e-bb0e" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="d44a-5429-5007-3517" name="Terminators:" hidden="false" targetId="bab3-f50d-3e5f-2f78" primary="false"/>
         <categoryLink id="4c36-2523-addd-8242" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="d90b-68bb-e362-fd4d" name="Heavy Sub-type:" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+        <categoryLink id="d90b-68bb-e362-fd4d" name="Heavy Sub-type" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="4f8a-d905-51a0-aa44" name="Deathwing Cataphractii Oathbearer" publicationId="d0df-7166-5cd3-89fd" page="48" hidden="false" collective="false" import="true" type="model">

--- a/2022 - LA - Dark Angels.cat
+++ b/2022 - LA - Dark Angels.cat
@@ -2929,7 +2929,7 @@
       </constraints>
       <categoryLinks>
         <categoryLink id="dada-97ba-b9da-7a55" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="4c67-e0ac-3d2b-391a" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="4c67-e0ac-3d2b-391a" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="0fec-c66f-9639-612f" name="Corswain" hidden="false" collective="false" import="true" type="model">
@@ -2977,12 +2977,10 @@
           </costs>
           <categoryLinks>
             <categoryLink targetId="4f07-3d45-4f28-a0c6" id="626e-a37e-107f-cf00" primary="false" name="Independent Character"/>
-            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="432f-dd73-4a4c-b3e5" name="Infantry" primary="false"/>
-            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="ea40-cbff-4b90-813e" name="Unique" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="432f-dd73-4a4c-b3e5" name="Infantry Unit Type" primary="false"/>
+            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="ea40-cbff-4b90-813e" name="Unique Sub-type" primary="false"/>
             <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="0671-0f1e-4901-a3c7" name="Character" primary="false"/>
           </categoryLinks>
-          <comment>!BSC Errors from 20240328-1346
-Could not find type or subtype &apos;Deathwing&apos;</comment>
         </selectionEntry>
         <selectionEntry id="80c5-e797-2dc1-2e07" name="Armour of the Forest and the Mantle of the Champion" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
@@ -3095,7 +3093,7 @@ Could not find type or subtype &apos;Deathwing&apos;</comment>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="bf1a-56af-8a6a-87da" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="2d85-3f36-554c-2bf1" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="2d85-3f36-554c-2bf1" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="941e-52ca-922e-26b7" name="Interemptor Praefectus" publicationId="817a-6288-e016-7469" page="162" hidden="false" collective="false" import="true" type="model">
@@ -3131,11 +3129,9 @@ Could not find type or subtype &apos;Deathwing&apos;</comment>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25"/>
           </costs>
           <categoryLinks>
-            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="4371-a91d-49b5-9b62" name="Infantry" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="4371-a91d-49b5-9b62" name="Infantry Unit Type" primary="false"/>
             <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="59a3-e9cc-4a36-a333" name="Character" primary="false"/>
           </categoryLinks>
-          <comment>!BSC Errors from 20240328-1346
-Could not find type or subtype &apos;Dreadwing&apos;</comment>
         </selectionEntry>
         <selectionEntry id="f5d5-440f-9caf-ae9f" name="Interemptors" publicationId="817a-6288-e016-7469" page="162" hidden="false" collective="false" import="true" type="model">
           <constraints>
@@ -3163,10 +3159,8 @@ Could not find type or subtype &apos;Dreadwing&apos;</comment>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20"/>
           </costs>
           <categoryLinks>
-            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="2146-69ab-4ec0-9a00" name="Infantry" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="2146-69ab-4ec0-9a00" name="Infantry Unit Type" primary="false"/>
           </categoryLinks>
-          <comment>!BSC Errors from 20240328-1346
-Could not find type or subtype &apos;Dreadwing&apos;</comment>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
@@ -3714,7 +3708,7 @@ Could not find type or subtype &apos;Dreadwing&apos;</comment>
       </constraints>
       <categoryLinks>
         <categoryLink id="5703-f989-0ae4-1a33" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="2fea-f85f-069a-1843" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="2fea-f85f-069a-1843" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink targetId="8247-54dc-9194-948f" id="50c7-5baf-231b-4f9f" primary="false" name="Siege Breaker:"/>
       </categoryLinks>
       <selectionEntries>
@@ -3875,12 +3869,10 @@ Could not find type or subtype &apos;Dreadwing&apos;</comment>
           </costs>
           <categoryLinks>
             <categoryLink targetId="4f07-3d45-4f28-a0c6" id="fb27-3a06-ae7f-3147" primary="false" name="Independent Character"/>
-            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="0fe3-32cc-4a5c-910d" name="Infantry" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="0fe3-32cc-4a5c-910d" name="Infantry Unit Type" primary="false"/>
             <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="a032-e5f1-4ff5-b03f" name="Character" primary="false"/>
-            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="c16f-7f75-4e46-ab84" name="Unique" primary="false"/>
+            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="c16f-7f75-4e46-ab84" name="Unique Sub-type" primary="false"/>
           </categoryLinks>
-          <comment>!BSC Errors from 20240328-1346
-Could not find type or subtype &apos;Dreadwing&apos;</comment>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
@@ -4007,7 +3999,7 @@ Selenite Shard-bolt Pistol</description>
       <categoryLinks>
         <categoryLink id="3a4b-b4f9-aeeb-da68" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="8c89-c8a4-6609-6878" name="Jump Infantry:" hidden="false" targetId="eee8-3c7c-2762-e33e" primary="false"/>
-        <categoryLink id="1edd-14b2-f178-4fba" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="1edd-14b2-f178-4fba" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="9549-9717-b59c-3f41" name="Firewing Enigmatii" publicationId="817a-6288-e016-7469" page="52" hidden="false" collective="false" import="true" type="model">
@@ -4138,10 +4130,8 @@ Selenite Shard-bolt Pistol</description>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25"/>
           </costs>
           <categoryLinks>
-            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="d901-20b3-44e8-a5e7" name="Infantry" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="d901-20b3-44e8-a5e7" name="Infantry Unit Type" primary="false"/>
           </categoryLinks>
-          <comment>!BSC Errors from 20240328-1346
-Could not find type or subtype &apos;Firewing&apos;</comment>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
@@ -4186,7 +4176,7 @@ Could not find type or subtype &apos;Firewing&apos;</comment>
       <categoryLinks>
         <categoryLink id="02a1-f083-b1fa-673a" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="ef49-f8a7-3bda-0fba" name="Heavy Sub-type" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
-        <categoryLink id="2dec-96ad-9237-42f0" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="2dec-96ad-9237-42f0" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="21de-4e57-9f08-b389" name="Terminators:" hidden="false" targetId="bab3-f50d-3e5f-2f78" primary="false"/>
       </categoryLinks>
       <selectionEntries>
@@ -4292,13 +4282,11 @@ special rule.</description>
           </costs>
           <categoryLinks>
             <categoryLink targetId="4f07-3d45-4f28-a0c6" id="63f-7b23-6d12-d7b5" primary="false" name="Independent Character"/>
-            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="f9e5-0a50-4589-a79d" name="Infantry" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="f9e5-0a50-4589-a79d" name="Infantry Unit Type" primary="false"/>
             <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="9261-b054-44a7-b36f" name="Character" primary="false"/>
-            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="95a0-e864-46eb-8c45" name="Unique" primary="false"/>
-            <categoryLink targetId="9231-183c-b97b-63f9" id="8c85-bfda-44a9-afed" name="Heavy" primary="false"/>
+            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="95a0-e864-46eb-8c45" name="Unique Sub-type" primary="false"/>
+            <categoryLink targetId="9231-183c-b97b-63f9" id="8c85-bfda-44a9-afed" name="Heavy Sub-type" primary="false"/>
           </categoryLinks>
-          <comment>!BSC Errors from 20240328-1346
-Could not find type or subtype &apos;Deathwing&apos;</comment>
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
@@ -4358,7 +4346,7 @@ Could not find type or subtype &apos;Deathwing&apos;</comment>
       <categoryLinks>
         <categoryLink id="359e-1590-1dcc-33d3" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="c379-1039-7f09-252d" name="Heavy Sub-type" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
-        <categoryLink id="94ed-ef24-43f7-ea1e" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="94ed-ef24-43f7-ea1e" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="b71f-8496-1f24-f116" name="Order Preceptor" publicationId="09b3-d525-cdea-260c" page="7" hidden="false" collective="false" import="true" type="model">
@@ -4431,9 +4419,9 @@ Could not find type or subtype &apos;Deathwing&apos;</comment>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
           </costs>
           <categoryLinks>
-            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="9833-dd51-4e1b-a5c6" name="Infantry" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="9833-dd51-4e1b-a5c6" name="Infantry Unit Type" primary="false"/>
             <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="2714-e6ad-41f6-a476" name="Character" primary="false"/>
-            <categoryLink targetId="9231-183c-b97b-63f9" id="d8b2-ce51-4520-8a1f" name="Heavy" primary="false"/>
+            <categoryLink targetId="9231-183c-b97b-63f9" id="d8b2-ce51-4520-8a1f" name="Heavy Sub-type" primary="false"/>
           </categoryLinks>
         </selectionEntry>
         <selectionEntry id="041e-d501-774a-a54b" name="Order Cenobites" publicationId="09b3-d525-cdea-260c" page="7" hidden="false" collective="false" import="true" type="model">
@@ -4492,9 +4480,9 @@ Could not find type or subtype &apos;Deathwing&apos;</comment>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="50"/>
           </costs>
           <categoryLinks>
-            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="fccb-0b88-4163-b4fd" name="Infantry" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="fccb-0b88-4163-b4fd" name="Infantry Unit Type" primary="false"/>
             <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="8ec1-ff4c-4c65-bab2" name="Character" primary="false"/>
-            <categoryLink targetId="9231-183c-b97b-63f9" id="badc-ead0-45bf-8b0e" name="Heavy" primary="false"/>
+            <categoryLink targetId="9231-183c-b97b-63f9" id="badc-ead0-45bf-8b0e" name="Heavy Sub-type" primary="false"/>
           </categoryLinks>
         </selectionEntry>
       </selectionEntries>
@@ -4699,7 +4687,7 @@ Could not find type or subtype &apos;Deathwing&apos;</comment>
       <categoryLinks>
         <categoryLink id="5ae3-be22-48b5-7f36" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="9a31-0a49-48f9-57ca" name="Heavy Sub-type" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
-        <categoryLink id="ca24-0dcb-67f2-0a38" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="ca24-0dcb-67f2-0a38" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="cfcb-776f-05b4-6c67" name="Order Preceptor" publicationId="09b3-d525-cdea-260c" page="7" hidden="false" collective="false" import="true" type="model">
@@ -4768,9 +4756,9 @@ Could not find type or subtype &apos;Deathwing&apos;</comment>
             <infoLink id="e9fb-1377-7028-d701" name="Order Preceptor" targetId="d61b-78bc-b74f-a04a" type="profile"/>
           </infoLinks>
           <categoryLinks>
-            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="4ca6-0844-428d-9fa7" name="Infantry" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="4ca6-0844-428d-9fa7" name="Infantry Unit Type" primary="false"/>
             <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="c026-5ae0-4d3a-8030" name="Character" primary="false"/>
-            <categoryLink targetId="9231-183c-b97b-63f9" id="f207-cd57-4265-9628" name="Heavy" primary="false"/>
+            <categoryLink targetId="9231-183c-b97b-63f9" id="f207-cd57-4265-9628" name="Heavy Sub-type" primary="false"/>
           </categoryLinks>
         </selectionEntry>
         <selectionEntry id="a2ae-5fac-436a-c4f6" name="Order Cenobites" publicationId="09b3-d525-cdea-260c" page="7" hidden="false" collective="false" import="true" type="model">
@@ -4816,9 +4804,9 @@ Could not find type or subtype &apos;Deathwing&apos;</comment>
             <infoLink id="3ce9-98fd-460c-6f88" name="Order Cenobites" targetId="dc37-aac1-0329-d898" type="profile"/>
           </infoLinks>
           <categoryLinks>
-            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="6a66-3693-4981-838d" name="Infantry" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="6a66-3693-4981-838d" name="Infantry Unit Type" primary="false"/>
             <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="ed97-3b42-4cfc-a242" name="Character" primary="false"/>
-            <categoryLink targetId="9231-183c-b97b-63f9" id="0123-5341-47c5-9948" name="Heavy" primary="false"/>
+            <categoryLink targetId="9231-183c-b97b-63f9" id="0123-5341-47c5-9948" name="Heavy Sub-type" primary="false"/>
           </categoryLinks>
         </selectionEntry>
       </selectionEntries>
@@ -4978,8 +4966,8 @@ Could not find type or subtype &apos;Deathwing&apos;</comment>
           </costs>
           <categoryLinks>
             <categoryLink targetId="4f07-3d45-4f28-a0c6" id="9c13-435c-1a1b-a315" primary="false" name="Independent Character"/>
-            <categoryLink targetId="ad5f-31db-8bc7-5c46" id="8b47-4465-4117-bf3a" name="Primarch" primary="false"/>
-            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="a565-b5a5-44e1-9de8" name="Unique" primary="false"/>
+            <categoryLink targetId="ad5f-31db-8bc7-5c46" id="8b47-4465-4117-bf3a" name="Primarch:" primary="false"/>
+            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="a565-b5a5-44e1-9de8" name="Unique Sub-type" primary="false"/>
           </categoryLinks>
         </selectionEntry>
         <selectionEntry id="63d3-7399-583d-b352" name="The Leonine Panoply" hidden="false" collective="false" import="true" type="upgrade">
@@ -5164,7 +5152,7 @@ Could not find type or subtype &apos;Deathwing&apos;</comment>
         <infoLink id="5289-0ca6-d64f-b1b0" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="2601-e1ee-e7fc-4791" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="2601-e1ee-e7fc-4791" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="ee1c-afee-f2c8-3259" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="2687-f1d9-6b82-5dc4" name="Terminators:" hidden="false" targetId="bab3-f50d-3e5f-2f78" primary="false"/>
         <categoryLink id="ffb0-fffb-d657-d8f2" name="Heavy Sub-type" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
@@ -5339,7 +5327,7 @@ Could not find type or subtype &apos;Deathwing&apos;</comment>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="1bb7-7e7e-ca18-0224" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="34be-5dc6-9701-910b" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="34be-5dc6-9701-910b" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="788a-3a92-655f-63ca" name="Deathwing Oathbearer" publicationId="817a-6288-e016-7469" page="164" hidden="false" collective="false" import="true" type="model">
@@ -5366,7 +5354,7 @@ Could not find type or subtype &apos;Deathwing&apos;</comment>
           </profiles>
           <categoryLinks>
             <categoryLink id="5386-ddf5-eca5-316a" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
-            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="bb5c-eacb-4408-b901" name="Infantry" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="bb5c-eacb-4408-b901" name="Infantry Unit Type" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="3bc5-2913-e35c-5675" name="May exchange its Calibanite warblade for:" hidden="false" collective="false" import="true" defaultSelectionEntryId="2b2c-26e0-deb2-9d9b">
@@ -5444,8 +5432,6 @@ Could not find type or subtype &apos;Deathwing&apos;</comment>
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
           </costs>
-          <comment>!BSC Errors from 20240328-1346
-Could not find type or subtype &apos;Deathwing&apos;</comment>
         </selectionEntry>
         <selectionEntry id="2c16-323f-7f4b-0be3" name="Deathwing Companion" publicationId="817a-6288-e016-7469" page="164" hidden="false" collective="false" import="true" type="model">
           <constraints>
@@ -5538,10 +5524,8 @@ Could not find type or subtype &apos;Deathwing&apos;</comment>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25"/>
           </costs>
           <categoryLinks>
-            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="bc59-fc6d-4f15-b145" name="Infantry" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="bc59-fc6d-4f15-b145" name="Infantry Unit Type" primary="false"/>
           </categoryLinks>
-          <comment>!BSC Errors from 20240328-1346
-Could not find type or subtype &apos;Deathwing&apos;</comment>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
@@ -5762,7 +5746,7 @@ Could not find type or subtype &apos;Deathwing&apos;</comment>
       <categoryLinks>
         <categoryLink id="e21c-04da-da7e-bb0e" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="d44a-5429-5007-3517" name="Terminators:" hidden="false" targetId="bab3-f50d-3e5f-2f78" primary="false"/>
-        <categoryLink id="4c36-2523-addd-8242" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="4c36-2523-addd-8242" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="d90b-68bb-e362-fd4d" name="Heavy Sub-type" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
       </categoryLinks>
       <selectionEntries>
@@ -5790,8 +5774,8 @@ Could not find type or subtype &apos;Deathwing&apos;</comment>
           </profiles>
           <categoryLinks>
             <categoryLink id="0fd9-666f-e9e3-f3ca" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
-            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="f396-c956-4f7f-b6e7" name="Infantry" primary="false"/>
-            <categoryLink targetId="9231-183c-b97b-63f9" id="5fa8-fd83-4ff2-ad2c" name="Heavy" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="f396-c956-4f7f-b6e7" name="Infantry Unit Type" primary="false"/>
+            <categoryLink targetId="9231-183c-b97b-63f9" id="5fa8-fd83-4ff2-ad2c" name="Heavy Sub-type" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="9f78-55c5-f254-bc7f" name="May take a:" hidden="false" collective="false" import="true">
@@ -5892,8 +5876,6 @@ Could not find type or subtype &apos;Deathwing&apos;</comment>
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
           </costs>
-          <comment>!BSC Errors from 20240328-1346
-Could not find type or subtype &apos;Deathwing&apos;</comment>
         </selectionEntry>
         <selectionEntry id="bdd6-1af9-b43d-6c01" name="Deathwing Cataphractii Companion" publicationId="d0df-7166-5cd3-89fd" page="48" hidden="false" collective="false" import="true" type="model">
           <constraints>
@@ -6005,11 +5987,9 @@ Could not find type or subtype &apos;Deathwing&apos;</comment>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
           </costs>
           <categoryLinks>
-            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="ddda-431e-4f9a-89c4" name="Infantry" primary="false"/>
-            <categoryLink targetId="9231-183c-b97b-63f9" id="9cbf-353a-4ce9-8643" name="Heavy" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="ddda-431e-4f9a-89c4" name="Infantry Unit Type" primary="false"/>
+            <categoryLink targetId="9231-183c-b97b-63f9" id="9cbf-353a-4ce9-8643" name="Heavy Sub-type" primary="false"/>
           </categoryLinks>
-          <comment>!BSC Errors from 20240328-1346
-Could not find type or subtype &apos;Deathwing&apos;</comment>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
@@ -6088,7 +6068,7 @@ Legion and Legiones Astartes (Dark Angels) special rules is referred to as the r
       </infoLinks>
       <categoryLinks>
         <categoryLink id="1685-35af-8fdd-ad14" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="f047-d090-eb49-7696" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="f047-d090-eb49-7696" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="1489-93f7-05f0-75c3" name="Terminators:" hidden="false" targetId="bab3-f50d-3e5f-2f78" primary="false"/>
       </categoryLinks>
       <selectionEntries>
@@ -6202,10 +6182,8 @@ Legion and Legiones Astartes (Dark Angels) special rules is referred to as the r
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
           </costs>
           <categoryLinks>
-            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="327c-ea3a-4432-ba11" name="Infantry" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="327c-ea3a-4432-ba11" name="Infantry Unit Type" primary="false"/>
           </categoryLinks>
-          <comment>!BSC Errors from 20240328-1346
-Could not find type or subtype &apos;Deathwing&apos;</comment>
         </selectionEntry>
         <selectionEntry id="c3a4-224b-ffb7-12f7" name="Deathwing Tartaros Oathbearer" publicationId="d0df-7166-5cd3-89fd" page="48" hidden="false" collective="false" import="true" type="model">
           <constraints>
@@ -6231,7 +6209,7 @@ Could not find type or subtype &apos;Deathwing&apos;</comment>
           </profiles>
           <categoryLinks>
             <categoryLink id="78d1-af37-64f4-55f6" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
-            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="816e-f6f1-4ef7-8d3c" name="Infantry" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="816e-f6f1-4ef7-8d3c" name="Infantry Unit Type" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="240b-051a-8626-4d01" name="May take a:" hidden="false" collective="false" import="true">
@@ -6332,8 +6310,6 @@ Could not find type or subtype &apos;Deathwing&apos;</comment>
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
           </costs>
-          <comment>!BSC Errors from 20240328-1346
-Could not find type or subtype &apos;Deathwing&apos;</comment>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>

--- a/2022 - LA - Dark Angels.cat
+++ b/2022 - LA - Dark Angels.cat
@@ -2977,7 +2977,12 @@
           </costs>
           <categoryLinks>
             <categoryLink targetId="4f07-3d45-4f28-a0c6" id="626e-a37e-107f-cf00" primary="false" name="Independent Character"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="432f-dd73-4a4c-b3e5" name="Infantry" primary="false"/>
+            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="ea40-cbff-4b90-813e" name="Unique" primary="false"/>
+            <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="0671-0f1e-4901-a3c7" name="Character" primary="false"/>
           </categoryLinks>
+          <comment>!BSC Errors from 20240328-1346
+Could not find type or subtype &apos;Deathwing&apos;</comment>
         </selectionEntry>
         <selectionEntry id="80c5-e797-2dc1-2e07" name="Armour of the Forest and the Mantle of the Champion" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
@@ -3125,6 +3130,12 @@
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25"/>
           </costs>
+          <categoryLinks>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="4371-a91d-49b5-9b62" name="Infantry" primary="false"/>
+            <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="59a3-e9cc-4a36-a333" name="Character" primary="false"/>
+          </categoryLinks>
+          <comment>!BSC Errors from 20240328-1346
+Could not find type or subtype &apos;Dreadwing&apos;</comment>
         </selectionEntry>
         <selectionEntry id="f5d5-440f-9caf-ae9f" name="Interemptors" publicationId="817a-6288-e016-7469" page="162" hidden="false" collective="false" import="true" type="model">
           <constraints>
@@ -3151,6 +3162,11 @@
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20"/>
           </costs>
+          <categoryLinks>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="2146-69ab-4ec0-9a00" name="Infantry" primary="false"/>
+          </categoryLinks>
+          <comment>!BSC Errors from 20240328-1346
+Could not find type or subtype &apos;Dreadwing&apos;</comment>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
@@ -3859,7 +3875,12 @@
           </costs>
           <categoryLinks>
             <categoryLink targetId="4f07-3d45-4f28-a0c6" id="fb27-3a06-ae7f-3147" primary="false" name="Independent Character"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="0fe3-32cc-4a5c-910d" name="Infantry" primary="false"/>
+            <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="a032-e5f1-4ff5-b03f" name="Character" primary="false"/>
+            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="c16f-7f75-4e46-ab84" name="Unique" primary="false"/>
           </categoryLinks>
+          <comment>!BSC Errors from 20240328-1346
+Could not find type or subtype &apos;Dreadwing&apos;</comment>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
@@ -4116,6 +4137,11 @@ Selenite Shard-bolt Pistol</description>
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25"/>
           </costs>
+          <categoryLinks>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="d901-20b3-44e8-a5e7" name="Infantry" primary="false"/>
+          </categoryLinks>
+          <comment>!BSC Errors from 20240328-1346
+Could not find type or subtype &apos;Firewing&apos;</comment>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
@@ -4266,7 +4292,13 @@ special rule.</description>
           </costs>
           <categoryLinks>
             <categoryLink targetId="4f07-3d45-4f28-a0c6" id="63f-7b23-6d12-d7b5" primary="false" name="Independent Character"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="f9e5-0a50-4589-a79d" name="Infantry" primary="false"/>
+            <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="9261-b054-44a7-b36f" name="Character" primary="false"/>
+            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="95a0-e864-46eb-8c45" name="Unique" primary="false"/>
+            <categoryLink targetId="9231-183c-b97b-63f9" id="8c85-bfda-44a9-afed" name="Heavy" primary="false"/>
           </categoryLinks>
+          <comment>!BSC Errors from 20240328-1346
+Could not find type or subtype &apos;Deathwing&apos;</comment>
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
@@ -4398,6 +4430,11 @@ special rule.</description>
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
           </costs>
+          <categoryLinks>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="9833-dd51-4e1b-a5c6" name="Infantry" primary="false"/>
+            <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="2714-e6ad-41f6-a476" name="Character" primary="false"/>
+            <categoryLink targetId="9231-183c-b97b-63f9" id="d8b2-ce51-4520-8a1f" name="Heavy" primary="false"/>
+          </categoryLinks>
         </selectionEntry>
         <selectionEntry id="041e-d501-774a-a54b" name="Order Cenobites" publicationId="09b3-d525-cdea-260c" page="7" hidden="false" collective="false" import="true" type="model">
           <constraints>
@@ -4454,6 +4491,11 @@ special rule.</description>
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="50"/>
           </costs>
+          <categoryLinks>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="fccb-0b88-4163-b4fd" name="Infantry" primary="false"/>
+            <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="8ec1-ff4c-4c65-bab2" name="Character" primary="false"/>
+            <categoryLink targetId="9231-183c-b97b-63f9" id="badc-ead0-45bf-8b0e" name="Heavy" primary="false"/>
+          </categoryLinks>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
@@ -4725,6 +4767,11 @@ special rule.</description>
           <infoLinks>
             <infoLink id="e9fb-1377-7028-d701" name="Order Preceptor" targetId="d61b-78bc-b74f-a04a" type="profile"/>
           </infoLinks>
+          <categoryLinks>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="4ca6-0844-428d-9fa7" name="Infantry" primary="false"/>
+            <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="c026-5ae0-4d3a-8030" name="Character" primary="false"/>
+            <categoryLink targetId="9231-183c-b97b-63f9" id="f207-cd57-4265-9628" name="Heavy" primary="false"/>
+          </categoryLinks>
         </selectionEntry>
         <selectionEntry id="a2ae-5fac-436a-c4f6" name="Order Cenobites" publicationId="09b3-d525-cdea-260c" page="7" hidden="false" collective="false" import="true" type="model">
           <constraints>
@@ -4768,6 +4815,11 @@ special rule.</description>
           <infoLinks>
             <infoLink id="3ce9-98fd-460c-6f88" name="Order Cenobites" targetId="dc37-aac1-0329-d898" type="profile"/>
           </infoLinks>
+          <categoryLinks>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="6a66-3693-4981-838d" name="Infantry" primary="false"/>
+            <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="ed97-3b42-4cfc-a242" name="Character" primary="false"/>
+            <categoryLink targetId="9231-183c-b97b-63f9" id="0123-5341-47c5-9948" name="Heavy" primary="false"/>
+          </categoryLinks>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
@@ -4926,6 +4978,8 @@ special rule.</description>
           </costs>
           <categoryLinks>
             <categoryLink targetId="4f07-3d45-4f28-a0c6" id="9c13-435c-1a1b-a315" primary="false" name="Independent Character"/>
+            <categoryLink targetId="ad5f-31db-8bc7-5c46" id="8b47-4465-4117-bf3a" name="Primarch" primary="false"/>
+            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="a565-b5a5-44e1-9de8" name="Unique" primary="false"/>
           </categoryLinks>
         </selectionEntry>
         <selectionEntry id="63d3-7399-583d-b352" name="The Leonine Panoply" hidden="false" collective="false" import="true" type="upgrade">
@@ -5312,6 +5366,7 @@ special rule.</description>
           </profiles>
           <categoryLinks>
             <categoryLink id="5386-ddf5-eca5-316a" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="bb5c-eacb-4408-b901" name="Infantry" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="3bc5-2913-e35c-5675" name="May exchange its Calibanite warblade for:" hidden="false" collective="false" import="true" defaultSelectionEntryId="2b2c-26e0-deb2-9d9b">
@@ -5389,6 +5444,8 @@ special rule.</description>
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
           </costs>
+          <comment>!BSC Errors from 20240328-1346
+Could not find type or subtype &apos;Deathwing&apos;</comment>
         </selectionEntry>
         <selectionEntry id="2c16-323f-7f4b-0be3" name="Deathwing Companion" publicationId="817a-6288-e016-7469" page="164" hidden="false" collective="false" import="true" type="model">
           <constraints>
@@ -5480,6 +5537,11 @@ special rule.</description>
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25"/>
           </costs>
+          <categoryLinks>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="bc59-fc6d-4f15-b145" name="Infantry" primary="false"/>
+          </categoryLinks>
+          <comment>!BSC Errors from 20240328-1346
+Could not find type or subtype &apos;Deathwing&apos;</comment>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
@@ -5728,6 +5790,8 @@ special rule.</description>
           </profiles>
           <categoryLinks>
             <categoryLink id="0fd9-666f-e9e3-f3ca" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="f396-c956-4f7f-b6e7" name="Infantry" primary="false"/>
+            <categoryLink targetId="9231-183c-b97b-63f9" id="5fa8-fd83-4ff2-ad2c" name="Heavy" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="9f78-55c5-f254-bc7f" name="May take a:" hidden="false" collective="false" import="true">
@@ -5828,6 +5892,8 @@ special rule.</description>
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
           </costs>
+          <comment>!BSC Errors from 20240328-1346
+Could not find type or subtype &apos;Deathwing&apos;</comment>
         </selectionEntry>
         <selectionEntry id="bdd6-1af9-b43d-6c01" name="Deathwing Cataphractii Companion" publicationId="d0df-7166-5cd3-89fd" page="48" hidden="false" collective="false" import="true" type="model">
           <constraints>
@@ -5938,6 +6004,12 @@ special rule.</description>
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
           </costs>
+          <categoryLinks>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="ddda-431e-4f9a-89c4" name="Infantry" primary="false"/>
+            <categoryLink targetId="9231-183c-b97b-63f9" id="9cbf-353a-4ce9-8643" name="Heavy" primary="false"/>
+          </categoryLinks>
+          <comment>!BSC Errors from 20240328-1346
+Could not find type or subtype &apos;Deathwing&apos;</comment>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
@@ -6129,6 +6201,11 @@ Legion and Legiones Astartes (Dark Angels) special rules is referred to as the r
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
           </costs>
+          <categoryLinks>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="327c-ea3a-4432-ba11" name="Infantry" primary="false"/>
+          </categoryLinks>
+          <comment>!BSC Errors from 20240328-1346
+Could not find type or subtype &apos;Deathwing&apos;</comment>
         </selectionEntry>
         <selectionEntry id="c3a4-224b-ffb7-12f7" name="Deathwing Tartaros Oathbearer" publicationId="d0df-7166-5cd3-89fd" page="48" hidden="false" collective="false" import="true" type="model">
           <constraints>
@@ -6154,6 +6231,7 @@ Legion and Legiones Astartes (Dark Angels) special rules is referred to as the r
           </profiles>
           <categoryLinks>
             <categoryLink id="78d1-af37-64f4-55f6" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="816e-f6f1-4ef7-8d3c" name="Infantry" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="240b-051a-8626-4d01" name="May take a:" hidden="false" collective="false" import="true">
@@ -6254,6 +6332,8 @@ Legion and Legiones Astartes (Dark Angels) special rules is referred to as the r
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
           </costs>
+          <comment>!BSC Errors from 20240328-1346
+Could not find type or subtype &apos;Deathwing&apos;</comment>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>

--- a/2022 - LA - Death Guard.cat
+++ b/2022 - LA - Death Guard.cat
@@ -3024,7 +3024,7 @@
         <constraint field="selections" scope="roster" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4d78-9648-8e21-ec44" type="max"/>
       </constraints>
       <categoryLinks>
-        <categoryLink id="def1-b261-8261-02fc" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="def1-b261-8261-02fc" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="33f7-f2cd-2c9b-34cb" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="8177-1aab-8a85-3acc" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
         <categoryLink id="2f7a-f3e1-0ebe-7f53" name="Heavy Sub-type" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
@@ -3201,11 +3201,11 @@
           </costs>
           <categoryLinks>
             <categoryLink targetId="4f07-3d45-4f28-a0c6" id="66b2-e426-da6c-7019" primary="false" name="Independent Character"/>
-            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="db2c-126e-4b8f-a365" name="Infantry" primary="false"/>
-            <categoryLink targetId="9231-183c-b97b-63f9" id="f3df-6fc6-4c4c-ab8d" name="Heavy" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="db2c-126e-4b8f-a365" name="Infantry Unit Type" primary="false"/>
+            <categoryLink targetId="9231-183c-b97b-63f9" id="f3df-6fc6-4c4c-ab8d" name="Heavy Sub-type" primary="false"/>
             <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="9436-4dfe-4e24-8230" name="Character" primary="false"/>
-            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="65ab-c604-431f-97d0" name="Unique" primary="false"/>
-            <categoryLink targetId="6e0c-29ba-a445-8321" id="ef23-d46e-401b-a648" name="Psyker" primary="false"/>
+            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="65ab-c604-431f-97d0" name="Unique Sub-type" primary="false"/>
+            <categoryLink targetId="6e0c-29ba-a445-8321" id="ef23-d46e-401b-a648" name="Psyker:" primary="false"/>
           </categoryLinks>
         </selectionEntry>
       </selectionEntries>
@@ -3383,8 +3383,8 @@ If this option is used then Mortarion is removed from the battlefield, leaving a
           </costs>
           <categoryLinks>
             <categoryLink targetId="4f07-3d45-4f28-a0c6" id="b434-eb1-c277-b762" primary="false" name="Independent Character"/>
-            <categoryLink targetId="ad5f-31db-8bc7-5c46" id="d288-72a0-4087-84e9" name="Primarch" primary="false"/>
-            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="370b-0dc9-4356-a1b4" name="Unique" primary="false"/>
+            <categoryLink targetId="ad5f-31db-8bc7-5c46" id="d288-72a0-4087-84e9" name="Primarch:" primary="false"/>
+            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="370b-0dc9-4356-a1b4" name="Unique Sub-type" primary="false"/>
           </categoryLinks>
           <constraints>
             <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="85c4-842a-d04b-a687"/>
@@ -3429,7 +3429,7 @@ If this option is used then Mortarion is removed from the battlefield, leaving a
         <infoLink id="4a9d-1f85-27d1-18c0" name="Legiones Astartes (Death Guard)" hidden="false" targetId="48a9-493f-e255-5070" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="8781-fa3a-a2f2-bfea" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="8781-fa3a-a2f2-bfea" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="dfa4-63db-3a8e-a198" name="Heavy Sub-type" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
         <categoryLink id="4ee0-168f-36f7-496d" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
       </categoryLinks>
@@ -3460,8 +3460,8 @@ If this option is used then Mortarion is removed from the battlefield, leaving a
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15"/>
           </costs>
           <categoryLinks>
-            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="4a8c-3af0-4559-b7a2" name="Infantry" primary="false"/>
-            <categoryLink targetId="9231-183c-b97b-63f9" id="3f96-2b35-4864-b3ba" name="Heavy" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="4a8c-3af0-4559-b7a2" name="Infantry Unit Type" primary="false"/>
+            <categoryLink targetId="9231-183c-b97b-63f9" id="3f96-2b35-4864-b3ba" name="Heavy Sub-type" primary="false"/>
           </categoryLinks>
         </selectionEntry>
         <selectionEntry id="ee15-87c8-0df5-5c2a" name="Poison-master" hidden="false" collective="false" import="true" type="model">
@@ -3495,8 +3495,8 @@ If this option is used then Mortarion is removed from the battlefield, leaving a
           </profiles>
           <categoryLinks>
             <categoryLink id="ef26-2042-3bc7-5552" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
-            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="2942-d255-464a-9d1d" name="Infantry" primary="false"/>
-            <categoryLink targetId="9231-183c-b97b-63f9" id="b4ab-2d13-4770-9d67" name="Heavy" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="2942-d255-464a-9d1d" name="Infantry Unit Type" primary="false"/>
+            <categoryLink targetId="9231-183c-b97b-63f9" id="b4ab-2d13-4770-9d67" name="Heavy Sub-type" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="180c-30bb-612c-106e" name="May take one:" hidden="false" collective="false" import="true">
@@ -3878,7 +3878,7 @@ If this option is used then Mortarion is removed from the battlefield, leaving a
       </infoLinks>
       <categoryLinks>
         <categoryLink id="ca31-c0b0-1723-d85a" name="Heavy Sub-type" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
-        <categoryLink id="4b86-b5c5-f3e9-3f35" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="4b86-b5c5-f3e9-3f35" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="0fe4-702f-0f7f-805c" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="51c7-b78d-5c3b-7ebd" name="Terminators:" hidden="false" targetId="bab3-f50d-3e5f-2f78" primary="false"/>
       </categoryLinks>
@@ -3907,8 +3907,8 @@ If this option is used then Mortarion is removed from the battlefield, leaving a
           </profiles>
           <categoryLinks>
             <categoryLink id="b08c-77b8-5038-a9cc" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
-            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="4aff-341b-4a4a-b374" name="Infantry" primary="false"/>
-            <categoryLink targetId="9231-183c-b97b-63f9" id="8ab1-6a30-4436-beba" name="Heavy" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="4aff-341b-4a4a-b374" name="Infantry Unit Type" primary="false"/>
+            <categoryLink targetId="9231-183c-b97b-63f9" id="8ab1-6a30-4436-beba" name="Heavy Sub-type" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="79e4-c3dc-af82-c169" name="2) Ranged Options:" hidden="false" collective="false" import="true" defaultSelectionEntryId="5f54-71b6-2b16-551c">
@@ -4114,8 +4114,8 @@ If this option is used then Mortarion is removed from the battlefield, leaving a
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="45"/>
           </costs>
           <categoryLinks>
-            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="3557-9944-44be-a755" name="Infantry" primary="false"/>
-            <categoryLink targetId="9231-183c-b97b-63f9" id="f55a-bcbd-42a1-9397" name="Heavy" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="3557-9944-44be-a755" name="Infantry Unit Type" primary="false"/>
+            <categoryLink targetId="9231-183c-b97b-63f9" id="f55a-bcbd-42a1-9397" name="Heavy Sub-type" primary="false"/>
           </categoryLinks>
         </selectionEntry>
       </selectionEntries>
@@ -4319,11 +4319,11 @@ If this option is used then Mortarion is removed from the battlefield, leaving a
           </profiles>
           <categoryLinks>
             <categoryLink targetId="4f07-3d45-4f28-a0c6" id="9ad7-d31f-2c4f-6ec3" primary="false" name="Independent Character"/>
-            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="2f24-e646-4247-aea1" name="Infantry" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="2f24-e646-4247-aea1" name="Infantry Unit Type" primary="false"/>
             <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="2ba4-1e89-4b37-8ef4" name="Character" primary="false"/>
-            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="7c6c-ebc7-4b0a-81be" name="Unique" primary="false"/>
-            <categoryLink targetId="6e0c-29ba-a445-8321" id="6cb6-de6b-485c-b048" name="Psyker" primary="false"/>
-            <categoryLink targetId="9231-183c-b97b-63f9" id="a435-d9db-47db-aa99" name="Heavy" primary="false"/>
+            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="7c6c-ebc7-4b0a-81be" name="Unique Sub-type" primary="false"/>
+            <categoryLink targetId="6e0c-29ba-a445-8321" id="6cb6-de6b-485c-b048" name="Psyker:" primary="false"/>
+            <categoryLink targetId="9231-183c-b97b-63f9" id="a435-d9db-47db-aa99" name="Heavy Sub-type" primary="false"/>
           </categoryLinks>
           <constraints>
             <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="a12-42f3-21af-1290"/>
@@ -4401,7 +4401,7 @@ If this option is used then Mortarion is removed from the battlefield, leaving a
       <categoryLinks>
         <categoryLink id="58d0-40f3-bf65-136f" name="Siege Breaker:" hidden="false" targetId="8247-54dc-9194-948f" primary="false"/>
         <categoryLink id="076e-8fde-df99-a46e" name="Heavy Sub-type" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
-        <categoryLink id="9919-bd28-8a44-115d" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="9919-bd28-8a44-115d" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="dd03-bdde-aa4c-d15d" name="Defiant" hidden="false" collective="false" import="true" type="upgrade">
@@ -4453,10 +4453,10 @@ If this option is used then Mortarion is removed from the battlefield, leaving a
           </profiles>
           <categoryLinks>
             <categoryLink targetId="4f07-3d45-4f28-a0c6" id="2908-e4f5-e973-4d30" primary="false" name="Independent Character"/>
-            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="93cd-0586-4bc2-9635" name="Infantry" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="93cd-0586-4bc2-9635" name="Infantry Unit Type" primary="false"/>
             <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="75c1-492b-4261-be75" name="Character" primary="false"/>
-            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="9376-791d-46b4-8a7f" name="Unique" primary="false"/>
-            <categoryLink targetId="9231-183c-b97b-63f9" id="6aad-2abb-4769-a166" name="Heavy" primary="false"/>
+            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="9376-791d-46b4-8a7f" name="Unique Sub-type" primary="false"/>
+            <categoryLink targetId="9231-183c-b97b-63f9" id="6aad-2abb-4769-a166" name="Heavy Sub-type" primary="false"/>
           </categoryLinks>
           <constraints>
             <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="a12-42f3-21af-1290"/>
@@ -4554,7 +4554,7 @@ If this option is used then Mortarion is removed from the battlefield, leaving a
       </infoLinks>
       <categoryLinks>
         <categoryLink id="d4f9-501e-a4fa-3f6f" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="63ee-4b93-4160-2bd7" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="63ee-4b93-4160-2bd7" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="9aa5-47d6-a6d0-cc9a" name="Terminators:" hidden="false" targetId="bab3-f50d-3e5f-2f78" primary="false"/>
       </categoryLinks>
       <selectionEntries>
@@ -4610,7 +4610,7 @@ If this option is used then Mortarion is removed from the battlefield, leaving a
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="70"/>
           </costs>
           <categoryLinks>
-            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="fe7a-240e-45f6-bc8f" name="Infantry" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="fe7a-240e-45f6-bc8f" name="Infantry Unit Type" primary="false"/>
           </categoryLinks>
         </selectionEntry>
       </selectionEntries>

--- a/2022 - LA - Death Guard.cat
+++ b/2022 - LA - Death Guard.cat
@@ -3201,6 +3201,11 @@
           </costs>
           <categoryLinks>
             <categoryLink targetId="4f07-3d45-4f28-a0c6" id="66b2-e426-da6c-7019" primary="false" name="Independent Character"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="db2c-126e-4b8f-a365" name="Infantry" primary="false"/>
+            <categoryLink targetId="9231-183c-b97b-63f9" id="f3df-6fc6-4c4c-ab8d" name="Heavy" primary="false"/>
+            <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="9436-4dfe-4e24-8230" name="Character" primary="false"/>
+            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="65ab-c604-431f-97d0" name="Unique" primary="false"/>
+            <categoryLink targetId="6e0c-29ba-a445-8321" id="ef23-d46e-401b-a648" name="Psyker" primary="false"/>
           </categoryLinks>
         </selectionEntry>
       </selectionEntries>
@@ -3378,6 +3383,8 @@ If this option is used then Mortarion is removed from the battlefield, leaving a
           </costs>
           <categoryLinks>
             <categoryLink targetId="4f07-3d45-4f28-a0c6" id="b434-eb1-c277-b762" primary="false" name="Independent Character"/>
+            <categoryLink targetId="ad5f-31db-8bc7-5c46" id="d288-72a0-4087-84e9" name="Primarch" primary="false"/>
+            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="370b-0dc9-4356-a1b4" name="Unique" primary="false"/>
           </categoryLinks>
           <constraints>
             <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="85c4-842a-d04b-a687"/>
@@ -3452,6 +3459,10 @@ If this option is used then Mortarion is removed from the battlefield, leaving a
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15"/>
           </costs>
+          <categoryLinks>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="4a8c-3af0-4559-b7a2" name="Infantry" primary="false"/>
+            <categoryLink targetId="9231-183c-b97b-63f9" id="3f96-2b35-4864-b3ba" name="Heavy" primary="false"/>
+          </categoryLinks>
         </selectionEntry>
         <selectionEntry id="ee15-87c8-0df5-5c2a" name="Poison-master" hidden="false" collective="false" import="true" type="model">
           <constraints>
@@ -3484,6 +3495,8 @@ If this option is used then Mortarion is removed from the battlefield, leaving a
           </profiles>
           <categoryLinks>
             <categoryLink id="ef26-2042-3bc7-5552" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="2942-d255-464a-9d1d" name="Infantry" primary="false"/>
+            <categoryLink targetId="9231-183c-b97b-63f9" id="b4ab-2d13-4770-9d67" name="Heavy" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="180c-30bb-612c-106e" name="May take one:" hidden="false" collective="false" import="true">
@@ -3894,6 +3907,8 @@ If this option is used then Mortarion is removed from the battlefield, leaving a
           </profiles>
           <categoryLinks>
             <categoryLink id="b08c-77b8-5038-a9cc" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="4aff-341b-4a4a-b374" name="Infantry" primary="false"/>
+            <categoryLink targetId="9231-183c-b97b-63f9" id="8ab1-6a30-4436-beba" name="Heavy" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="79e4-c3dc-af82-c169" name="2) Ranged Options:" hidden="false" collective="false" import="true" defaultSelectionEntryId="5f54-71b6-2b16-551c">
@@ -4098,6 +4113,10 @@ If this option is used then Mortarion is removed from the battlefield, leaving a
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="45"/>
           </costs>
+          <categoryLinks>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="3557-9944-44be-a755" name="Infantry" primary="false"/>
+            <categoryLink targetId="9231-183c-b97b-63f9" id="f55a-bcbd-42a1-9397" name="Heavy" primary="false"/>
+          </categoryLinks>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
@@ -4300,6 +4319,11 @@ If this option is used then Mortarion is removed from the battlefield, leaving a
           </profiles>
           <categoryLinks>
             <categoryLink targetId="4f07-3d45-4f28-a0c6" id="9ad7-d31f-2c4f-6ec3" primary="false" name="Independent Character"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="2f24-e646-4247-aea1" name="Infantry" primary="false"/>
+            <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="2ba4-1e89-4b37-8ef4" name="Character" primary="false"/>
+            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="7c6c-ebc7-4b0a-81be" name="Unique" primary="false"/>
+            <categoryLink targetId="6e0c-29ba-a445-8321" id="6cb6-de6b-485c-b048" name="Psyker" primary="false"/>
+            <categoryLink targetId="9231-183c-b97b-63f9" id="a435-d9db-47db-aa99" name="Heavy" primary="false"/>
           </categoryLinks>
           <constraints>
             <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="a12-42f3-21af-1290"/>
@@ -4429,6 +4453,10 @@ If this option is used then Mortarion is removed from the battlefield, leaving a
           </profiles>
           <categoryLinks>
             <categoryLink targetId="4f07-3d45-4f28-a0c6" id="2908-e4f5-e973-4d30" primary="false" name="Independent Character"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="93cd-0586-4bc2-9635" name="Infantry" primary="false"/>
+            <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="75c1-492b-4261-be75" name="Character" primary="false"/>
+            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="9376-791d-46b4-8a7f" name="Unique" primary="false"/>
+            <categoryLink targetId="9231-183c-b97b-63f9" id="6aad-2abb-4769-a166" name="Heavy" primary="false"/>
           </categoryLinks>
           <constraints>
             <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="a12-42f3-21af-1290"/>
@@ -4581,6 +4609,9 @@ If this option is used then Mortarion is removed from the battlefield, leaving a
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="70"/>
           </costs>
+          <categoryLinks>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="fe7a-240e-45f6-bc8f" name="Infantry" primary="false"/>
+          </categoryLinks>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>

--- a/2022 - LA - Death Guard.cat
+++ b/2022 - LA - Death Guard.cat
@@ -2682,7 +2682,7 @@
       <categoryLinks>
         <categoryLink id="63ff-0a92-42ab-ae8c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="204c-7b0f-4fb9-b1b3" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="85e6-cb31-427c-a040" name="Line Sub-type:" hidden="false" targetId="6399-5c65-7833-1025" primary="false"/>
+        <categoryLink id="85e6-cb31-427c-a040" name="Line Sub-type" hidden="false" targetId="6399-5c65-7833-1025" primary="false"/>
         <categoryLink id="0281-8957-1b18-1e6c" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -3027,7 +3027,7 @@
         <categoryLink id="def1-b261-8261-02fc" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="33f7-f2cd-2c9b-34cb" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="8177-1aab-8a85-3acc" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
-        <categoryLink id="2f7a-f3e1-0ebe-7f53" name="Heavy Sub-type:" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+        <categoryLink id="2f7a-f3e1-0ebe-7f53" name="Heavy Sub-type" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
         <categoryLink id="043c-bb03-e878-0086" name="Psyker:" hidden="false" targetId="6e0c-29ba-a445-8321" primary="false"/>
         <categoryLink id="8ef4-70d2-ba35-70b9" name="Terminators:" hidden="false" targetId="bab3-f50d-3e5f-2f78" primary="false"/>
       </categoryLinks>
@@ -3430,7 +3430,7 @@ If this option is used then Mortarion is removed from the battlefield, leaving a
       </infoLinks>
       <categoryLinks>
         <categoryLink id="8781-fa3a-a2f2-bfea" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="dfa4-63db-3a8e-a198" name="Heavy Sub-type:" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+        <categoryLink id="dfa4-63db-3a8e-a198" name="Heavy Sub-type" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
         <categoryLink id="4ee0-168f-36f7-496d" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
       </categoryLinks>
       <selectionEntries>
@@ -3877,7 +3877,7 @@ If this option is used then Mortarion is removed from the battlefield, leaving a
         <infoLink id="05c4-1c08-0950-b643" name="Shrouded in Death" hidden="false" targetId="2a8e-65b7-11c5-f84a" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="ca31-c0b0-1723-d85a" name="Heavy Sub-type:" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+        <categoryLink id="ca31-c0b0-1723-d85a" name="Heavy Sub-type" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
         <categoryLink id="4b86-b5c5-f3e9-3f35" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="0fe4-702f-0f7f-805c" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="51c7-b78d-5c3b-7ebd" name="Terminators:" hidden="false" targetId="bab3-f50d-3e5f-2f78" primary="false"/>
@@ -4232,7 +4232,7 @@ If this option is used then Mortarion is removed from the battlefield, leaving a
       <categoryLinks>
         <categoryLink id="09dd-97f2-3578-0b77" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="c14e-e1ca-7d1e-8ba9" name="Psyker:" hidden="false" targetId="6e0c-29ba-a445-8321" primary="false"/>
-        <categoryLink id="3ab9-09ca-d35c-7778" name="Heavy Sub-type:" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+        <categoryLink id="3ab9-09ca-d35c-7778" name="Heavy Sub-type" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="82e1-3fe4-d8a1-63c5" name="The Revenant&apos;s Aegis" hidden="false" collective="false" import="true" type="upgrade">
@@ -4400,7 +4400,7 @@ If this option is used then Mortarion is removed from the battlefield, leaving a
       </infoLinks>
       <categoryLinks>
         <categoryLink id="58d0-40f3-bf65-136f" name="Siege Breaker:" hidden="false" targetId="8247-54dc-9194-948f" primary="false"/>
-        <categoryLink id="076e-8fde-df99-a46e" name="Heavy Sub-type:" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+        <categoryLink id="076e-8fde-df99-a46e" name="Heavy Sub-type" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
         <categoryLink id="9919-bd28-8a44-115d" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
       </categoryLinks>
       <selectionEntries>

--- a/2022 - LA - Emperor's Children.cat
+++ b/2022 - LA - Emperor's Children.cat
@@ -2733,7 +2733,7 @@
       <categoryLinks>
         <categoryLink id="63ff-0a92-42ab-ae8c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="204c-7b0f-4fb9-b1b3" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="85e6-cb31-427c-a040" name="Line Sub-type:" hidden="false" targetId="6399-5c65-7833-1025" primary="false"/>
+        <categoryLink id="85e6-cb31-427c-a040" name="Line Sub-type" hidden="false" targetId="6399-5c65-7833-1025" primary="false"/>
         <categoryLink id="eb1a-028b-3e62-994a" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -3685,7 +3685,7 @@ A unit with this special rule gains +1 to the score used to calculate the winner
         <infoLink id="fef3-5508-cd08-3c42" name="Legiones Hereticus (Emperor’s Children)" hidden="false" targetId="b9e-b2ef-86e-e52d" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="4ad3-2a6e-3de4-93f5" name="Heavy Sub-type:" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+        <categoryLink id="4ad3-2a6e-3de4-93f5" name="Heavy Sub-type" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
         <categoryLink id="d713-71c8-57c2-e819" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="a519-1c43-8810-6c3b" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
       </categoryLinks>
@@ -4659,7 +4659,7 @@ then he gains +1 to his Attacks Characteristic.</description>
         <infoLink id="8fff-2cd7-b38c-e631" name="Loyalist" hidden="false" targetId="d1de-a45d-2b9b-c878" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="7acc-1ab8-5189-f03c" name="Dreadnought Unit-type:" hidden="false" targetId="4280-4963-02b5-e31d" primary="false"/>
+        <categoryLink id="7acc-1ab8-5189-f03c" name="Dreadnought Unit Type" hidden="false" targetId="4280-4963-02b5-e31d" primary="false"/>
         <categoryLink id="0a18-eece-0831-f72d" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink targetId="aa94-5c65-d1f1-46a4" id="ba67-2d9d-478f-ab37" name="Unique" primary="false"/>
       </categoryLinks>
@@ -4735,7 +4735,7 @@ then he gains +1 to his Attacks Characteristic.</description>
         <infoLink id="67f2-7c26-f16e-8c6" name="Legiones Hereticus (Emperor’s Children)" hidden="false" targetId="b9e-b2ef-86e-e52d" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="9ffc-7328-547c-da5c" name="Heavy Sub-type:" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+        <categoryLink id="9ffc-7328-547c-da5c" name="Heavy Sub-type" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
         <categoryLink id="3590-8673-cb28-8ec9" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="4c73-6800-a149-a8a9" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
       </categoryLinks>

--- a/2022 - LA - Emperor's Children.cat
+++ b/2022 - LA - Emperor's Children.cat
@@ -6116,9 +6116,8 @@ During a Reaction made in any Phase, a player may not choose to activate a model
           <categoryLinks>
             <categoryLink targetId="4f07-3d45-4f28-a0c6" id="7ffb-9bda-dc71-222e" primary="false" name="Independent Character"/>
             <categoryLink targetId="aa94-5c65-d1f1-46a4" id="6621-de29-4fe2-b2d2" name="Unique" primary="false"/>
+            <categoryLink targetId="1292-421a-85aa-c1bc" id="db06-de3b-47a2-8b8e" name="Daemon Primarch" primary="false"/>
           </categoryLinks>
-          <comment>!BSC Errors from 20240328-1346
-Could not find type or subtype &apos;Daemon Primarch&apos;</comment>
         </selectionEntry>
       </selectionEntries>
       <categoryLinks>

--- a/2022 - LA - Emperor's Children.cat
+++ b/2022 - LA - Emperor's Children.cat
@@ -3183,6 +3183,8 @@ Sire of the Emperor’s Children - All friendly models with the Legiones Astarte
           </costs>
           <categoryLinks>
             <categoryLink targetId="4f07-3d45-4f28-a0c6" id="9efe-494b-8a6a-c450" primary="false" name="Independent Character"/>
+            <categoryLink targetId="ad5f-31db-8bc7-5c46" id="cc48-0db3-4a12-abee" name="Primarch" primary="false"/>
+            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="4e8c-ffd2-4591-92ae" name="Unique" primary="false"/>
           </categoryLinks>
         </selectionEntry>
       </selectionEntries>
@@ -3398,6 +3400,10 @@ A unit with this special rule gains +1 to the score used to calculate the winner
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
           </costs>
+          <categoryLinks>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="c565-665c-4140-8e0d" name="Infantry" primary="false"/>
+            <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="97cb-bbe1-4c1c-9bf7" name="Character" primary="false"/>
+          </categoryLinks>
         </selectionEntry>
         <selectionEntry id="f359-944c-ca5d-f245" name="Phoenix Terminators" hidden="false" collective="false" import="true" type="model">
           <modifiers>
@@ -3436,6 +3442,10 @@ A unit with this special rule gains +1 to the score used to calculate the winner
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="35"/>
           </costs>
+          <categoryLinks>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="7e6f-412a-459d-abe2" name="Infantry" primary="false"/>
+            <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="ae57-2cc4-4f44-a360" name="Character" primary="false"/>
+          </categoryLinks>
         </selectionEntry>
         <selectionEntry id="8299-7028-93bc-0355" name="Phoenix Terminator Standard Bearer" hidden="true" collective="false" import="true" type="model">
           <modifiers>
@@ -3476,6 +3486,10 @@ A unit with this special rule gains +1 to the score used to calculate the winner
           <infoLinks>
             <infoLink id="c1a0-7cbc-c18e-e62d" name="Phoenix Terminator" targetId="49f9-a644-e073-d49d" type="profile"/>
           </infoLinks>
+          <categoryLinks>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="e81c-b3b9-42a2-86fc" name="Infantry" primary="false"/>
+            <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="42f6-5c17-45d7-9838" name="Character" primary="false"/>
+          </categoryLinks>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
@@ -3701,6 +3715,10 @@ A unit with this special rule gains +1 to the score used to calculate the winner
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25"/>
           </costs>
+          <categoryLinks>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="be0b-81e0-493a-a068" name="Infantry" primary="false"/>
+            <categoryLink targetId="9231-183c-b97b-63f9" id="ad96-b951-47ea-b640" name="Heavy" primary="false"/>
+          </categoryLinks>
         </selectionEntry>
         <selectionEntry id="fee0-34ad-15de-cb8a" name="Orchestrator" hidden="false" collective="false" import="true" type="model">
           <constraints>
@@ -3729,6 +3747,8 @@ A unit with this special rule gains +1 to the score used to calculate the winner
           </costs>
           <categoryLinks>
             <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="760a-f69-9b05-a972" primary="false" name="Character"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="2213-4460-4c1b-8b6d" name="Infantry" primary="false"/>
+            <categoryLink targetId="9231-183c-b97b-63f9" id="810f-29b5-4f60-b69e" name="Heavy" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="ad3-6894-f7cc-77b7" name="May take any of the following:" hidden="false" collective="false" import="true">
@@ -4080,6 +4100,9 @@ A unit with this special rule gains +1 to the score used to calculate the winner
           </costs>
           <categoryLinks>
             <categoryLink targetId="4f07-3d45-4f28-a0c6" id="9610-f53-4564-bdd3" primary="false" name="Independent Character"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="c75c-7c66-42de-a53f" name="Infantry" primary="false"/>
+            <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="456f-6d2e-4998-8962" name="Character" primary="false"/>
+            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="cb34-60e6-4631-a636" name="Unique" primary="false"/>
           </categoryLinks>
         </selectionEntry>
         <selectionEntry id="067e-c26e-0693-2a74" name="Glory Aeterna" hidden="false" collective="false" import="true" type="upgrade">
@@ -4638,6 +4661,7 @@ then he gains +1 to his Attacks Characteristic.</description>
       <categoryLinks>
         <categoryLink id="7acc-1ab8-5189-f03c" name="Dreadnought Unit-type:" hidden="false" targetId="4280-4963-02b5-e31d" primary="false"/>
         <categoryLink id="0a18-eece-0831-f72d" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink targetId="aa94-5c65-d1f1-46a4" id="ba67-2d9d-478f-ab37" name="Unique" primary="false"/>
       </categoryLinks>
       <entryLinks>
         <entryLink id="53b4-68bd-0941-24e4" name="Atomantic Deflector" hidden="false" collective="false" import="true" targetId="38fb-9a0b-edef-a497" type="selectionEntry">
@@ -4748,6 +4772,10 @@ then he gains +1 to his Attacks Characteristic.</description>
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="40"/>
           </costs>
+          <categoryLinks>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="8db2-ee8a-4950-988f" name="Infantry" primary="false"/>
+            <categoryLink targetId="9231-183c-b97b-63f9" id="cd57-b748-4fc4-9992" name="Heavy" primary="false"/>
+          </categoryLinks>
         </selectionEntry>
         <selectionEntry id="95ca-4c13-d1b2-9555" name="Novaetor" hidden="false" collective="false" import="true" type="model">
           <constraints>
@@ -4924,6 +4952,11 @@ then he gains +1 to his Attacks Characteristic.</description>
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
           </costs>
+          <categoryLinks>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="8793-fdac-449b-87e6" name="Infantry" primary="false"/>
+            <categoryLink targetId="9231-183c-b97b-63f9" id="7740-a3b6-4cc2-a760" name="Heavy" primary="false"/>
+            <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="ab29-3d69-4fe7-8034" name="Character" primary="false"/>
+          </categoryLinks>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
@@ -5258,6 +5291,10 @@ then he gains +1 to his Attacks Characteristic.</description>
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
           </costs>
+          <categoryLinks>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="e772-aa44-468d-b47e" name="Infantry" primary="false"/>
+            <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="0bad-31c1-4d99-9b2d" name="Character" primary="false"/>
+          </categoryLinks>
         </selectionEntry>
         <selectionEntry id="44da-b5c1-6336-0370" name="Palatine Warrior" hidden="false" collective="false" import="true" type="model">
           <constraints>
@@ -5284,6 +5321,9 @@ then he gains +1 to his Attacks Characteristic.</description>
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="30"/>
           </costs>
+          <categoryLinks>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="7075-a6bc-4f8b-8134" name="Infantry" primary="false"/>
+          </categoryLinks>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
@@ -5638,6 +5678,10 @@ then he gains +1 to his Attacks Characteristic.</description>
           <infoLinks>
             <infoLink id="0db0-8a3e-4eea-d301" name="Palatine Prefector" targetId="4ac4-7f8b-924f-f82a" type="profile"/>
           </infoLinks>
+          <categoryLinks>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="9087-fd92-4da1-a941" name="Infantry" primary="false"/>
+            <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="82f6-3f95-45f5-9c56" name="Character" primary="false"/>
+          </categoryLinks>
         </selectionEntry>
         <selectionEntry id="03a4-ab97-b21d-3fb4" name="Palatine Warrior" hidden="false" collective="false" import="true" type="model">
           <constraints>
@@ -5650,6 +5694,9 @@ then he gains +1 to his Attacks Characteristic.</description>
           <infoLinks>
             <infoLink id="f13f-f615-2728-36b4" name="Palatine Warrior" targetId="0601-2dba-a13d-07e4" type="profile"/>
           </infoLinks>
+          <categoryLinks>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="381d-b9cf-4640-a55e" name="Infantry" primary="false"/>
+          </categoryLinks>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
@@ -6068,7 +6115,10 @@ During a Reaction made in any Phase, a player may not choose to activate a model
           </costs>
           <categoryLinks>
             <categoryLink targetId="4f07-3d45-4f28-a0c6" id="7ffb-9bda-dc71-222e" primary="false" name="Independent Character"/>
+            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="6621-de29-4fe2-b2d2" name="Unique" primary="false"/>
           </categoryLinks>
+          <comment>!BSC Errors from 20240328-1346
+Could not find type or subtype &apos;Daemon Primarch&apos;</comment>
         </selectionEntry>
       </selectionEntries>
       <categoryLinks>

--- a/2022 - LA - Emperor's Children.cat
+++ b/2022 - LA - Emperor's Children.cat
@@ -3183,8 +3183,8 @@ Sire of the Emperor’s Children - All friendly models with the Legiones Astarte
           </costs>
           <categoryLinks>
             <categoryLink targetId="4f07-3d45-4f28-a0c6" id="9efe-494b-8a6a-c450" primary="false" name="Independent Character"/>
-            <categoryLink targetId="ad5f-31db-8bc7-5c46" id="cc48-0db3-4a12-abee" name="Primarch" primary="false"/>
-            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="4e8c-ffd2-4591-92ae" name="Unique" primary="false"/>
+            <categoryLink targetId="ad5f-31db-8bc7-5c46" id="cc48-0db3-4a12-abee" name="Primarch:" primary="false"/>
+            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="4e8c-ffd2-4591-92ae" name="Unique Sub-type" primary="false"/>
           </categoryLinks>
         </selectionEntry>
       </selectionEntries>
@@ -3319,7 +3319,7 @@ A unit with this special rule gains +1 to the score used to calculate the winner
         <infoLink id="dff4-89f0-a334-fbb9" name="Legiones Hereticus (Emperor’s Children)" hidden="false" targetId="b9e-b2ef-86e-e52d" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="99d4-024f-39b9-f2dd" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="99d4-024f-39b9-f2dd" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="5042-adc1-b6a6-33c7" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="f095-c7f1-6d36-0bf8" name="Terminators:" hidden="false" targetId="bab3-f50d-3e5f-2f78" primary="false"/>
       </categoryLinks>
@@ -3401,7 +3401,7 @@ A unit with this special rule gains +1 to the score used to calculate the winner
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
           </costs>
           <categoryLinks>
-            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="c565-665c-4140-8e0d" name="Infantry" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="c565-665c-4140-8e0d" name="Infantry Unit Type" primary="false"/>
             <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="97cb-bbe1-4c1c-9bf7" name="Character" primary="false"/>
           </categoryLinks>
         </selectionEntry>
@@ -3443,7 +3443,7 @@ A unit with this special rule gains +1 to the score used to calculate the winner
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="35"/>
           </costs>
           <categoryLinks>
-            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="7e6f-412a-459d-abe2" name="Infantry" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="7e6f-412a-459d-abe2" name="Infantry Unit Type" primary="false"/>
             <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="ae57-2cc4-4f44-a360" name="Character" primary="false"/>
           </categoryLinks>
         </selectionEntry>
@@ -3487,7 +3487,7 @@ A unit with this special rule gains +1 to the score used to calculate the winner
             <infoLink id="c1a0-7cbc-c18e-e62d" name="Phoenix Terminator" targetId="49f9-a644-e073-d49d" type="profile"/>
           </infoLinks>
           <categoryLinks>
-            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="e81c-b3b9-42a2-86fc" name="Infantry" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="e81c-b3b9-42a2-86fc" name="Infantry Unit Type" primary="false"/>
             <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="42f6-5c17-45d7-9838" name="Character" primary="false"/>
           </categoryLinks>
         </selectionEntry>
@@ -3686,7 +3686,7 @@ A unit with this special rule gains +1 to the score used to calculate the winner
       </infoLinks>
       <categoryLinks>
         <categoryLink id="4ad3-2a6e-3de4-93f5" name="Heavy Sub-type" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
-        <categoryLink id="d713-71c8-57c2-e819" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="d713-71c8-57c2-e819" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="a519-1c43-8810-6c3b" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
       </categoryLinks>
       <selectionEntries>
@@ -3716,8 +3716,8 @@ A unit with this special rule gains +1 to the score used to calculate the winner
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25"/>
           </costs>
           <categoryLinks>
-            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="be0b-81e0-493a-a068" name="Infantry" primary="false"/>
-            <categoryLink targetId="9231-183c-b97b-63f9" id="ad96-b951-47ea-b640" name="Heavy" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="be0b-81e0-493a-a068" name="Infantry Unit Type" primary="false"/>
+            <categoryLink targetId="9231-183c-b97b-63f9" id="ad96-b951-47ea-b640" name="Heavy Sub-type" primary="false"/>
           </categoryLinks>
         </selectionEntry>
         <selectionEntry id="fee0-34ad-15de-cb8a" name="Orchestrator" hidden="false" collective="false" import="true" type="model">
@@ -3747,8 +3747,8 @@ A unit with this special rule gains +1 to the score used to calculate the winner
           </costs>
           <categoryLinks>
             <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="760a-f69-9b05-a972" primary="false" name="Character"/>
-            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="2213-4460-4c1b-8b6d" name="Infantry" primary="false"/>
-            <categoryLink targetId="9231-183c-b97b-63f9" id="810f-29b5-4f60-b69e" name="Heavy" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="2213-4460-4c1b-8b6d" name="Infantry Unit Type" primary="false"/>
+            <categoryLink targetId="9231-183c-b97b-63f9" id="810f-29b5-4f60-b69e" name="Heavy Sub-type" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="ad3-6894-f7cc-77b7" name="May take any of the following:" hidden="false" collective="false" import="true">
@@ -4055,7 +4055,7 @@ A unit with this special rule gains +1 to the score used to calculate the winner
         <constraint field="selections" scope="roster" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="77cf-98c8-12f6-e491" type="max"/>
       </constraints>
       <categoryLinks>
-        <categoryLink id="b7e4-e6dd-51b7-6cdb" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="b7e4-e6dd-51b7-6cdb" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="846d-5f51-c454-c2fc" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
       </categoryLinks>
       <selectionEntries>
@@ -4100,9 +4100,9 @@ A unit with this special rule gains +1 to the score used to calculate the winner
           </costs>
           <categoryLinks>
             <categoryLink targetId="4f07-3d45-4f28-a0c6" id="9610-f53-4564-bdd3" primary="false" name="Independent Character"/>
-            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="c75c-7c66-42de-a53f" name="Infantry" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="c75c-7c66-42de-a53f" name="Infantry Unit Type" primary="false"/>
             <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="456f-6d2e-4998-8962" name="Character" primary="false"/>
-            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="cb34-60e6-4631-a636" name="Unique" primary="false"/>
+            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="cb34-60e6-4631-a636" name="Unique Sub-type" primary="false"/>
           </categoryLinks>
         </selectionEntry>
         <selectionEntry id="067e-c26e-0693-2a74" name="Glory Aeterna" hidden="false" collective="false" import="true" type="upgrade">
@@ -4236,7 +4236,7 @@ A unit with this special rule gains +1 to the score used to calculate the winner
         <constraint field="selections" scope="roster" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e781-7860-b7ab-ca6f" type="max"/>
       </constraints>
       <categoryLinks>
-        <categoryLink id="097f-3ba4-1906-564b" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="097f-3ba4-1906-564b" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="5ce7-8211-fce9-9cc1" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
       </categoryLinks>
       <selectionEntries>
@@ -4414,7 +4414,7 @@ If any of these are true then Captain Saul Tarvitz and any friendly units with a
         <constraint field="selections" scope="roster" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9326-cd69-c6f1-949b" type="max"/>
       </constraints>
       <categoryLinks>
-        <categoryLink id="881f-052e-58c5-49de" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="881f-052e-58c5-49de" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="8d21-e2d9-7847-b808" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
       </categoryLinks>
       <selectionEntries>
@@ -4661,7 +4661,7 @@ then he gains +1 to his Attacks Characteristic.</description>
       <categoryLinks>
         <categoryLink id="7acc-1ab8-5189-f03c" name="Dreadnought Unit Type" hidden="false" targetId="4280-4963-02b5-e31d" primary="false"/>
         <categoryLink id="0a18-eece-0831-f72d" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink targetId="aa94-5c65-d1f1-46a4" id="ba67-2d9d-478f-ab37" name="Unique" primary="false"/>
+        <categoryLink targetId="aa94-5c65-d1f1-46a4" id="ba67-2d9d-478f-ab37" name="Unique Sub-type" primary="false"/>
       </categoryLinks>
       <entryLinks>
         <entryLink id="53b4-68bd-0941-24e4" name="Atomantic Deflector" hidden="false" collective="false" import="true" targetId="38fb-9a0b-edef-a497" type="selectionEntry">
@@ -4736,7 +4736,7 @@ then he gains +1 to his Attacks Characteristic.</description>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="9ffc-7328-547c-da5c" name="Heavy Sub-type" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
-        <categoryLink id="3590-8673-cb28-8ec9" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="3590-8673-cb28-8ec9" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="4c73-6800-a149-a8a9" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
       </categoryLinks>
       <selectionEntries>
@@ -4773,8 +4773,8 @@ then he gains +1 to his Attacks Characteristic.</description>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="40"/>
           </costs>
           <categoryLinks>
-            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="8db2-ee8a-4950-988f" name="Infantry" primary="false"/>
-            <categoryLink targetId="9231-183c-b97b-63f9" id="cd57-b748-4fc4-9992" name="Heavy" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="8db2-ee8a-4950-988f" name="Infantry Unit Type" primary="false"/>
+            <categoryLink targetId="9231-183c-b97b-63f9" id="cd57-b748-4fc4-9992" name="Heavy Sub-type" primary="false"/>
           </categoryLinks>
         </selectionEntry>
         <selectionEntry id="95ca-4c13-d1b2-9555" name="Novaetor" hidden="false" collective="false" import="true" type="model">
@@ -4953,8 +4953,8 @@ then he gains +1 to his Attacks Characteristic.</description>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
           </costs>
           <categoryLinks>
-            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="8793-fdac-449b-87e6" name="Infantry" primary="false"/>
-            <categoryLink targetId="9231-183c-b97b-63f9" id="7740-a3b6-4cc2-a760" name="Heavy" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="8793-fdac-449b-87e6" name="Infantry Unit Type" primary="false"/>
+            <categoryLink targetId="9231-183c-b97b-63f9" id="7740-a3b6-4cc2-a760" name="Heavy Sub-type" primary="false"/>
             <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="ab29-3d69-4fe7-8034" name="Character" primary="false"/>
           </categoryLinks>
         </selectionEntry>
@@ -5136,7 +5136,7 @@ then he gains +1 to his Attacks Characteristic.</description>
         <infoLink id="158-c63d-3ae-6f93" name="Legiones Hereticus (Emperor’s Children)" hidden="false" targetId="b9e-b2ef-86e-e52d" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="782e-da64-b0e9-5ed2" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="782e-da64-b0e9-5ed2" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="5e12-9048-77ab-61e5" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="6f26-15ef-8be7-e999" name="Jump Infantry:" hidden="false" targetId="eee8-3c7c-2762-e33e" primary="false"/>
       </categoryLinks>
@@ -5292,7 +5292,7 @@ then he gains +1 to his Attacks Characteristic.</description>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
           </costs>
           <categoryLinks>
-            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="e772-aa44-468d-b47e" name="Infantry" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="e772-aa44-468d-b47e" name="Infantry Unit Type" primary="false"/>
             <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="0bad-31c1-4d99-9b2d" name="Character" primary="false"/>
           </categoryLinks>
         </selectionEntry>
@@ -5322,7 +5322,7 @@ then he gains +1 to his Attacks Characteristic.</description>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="30"/>
           </costs>
           <categoryLinks>
-            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="7075-a6bc-4f8b-8134" name="Infantry" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="7075-a6bc-4f8b-8134" name="Infantry Unit Type" primary="false"/>
           </categoryLinks>
         </selectionEntry>
       </selectionEntries>
@@ -5530,7 +5530,7 @@ then he gains +1 to his Attacks Characteristic.</description>
         <infoLink id="67a8-ce36-6e3f-eba8" name="Legiones Hereticus (Emperor’s Children)" hidden="false" targetId="b9e-b2ef-86e-e52d" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="c0d4-de90-6b38-68d5" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="c0d4-de90-6b38-68d5" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="a6b8-94b0-1a77-76c5" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
       </categoryLinks>
       <selectionEntries>
@@ -5679,7 +5679,7 @@ then he gains +1 to his Attacks Characteristic.</description>
             <infoLink id="0db0-8a3e-4eea-d301" name="Palatine Prefector" targetId="4ac4-7f8b-924f-f82a" type="profile"/>
           </infoLinks>
           <categoryLinks>
-            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="9087-fd92-4da1-a941" name="Infantry" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="9087-fd92-4da1-a941" name="Infantry Unit Type" primary="false"/>
             <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="82f6-3f95-45f5-9c56" name="Character" primary="false"/>
           </categoryLinks>
         </selectionEntry>
@@ -5695,7 +5695,7 @@ then he gains +1 to his Attacks Characteristic.</description>
             <infoLink id="f13f-f615-2728-36b4" name="Palatine Warrior" targetId="0601-2dba-a13d-07e4" type="profile"/>
           </infoLinks>
           <categoryLinks>
-            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="381d-b9cf-4640-a55e" name="Infantry" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="381d-b9cf-4640-a55e" name="Infantry Unit Type" primary="false"/>
           </categoryLinks>
         </selectionEntry>
       </selectionEntries>
@@ -6115,8 +6115,8 @@ During a Reaction made in any Phase, a player may not choose to activate a model
           </costs>
           <categoryLinks>
             <categoryLink targetId="4f07-3d45-4f28-a0c6" id="7ffb-9bda-dc71-222e" primary="false" name="Independent Character"/>
-            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="6621-de29-4fe2-b2d2" name="Unique" primary="false"/>
-            <categoryLink targetId="1292-421a-85aa-c1bc" id="db06-de3b-47a2-8b8e" name="Daemon Primarch" primary="false"/>
+            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="6621-de29-4fe2-b2d2" name="Unique Sub-type" primary="false"/>
+            <categoryLink targetId="1292-421a-85aa-c1bc" id="db06-de3b-47a2-8b8e" name="Daemon Primarch Unit Type" primary="false"/>
           </categoryLinks>
         </selectionEntry>
       </selectionEntries>

--- a/2022 - LA - Imperial Fists.cat
+++ b/2022 - LA - Imperial Fists.cat
@@ -3383,7 +3383,7 @@
       <categoryLinks>
         <categoryLink id="63ff-0a92-42ab-ae8c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="204c-7b0f-4fb9-b1b3" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="85e6-cb31-427c-a040" name="Line Sub-type:" hidden="false" targetId="6399-5c65-7833-1025" primary="false"/>
+        <categoryLink id="85e6-cb31-427c-a040" name="Line Sub-type" hidden="false" targetId="6399-5c65-7833-1025" primary="false"/>
         <categoryLink id="3d10-19eb-5585-7c96" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -3795,7 +3795,7 @@
         <infoLink id="bac0-f49c-0b38-29bc" name="Legiones Astartes (Imperial Fists)" hidden="false" targetId="e876-4f8f-a30f-8b22" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="fdda-3efe-5d7d-bf3e" name="Heavy Sub-type:" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+        <categoryLink id="fdda-3efe-5d7d-bf3e" name="Heavy Sub-type" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
         <categoryLink id="37c5-26ea-8f6f-cc83" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="b742-fcda-a7e3-3a0e" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
       </categoryLinks>
@@ -4443,7 +4443,7 @@
       <categoryLinks>
         <categoryLink id="93db-ffc9-0558-73e6" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="e823-f428-97c9-b5d7" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="7668-e167-087e-ec1a" name="Heavy Sub-type:" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+        <categoryLink id="7668-e167-087e-ec1a" name="Heavy Sub-type" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
       </categoryLinks>
       <entryLinks>
         <entryLink id="02b9-034a-2569-5151" name="Warlord" hidden="false" collective="false" import="true" targetId="0176-56a3-d590-b103" type="selectionEntry">
@@ -4567,7 +4567,7 @@
       <categoryLinks>
         <categoryLink id="7d2a-1492-8056-3083" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="f860-72fd-d93c-1290" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="1715-31a2-3ed9-4522" name="Heavy Sub-type:" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+        <categoryLink id="1715-31a2-3ed9-4522" name="Heavy Sub-type" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="5353-20d5-7bd9-9db1" name="The Headsman and The Hunter" hidden="false" collective="false" import="true" type="upgrade">
@@ -5275,7 +5275,7 @@ Both weapons are counted as ‘Power’ weapons for those rules that affect such
         <infoLink id="1b54-dd41-0d20-8ea4" name="Deep Strike" hidden="false" targetId="f1e1-986f-c783-ca9e" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="9c2c-a3a7-f173-2fd3" name="Heavy Sub-type:" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+        <categoryLink id="9c2c-a3a7-f173-2fd3" name="Heavy Sub-type" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
         <categoryLink id="1611-1fbf-b28d-082b" name="Terminators:" hidden="false" targetId="bab3-f50d-3e5f-2f78" primary="false"/>
         <categoryLink id="7d8a-f02e-04ca-e7e6" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="c04e-d6da-5531-7c3a" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
@@ -5732,7 +5732,7 @@ A model with a Vigil storm shield gains a 3+ Invulnerable Save – Invulnerable 
         <infoLink id="bae4-9e19-5a59-baf6" name="Loyalist" hidden="false" targetId="d1de-a45d-2b9b-c878" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="c6ac-384a-7358-248d" name="Heavy Sub-type:" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+        <categoryLink id="c6ac-384a-7358-248d" name="Heavy Sub-type" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
         <categoryLink id="9e03-5b35-e7b8-fd61" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="91fc-cbe5-c635-605b" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
       </categoryLinks>

--- a/2022 - LA - Imperial Fists.cat
+++ b/2022 - LA - Imperial Fists.cat
@@ -3796,7 +3796,7 @@
       </infoLinks>
       <categoryLinks>
         <categoryLink id="fdda-3efe-5d7d-bf3e" name="Heavy Sub-type" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
-        <categoryLink id="37c5-26ea-8f6f-cc83" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="37c5-26ea-8f6f-cc83" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="b742-fcda-a7e3-3a0e" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
       </categoryLinks>
       <selectionEntries>
@@ -3831,8 +3831,8 @@
           </profiles>
           <categoryLinks>
             <categoryLink id="fdf2-f339-3520-8788" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
-            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="80b4-a436-4edd-b846" name="Infantry" primary="false"/>
-            <categoryLink targetId="9231-183c-b97b-63f9" id="612c-6c3c-4486-b096" name="Heavy" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="80b4-a436-4edd-b846" name="Infantry Unit Type" primary="false"/>
+            <categoryLink targetId="9231-183c-b97b-63f9" id="612c-6c3c-4486-b096" name="Heavy Sub-type" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="1cc8-ac5c-b5c2-b7ad" name="Weapon Options:" hidden="false" collective="false" import="true">
@@ -4124,8 +4124,8 @@
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20"/>
               </costs>
               <categoryLinks>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="8087-417f-4010-ba21" name="Infantry" primary="false"/>
-                <categoryLink targetId="9231-183c-b97b-63f9" id="3cb0-dbcb-43b6-aac6" name="Heavy" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="8087-417f-4010-ba21" name="Infantry Unit Type" primary="false"/>
+                <categoryLink targetId="9231-183c-b97b-63f9" id="3cb0-dbcb-43b6-aac6" name="Heavy Sub-type" primary="false"/>
               </categoryLinks>
             </selectionEntry>
             <selectionEntry id="d62c-34f4-876f-a499" name="Phalanx Warder w/Special Weapon (1 in 5)" hidden="false" collective="false" import="true" type="model">
@@ -4294,7 +4294,7 @@
         </infoLink>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="0f9a-794e-6027-b9cf" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="0f9a-794e-6027-b9cf" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="e5a6-f3dc-73de-2bdb" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
       </categoryLinks>
       <selectionEntries>
@@ -4347,9 +4347,9 @@
         <selectionEntry type="model" import="true" name="Sigismund" hidden="false" id="176e-535a-10ed-ee07">
           <categoryLinks>
             <categoryLink targetId="4f07-3d45-4f28-a0c6" id="d79e-835-28c1-4540" primary="false" name="Independent Character"/>
-            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="230b-cbb9-4124-9d75" name="Infantry" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="230b-cbb9-4124-9d75" name="Infantry Unit Type" primary="false"/>
             <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="71a1-2560-411c-9386" name="Character" primary="false"/>
-            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="c12b-ffec-47ec-8dc7" name="Unique" primary="false"/>
+            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="c12b-ffec-47ec-8dc7" name="Unique Sub-type" primary="false"/>
           </categoryLinks>
           <constraints>
             <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="6c4a-7b87-f844-27b"/>
@@ -4441,7 +4441,7 @@
         <infoLink id="8d96-6a4a-f91f-d21d" name="Legiones Astartes (Imperial Fists)" hidden="false" targetId="e876-4f8f-a30f-8b22" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="93db-ffc9-0558-73e6" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="93db-ffc9-0558-73e6" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="e823-f428-97c9-b5d7" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="7668-e167-087e-ec1a" name="Heavy Sub-type" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
       </categoryLinks>
@@ -4514,10 +4514,10 @@
         <selectionEntry type="model" import="true" name="Alexis Polux" hidden="false" id="b9c8-3956-2efc-6011">
           <categoryLinks>
             <categoryLink targetId="4f07-3d45-4f28-a0c6" id="5249-aa6b-28d-81d7" primary="false" name="Independent Character"/>
-            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="4c68-3553-43d9-90c0" name="Infantry" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="4c68-3553-43d9-90c0" name="Infantry Unit Type" primary="false"/>
             <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="8dba-79ae-43cf-87ad" name="Character" primary="false"/>
-            <categoryLink targetId="9231-183c-b97b-63f9" id="28b7-e876-420b-b1db" name="Heavy" primary="false"/>
-            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="7cbf-5425-407c-bb4d" name="Unique" primary="false"/>
+            <categoryLink targetId="9231-183c-b97b-63f9" id="28b7-e876-420b-b1db" name="Heavy Sub-type" primary="false"/>
+            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="7cbf-5425-407c-bb4d" name="Unique Sub-type" primary="false"/>
           </categoryLinks>
           <constraints>
             <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="6c4a-7b87-f844-27b"/>
@@ -4565,7 +4565,7 @@
         </infoLink>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="7d2a-1492-8056-3083" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="7d2a-1492-8056-3083" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="f860-72fd-d93c-1290" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="1715-31a2-3ed9-4522" name="Heavy Sub-type" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
       </categoryLinks>
@@ -4616,10 +4616,10 @@ Both weapons are counted as ‘Power’ weapons for those rules that affect such
         <selectionEntry type="model" import="true" name="Fafnir Rann" hidden="false" id="68ad-f39b-ff1-3129">
           <categoryLinks>
             <categoryLink targetId="4f07-3d45-4f28-a0c6" id="5056-89c0-c8c1-fda4" primary="false" name="Independent Character"/>
-            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="7c93-5b68-4a72-b2c4" name="Infantry" primary="false"/>
-            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="0ab1-36cd-4271-92c6" name="Unique" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="7c93-5b68-4a72-b2c4" name="Infantry Unit Type" primary="false"/>
+            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="0ab1-36cd-4271-92c6" name="Unique Sub-type" primary="false"/>
             <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="6639-dbb4-4738-9061" name="Character" primary="false"/>
-            <categoryLink targetId="9231-183c-b97b-63f9" id="dcca-84d5-49f4-96a5" name="Heavy" primary="false"/>
+            <categoryLink targetId="9231-183c-b97b-63f9" id="dcca-84d5-49f4-96a5" name="Heavy Sub-type" primary="false"/>
           </categoryLinks>
           <constraints>
             <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="6c4a-7b87-f844-27b"/>
@@ -4715,7 +4715,7 @@ Both weapons are counted as ‘Power’ weapons for those rules that affect such
         </infoLink>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="cb18-a58d-6e9d-83c8" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="cb18-a58d-6e9d-83c8" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="a39f-1c2d-1a53-289b" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
       </categoryLinks>
       <selectionEntries>
@@ -4743,7 +4743,7 @@ Both weapons are counted as ‘Power’ weapons for those rules that affect such
           </profiles>
           <categoryLinks>
             <categoryLink id="f4ea-6f45-96bc-414b" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
-            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="bb9d-8c85-43e2-97de" name="Infantry" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="bb9d-8c85-43e2-97de" name="Infantry Unit Type" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="c926-b781-4ed2-a1eb" name="Bolt Pistol Options" hidden="false" collective="false" import="true" defaultSelectionEntryId="3187-e170-646a-9c41">
@@ -4864,7 +4864,7 @@ Both weapons are counted as ‘Power’ weapons for those rules that affect such
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25"/>
           </costs>
           <categoryLinks>
-            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="ae42-2edf-4d62-ab0f" name="Infantry" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="ae42-2edf-4d62-ab0f" name="Infantry Unit Type" primary="false"/>
           </categoryLinks>
         </selectionEntry>
       </selectionEntries>
@@ -5198,8 +5198,8 @@ Both weapons are counted as ‘Power’ weapons for those rules that affect such
         <selectionEntry type="model" import="true" name="Rogal Dorn" hidden="false" id="3ae1-8a20-2105-6412">
           <categoryLinks>
             <categoryLink targetId="4f07-3d45-4f28-a0c6" id="1f17-6de2-5b9b-7ac3" primary="false" name="Independent Character"/>
-            <categoryLink targetId="ad5f-31db-8bc7-5c46" id="f029-9448-404f-ae32" name="Primarch" primary="false"/>
-            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="f116-a066-47cf-8359" name="Unique" primary="false"/>
+            <categoryLink targetId="ad5f-31db-8bc7-5c46" id="f029-9448-404f-ae32" name="Primarch:" primary="false"/>
+            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="f116-a066-47cf-8359" name="Unique Sub-type" primary="false"/>
           </categoryLinks>
           <constraints>
             <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="6c4a-7b87-f844-27b"/>
@@ -5277,7 +5277,7 @@ Both weapons are counted as ‘Power’ weapons for those rules that affect such
       <categoryLinks>
         <categoryLink id="9c2c-a3a7-f173-2fd3" name="Heavy Sub-type" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
         <categoryLink id="1611-1fbf-b28d-082b" name="Terminators:" hidden="false" targetId="bab3-f50d-3e5f-2f78" primary="false"/>
-        <categoryLink id="7d8a-f02e-04ca-e7e6" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="7d8a-f02e-04ca-e7e6" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="c04e-d6da-5531-7c3a" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="63f9-edc7-8dbe-a89d" name="Deep Strike:" hidden="false" targetId="0d4f-ff28-d819-a512" primary="false"/>
       </categoryLinks>
@@ -5306,8 +5306,8 @@ Both weapons are counted as ‘Power’ weapons for those rules that affect such
           </profiles>
           <categoryLinks>
             <categoryLink id="229e-c226-4feb-c31d" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
-            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="66a2-c25d-49aa-b931" name="Infantry" primary="false"/>
-            <categoryLink targetId="9231-183c-b97b-63f9" id="edc0-a244-4e18-a601" name="Heavy" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="66a2-c25d-49aa-b931" name="Infantry Unit Type" primary="false"/>
+            <categoryLink targetId="9231-183c-b97b-63f9" id="edc0-a244-4e18-a601" name="Heavy Sub-type" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="94fa-0bcd-69d0-d2ad" name="Melee Weapon Choice:" hidden="false" collective="false" import="true" defaultSelectionEntryId="4f2d-84c0-97b0-f8b2">
@@ -5421,8 +5421,8 @@ Both weapons are counted as ‘Power’ weapons for those rules that affect such
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="50"/>
               </costs>
               <categoryLinks>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="bdd7-fb01-4feb-bd9e" name="Infantry" primary="false"/>
-                <categoryLink targetId="9231-183c-b97b-63f9" id="f154-a3d5-408a-87ca" name="Heavy" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="bdd7-fb01-4feb-bd9e" name="Infantry Unit Type" primary="false"/>
+                <categoryLink targetId="9231-183c-b97b-63f9" id="f154-a3d5-408a-87ca" name="Heavy Sub-type" primary="false"/>
               </categoryLinks>
             </selectionEntry>
             <selectionEntry id="9f54-f812-8da1-06f8" name="Huscarl w/Solarite Power Gauntlet" hidden="false" collective="false" import="true" type="model">
@@ -5453,8 +5453,8 @@ Both weapons are counted as ‘Power’ weapons for those rules that affect such
                 <infoLink id="3938-5546-4320-655d" name="Huscarl" targetId="490c-e5a9-2298-9772" type="profile"/>
               </infoLinks>
               <categoryLinks>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="e029-db1e-4b8a-a3b1" name="Infantry" primary="false"/>
-                <categoryLink targetId="9231-183c-b97b-63f9" id="2fbe-07d1-429c-8d6a" name="Heavy" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="e029-db1e-4b8a-a3b1" name="Infantry Unit Type" primary="false"/>
+                <categoryLink targetId="9231-183c-b97b-63f9" id="2fbe-07d1-429c-8d6a" name="Heavy Sub-type" primary="false"/>
               </categoryLinks>
             </selectionEntry>
             <selectionEntry id="79c5-4c2d-9c5a-1264" name="Huscarl w/Power Maul" hidden="false" collective="false" import="true" type="model">
@@ -5482,8 +5482,8 @@ Both weapons are counted as ‘Power’ weapons for those rules that affect such
                 <infoLink id="3f69-775b-8c17-1dd5" name="Huscarl" targetId="490c-e5a9-2298-9772" type="profile"/>
               </infoLinks>
               <categoryLinks>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="e187-8ae4-482e-9e54" name="Infantry" primary="false"/>
-                <categoryLink targetId="9231-183c-b97b-63f9" id="2897-869b-4d10-9c70" name="Heavy" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="e187-8ae4-482e-9e54" name="Infantry Unit Type" primary="false"/>
+                <categoryLink targetId="9231-183c-b97b-63f9" id="2897-869b-4d10-9c70" name="Heavy Sub-type" primary="false"/>
               </categoryLinks>
             </selectionEntry>
             <selectionEntry id="f4df-5a23-421b-f605" name="Huscarl w/Power Lance" hidden="false" collective="false" import="true" type="model">
@@ -5511,8 +5511,8 @@ Both weapons are counted as ‘Power’ weapons for those rules that affect such
                 <infoLink id="3a86-76df-edbf-a484" name="Huscarl" targetId="490c-e5a9-2298-9772" type="profile"/>
               </infoLinks>
               <categoryLinks>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="7cfa-11cc-47ae-a11b" name="Infantry" primary="false"/>
-                <categoryLink targetId="9231-183c-b97b-63f9" id="58bc-a849-489b-a8f2" name="Heavy" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="7cfa-11cc-47ae-a11b" name="Infantry Unit Type" primary="false"/>
+                <categoryLink targetId="9231-183c-b97b-63f9" id="58bc-a849-489b-a8f2" name="Heavy Sub-type" primary="false"/>
               </categoryLinks>
             </selectionEntry>
             <selectionEntry id="9320-8138-b8d2-9717" name="Huscarl w/Power Axe" hidden="false" collective="false" import="true" type="model">
@@ -5540,8 +5540,8 @@ Both weapons are counted as ‘Power’ weapons for those rules that affect such
                 <infoLink id="9c57-bfd1-0da3-03a3" name="Huscarl" targetId="490c-e5a9-2298-9772" type="profile"/>
               </infoLinks>
               <categoryLinks>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="0cc9-f843-40da-935b" name="Infantry" primary="false"/>
-                <categoryLink targetId="9231-183c-b97b-63f9" id="5185-bf91-4ad6-8d23" name="Heavy" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="0cc9-f843-40da-935b" name="Infantry Unit Type" primary="false"/>
+                <categoryLink targetId="9231-183c-b97b-63f9" id="5185-bf91-4ad6-8d23" name="Heavy Sub-type" primary="false"/>
               </categoryLinks>
             </selectionEntry>
           </selectionEntries>
@@ -5733,7 +5733,7 @@ A model with a Vigil storm shield gains a 3+ Invulnerable Save – Invulnerable 
       </infoLinks>
       <categoryLinks>
         <categoryLink id="c6ac-384a-7358-248d" name="Heavy Sub-type" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
-        <categoryLink id="9e03-5b35-e7b8-fd61" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="9e03-5b35-e7b8-fd61" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="91fc-cbe5-c635-605b" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
       </categoryLinks>
       <selectionEntries>
@@ -5809,10 +5809,10 @@ A model with a Vigil storm shield gains a 3+ Invulnerable Save – Invulnerable 
         <selectionEntry type="model" import="true" name="Lord-Castellan Evander Garrius" hidden="false" id="3b93-5d39-1c1c-e45b">
           <categoryLinks>
             <categoryLink targetId="4f07-3d45-4f28-a0c6" id="35dd-9027-18a4-b333" primary="false" name="Independent Character"/>
-            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="a920-20a7-4002-9575" name="Infantry" primary="false"/>
-            <categoryLink targetId="9231-183c-b97b-63f9" id="f529-b8ac-4837-8d57" name="Heavy" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="a920-20a7-4002-9575" name="Infantry Unit Type" primary="false"/>
+            <categoryLink targetId="9231-183c-b97b-63f9" id="f529-b8ac-4837-8d57" name="Heavy Sub-type" primary="false"/>
             <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="7567-d702-442a-b366" name="Character" primary="false"/>
-            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="01d4-4a1a-4d74-a5e5" name="Unique" primary="false"/>
+            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="01d4-4a1a-4d74-a5e5" name="Unique Sub-type" primary="false"/>
           </categoryLinks>
           <constraints>
             <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="6c4a-7b87-f844-27b"/>

--- a/2022 - LA - Imperial Fists.cat
+++ b/2022 - LA - Imperial Fists.cat
@@ -3831,6 +3831,8 @@
           </profiles>
           <categoryLinks>
             <categoryLink id="fdf2-f339-3520-8788" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="80b4-a436-4edd-b846" name="Infantry" primary="false"/>
+            <categoryLink targetId="9231-183c-b97b-63f9" id="612c-6c3c-4486-b096" name="Heavy" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="1cc8-ac5c-b5c2-b7ad" name="Weapon Options:" hidden="false" collective="false" import="true">
@@ -4121,6 +4123,10 @@
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20"/>
               </costs>
+              <categoryLinks>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="8087-417f-4010-ba21" name="Infantry" primary="false"/>
+                <categoryLink targetId="9231-183c-b97b-63f9" id="3cb0-dbcb-43b6-aac6" name="Heavy" primary="false"/>
+              </categoryLinks>
             </selectionEntry>
             <selectionEntry id="d62c-34f4-876f-a499" name="Phalanx Warder w/Special Weapon (1 in 5)" hidden="false" collective="false" import="true" type="model">
               <modifiers>
@@ -4341,6 +4347,9 @@
         <selectionEntry type="model" import="true" name="Sigismund" hidden="false" id="176e-535a-10ed-ee07">
           <categoryLinks>
             <categoryLink targetId="4f07-3d45-4f28-a0c6" id="d79e-835-28c1-4540" primary="false" name="Independent Character"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="230b-cbb9-4124-9d75" name="Infantry" primary="false"/>
+            <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="71a1-2560-411c-9386" name="Character" primary="false"/>
+            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="c12b-ffec-47ec-8dc7" name="Unique" primary="false"/>
           </categoryLinks>
           <constraints>
             <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="6c4a-7b87-f844-27b"/>
@@ -4505,6 +4514,10 @@
         <selectionEntry type="model" import="true" name="Alexis Polux" hidden="false" id="b9c8-3956-2efc-6011">
           <categoryLinks>
             <categoryLink targetId="4f07-3d45-4f28-a0c6" id="5249-aa6b-28d-81d7" primary="false" name="Independent Character"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="4c68-3553-43d9-90c0" name="Infantry" primary="false"/>
+            <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="8dba-79ae-43cf-87ad" name="Character" primary="false"/>
+            <categoryLink targetId="9231-183c-b97b-63f9" id="28b7-e876-420b-b1db" name="Heavy" primary="false"/>
+            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="7cbf-5425-407c-bb4d" name="Unique" primary="false"/>
           </categoryLinks>
           <constraints>
             <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="6c4a-7b87-f844-27b"/>
@@ -4603,6 +4616,10 @@ Both weapons are counted as ‘Power’ weapons for those rules that affect such
         <selectionEntry type="model" import="true" name="Fafnir Rann" hidden="false" id="68ad-f39b-ff1-3129">
           <categoryLinks>
             <categoryLink targetId="4f07-3d45-4f28-a0c6" id="5056-89c0-c8c1-fda4" primary="false" name="Independent Character"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="7c93-5b68-4a72-b2c4" name="Infantry" primary="false"/>
+            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="0ab1-36cd-4271-92c6" name="Unique" primary="false"/>
+            <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="6639-dbb4-4738-9061" name="Character" primary="false"/>
+            <categoryLink targetId="9231-183c-b97b-63f9" id="dcca-84d5-49f4-96a5" name="Heavy" primary="false"/>
           </categoryLinks>
           <constraints>
             <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="6c4a-7b87-f844-27b"/>
@@ -4726,6 +4743,7 @@ Both weapons are counted as ‘Power’ weapons for those rules that affect such
           </profiles>
           <categoryLinks>
             <categoryLink id="f4ea-6f45-96bc-414b" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="bb9d-8c85-43e2-97de" name="Infantry" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="c926-b781-4ed2-a1eb" name="Bolt Pistol Options" hidden="false" collective="false" import="true" defaultSelectionEntryId="3187-e170-646a-9c41">
@@ -4845,6 +4863,9 @@ Both weapons are counted as ‘Power’ weapons for those rules that affect such
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25"/>
           </costs>
+          <categoryLinks>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="ae42-2edf-4d62-ab0f" name="Infantry" primary="false"/>
+          </categoryLinks>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
@@ -5177,6 +5198,8 @@ Both weapons are counted as ‘Power’ weapons for those rules that affect such
         <selectionEntry type="model" import="true" name="Rogal Dorn" hidden="false" id="3ae1-8a20-2105-6412">
           <categoryLinks>
             <categoryLink targetId="4f07-3d45-4f28-a0c6" id="1f17-6de2-5b9b-7ac3" primary="false" name="Independent Character"/>
+            <categoryLink targetId="ad5f-31db-8bc7-5c46" id="f029-9448-404f-ae32" name="Primarch" primary="false"/>
+            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="f116-a066-47cf-8359" name="Unique" primary="false"/>
           </categoryLinks>
           <constraints>
             <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="6c4a-7b87-f844-27b"/>
@@ -5283,6 +5306,8 @@ Both weapons are counted as ‘Power’ weapons for those rules that affect such
           </profiles>
           <categoryLinks>
             <categoryLink id="229e-c226-4feb-c31d" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="66a2-c25d-49aa-b931" name="Infantry" primary="false"/>
+            <categoryLink targetId="9231-183c-b97b-63f9" id="edc0-a244-4e18-a601" name="Heavy" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="94fa-0bcd-69d0-d2ad" name="Melee Weapon Choice:" hidden="false" collective="false" import="true" defaultSelectionEntryId="4f2d-84c0-97b0-f8b2">
@@ -5395,6 +5420,10 @@ Both weapons are counted as ‘Power’ weapons for those rules that affect such
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="50"/>
               </costs>
+              <categoryLinks>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="bdd7-fb01-4feb-bd9e" name="Infantry" primary="false"/>
+                <categoryLink targetId="9231-183c-b97b-63f9" id="f154-a3d5-408a-87ca" name="Heavy" primary="false"/>
+              </categoryLinks>
             </selectionEntry>
             <selectionEntry id="9f54-f812-8da1-06f8" name="Huscarl w/Solarite Power Gauntlet" hidden="false" collective="false" import="true" type="model">
               <entryLinks>
@@ -5423,6 +5452,10 @@ Both weapons are counted as ‘Power’ weapons for those rules that affect such
               <infoLinks>
                 <infoLink id="3938-5546-4320-655d" name="Huscarl" targetId="490c-e5a9-2298-9772" type="profile"/>
               </infoLinks>
+              <categoryLinks>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="e029-db1e-4b8a-a3b1" name="Infantry" primary="false"/>
+                <categoryLink targetId="9231-183c-b97b-63f9" id="2fbe-07d1-429c-8d6a" name="Heavy" primary="false"/>
+              </categoryLinks>
             </selectionEntry>
             <selectionEntry id="79c5-4c2d-9c5a-1264" name="Huscarl w/Power Maul" hidden="false" collective="false" import="true" type="model">
               <entryLinks>
@@ -5448,6 +5481,10 @@ Both weapons are counted as ‘Power’ weapons for those rules that affect such
               <infoLinks>
                 <infoLink id="3f69-775b-8c17-1dd5" name="Huscarl" targetId="490c-e5a9-2298-9772" type="profile"/>
               </infoLinks>
+              <categoryLinks>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="e187-8ae4-482e-9e54" name="Infantry" primary="false"/>
+                <categoryLink targetId="9231-183c-b97b-63f9" id="2897-869b-4d10-9c70" name="Heavy" primary="false"/>
+              </categoryLinks>
             </selectionEntry>
             <selectionEntry id="f4df-5a23-421b-f605" name="Huscarl w/Power Lance" hidden="false" collective="false" import="true" type="model">
               <entryLinks>
@@ -5473,6 +5510,10 @@ Both weapons are counted as ‘Power’ weapons for those rules that affect such
               <infoLinks>
                 <infoLink id="3a86-76df-edbf-a484" name="Huscarl" targetId="490c-e5a9-2298-9772" type="profile"/>
               </infoLinks>
+              <categoryLinks>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="7cfa-11cc-47ae-a11b" name="Infantry" primary="false"/>
+                <categoryLink targetId="9231-183c-b97b-63f9" id="58bc-a849-489b-a8f2" name="Heavy" primary="false"/>
+              </categoryLinks>
             </selectionEntry>
             <selectionEntry id="9320-8138-b8d2-9717" name="Huscarl w/Power Axe" hidden="false" collective="false" import="true" type="model">
               <entryLinks>
@@ -5498,6 +5539,10 @@ Both weapons are counted as ‘Power’ weapons for those rules that affect such
               <infoLinks>
                 <infoLink id="9c57-bfd1-0da3-03a3" name="Huscarl" targetId="490c-e5a9-2298-9772" type="profile"/>
               </infoLinks>
+              <categoryLinks>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="0cc9-f843-40da-935b" name="Infantry" primary="false"/>
+                <categoryLink targetId="9231-183c-b97b-63f9" id="5185-bf91-4ad6-8d23" name="Heavy" primary="false"/>
+              </categoryLinks>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
@@ -5764,6 +5809,10 @@ A model with a Vigil storm shield gains a 3+ Invulnerable Save – Invulnerable 
         <selectionEntry type="model" import="true" name="Lord-Castellan Evander Garrius" hidden="false" id="3b93-5d39-1c1c-e45b">
           <categoryLinks>
             <categoryLink targetId="4f07-3d45-4f28-a0c6" id="35dd-9027-18a4-b333" primary="false" name="Independent Character"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="a920-20a7-4002-9575" name="Infantry" primary="false"/>
+            <categoryLink targetId="9231-183c-b97b-63f9" id="f529-b8ac-4837-8d57" name="Heavy" primary="false"/>
+            <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="7567-d702-442a-b366" name="Character" primary="false"/>
+            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="01d4-4a1a-4d74-a5e5" name="Unique" primary="false"/>
           </categoryLinks>
           <constraints>
             <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="6c4a-7b87-f844-27b"/>

--- a/2022 - LA - Iron Hands.cat
+++ b/2022 - LA - Iron Hands.cat
@@ -2663,7 +2663,7 @@
       <categoryLinks>
         <categoryLink id="63ff-0a92-42ab-ae8c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="204c-7b0f-4fb9-b1b3" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="85e6-cb31-427c-a040" name="Line Sub-type:" hidden="false" targetId="6399-5c65-7833-1025" primary="false"/>
+        <categoryLink id="85e6-cb31-427c-a040" name="Line Sub-type" hidden="false" targetId="6399-5c65-7833-1025" primary="false"/>
         <categoryLink id="7e11-9f14-3960-d32c" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -2953,7 +2953,7 @@
         <categoryLink id="d344-03de-8f50-c08d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="ab40-f905-6161-4440" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
         <categoryLink id="b76f-f82b-7dc1-8a34" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="b57b-698b-f6ad-836d" name="Line Sub-type:" hidden="false" targetId="6399-5c65-7833-1025" primary="false"/>
+        <categoryLink id="b57b-698b-f6ad-836d" name="Line Sub-type" hidden="false" targetId="6399-5c65-7833-1025" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="1082-e4bd-76a0-9dce" name="Castellax Battle-Automata Maniple" hidden="true" collective="false" import="false" targetId="537f-846d-90e3-2526" type="selectionEntry">
@@ -3015,7 +3015,7 @@
         <infoLink id="db91-3a2e-46b5-3998" name="Stubborn" hidden="false" targetId="7989-1f2c-a43d-82ae" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="9593-8dda-915e-8ef4" name="Heavy Sub-type:" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+        <categoryLink id="9593-8dda-915e-8ef4" name="Heavy Sub-type" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
         <categoryLink id="0de3-d934-b836-a40c" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="5df3-9231-c29a-5bf6" name="Terminators:" hidden="false" targetId="bab3-f50d-3e5f-2f78" primary="false"/>
         <categoryLink id="9bfa-f05f-d04f-e983" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
@@ -3437,7 +3437,7 @@
       </infoLinks>
       <categoryLinks>
         <categoryLink id="922a-9c91-509f-36fd" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="b0a0-c02f-f97d-8b78" name="Heavy Sub-type:" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+        <categoryLink id="b0a0-c02f-f97d-8b78" name="Heavy Sub-type" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
         <categoryLink id="221e-a4f5-b097-1747" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
       </categoryLinks>
       <selectionEntries>
@@ -3471,7 +3471,7 @@
             </profile>
           </profiles>
           <categoryLinks>
-            <categoryLink id="ce14-5b51-ca57-a479" name="Heavy Sub-type:" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+            <categoryLink id="ce14-5b51-ca57-a479" name="Heavy Sub-type" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
             <categoryLink id="3981-f592-d5f7-9f94" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
             <categoryLink id="ecc9-de7f-c8ba-d75a" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
           </categoryLinks>
@@ -3779,7 +3779,7 @@
                 </profile>
               </profiles>
               <categoryLinks>
-                <categoryLink id="49a1-da73-5b34-36d5" name="Heavy Sub-type:" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+                <categoryLink id="49a1-da73-5b34-36d5" name="Heavy Sub-type" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
                 <categoryLink id="8046-11c0-741f-8507" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
               </categoryLinks>
               <selectionEntryGroups>
@@ -3941,7 +3941,7 @@
       </constraints>
       <categoryLinks>
         <categoryLink id="9014-262a-9067-0e59" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="d7ac-8652-d9dd-8de6" name="Heavy Sub-type:" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+        <categoryLink id="d7ac-8652-d9dd-8de6" name="Heavy Sub-type" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
         <categoryLink id="4ea5-44d6-046c-15da" name="LoW &amp; Primarchs (25% Limit)" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false"/>
       </categoryLinks>
       <selectionEntries>
@@ -4496,7 +4496,7 @@
         </infoLink>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="71b4-5391-0fcd-1895" name="Heavy Sub-type:" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+        <categoryLink id="71b4-5391-0fcd-1895" name="Heavy Sub-type" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
         <categoryLink id="c0fb-ead3-73f4-5d1f" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="ceae-48fa-ca03-9bae" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
       </categoryLinks>

--- a/2022 - LA - Iron Hands.cat
+++ b/2022 - LA - Iron Hands.cat
@@ -3016,7 +3016,7 @@
       </infoLinks>
       <categoryLinks>
         <categoryLink id="9593-8dda-915e-8ef4" name="Heavy Sub-type" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
-        <categoryLink id="0de3-d934-b836-a40c" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="0de3-d934-b836-a40c" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="5df3-9231-c29a-5bf6" name="Terminators:" hidden="false" targetId="bab3-f50d-3e5f-2f78" primary="false"/>
         <categoryLink id="9bfa-f05f-d04f-e983" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
       </categoryLinks>
@@ -3128,9 +3128,9 @@
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="35"/>
           </costs>
           <categoryLinks>
-            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="0bbe-0861-452c-9b37" name="Infantry" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="0bbe-0861-452c-9b37" name="Infantry Unit Type" primary="false"/>
             <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="aa46-9d3c-4edc-af47" name="Character" primary="false"/>
-            <categoryLink targetId="9231-183c-b97b-63f9" id="b204-8112-41e6-bf2f" name="Heavy" primary="false"/>
+            <categoryLink targetId="9231-183c-b97b-63f9" id="b204-8112-41e6-bf2f" name="Heavy Sub-type" primary="false"/>
           </categoryLinks>
         </selectionEntry>
       </selectionEntries>
@@ -3299,8 +3299,8 @@
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="35"/>
               </costs>
               <categoryLinks>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="b538-72ff-42de-93c3" name="Infantry" primary="false"/>
-                <categoryLink targetId="9231-183c-b97b-63f9" id="2855-aa1f-4ba1-8a3e" name="Heavy" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="b538-72ff-42de-93c3" name="Infantry Unit Type" primary="false"/>
+                <categoryLink targetId="9231-183c-b97b-63f9" id="2855-aa1f-4ba1-8a3e" name="Heavy Sub-type" primary="false"/>
               </categoryLinks>
             </selectionEntry>
             <selectionEntry id="c51d-6b5f-3efe-8aef" name="Gorgon Terminator w/Heavy Weapon" hidden="false" collective="false" import="true" type="model">
@@ -3380,8 +3380,8 @@
                 <infoLink id="8aa5-59cd-1ca2-3b03" name="Gorgon Terminator" targetId="58e9-f8f4-e13f-1586" type="profile"/>
               </infoLinks>
               <categoryLinks>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="7a63-bd3e-4cf5-9be2" name="Infantry" primary="false"/>
-                <categoryLink targetId="9231-183c-b97b-63f9" id="cd6a-ab8d-46bd-ab8d" name="Heavy" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="7a63-bd3e-4cf5-9be2" name="Infantry Unit Type" primary="false"/>
+                <categoryLink targetId="9231-183c-b97b-63f9" id="cd6a-ab8d-46bd-ab8d" name="Heavy Sub-type" primary="false"/>
               </categoryLinks>
             </selectionEntry>
           </selectionEntries>
@@ -3438,7 +3438,7 @@
       <categoryLinks>
         <categoryLink id="922a-9c91-509f-36fd" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="b0a0-c02f-f97d-8b78" name="Heavy Sub-type" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
-        <categoryLink id="221e-a4f5-b097-1747" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="221e-a4f5-b097-1747" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="c831-444b-9325-de3b" name="Immortal Sergeant" hidden="false" collective="false" import="true" type="model">
@@ -3472,7 +3472,7 @@
           </profiles>
           <categoryLinks>
             <categoryLink id="ce14-5b51-ca57-a479" name="Heavy Sub-type" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
-            <categoryLink id="3981-f592-d5f7-9f94" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+            <categoryLink id="3981-f592-d5f7-9f94" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
             <categoryLink id="ecc9-de7f-c8ba-d75a" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
@@ -3780,7 +3780,7 @@
               </profiles>
               <categoryLinks>
                 <categoryLink id="49a1-da73-5b34-36d5" name="Heavy Sub-type" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
-                <categoryLink id="8046-11c0-741f-8507" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+                <categoryLink id="8046-11c0-741f-8507" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
               </categoryLinks>
               <selectionEntryGroups>
                 <selectionEntryGroup id="5c24-cc99-00cd-564a" name="Heavy Weapon Options:" hidden="false" collective="false" import="true" defaultSelectionEntryId="2fcc-c821-e9de-ad5b">
@@ -3851,8 +3851,8 @@
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="18"/>
               </costs>
               <categoryLinks>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="9283-1898-4a3b-8f5f" name="Infantry" primary="false"/>
-                <categoryLink targetId="9231-183c-b97b-63f9" id="8350-35d1-49db-8dbc" name="Heavy" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="9283-1898-4a3b-8f5f" name="Infantry Unit Type" primary="false"/>
+                <categoryLink targetId="9231-183c-b97b-63f9" id="8350-35d1-49db-8dbc" name="Heavy Sub-type" primary="false"/>
               </categoryLinks>
             </selectionEntry>
             <selectionEntry id="e55b-24af-5f9c-7361" name="Immortal w/Volkite Charger" hidden="false" collective="false" import="true" type="model">
@@ -3871,8 +3871,8 @@
                 <infoLink id="6fa8-1f26-ebc5-6645" name="Immortal" targetId="732a-01c0-7487-7dcd" type="profile"/>
               </infoLinks>
               <categoryLinks>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="cb3b-dde2-4e01-8410" name="Infantry" primary="false"/>
-                <categoryLink targetId="9231-183c-b97b-63f9" id="1d13-8d3b-4e4b-84f1" name="Heavy" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="cb3b-dde2-4e01-8410" name="Infantry Unit Type" primary="false"/>
+                <categoryLink targetId="9231-183c-b97b-63f9" id="1d13-8d3b-4e4b-84f1" name="Heavy Sub-type" primary="false"/>
               </categoryLinks>
             </selectionEntry>
             <selectionEntry id="f562-5d9a-3e00-a74d" name="Immortal w/Chainsword" hidden="false" collective="false" import="true" type="model">
@@ -3891,8 +3891,8 @@
                 <infoLink id="957c-9555-da93-5733" name="Immortal" targetId="732a-01c0-7487-7dcd" type="profile"/>
               </infoLinks>
               <categoryLinks>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="6722-3703-44aa-b715" name="Infantry" primary="false"/>
-                <categoryLink targetId="9231-183c-b97b-63f9" id="cb21-f8e9-42df-9850" name="Heavy" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="6722-3703-44aa-b715" name="Infantry Unit Type" primary="false"/>
+                <categoryLink targetId="9231-183c-b97b-63f9" id="cb21-f8e9-42df-9850" name="Heavy Sub-type" primary="false"/>
               </categoryLinks>
             </selectionEntry>
           </selectionEntries>
@@ -4111,9 +4111,9 @@
           </costs>
           <categoryLinks>
             <categoryLink targetId="4f07-3d45-4f28-a0c6" id="8d7f-5602-649d-caf9" primary="false" name="Independent Character"/>
-            <categoryLink targetId="ad5f-31db-8bc7-5c46" id="84d8-8195-4d0a-ad94" name="Primarch" primary="false"/>
-            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="5d48-8047-4478-8ae2" name="Unique" primary="false"/>
-            <categoryLink targetId="9231-183c-b97b-63f9" id="2f2e-1ab7-4b48-94e7" name="Heavy" primary="false"/>
+            <categoryLink targetId="ad5f-31db-8bc7-5c46" id="84d8-8195-4d0a-ad94" name="Primarch:" primary="false"/>
+            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="5d48-8047-4478-8ae2" name="Unique Sub-type" primary="false"/>
+            <categoryLink targetId="9231-183c-b97b-63f9" id="2f2e-1ab7-4b48-94e7" name="Heavy Sub-type" primary="false"/>
           </categoryLinks>
         </selectionEntry>
       </selectionEntries>
@@ -4149,7 +4149,7 @@
       </constraints>
       <categoryLinks>
         <categoryLink id="4cb3-dd41-3d7c-685e" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="d41e-871d-300d-cb4b" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="d41e-871d-300d-cb4b" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="9aef-f396-b30d-8cd0" name="Iron Father Autek Mor" hidden="false" collective="false" import="true" type="model">
@@ -4279,10 +4279,10 @@
           </costs>
           <categoryLinks>
             <categoryLink targetId="4f07-3d45-4f28-a0c6" id="10a3-af9e-3a71-3e5f" primary="false" name="Independent Character"/>
-            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="5547-9343-4f25-9df1" name="Infantry" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="5547-9343-4f25-9df1" name="Infantry Unit Type" primary="false"/>
             <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="6370-7cb3-45e5-ab8e" name="Character" primary="false"/>
-            <categoryLink targetId="9231-183c-b97b-63f9" id="49b9-2448-497f-9f40" name="Heavy" primary="false"/>
-            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="dee0-8ff6-489f-997b" name="Unique" primary="false"/>
+            <categoryLink targetId="9231-183c-b97b-63f9" id="49b9-2448-497f-9f40" name="Heavy Sub-type" primary="false"/>
+            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="dee0-8ff6-489f-997b" name="Unique Sub-type" primary="false"/>
           </categoryLinks>
         </selectionEntry>
       </selectionEntries>
@@ -4314,7 +4314,7 @@
       </constraints>
       <categoryLinks>
         <categoryLink id="b22b-21c0-8c4b-d804" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="87be-a40d-63fe-1eed" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="87be-a40d-63fe-1eed" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="94ef-185a-f5bc-cc1c" name="Shadrak Meduson" hidden="false" collective="false" import="true" type="model">
@@ -4414,9 +4414,9 @@
           </costs>
           <categoryLinks>
             <categoryLink targetId="4f07-3d45-4f28-a0c6" id="d21b-f1ff-43a-257" primary="false" name="Independent Character"/>
-            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="298f-b27b-491c-b7b6" name="Infantry" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="298f-b27b-491c-b7b6" name="Infantry Unit Type" primary="false"/>
             <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="5136-1641-4f99-ad6b" name="Character" primary="false"/>
-            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="6f88-0cfb-4d34-88c0" name="Unique" primary="false"/>
+            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="6f88-0cfb-4d34-88c0" name="Unique Sub-type" primary="false"/>
           </categoryLinks>
         </selectionEntry>
       </selectionEntries>
@@ -4498,7 +4498,7 @@
       <categoryLinks>
         <categoryLink id="71b4-5391-0fcd-1895" name="Heavy Sub-type" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
         <categoryLink id="c0fb-ead3-73f4-5d1f" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="ceae-48fa-ca03-9bae" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="ceae-48fa-ca03-9bae" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="c5a8-4c26-20f2-0cd0" name="1) Augmentor" hidden="false" collective="false" import="true" type="model">
@@ -4525,8 +4525,8 @@
           </profiles>
           <categoryLinks>
             <categoryLink id="da97-e1b8-c646-120c" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
-            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="f9cf-6751-4c4c-aa32" name="Infantry" primary="false"/>
-            <categoryLink targetId="9231-183c-b97b-63f9" id="f38b-d081-430f-b8e1" name="Heavy" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="f9cf-6751-4c4c-aa32" name="Infantry Unit Type" primary="false"/>
+            <categoryLink targetId="9231-183c-b97b-63f9" id="f38b-d081-430f-b8e1" name="Heavy Sub-type" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="bd3e-1ba0-9ac5-1aae" name="2) Melee Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="4269-df49-cd32-edaf">
@@ -4720,8 +4720,8 @@
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="35"/>
           </costs>
           <categoryLinks>
-            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="2764-1e4f-4c54-a618" name="Infantry" primary="false"/>
-            <categoryLink targetId="9231-183c-b97b-63f9" id="041d-0af9-4fd3-9455" name="Heavy" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="2764-1e4f-4c54-a618" name="Infantry Unit Type" primary="false"/>
+            <categoryLink targetId="9231-183c-b97b-63f9" id="041d-0af9-4fd3-9455" name="Heavy Sub-type" primary="false"/>
           </categoryLinks>
         </selectionEntry>
       </selectionEntries>

--- a/2022 - LA - Iron Hands.cat
+++ b/2022 - LA - Iron Hands.cat
@@ -3127,6 +3127,11 @@
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="35"/>
           </costs>
+          <categoryLinks>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="0bbe-0861-452c-9b37" name="Infantry" primary="false"/>
+            <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="aa46-9d3c-4edc-af47" name="Character" primary="false"/>
+            <categoryLink targetId="9231-183c-b97b-63f9" id="b204-8112-41e6-bf2f" name="Heavy" primary="false"/>
+          </categoryLinks>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
@@ -3293,6 +3298,10 @@
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="35"/>
               </costs>
+              <categoryLinks>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="b538-72ff-42de-93c3" name="Infantry" primary="false"/>
+                <categoryLink targetId="9231-183c-b97b-63f9" id="2855-aa1f-4ba1-8a3e" name="Heavy" primary="false"/>
+              </categoryLinks>
             </selectionEntry>
             <selectionEntry id="c51d-6b5f-3efe-8aef" name="Gorgon Terminator w/Heavy Weapon" hidden="false" collective="false" import="true" type="model">
               <modifiers>
@@ -3370,6 +3379,10 @@
               <infoLinks>
                 <infoLink id="8aa5-59cd-1ca2-3b03" name="Gorgon Terminator" targetId="58e9-f8f4-e13f-1586" type="profile"/>
               </infoLinks>
+              <categoryLinks>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="7a63-bd3e-4cf5-9be2" name="Infantry" primary="false"/>
+                <categoryLink targetId="9231-183c-b97b-63f9" id="cd6a-ab8d-46bd-ab8d" name="Heavy" primary="false"/>
+              </categoryLinks>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
@@ -3837,6 +3850,10 @@
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="18"/>
               </costs>
+              <categoryLinks>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="9283-1898-4a3b-8f5f" name="Infantry" primary="false"/>
+                <categoryLink targetId="9231-183c-b97b-63f9" id="8350-35d1-49db-8dbc" name="Heavy" primary="false"/>
+              </categoryLinks>
             </selectionEntry>
             <selectionEntry id="e55b-24af-5f9c-7361" name="Immortal w/Volkite Charger" hidden="false" collective="false" import="true" type="model">
               <entryLinks>
@@ -3853,6 +3870,10 @@
               <infoLinks>
                 <infoLink id="6fa8-1f26-ebc5-6645" name="Immortal" targetId="732a-01c0-7487-7dcd" type="profile"/>
               </infoLinks>
+              <categoryLinks>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="cb3b-dde2-4e01-8410" name="Infantry" primary="false"/>
+                <categoryLink targetId="9231-183c-b97b-63f9" id="1d13-8d3b-4e4b-84f1" name="Heavy" primary="false"/>
+              </categoryLinks>
             </selectionEntry>
             <selectionEntry id="f562-5d9a-3e00-a74d" name="Immortal w/Chainsword" hidden="false" collective="false" import="true" type="model">
               <entryLinks>
@@ -3869,6 +3890,10 @@
               <infoLinks>
                 <infoLink id="957c-9555-da93-5733" name="Immortal" targetId="732a-01c0-7487-7dcd" type="profile"/>
               </infoLinks>
+              <categoryLinks>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="6722-3703-44aa-b715" name="Infantry" primary="false"/>
+                <categoryLink targetId="9231-183c-b97b-63f9" id="cb21-f8e9-42df-9850" name="Heavy" primary="false"/>
+              </categoryLinks>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
@@ -4086,6 +4111,9 @@
           </costs>
           <categoryLinks>
             <categoryLink targetId="4f07-3d45-4f28-a0c6" id="8d7f-5602-649d-caf9" primary="false" name="Independent Character"/>
+            <categoryLink targetId="ad5f-31db-8bc7-5c46" id="84d8-8195-4d0a-ad94" name="Primarch" primary="false"/>
+            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="5d48-8047-4478-8ae2" name="Unique" primary="false"/>
+            <categoryLink targetId="9231-183c-b97b-63f9" id="2f2e-1ab7-4b48-94e7" name="Heavy" primary="false"/>
           </categoryLinks>
         </selectionEntry>
       </selectionEntries>
@@ -4251,6 +4279,10 @@
           </costs>
           <categoryLinks>
             <categoryLink targetId="4f07-3d45-4f28-a0c6" id="10a3-af9e-3a71-3e5f" primary="false" name="Independent Character"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="5547-9343-4f25-9df1" name="Infantry" primary="false"/>
+            <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="6370-7cb3-45e5-ab8e" name="Character" primary="false"/>
+            <categoryLink targetId="9231-183c-b97b-63f9" id="49b9-2448-497f-9f40" name="Heavy" primary="false"/>
+            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="dee0-8ff6-489f-997b" name="Unique" primary="false"/>
           </categoryLinks>
         </selectionEntry>
       </selectionEntries>
@@ -4382,6 +4414,9 @@
           </costs>
           <categoryLinks>
             <categoryLink targetId="4f07-3d45-4f28-a0c6" id="d21b-f1ff-43a-257" primary="false" name="Independent Character"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="298f-b27b-491c-b7b6" name="Infantry" primary="false"/>
+            <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="5136-1641-4f99-ad6b" name="Character" primary="false"/>
+            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="6f88-0cfb-4d34-88c0" name="Unique" primary="false"/>
           </categoryLinks>
         </selectionEntry>
       </selectionEntries>
@@ -4490,6 +4525,8 @@
           </profiles>
           <categoryLinks>
             <categoryLink id="da97-e1b8-c646-120c" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="f9cf-6751-4c4c-aa32" name="Infantry" primary="false"/>
+            <categoryLink targetId="9231-183c-b97b-63f9" id="f38b-d081-430f-b8e1" name="Heavy" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="bd3e-1ba0-9ac5-1aae" name="2) Melee Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="4269-df49-cd32-edaf">
@@ -4682,6 +4719,10 @@
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="35"/>
           </costs>
+          <categoryLinks>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="2764-1e4f-4c54-a618" name="Infantry" primary="false"/>
+            <categoryLink targetId="9231-183c-b97b-63f9" id="041d-0af9-4fd3-9455" name="Heavy" primary="false"/>
+          </categoryLinks>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>

--- a/2022 - LA - Iron Warriors.cat
+++ b/2022 - LA - Iron Warriors.cat
@@ -3330,6 +3330,8 @@
           </costs>
           <categoryLinks>
             <categoryLink targetId="4f07-3d45-4f28-a0c6" id="45ea-1241-dc10-6fce" primary="false" name="Independent Character"/>
+            <categoryLink targetId="ad5f-31db-8bc7-5c46" id="c1f1-291f-4dd8-9c42" name="Primarch" primary="false"/>
+            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="d07c-1600-4a74-a5c5" name="Unique" primary="false"/>
           </categoryLinks>
         </selectionEntry>
       </selectionEntries>
@@ -3422,6 +3424,10 @@
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20"/>
           </costs>
+          <categoryLinks>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="0f6e-5bb8-464f-b29f" name="Infantry" primary="false"/>
+            <categoryLink targetId="9231-183c-b97b-63f9" id="5a3c-450c-45b2-afda" name="Heavy" primary="false"/>
+          </categoryLinks>
         </selectionEntry>
         <selectionEntry id="f48a-d158-ea79-0043" name="Iron Havoc Sgt" hidden="false" collective="false" import="true" type="model">
           <constraints>
@@ -3454,6 +3460,8 @@
           </profiles>
           <categoryLinks>
             <categoryLink id="5a36-b0f6-649f-c4f5" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="790e-ba58-43ea-9643" name="Infantry" primary="false"/>
+            <categoryLink targetId="9231-183c-b97b-63f9" id="eae9-9cdd-40d2-a1c2" name="Heavy" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="3455-cfff-8f3f-2765" name="May exchange main weapon for:" hidden="false" collective="false" import="true">
@@ -3762,6 +3770,11 @@
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="135"/>
           </costs>
+          <categoryLinks>
+            <categoryLink targetId="d8ab-8e21-e193-63ba" id="cb1a-4a89-49bd-88d3" name="Automata" primary="false"/>
+            <categoryLink targetId="2440-b64e-cb24-87f0" id="b0ae-8d9d-4a31-8451" name="Cybernetica" primary="false"/>
+            <categoryLink targetId="9231-183c-b97b-63f9" id="f4bc-f1bb-4060-aae8" name="Heavy" primary="false"/>
+          </categoryLinks>
         </selectionEntry>
         <selectionEntry id="205c-194e-4d88-f40f" name="Karceri Battle Shield" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
@@ -3928,6 +3941,10 @@
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="55"/>
               </costs>
+              <categoryLinks>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="4b8e-010e-4d7d-84d4" name="Infantry" primary="false"/>
+                <categoryLink targetId="9231-183c-b97b-63f9" id="15ea-637d-4ab0-a00b" name="Heavy" primary="false"/>
+              </categoryLinks>
             </selectionEntry>
             <selectionEntry id="e3ec-cb69-e087-e5f4" name="Tyrant w/Chainfist" hidden="false" collective="false" import="true" type="model">
               <constraints>
@@ -3953,6 +3970,10 @@
               <infoLinks>
                 <infoLink id="cd1f-f069-1204-9011" name="Tyrant" targetId="a7d7-45bf-be8d-e27c" type="profile"/>
               </infoLinks>
+              <categoryLinks>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="4569-b17e-40c6-95bd" name="Infantry" primary="false"/>
+                <categoryLink targetId="9231-183c-b97b-63f9" id="6028-dddd-4c39-892e" name="Heavy" primary="false"/>
+              </categoryLinks>
             </selectionEntry>
             <selectionEntry id="0e0b-e394-c43e-6704" name="Tyrant w/Pair of Lightning Claws" hidden="false" collective="false" import="true" type="model">
               <constraints>
@@ -3972,6 +3993,10 @@
               <infoLinks>
                 <infoLink id="283d-6722-2f46-e92d" name="Tyrant" targetId="a7d7-45bf-be8d-e27c" type="profile"/>
               </infoLinks>
+              <categoryLinks>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="6d90-45e5-42ce-815b" name="Infantry" primary="false"/>
+                <categoryLink targetId="9231-183c-b97b-63f9" id="10cf-be4f-4543-ba12" name="Heavy" primary="false"/>
+              </categoryLinks>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
@@ -4065,6 +4090,8 @@
             <selectionEntry id="7b8b-6634-c202-fb31" name="Siege Master w/Pair of Lightning Claws" hidden="false" collective="false" import="true" type="model">
               <categoryLinks>
                 <categoryLink id="e244-e220-41e3-2b9b" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="556c-c3bd-4c34-bd58" name="Infantry" primary="false"/>
+                <categoryLink targetId="9231-183c-b97b-63f9" id="cd4e-1ec5-4557-a0eb" name="Heavy" primary="false"/>
               </categoryLinks>
               <entryLinks>
                 <entryLink id="e0f3-34cb-4b06-ec04" name="Grenade Harness" hidden="false" collective="false" import="true" targetId="251a-860d-2c4d-62cc" type="selectionEntry">
@@ -4176,6 +4203,9 @@
         <categoryLink id="139a-249d-4c38-650d" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="cf0b-835c-75dd-6527" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
         <categoryLink id="733c-2fe4-e40d-c3e4" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink targetId="7381-1130-ca6e-1806" id="a370-0b0b-4f88-acd7" name="Super-heavy" primary="false"/>
+        <categoryLink targetId="7b0a-a743-a8da-3a39" id="d9ec-d4dc-4784-a7bd" name="Transport" primary="false"/>
+        <categoryLink targetId="aa94-5c65-d1f1-46a4" id="a5df-50ef-451d-aa8c" name="Unique" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="e241-8547-5f25-6bb1" name="Turret Mounted volcano cannon" hidden="false" collective="false" import="true" type="upgrade">
@@ -4437,6 +4467,9 @@
           </costs>
           <categoryLinks>
             <categoryLink targetId="4f07-3d45-4f28-a0c6" id="b000-ea79-f7d4-6bb2" primary="false" name="Independent Character"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="a9f0-92d3-4585-b7c4" name="Infantry" primary="false"/>
+            <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="d259-c0c4-41b4-bcd1" name="Character" primary="false"/>
+            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="526d-1c81-4e99-a810" name="Unique" primary="false"/>
           </categoryLinks>
         </selectionEntry>
       </selectionEntries>
@@ -4722,6 +4755,10 @@
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="40"/>
               </costs>
+              <categoryLinks>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="542b-ded9-42e1-acc6" name="Infantry" primary="false"/>
+                <categoryLink targetId="9231-183c-b97b-63f9" id="d236-0afb-455c-8e7d" name="Heavy" primary="false"/>
+              </categoryLinks>
             </selectionEntry>
             <selectionEntry id="4794-a3ce-730c-4c66" name="Dominator w/Heavy Weapon" hidden="false" collective="false" import="true" type="model">
               <modifiers>
@@ -4775,6 +4812,10 @@
               <infoLinks>
                 <infoLink name="Dominator" hidden="false" type="profile" id="b214-28df-db9d-a78c" targetId="7afc-5b54-81b0-d809"/>
               </infoLinks>
+              <categoryLinks>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="1dfb-1c6d-41d4-beb4" name="Infantry" primary="false"/>
+                <categoryLink targetId="9231-183c-b97b-63f9" id="0e6c-03f5-4911-8c8c" name="Heavy" primary="false"/>
+              </categoryLinks>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>

--- a/2022 - LA - Iron Warriors.cat
+++ b/2022 - LA - Iron Warriors.cat
@@ -3060,7 +3060,7 @@
         <infoLink id="939a-42cc-bf7d-57e6" name="Legiones Cybernetica" hidden="false" targetId="a2ef-63a4-3531-db91" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="ee56-4096-c582-710a" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="ee56-4096-c582-710a" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="99a3-f200-6427-bcfb" name="Heavy Sub-type" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
         <categoryLink id="3f0c-0709-e9a4-dafd" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
       </categoryLinks>
@@ -3330,8 +3330,8 @@
           </costs>
           <categoryLinks>
             <categoryLink targetId="4f07-3d45-4f28-a0c6" id="45ea-1241-dc10-6fce" primary="false" name="Independent Character"/>
-            <categoryLink targetId="ad5f-31db-8bc7-5c46" id="c1f1-291f-4dd8-9c42" name="Primarch" primary="false"/>
-            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="d07c-1600-4a74-a5c5" name="Unique" primary="false"/>
+            <categoryLink targetId="ad5f-31db-8bc7-5c46" id="c1f1-291f-4dd8-9c42" name="Primarch:" primary="false"/>
+            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="d07c-1600-4a74-a5c5" name="Unique Sub-type" primary="false"/>
           </categoryLinks>
         </selectionEntry>
       </selectionEntries>
@@ -3395,7 +3395,7 @@
       </infoLinks>
       <categoryLinks>
         <categoryLink id="ee64-c915-d9f8-3b09" name="Heavy Sub-type" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
-        <categoryLink id="57e9-d1c5-973b-1aca" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="57e9-d1c5-973b-1aca" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="32ae-ac04-cb33-39c9" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
       </categoryLinks>
       <selectionEntries>
@@ -3425,8 +3425,8 @@
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20"/>
           </costs>
           <categoryLinks>
-            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="0f6e-5bb8-464f-b29f" name="Infantry" primary="false"/>
-            <categoryLink targetId="9231-183c-b97b-63f9" id="5a3c-450c-45b2-afda" name="Heavy" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="0f6e-5bb8-464f-b29f" name="Infantry Unit Type" primary="false"/>
+            <categoryLink targetId="9231-183c-b97b-63f9" id="5a3c-450c-45b2-afda" name="Heavy Sub-type" primary="false"/>
           </categoryLinks>
         </selectionEntry>
         <selectionEntry id="f48a-d158-ea79-0043" name="Iron Havoc Sgt" hidden="false" collective="false" import="true" type="model">
@@ -3460,8 +3460,8 @@
           </profiles>
           <categoryLinks>
             <categoryLink id="5a36-b0f6-649f-c4f5" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
-            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="790e-ba58-43ea-9643" name="Infantry" primary="false"/>
-            <categoryLink targetId="9231-183c-b97b-63f9" id="eae9-9cdd-40d2-a1c2" name="Heavy" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="790e-ba58-43ea-9643" name="Infantry Unit Type" primary="false"/>
+            <categoryLink targetId="9231-183c-b97b-63f9" id="eae9-9cdd-40d2-a1c2" name="Heavy Sub-type" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="3455-cfff-8f3f-2765" name="May exchange main weapon for:" hidden="false" collective="false" import="true">
@@ -3771,9 +3771,9 @@
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="135"/>
           </costs>
           <categoryLinks>
-            <categoryLink targetId="d8ab-8e21-e193-63ba" id="cb1a-4a89-49bd-88d3" name="Automata" primary="false"/>
-            <categoryLink targetId="2440-b64e-cb24-87f0" id="b0ae-8d9d-4a31-8451" name="Cybernetica" primary="false"/>
-            <categoryLink targetId="9231-183c-b97b-63f9" id="f4bc-f1bb-4060-aae8" name="Heavy" primary="false"/>
+            <categoryLink targetId="d8ab-8e21-e193-63ba" id="cb1a-4a89-49bd-88d3" name="Automata Unit Type" primary="false"/>
+            <categoryLink targetId="2440-b64e-cb24-87f0" id="b0ae-8d9d-4a31-8451" name="Cybernetica Sub-type" primary="false"/>
+            <categoryLink targetId="9231-183c-b97b-63f9" id="f4bc-f1bb-4060-aae8" name="Heavy Sub-type" primary="false"/>
           </categoryLinks>
         </selectionEntry>
         <selectionEntry id="205c-194e-4d88-f40f" name="Karceri Battle Shield" hidden="false" collective="false" import="true" type="upgrade">
@@ -3834,7 +3834,7 @@
         <infoLink id="7332-ee1c-1ce2-0d4b" name="Legiones Astartes (Iron Warriors)" hidden="false" targetId="c77b-f3fc-5dc8-1330" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="7a42-24a0-f251-742d" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="7a42-24a0-f251-742d" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="d025-1500-764b-7cb1" name="Terminators:" hidden="false" targetId="bab3-f50d-3e5f-2f78" primary="false"/>
         <categoryLink id="1084-a64f-bae5-5999" name="Heavy Sub-type" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
         <categoryLink id="029a-d8b2-d712-01df" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
@@ -3942,8 +3942,8 @@
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="55"/>
               </costs>
               <categoryLinks>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="4b8e-010e-4d7d-84d4" name="Infantry" primary="false"/>
-                <categoryLink targetId="9231-183c-b97b-63f9" id="15ea-637d-4ab0-a00b" name="Heavy" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="4b8e-010e-4d7d-84d4" name="Infantry Unit Type" primary="false"/>
+                <categoryLink targetId="9231-183c-b97b-63f9" id="15ea-637d-4ab0-a00b" name="Heavy Sub-type" primary="false"/>
               </categoryLinks>
             </selectionEntry>
             <selectionEntry id="e3ec-cb69-e087-e5f4" name="Tyrant w/Chainfist" hidden="false" collective="false" import="true" type="model">
@@ -3971,8 +3971,8 @@
                 <infoLink id="cd1f-f069-1204-9011" name="Tyrant" targetId="a7d7-45bf-be8d-e27c" type="profile"/>
               </infoLinks>
               <categoryLinks>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="4569-b17e-40c6-95bd" name="Infantry" primary="false"/>
-                <categoryLink targetId="9231-183c-b97b-63f9" id="6028-dddd-4c39-892e" name="Heavy" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="4569-b17e-40c6-95bd" name="Infantry Unit Type" primary="false"/>
+                <categoryLink targetId="9231-183c-b97b-63f9" id="6028-dddd-4c39-892e" name="Heavy Sub-type" primary="false"/>
               </categoryLinks>
             </selectionEntry>
             <selectionEntry id="0e0b-e394-c43e-6704" name="Tyrant w/Pair of Lightning Claws" hidden="false" collective="false" import="true" type="model">
@@ -3994,8 +3994,8 @@
                 <infoLink id="283d-6722-2f46-e92d" name="Tyrant" targetId="a7d7-45bf-be8d-e27c" type="profile"/>
               </infoLinks>
               <categoryLinks>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="6d90-45e5-42ce-815b" name="Infantry" primary="false"/>
-                <categoryLink targetId="9231-183c-b97b-63f9" id="10cf-be4f-4543-ba12" name="Heavy" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="6d90-45e5-42ce-815b" name="Infantry Unit Type" primary="false"/>
+                <categoryLink targetId="9231-183c-b97b-63f9" id="10cf-be4f-4543-ba12" name="Heavy Sub-type" primary="false"/>
               </categoryLinks>
             </selectionEntry>
           </selectionEntries>
@@ -4090,8 +4090,8 @@
             <selectionEntry id="7b8b-6634-c202-fb31" name="Siege Master w/Pair of Lightning Claws" hidden="false" collective="false" import="true" type="model">
               <categoryLinks>
                 <categoryLink id="e244-e220-41e3-2b9b" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="556c-c3bd-4c34-bd58" name="Infantry" primary="false"/>
-                <categoryLink targetId="9231-183c-b97b-63f9" id="cd4e-1ec5-4557-a0eb" name="Heavy" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="556c-c3bd-4c34-bd58" name="Infantry Unit Type" primary="false"/>
+                <categoryLink targetId="9231-183c-b97b-63f9" id="cd4e-1ec5-4557-a0eb" name="Heavy Sub-type" primary="false"/>
               </categoryLinks>
               <entryLinks>
                 <entryLink id="e0f3-34cb-4b06-ec04" name="Grenade Harness" hidden="false" collective="false" import="true" targetId="251a-860d-2c4d-62cc" type="selectionEntry">
@@ -4203,9 +4203,9 @@
         <categoryLink id="139a-249d-4c38-650d" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="cf0b-835c-75dd-6527" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
         <categoryLink id="733c-2fe4-e40d-c3e4" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink targetId="7381-1130-ca6e-1806" id="a370-0b0b-4f88-acd7" name="Super-heavy" primary="false"/>
-        <categoryLink targetId="7b0a-a743-a8da-3a39" id="d9ec-d4dc-4784-a7bd" name="Transport" primary="false"/>
-        <categoryLink targetId="aa94-5c65-d1f1-46a4" id="a5df-50ef-451d-aa8c" name="Unique" primary="false"/>
+        <categoryLink targetId="7381-1130-ca6e-1806" id="a370-0b0b-4f88-acd7" name="Super-heavy Sub-type" primary="false"/>
+        <categoryLink targetId="7b0a-a743-a8da-3a39" id="d9ec-d4dc-4784-a7bd" name="Transport Sub-type" primary="false"/>
+        <categoryLink targetId="aa94-5c65-d1f1-46a4" id="a5df-50ef-451d-aa8c" name="Unique Sub-type" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="e241-8547-5f25-6bb1" name="Turret Mounted volcano cannon" hidden="false" collective="false" import="true" type="upgrade">
@@ -4337,7 +4337,7 @@
         <infoLink id="a301-b079-3cd3-9d37" name="Legiones Astartes (Iron Warriors)" hidden="false" targetId="c77b-f3fc-5dc8-1330" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="5215-204f-c641-45e8" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="5215-204f-c641-45e8" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="aadf-fc65-d13f-de42" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink targetId="7a92-1a29-c087-51c6" id="8952-587-dd6e-b1f5" primary="false" name="Hammer of Olympia (Warsmith or Perturabo)"/>
       </categoryLinks>
@@ -4467,9 +4467,9 @@
           </costs>
           <categoryLinks>
             <categoryLink targetId="4f07-3d45-4f28-a0c6" id="b000-ea79-f7d4-6bb2" primary="false" name="Independent Character"/>
-            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="a9f0-92d3-4585-b7c4" name="Infantry" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="a9f0-92d3-4585-b7c4" name="Infantry Unit Type" primary="false"/>
             <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="d259-c0c4-41b4-bcd1" name="Character" primary="false"/>
-            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="526d-1c81-4e99-a810" name="Unique" primary="false"/>
+            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="526d-1c81-4e99-a810" name="Unique Sub-type" primary="false"/>
           </categoryLinks>
         </selectionEntry>
       </selectionEntries>
@@ -4519,7 +4519,7 @@
       </infoLinks>
       <categoryLinks>
         <categoryLink id="1e3b-3776-e033-cd91" name="Terminators:" hidden="false" targetId="bab3-f50d-3e5f-2f78" primary="false"/>
-        <categoryLink id="3cce-4df7-9ff9-c8eb" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="3cce-4df7-9ff9-c8eb" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="c0cf-d856-baa2-b2d9" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
       </categoryLinks>
       <selectionEntries>
@@ -4674,7 +4674,7 @@
       </infoLinks>
       <categoryLinks>
         <categoryLink id="0be3-3ef2-06d5-513f" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="7d54-110a-f4d0-fbac" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="7d54-110a-f4d0-fbac" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="eb9f-a770-ac11-f3c5" name="Heavy Sub-type" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
         <categoryLink id="2c06-dd4a-568c-f5f3" name="Terminators:" hidden="false" targetId="bab3-f50d-3e5f-2f78" primary="false"/>
       </categoryLinks>
@@ -4756,8 +4756,8 @@
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="40"/>
               </costs>
               <categoryLinks>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="542b-ded9-42e1-acc6" name="Infantry" primary="false"/>
-                <categoryLink targetId="9231-183c-b97b-63f9" id="d236-0afb-455c-8e7d" name="Heavy" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="542b-ded9-42e1-acc6" name="Infantry Unit Type" primary="false"/>
+                <categoryLink targetId="9231-183c-b97b-63f9" id="d236-0afb-455c-8e7d" name="Heavy Sub-type" primary="false"/>
               </categoryLinks>
             </selectionEntry>
             <selectionEntry id="4794-a3ce-730c-4c66" name="Dominator w/Heavy Weapon" hidden="false" collective="false" import="true" type="model">
@@ -4813,8 +4813,8 @@
                 <infoLink name="Dominator" hidden="false" type="profile" id="b214-28df-db9d-a78c" targetId="7afc-5b54-81b0-d809"/>
               </infoLinks>
               <categoryLinks>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="1dfb-1c6d-41d4-beb4" name="Infantry" primary="false"/>
-                <categoryLink targetId="9231-183c-b97b-63f9" id="0e6c-03f5-4911-8c8c" name="Heavy" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="1dfb-1c6d-41d4-beb4" name="Infantry Unit Type" primary="false"/>
+                <categoryLink targetId="9231-183c-b97b-63f9" id="0e6c-03f5-4911-8c8c" name="Heavy Sub-type" primary="false"/>
               </categoryLinks>
             </selectionEntry>
           </selectionEntries>

--- a/2022 - LA - Iron Warriors.cat
+++ b/2022 - LA - Iron Warriors.cat
@@ -2726,7 +2726,7 @@
       <categoryLinks>
         <categoryLink id="63ff-0a92-42ab-ae8c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="204c-7b0f-4fb9-b1b3" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="85e6-cb31-427c-a040" name="Line Sub-type:" hidden="false" targetId="6399-5c65-7833-1025" primary="false"/>
+        <categoryLink id="85e6-cb31-427c-a040" name="Line Sub-type" hidden="false" targetId="6399-5c65-7833-1025" primary="false"/>
         <categoryLink id="0a88-bbe3-e9f2-050a" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -3061,7 +3061,7 @@
       </infoLinks>
       <categoryLinks>
         <categoryLink id="ee56-4096-c582-710a" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="99a3-f200-6427-bcfb" name="Heavy Sub-type:" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+        <categoryLink id="99a3-f200-6427-bcfb" name="Heavy Sub-type" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
         <categoryLink id="3f0c-0709-e9a4-dafd" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
       </categoryLinks>
       <selectionEntries>
@@ -3394,7 +3394,7 @@
         </infoLink>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="ee64-c915-d9f8-3b09" name="Heavy Sub-type:" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+        <categoryLink id="ee64-c915-d9f8-3b09" name="Heavy Sub-type" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
         <categoryLink id="57e9-d1c5-973b-1aca" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="32ae-ac04-cb33-39c9" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
       </categoryLinks>
@@ -3728,9 +3728,9 @@
         </infoLink>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="5f56-93f9-d0e5-627d" name="Automata Unit-type:" hidden="false" targetId="d8ab-8e21-e193-63ba" primary="false"/>
+        <categoryLink id="5f56-93f9-d0e5-627d" name="Automata Unit Type" hidden="false" targetId="d8ab-8e21-e193-63ba" primary="false"/>
         <categoryLink id="f1af-9bb8-90df-4ae6" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="dfac-bd55-47dd-cf0f" name="Heavy Sub-type:" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+        <categoryLink id="dfac-bd55-47dd-cf0f" name="Heavy Sub-type" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="44e0-946b-0a3a-ae22" name="Domitar-ferrum" hidden="false" collective="false" import="true" type="model">
@@ -3836,7 +3836,7 @@
       <categoryLinks>
         <categoryLink id="7a42-24a0-f251-742d" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="d025-1500-764b-7cb1" name="Terminators:" hidden="false" targetId="bab3-f50d-3e5f-2f78" primary="false"/>
-        <categoryLink id="1084-a64f-bae5-5999" name="Heavy Sub-type:" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+        <categoryLink id="1084-a64f-bae5-5999" name="Heavy Sub-type" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
         <categoryLink id="029a-d8b2-d712-01df" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
@@ -4675,7 +4675,7 @@
       <categoryLinks>
         <categoryLink id="0be3-3ef2-06d5-513f" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="7d54-110a-f4d0-fbac" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="eb9f-a770-ac11-f3c5" name="Heavy Sub-type:" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+        <categoryLink id="eb9f-a770-ac11-f3c5" name="Heavy Sub-type" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
         <categoryLink id="2c06-dd4a-568c-f5f3" name="Terminators:" hidden="false" targetId="bab3-f50d-3e5f-2f78" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>

--- a/2022 - LA - Night Lords.cat
+++ b/2022 - LA - Night Lords.cat
@@ -2870,7 +2870,7 @@
       <categoryLinks>
         <categoryLink id="63ff-0a92-42ab-ae8c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="204c-7b0f-4fb9-b1b3" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="85e6-cb31-427c-a040" name="Line Sub-type:" hidden="false" targetId="6399-5c65-7833-1025" primary="false"/>
+        <categoryLink id="85e6-cb31-427c-a040" name="Line Sub-type" hidden="false" targetId="6399-5c65-7833-1025" primary="false"/>
         <categoryLink id="851a-3846-6367-9337" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -3396,7 +3396,7 @@
       <categoryLinks>
         <categoryLink id="45ec-b1d0-a2e1-74b5" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="f894-26fc-995c-2221" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="6562-0870-bbf3-d113" name="Skirmish Sub-type:" hidden="false" targetId="59a4-7b61-600a-c457" primary="false"/>
+        <categoryLink id="6562-0870-bbf3-d113" name="Skirmish Sub-type" hidden="false" targetId="59a4-7b61-600a-c457" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="032a-578d-8f65-22b3" name="Headsman" hidden="false" collective="false" import="true" type="model">
@@ -3891,7 +3891,7 @@
         <categoryLink id="b113-30d1-8842-415d" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="9fbe-1dcd-30c4-c310" name="Jump Infantry:" hidden="false" targetId="eee8-3c7c-2762-e33e" primary="false"/>
         <categoryLink id="cfa2-614d-454f-36d8" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="fc54-bc93-8aec-8c8c" name="Skirmish Sub-type:" hidden="false" targetId="59a4-7b61-600a-c457" primary="false"/>
+        <categoryLink id="fc54-bc93-8aec-8c8c" name="Skirmish Sub-type" hidden="false" targetId="59a4-7b61-600a-c457" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="8c9e-a718-9d07-2e08" name="Huntmaster" publicationId="09c5-eeae-f398-b653" hidden="false" collective="false" import="true" type="model">

--- a/2022 - LA - Night Lords.cat
+++ b/2022 - LA - Night Lords.cat
@@ -3189,7 +3189,7 @@
         <constraint field="selections" scope="roster" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="54e2-11e9-e908-4ed9" type="max"/>
       </constraints>
       <categoryLinks>
-        <categoryLink id="1647-bbf1-c523-59a9" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="1647-bbf1-c523-59a9" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="cb8a-15df-ffe4-a464" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="a2a9-2111-1212-f029" name="Psyker:" hidden="false" targetId="6e0c-29ba-a445-8321" primary="false"/>
       </categoryLinks>
@@ -3254,10 +3254,10 @@
           </costs>
           <categoryLinks>
             <categoryLink targetId="4f07-3d45-4f28-a0c6" id="ae3e-5cb1-896d-85af" primary="false" name="Independent Character"/>
-            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="bcc5-b273-4573-9b0a" name="Infantry" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="bcc5-b273-4573-9b0a" name="Infantry Unit Type" primary="false"/>
             <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="5de9-da0e-464f-b9bf" name="Character" primary="false"/>
-            <categoryLink targetId="6e0c-29ba-a445-8321" id="08d9-3059-4511-ad28" name="Psyker" primary="false"/>
-            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="f8d8-8a70-4e5f-8220" name="Unique" primary="false"/>
+            <categoryLink targetId="6e0c-29ba-a445-8321" id="08d9-3059-4511-ad28" name="Psyker:" primary="false"/>
+            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="f8d8-8a70-4e5f-8220" name="Unique Sub-type" primary="false"/>
           </categoryLinks>
         </selectionEntry>
         <selectionEntry id="c6cd-fc91-802f-af6e" name="Psychic Powers" hidden="false" collective="false" import="true" type="upgrade">
@@ -3394,7 +3394,7 @@
         </infoLink>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="45ec-b1d0-a2e1-74b5" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="45ec-b1d0-a2e1-74b5" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="f894-26fc-995c-2221" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="6562-0870-bbf3-d113" name="Skirmish Sub-type" hidden="false" targetId="59a4-7b61-600a-c457" primary="false"/>
       </categoryLinks>
@@ -3430,8 +3430,8 @@
           </profiles>
           <categoryLinks>
             <categoryLink id="632b-c772-22db-d185" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
-            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="1eef-6a06-483b-bf88" name="Infantry" primary="false"/>
-            <categoryLink targetId="59a4-7b61-600a-c457" id="b987-b839-4054-880e" name="Skirmish" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="1eef-6a06-483b-bf88" name="Infantry Unit Type" primary="false"/>
+            <categoryLink targetId="59a4-7b61-600a-c457" id="b987-b839-4054-880e" name="Skirmish Sub-type" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="dc80-f2a1-a2c9-7b57" name="May exchange his bolt pistol for:" hidden="false" collective="false" import="true" defaultSelectionEntryId="1c45-d2db-70ef-4bbd">
@@ -3746,8 +3746,8 @@
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="18"/>
               </costs>
               <categoryLinks>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="16a0-067d-4aed-97a3" name="Infantry" primary="false"/>
-                <categoryLink targetId="59a4-7b61-600a-c457" id="aff6-f14d-4988-8d5e" name="Skirmish" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="16a0-067d-4aed-97a3" name="Infantry Unit Type" primary="false"/>
+                <categoryLink targetId="59a4-7b61-600a-c457" id="aff6-f14d-4988-8d5e" name="Skirmish Sub-type" primary="false"/>
               </categoryLinks>
             </selectionEntry>
             <selectionEntry id="35b7-94ae-96ad-3bac" name="Executioner w/Chainglaive" hidden="false" collective="false" import="true" type="model">
@@ -3775,8 +3775,8 @@
                 <infoLink id="a308-732a-7b5f-ccac" name="Executioner" targetId="804a-5bae-3402-af07" type="profile"/>
               </infoLinks>
               <categoryLinks>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="1a99-14a0-4f6d-ae24" name="Infantry" primary="false"/>
-                <categoryLink targetId="59a4-7b61-600a-c457" id="1d24-3d1a-4d32-b0d3" name="Skirmish" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="1a99-14a0-4f6d-ae24" name="Infantry Unit Type" primary="false"/>
+                <categoryLink targetId="59a4-7b61-600a-c457" id="1d24-3d1a-4d32-b0d3" name="Skirmish Sub-type" primary="false"/>
               </categoryLinks>
             </selectionEntry>
             <selectionEntry id="2d06-4475-9e77-456d" name="Executioner w/Chainblade" hidden="false" collective="false" import="true" type="model">
@@ -3804,8 +3804,8 @@
                 <infoLink id="1339-f9ea-c360-3f6b" name="Executioner" targetId="804a-5bae-3402-af07" type="profile"/>
               </infoLinks>
               <categoryLinks>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="5d1f-08d5-4b1a-aece" name="Infantry" primary="false"/>
-                <categoryLink targetId="59a4-7b61-600a-c457" id="df17-5916-4376-a582" name="Skirmish" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="5d1f-08d5-4b1a-aece" name="Infantry Unit Type" primary="false"/>
+                <categoryLink targetId="59a4-7b61-600a-c457" id="df17-5916-4376-a582" name="Skirmish Sub-type" primary="false"/>
               </categoryLinks>
             </selectionEntry>
             <selectionEntry id="617e-40d5-35b3-3f7c" name="Executioner w/Chainaxe" hidden="false" collective="false" import="true" type="model">
@@ -3833,8 +3833,8 @@
                 <infoLink id="7a97-adb0-55d6-426a" name="Executioner" targetId="804a-5bae-3402-af07" type="profile"/>
               </infoLinks>
               <categoryLinks>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="863b-0003-41ef-8ba0" name="Infantry" primary="false"/>
-                <categoryLink targetId="59a4-7b61-600a-c457" id="48df-942e-462f-a6e6" name="Skirmish" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="863b-0003-41ef-8ba0" name="Infantry Unit Type" primary="false"/>
+                <categoryLink targetId="59a4-7b61-600a-c457" id="48df-942e-462f-a6e6" name="Skirmish Sub-type" primary="false"/>
               </categoryLinks>
             </selectionEntry>
           </selectionEntries>
@@ -3888,7 +3888,7 @@
         <infoLink id="5b1f-dbdd-e28e-d28f" name="Night Vision" hidden="false" targetId="683e-b4f2-f032-d31b" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="b113-30d1-8842-415d" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="b113-30d1-8842-415d" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="9fbe-1dcd-30c4-c310" name="Jump Infantry:" hidden="false" targetId="eee8-3c7c-2762-e33e" primary="false"/>
         <categoryLink id="cfa2-614d-454f-36d8" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="fc54-bc93-8aec-8c8c" name="Skirmish Sub-type" hidden="false" targetId="59a4-7b61-600a-c457" primary="false"/>
@@ -3925,8 +3925,8 @@
           </profiles>
           <categoryLinks>
             <categoryLink id="3359-c174-6c53-9968" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
-            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="12ef-f2fc-4ac5-ab73" name="Infantry" primary="false"/>
-            <categoryLink targetId="59a4-7b61-600a-c457" id="5297-595b-4914-aefc" name="Skirmish" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="12ef-f2fc-4ac5-ab73" name="Infantry Unit Type" primary="false"/>
+            <categoryLink targetId="59a4-7b61-600a-c457" id="5297-595b-4914-aefc" name="Skirmish Sub-type" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="8f69-1e1e-3fc9-fa4f" name="Wargear:" hidden="false" collective="false" import="true">
@@ -4073,8 +4073,8 @@
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="35"/>
               </costs>
               <categoryLinks>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="0a57-84b0-43ca-bc86" name="Infantry" primary="false"/>
-                <categoryLink targetId="59a4-7b61-600a-c457" id="a66a-7ca7-46ee-a422" name="Skirmish" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="0a57-84b0-43ca-bc86" name="Infantry Unit Type" primary="false"/>
+                <categoryLink targetId="59a4-7b61-600a-c457" id="a66a-7ca7-46ee-a422" name="Skirmish Sub-type" primary="false"/>
               </categoryLinks>
             </selectionEntry>
             <selectionEntry id="bc9e-194c-d712-2dd0" name="Night Raptor w/Power Weapon" publicationId="09c5-eeae-f398-b653" hidden="false" collective="false" import="true" type="model">
@@ -4123,8 +4123,8 @@
                 <infoLink id="5655-838d-1de0-cc1b" name="Night Raptor" targetId="9652-52cc-4914-ad13" type="profile"/>
               </infoLinks>
               <categoryLinks>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="dce8-d88a-4a5c-8254" name="Infantry" primary="false"/>
-                <categoryLink targetId="59a4-7b61-600a-c457" id="d887-5596-42a6-b741" name="Skirmish" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="dce8-d88a-4a5c-8254" name="Infantry Unit Type" primary="false"/>
+                <categoryLink targetId="59a4-7b61-600a-c457" id="d887-5596-42a6-b741" name="Skirmish Sub-type" primary="false"/>
               </categoryLinks>
             </selectionEntry>
             <selectionEntry id="bc1a-52f8-a729-938c" name="Night Raptor w/Lightning Claw" publicationId="09c5-eeae-f398-b653" hidden="false" collective="false" import="true" type="model">
@@ -4149,8 +4149,8 @@
                 <infoLink id="c111-c4d0-7d8f-45d2" name="Night Raptor" targetId="9652-52cc-4914-ad13" type="profile"/>
               </infoLinks>
               <categoryLinks>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="d6b6-093c-40dd-8367" name="Infantry" primary="false"/>
-                <categoryLink targetId="59a4-7b61-600a-c457" id="7d5f-f4d6-4afd-8f9a" name="Skirmish" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="d6b6-093c-40dd-8367" name="Infantry Unit Type" primary="false"/>
+                <categoryLink targetId="59a4-7b61-600a-c457" id="7d5f-f4d6-4afd-8f9a" name="Skirmish Sub-type" primary="false"/>
               </categoryLinks>
             </selectionEntry>
             <selectionEntry id="821f-583b-f322-71c0" name="Night Raptor w/Chainblade" publicationId="09c5-eeae-f398-b653" hidden="false" collective="false" import="true" type="model">
@@ -4178,8 +4178,8 @@
                 <infoLink id="ff19-c55e-12b5-6937" name="Night Raptor" targetId="9652-52cc-4914-ad13" type="profile"/>
               </infoLinks>
               <categoryLinks>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="1d72-d4e0-499f-9ee1" name="Infantry" primary="false"/>
-                <categoryLink targetId="59a4-7b61-600a-c457" id="ec6e-8312-4d63-a3dc" name="Skirmish" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="1d72-d4e0-499f-9ee1" name="Infantry Unit Type" primary="false"/>
+                <categoryLink targetId="59a4-7b61-600a-c457" id="ec6e-8312-4d63-a3dc" name="Skirmish Sub-type" primary="false"/>
               </categoryLinks>
             </selectionEntry>
             <selectionEntry id="14cb-d481-3fb3-37cc" name="Night Raptor w/Chainglaive" publicationId="09c5-eeae-f398-b653" hidden="false" collective="false" import="true" type="model">
@@ -4204,8 +4204,8 @@
                 <infoLink id="10ce-ab11-abbb-5ff5" name="Night Raptor" targetId="9652-52cc-4914-ad13" type="profile"/>
               </infoLinks>
               <categoryLinks>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="ea2c-21fd-444f-8886" name="Infantry" primary="false"/>
-                <categoryLink targetId="59a4-7b61-600a-c457" id="a64d-4d23-44ac-9448" name="Skirmish" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="ea2c-21fd-444f-8886" name="Infantry Unit Type" primary="false"/>
+                <categoryLink targetId="59a4-7b61-600a-c457" id="a64d-4d23-44ac-9448" name="Skirmish Sub-type" primary="false"/>
               </categoryLinks>
             </selectionEntry>
             <selectionEntry id="b7d5-489d-e8dc-70cc" name="Night Raptor w/Chainsword" publicationId="09c5-eeae-f398-b653" hidden="false" collective="false" import="true" type="model">
@@ -4230,8 +4230,8 @@
                 <infoLink id="adf2-b4cc-7feb-837f" name="Night Raptor" targetId="9652-52cc-4914-ad13" type="profile"/>
               </infoLinks>
               <categoryLinks>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="992d-46a9-4d93-8894" name="Infantry" primary="false"/>
-                <categoryLink targetId="59a4-7b61-600a-c457" id="3348-4d9e-4b34-82f6" name="Skirmish" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="992d-46a9-4d93-8894" name="Infantry Unit Type" primary="false"/>
+                <categoryLink targetId="59a4-7b61-600a-c457" id="3348-4d9e-4b34-82f6" name="Skirmish Sub-type" primary="false"/>
               </categoryLinks>
             </selectionEntry>
             <selectionEntry id="435c-7ace-9ec2-c863" name="Night Raptor w/Options (1 in 5)" publicationId="09c5-eeae-f398-b653" hidden="false" collective="false" import="true" type="model">
@@ -4339,8 +4339,8 @@
                 <infoLink id="ff0d-68a1-5fe9-9cfd" name="Night Raptor" targetId="9652-52cc-4914-ad13" type="profile"/>
               </infoLinks>
               <categoryLinks>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="f727-d375-4082-8139" name="Infantry" primary="false"/>
-                <categoryLink targetId="59a4-7b61-600a-c457" id="7fe1-d1d1-4944-9276" name="Skirmish" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="f727-d375-4082-8139" name="Infantry Unit Type" primary="false"/>
+                <categoryLink targetId="59a4-7b61-600a-c457" id="7fe1-d1d1-4944-9276" name="Skirmish Sub-type" primary="false"/>
               </categoryLinks>
             </selectionEntry>
           </selectionEntries>
@@ -4419,9 +4419,9 @@
           </costs>
           <categoryLinks>
             <categoryLink targetId="4f07-3d45-4f28-a0c6" id="3cb6-e6e6-4462-efb6" primary="false" name="Independent Character"/>
-            <categoryLink targetId="ad5f-31db-8bc7-5c46" id="2b01-92ba-4da6-886c" name="Primarch" primary="false"/>
-            <categoryLink targetId="6e0c-29ba-a445-8321" id="f4c5-f080-487d-87e5" name="Psyker" primary="false"/>
-            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="a576-a669-4293-89d2" name="Unique" primary="false"/>
+            <categoryLink targetId="ad5f-31db-8bc7-5c46" id="2b01-92ba-4da6-886c" name="Primarch:" primary="false"/>
+            <categoryLink targetId="6e0c-29ba-a445-8321" id="f4c5-f080-487d-87e5" name="Psyker:" primary="false"/>
+            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="a576-a669-4293-89d2" name="Unique Sub-type" primary="false"/>
           </categoryLinks>
         </selectionEntry>
         <selectionEntry id="c12d-0270-ecfe-f3e2" name="Mercy &amp; Forgiveness" hidden="false" collective="false" import="true" type="upgrade">
@@ -4560,7 +4560,7 @@ In additon, a Contekar Terminator Squad may be selected as a Retinue Squad in a 
         </infoLink>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="3aef-1623-40f8-2144" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="3aef-1623-40f8-2144" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="0714-07b8-9969-8559" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="8aab-8508-d7d0-37b6" name="Terminators:" hidden="false" targetId="bab3-f50d-3e5f-2f78" primary="false"/>
       </categoryLinks>
@@ -4589,7 +4589,7 @@ In additon, a Contekar Terminator Squad may be selected as a Retinue Squad in a 
           </profiles>
           <categoryLinks>
             <categoryLink id="bca6-cd04-8a1f-52fa" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
-            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="8cbc-818e-4898-a941" name="Infantry" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="8cbc-818e-4898-a941" name="Infantry Unit Type" primary="false"/>
           </categoryLinks>
           <entryLinks>
             <entryLink id="ae72-3efd-8d8f-5ae8" name="Power Dagger" hidden="false" collective="false" import="true" targetId="8157-b77c-0dd3-85b2" type="selectionEntry">
@@ -4646,7 +4646,7 @@ In additon, a Contekar Terminator Squad may be selected as a Retinue Squad in a 
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="40"/>
           </costs>
           <categoryLinks>
-            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="d21e-8ae7-4d01-af26" name="Infantry" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="d21e-8ae7-4d01-af26" name="Infantry Unit Type" primary="false"/>
           </categoryLinks>
         </selectionEntry>
       </selectionEntries>
@@ -4812,7 +4812,7 @@ In additon, a Contekar Terminator Squad may be selected as a Retinue Squad in a 
       </infoLinks>
       <categoryLinks>
         <categoryLink id="f392-634b-9bb0-06e9" name="Terminators:" hidden="false" targetId="bab3-f50d-3e5f-2f78" primary="false"/>
-        <categoryLink id="68f4-cc55-b1b9-8c1c" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="68f4-cc55-b1b9-8c1c" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="0368-244a-7061-6fb7" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
       </categoryLinks>
       <selectionEntries>
@@ -4852,7 +4852,7 @@ In additon, a Contekar Terminator Squad may be selected as a Retinue Squad in a 
           </infoLinks>
           <categoryLinks>
             <categoryLink id="b6a9-d248-76ec-f59d" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
-            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="d28b-e46e-4ba2-aed8" name="Infantry" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="d28b-e46e-4ba2-aed8" name="Infantry Unit Type" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="0428-9fc4-ab99-98b1" name="1) Ranged Weapon:" hidden="false" collective="false" import="true" defaultSelectionEntryId="716d-10fc-0e92-6028">
@@ -5109,7 +5109,7 @@ In additon, a Contekar Terminator Squad may be selected as a Retinue Squad in a 
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="35"/>
               </costs>
               <categoryLinks>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="ba24-ebd9-477c-ad80" name="Infantry" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="ba24-ebd9-477c-ad80" name="Infantry Unit Type" primary="false"/>
               </categoryLinks>
             </selectionEntry>
             <selectionEntry id="424f-d61d-71f8-85b6" name="Atramentar w/Heavy Weapon" hidden="false" collective="false" import="true" type="model">
@@ -5188,7 +5188,7 @@ In additon, a Contekar Terminator Squad may be selected as a Retinue Squad in a 
                 <infoLink id="1643-ece6-5dd7-df4c" name="Atramentar" targetId="ebf7-e2f8-38f1-8789" type="profile"/>
               </infoLinks>
               <categoryLinks>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="3f3d-270d-4586-ae3a" name="Infantry" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="3f3d-270d-4586-ae3a" name="Infantry Unit Type" primary="false"/>
               </categoryLinks>
             </selectionEntry>
             <selectionEntry id="ae9d-1789-6d81-08bc" name="Atramentar w/Pair of Lightning Claws" hidden="false" collective="false" import="true" type="model">
@@ -5210,7 +5210,7 @@ In additon, a Contekar Terminator Squad may be selected as a Retinue Squad in a 
                 <infoLink id="9956-d72c-5fc0-7dc5" name="Atramentar" targetId="ebf7-e2f8-38f1-8789" type="profile"/>
               </infoLinks>
               <categoryLinks>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="9a3a-e197-4846-909e" name="Infantry" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="9a3a-e197-4846-909e" name="Infantry Unit Type" primary="false"/>
               </categoryLinks>
             </selectionEntry>
           </selectionEntries>
@@ -5245,7 +5245,7 @@ In additon, a Contekar Terminator Squad may be selected as a Retinue Squad in a 
         <constraint field="selections" scope="roster" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ad68-cdd4-e29a-31a7" type="max"/>
       </constraints>
       <categoryLinks>
-        <categoryLink id="529d-c6da-a22c-ddf2" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="529d-c6da-a22c-ddf2" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="6af9-fdc8-c956-125c" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink targetId="b81a-8f4a-ff50-ef99" id="d89a-d03-4ac2-9df8" primary="false" name="Primus Medicae"/>
       </categoryLinks>
@@ -5290,9 +5290,9 @@ Additionally, all models with the Infantry or Cavalry Unit Types in a unit that 
           </costs>
           <categoryLinks>
             <categoryLink targetId="4f07-3d45-4f28-a0c6" id="ce0e-59e2-170e-9a73" primary="false" name="Independent Character"/>
-            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="771c-c9f8-476f-84aa" name="Infantry" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="771c-c9f8-476f-84aa" name="Infantry Unit Type" primary="false"/>
             <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="bde3-b943-435f-8166" name="Character" primary="false"/>
-            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="047a-ee43-444e-a785" name="Unique" primary="false"/>
+            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="047a-ee43-444e-a785" name="Unique Sub-type" primary="false"/>
           </categoryLinks>
         </selectionEntry>
         <selectionEntry id="8207-ff39-342f-7905" name="Red Jaqa" hidden="false" collective="false" import="true" type="upgrade">
@@ -5356,7 +5356,7 @@ Additionally, all models with the Infantry or Cavalry Unit Types in a unit that 
         <constraint field="selections" scope="roster" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8690-29d3-a450-6900" type="max"/>
       </constraints>
       <categoryLinks>
-        <categoryLink id="6344-0186-583a-9fd6" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="6344-0186-583a-9fd6" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="170a-9067-b138-78e6" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
       </categoryLinks>
       <selectionEntries>
@@ -5406,9 +5406,9 @@ Additionally, all models with the Infantry or Cavalry Unit Types in a unit that 
           </costs>
           <categoryLinks>
             <categoryLink targetId="4f07-3d45-4f28-a0c6" id="1524-fb63-e22b-b658" primary="false" name="Independent Character"/>
-            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="6579-4c18-4be5-87f3" name="Infantry" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="6579-4c18-4be5-87f3" name="Infantry Unit Type" primary="false"/>
             <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="4fc5-1451-4a65-8ce5" name="Character" primary="false"/>
-            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="3125-f6a8-4c9f-a27e" name="Unique" primary="false"/>
+            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="3125-f6a8-4c9f-a27e" name="Unique Sub-type" primary="false"/>
           </categoryLinks>
         </selectionEntry>
         <selectionEntry id="ab56-ada5-5957-f889" name="Revenant" hidden="false" collective="false" import="true" type="upgrade">
@@ -5497,7 +5497,7 @@ Additionally, all models with the Infantry or Cavalry Unit Types in a unit that 
         <constraint field="selections" scope="roster" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9001-0d6b-08b5-4ae8" type="max"/>
       </constraints>
       <categoryLinks>
-        <categoryLink id="a5cc-6775-35e2-167c" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="a5cc-6775-35e2-167c" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="5e08-d8ee-cf56-6118" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
       </categoryLinks>
       <selectionEntries>
@@ -5555,9 +5555,9 @@ Additionally, all models with the Infantry or Cavalry Unit Types in a unit that 
           </costs>
           <categoryLinks>
             <categoryLink targetId="4f07-3d45-4f28-a0c6" id="7228-cb00-e7e0-aa45" primary="false" name="Independent Character"/>
-            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="968e-48f4-4927-b25e" name="Infantry" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="968e-48f4-4927-b25e" name="Infantry Unit Type" primary="false"/>
             <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="c646-96db-448c-94f3" name="Character" primary="false"/>
-            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="9afc-ab06-43d6-a0ba" name="Unique" primary="false"/>
+            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="9afc-ab06-43d6-a0ba" name="Unique Sub-type" primary="false"/>
           </categoryLinks>
         </selectionEntry>
         <selectionEntry id="1e83-8aa1-7329-2846" name="Nostraman Flay-whip" hidden="false" collective="false" import="true" type="upgrade">

--- a/2022 - LA - Night Lords.cat
+++ b/2022 - LA - Night Lords.cat
@@ -3254,6 +3254,10 @@
           </costs>
           <categoryLinks>
             <categoryLink targetId="4f07-3d45-4f28-a0c6" id="ae3e-5cb1-896d-85af" primary="false" name="Independent Character"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="bcc5-b273-4573-9b0a" name="Infantry" primary="false"/>
+            <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="5de9-da0e-464f-b9bf" name="Character" primary="false"/>
+            <categoryLink targetId="6e0c-29ba-a445-8321" id="08d9-3059-4511-ad28" name="Psyker" primary="false"/>
+            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="f8d8-8a70-4e5f-8220" name="Unique" primary="false"/>
           </categoryLinks>
         </selectionEntry>
         <selectionEntry id="c6cd-fc91-802f-af6e" name="Psychic Powers" hidden="false" collective="false" import="true" type="upgrade">
@@ -3426,6 +3430,8 @@
           </profiles>
           <categoryLinks>
             <categoryLink id="632b-c772-22db-d185" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="1eef-6a06-483b-bf88" name="Infantry" primary="false"/>
+            <categoryLink targetId="59a4-7b61-600a-c457" id="b987-b839-4054-880e" name="Skirmish" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="dc80-f2a1-a2c9-7b57" name="May exchange his bolt pistol for:" hidden="false" collective="false" import="true" defaultSelectionEntryId="1c45-d2db-70ef-4bbd">
@@ -3739,6 +3745,10 @@
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="18"/>
               </costs>
+              <categoryLinks>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="16a0-067d-4aed-97a3" name="Infantry" primary="false"/>
+                <categoryLink targetId="59a4-7b61-600a-c457" id="aff6-f14d-4988-8d5e" name="Skirmish" primary="false"/>
+              </categoryLinks>
             </selectionEntry>
             <selectionEntry id="35b7-94ae-96ad-3bac" name="Executioner w/Chainglaive" hidden="false" collective="false" import="true" type="model">
               <entryLinks>
@@ -3764,6 +3774,10 @@
               <infoLinks>
                 <infoLink id="a308-732a-7b5f-ccac" name="Executioner" targetId="804a-5bae-3402-af07" type="profile"/>
               </infoLinks>
+              <categoryLinks>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="1a99-14a0-4f6d-ae24" name="Infantry" primary="false"/>
+                <categoryLink targetId="59a4-7b61-600a-c457" id="1d24-3d1a-4d32-b0d3" name="Skirmish" primary="false"/>
+              </categoryLinks>
             </selectionEntry>
             <selectionEntry id="2d06-4475-9e77-456d" name="Executioner w/Chainblade" hidden="false" collective="false" import="true" type="model">
               <entryLinks>
@@ -3789,6 +3803,10 @@
               <infoLinks>
                 <infoLink id="1339-f9ea-c360-3f6b" name="Executioner" targetId="804a-5bae-3402-af07" type="profile"/>
               </infoLinks>
+              <categoryLinks>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="5d1f-08d5-4b1a-aece" name="Infantry" primary="false"/>
+                <categoryLink targetId="59a4-7b61-600a-c457" id="df17-5916-4376-a582" name="Skirmish" primary="false"/>
+              </categoryLinks>
             </selectionEntry>
             <selectionEntry id="617e-40d5-35b3-3f7c" name="Executioner w/Chainaxe" hidden="false" collective="false" import="true" type="model">
               <entryLinks>
@@ -3814,6 +3832,10 @@
               <infoLinks>
                 <infoLink id="7a97-adb0-55d6-426a" name="Executioner" targetId="804a-5bae-3402-af07" type="profile"/>
               </infoLinks>
+              <categoryLinks>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="863b-0003-41ef-8ba0" name="Infantry" primary="false"/>
+                <categoryLink targetId="59a4-7b61-600a-c457" id="48df-942e-462f-a6e6" name="Skirmish" primary="false"/>
+              </categoryLinks>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
@@ -3903,6 +3925,8 @@
           </profiles>
           <categoryLinks>
             <categoryLink id="3359-c174-6c53-9968" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="12ef-f2fc-4ac5-ab73" name="Infantry" primary="false"/>
+            <categoryLink targetId="59a4-7b61-600a-c457" id="5297-595b-4914-aefc" name="Skirmish" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="8f69-1e1e-3fc9-fa4f" name="Wargear:" hidden="false" collective="false" import="true">
@@ -4048,6 +4072,10 @@
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="35"/>
               </costs>
+              <categoryLinks>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="0a57-84b0-43ca-bc86" name="Infantry" primary="false"/>
+                <categoryLink targetId="59a4-7b61-600a-c457" id="a66a-7ca7-46ee-a422" name="Skirmish" primary="false"/>
+              </categoryLinks>
             </selectionEntry>
             <selectionEntry id="bc9e-194c-d712-2dd0" name="Night Raptor w/Power Weapon" publicationId="09c5-eeae-f398-b653" hidden="false" collective="false" import="true" type="model">
               <selectionEntryGroups>
@@ -4094,6 +4122,10 @@
               <infoLinks>
                 <infoLink id="5655-838d-1de0-cc1b" name="Night Raptor" targetId="9652-52cc-4914-ad13" type="profile"/>
               </infoLinks>
+              <categoryLinks>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="dce8-d88a-4a5c-8254" name="Infantry" primary="false"/>
+                <categoryLink targetId="59a4-7b61-600a-c457" id="d887-5596-42a6-b741" name="Skirmish" primary="false"/>
+              </categoryLinks>
             </selectionEntry>
             <selectionEntry id="bc1a-52f8-a729-938c" name="Night Raptor w/Lightning Claw" publicationId="09c5-eeae-f398-b653" hidden="false" collective="false" import="true" type="model">
               <entryLinks>
@@ -4116,6 +4148,10 @@
               <infoLinks>
                 <infoLink id="c111-c4d0-7d8f-45d2" name="Night Raptor" targetId="9652-52cc-4914-ad13" type="profile"/>
               </infoLinks>
+              <categoryLinks>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="d6b6-093c-40dd-8367" name="Infantry" primary="false"/>
+                <categoryLink targetId="59a4-7b61-600a-c457" id="7d5f-f4d6-4afd-8f9a" name="Skirmish" primary="false"/>
+              </categoryLinks>
             </selectionEntry>
             <selectionEntry id="821f-583b-f322-71c0" name="Night Raptor w/Chainblade" publicationId="09c5-eeae-f398-b653" hidden="false" collective="false" import="true" type="model">
               <entryLinks>
@@ -4141,6 +4177,10 @@
               <infoLinks>
                 <infoLink id="ff19-c55e-12b5-6937" name="Night Raptor" targetId="9652-52cc-4914-ad13" type="profile"/>
               </infoLinks>
+              <categoryLinks>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="1d72-d4e0-499f-9ee1" name="Infantry" primary="false"/>
+                <categoryLink targetId="59a4-7b61-600a-c457" id="ec6e-8312-4d63-a3dc" name="Skirmish" primary="false"/>
+              </categoryLinks>
             </selectionEntry>
             <selectionEntry id="14cb-d481-3fb3-37cc" name="Night Raptor w/Chainglaive" publicationId="09c5-eeae-f398-b653" hidden="false" collective="false" import="true" type="model">
               <entryLinks>
@@ -4163,6 +4203,10 @@
               <infoLinks>
                 <infoLink id="10ce-ab11-abbb-5ff5" name="Night Raptor" targetId="9652-52cc-4914-ad13" type="profile"/>
               </infoLinks>
+              <categoryLinks>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="ea2c-21fd-444f-8886" name="Infantry" primary="false"/>
+                <categoryLink targetId="59a4-7b61-600a-c457" id="a64d-4d23-44ac-9448" name="Skirmish" primary="false"/>
+              </categoryLinks>
             </selectionEntry>
             <selectionEntry id="b7d5-489d-e8dc-70cc" name="Night Raptor w/Chainsword" publicationId="09c5-eeae-f398-b653" hidden="false" collective="false" import="true" type="model">
               <entryLinks>
@@ -4185,6 +4229,10 @@
               <infoLinks>
                 <infoLink id="adf2-b4cc-7feb-837f" name="Night Raptor" targetId="9652-52cc-4914-ad13" type="profile"/>
               </infoLinks>
+              <categoryLinks>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="992d-46a9-4d93-8894" name="Infantry" primary="false"/>
+                <categoryLink targetId="59a4-7b61-600a-c457" id="3348-4d9e-4b34-82f6" name="Skirmish" primary="false"/>
+              </categoryLinks>
             </selectionEntry>
             <selectionEntry id="435c-7ace-9ec2-c863" name="Night Raptor w/Options (1 in 5)" publicationId="09c5-eeae-f398-b653" hidden="false" collective="false" import="true" type="model">
               <modifiers>
@@ -4290,6 +4338,10 @@
               <infoLinks>
                 <infoLink id="ff0d-68a1-5fe9-9cfd" name="Night Raptor" targetId="9652-52cc-4914-ad13" type="profile"/>
               </infoLinks>
+              <categoryLinks>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="f727-d375-4082-8139" name="Infantry" primary="false"/>
+                <categoryLink targetId="59a4-7b61-600a-c457" id="7fe1-d1d1-4944-9276" name="Skirmish" primary="false"/>
+              </categoryLinks>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
@@ -4367,6 +4419,9 @@
           </costs>
           <categoryLinks>
             <categoryLink targetId="4f07-3d45-4f28-a0c6" id="3cb6-e6e6-4462-efb6" primary="false" name="Independent Character"/>
+            <categoryLink targetId="ad5f-31db-8bc7-5c46" id="2b01-92ba-4da6-886c" name="Primarch" primary="false"/>
+            <categoryLink targetId="6e0c-29ba-a445-8321" id="f4c5-f080-487d-87e5" name="Psyker" primary="false"/>
+            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="a576-a669-4293-89d2" name="Unique" primary="false"/>
           </categoryLinks>
         </selectionEntry>
         <selectionEntry id="c12d-0270-ecfe-f3e2" name="Mercy &amp; Forgiveness" hidden="false" collective="false" import="true" type="upgrade">
@@ -4534,6 +4589,7 @@ In additon, a Contekar Terminator Squad may be selected as a Retinue Squad in a 
           </profiles>
           <categoryLinks>
             <categoryLink id="bca6-cd04-8a1f-52fa" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="8cbc-818e-4898-a941" name="Infantry" primary="false"/>
           </categoryLinks>
           <entryLinks>
             <entryLink id="ae72-3efd-8d8f-5ae8" name="Power Dagger" hidden="false" collective="false" import="true" targetId="8157-b77c-0dd3-85b2" type="selectionEntry">
@@ -4589,6 +4645,9 @@ In additon, a Contekar Terminator Squad may be selected as a Retinue Squad in a 
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="40"/>
           </costs>
+          <categoryLinks>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="d21e-8ae7-4d01-af26" name="Infantry" primary="false"/>
+          </categoryLinks>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
@@ -4793,6 +4852,7 @@ In additon, a Contekar Terminator Squad may be selected as a Retinue Squad in a 
           </infoLinks>
           <categoryLinks>
             <categoryLink id="b6a9-d248-76ec-f59d" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="d28b-e46e-4ba2-aed8" name="Infantry" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="0428-9fc4-ab99-98b1" name="1) Ranged Weapon:" hidden="false" collective="false" import="true" defaultSelectionEntryId="716d-10fc-0e92-6028">
@@ -5048,6 +5108,9 @@ In additon, a Contekar Terminator Squad may be selected as a Retinue Squad in a 
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="35"/>
               </costs>
+              <categoryLinks>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="ba24-ebd9-477c-ad80" name="Infantry" primary="false"/>
+              </categoryLinks>
             </selectionEntry>
             <selectionEntry id="424f-d61d-71f8-85b6" name="Atramentar w/Heavy Weapon" hidden="false" collective="false" import="true" type="model">
               <modifiers>
@@ -5124,6 +5187,9 @@ In additon, a Contekar Terminator Squad may be selected as a Retinue Squad in a 
               <infoLinks>
                 <infoLink id="1643-ece6-5dd7-df4c" name="Atramentar" targetId="ebf7-e2f8-38f1-8789" type="profile"/>
               </infoLinks>
+              <categoryLinks>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="3f3d-270d-4586-ae3a" name="Infantry" primary="false"/>
+              </categoryLinks>
             </selectionEntry>
             <selectionEntry id="ae9d-1789-6d81-08bc" name="Atramentar w/Pair of Lightning Claws" hidden="false" collective="false" import="true" type="model">
               <entryLinks>
@@ -5143,6 +5209,9 @@ In additon, a Contekar Terminator Squad may be selected as a Retinue Squad in a 
               <infoLinks>
                 <infoLink id="9956-d72c-5fc0-7dc5" name="Atramentar" targetId="ebf7-e2f8-38f1-8789" type="profile"/>
               </infoLinks>
+              <categoryLinks>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="9a3a-e197-4846-909e" name="Infantry" primary="false"/>
+              </categoryLinks>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
@@ -5221,6 +5290,9 @@ Additionally, all models with the Infantry or Cavalry Unit Types in a unit that 
           </costs>
           <categoryLinks>
             <categoryLink targetId="4f07-3d45-4f28-a0c6" id="ce0e-59e2-170e-9a73" primary="false" name="Independent Character"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="771c-c9f8-476f-84aa" name="Infantry" primary="false"/>
+            <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="bde3-b943-435f-8166" name="Character" primary="false"/>
+            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="047a-ee43-444e-a785" name="Unique" primary="false"/>
           </categoryLinks>
         </selectionEntry>
         <selectionEntry id="8207-ff39-342f-7905" name="Red Jaqa" hidden="false" collective="false" import="true" type="upgrade">
@@ -5334,6 +5406,9 @@ Additionally, all models with the Infantry or Cavalry Unit Types in a unit that 
           </costs>
           <categoryLinks>
             <categoryLink targetId="4f07-3d45-4f28-a0c6" id="1524-fb63-e22b-b658" primary="false" name="Independent Character"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="6579-4c18-4be5-87f3" name="Infantry" primary="false"/>
+            <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="4fc5-1451-4a65-8ce5" name="Character" primary="false"/>
+            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="3125-f6a8-4c9f-a27e" name="Unique" primary="false"/>
           </categoryLinks>
         </selectionEntry>
         <selectionEntry id="ab56-ada5-5957-f889" name="Revenant" hidden="false" collective="false" import="true" type="upgrade">
@@ -5480,6 +5555,9 @@ Additionally, all models with the Infantry or Cavalry Unit Types in a unit that 
           </costs>
           <categoryLinks>
             <categoryLink targetId="4f07-3d45-4f28-a0c6" id="7228-cb00-e7e0-aa45" primary="false" name="Independent Character"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="968e-48f4-4927-b25e" name="Infantry" primary="false"/>
+            <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="c646-96db-448c-94f3" name="Character" primary="false"/>
+            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="9afc-ab06-43d6-a0ba" name="Unique" primary="false"/>
           </categoryLinks>
         </selectionEntry>
         <selectionEntry id="1e83-8aa1-7329-2846" name="Nostraman Flay-whip" hidden="false" collective="false" import="true" type="upgrade">

--- a/2022 - LA - Raven Guard.cat
+++ b/2022 - LA - Raven Guard.cat
@@ -3030,6 +3030,10 @@
           </costs>
           <categoryLinks>
             <categoryLink targetId="4f07-3d45-4f28-a0c6" id="bb81-a4e6-a503-56ae" primary="false" name="Independent Character"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="78d8-58da-40b1-9b04" name="Infantry" primary="false"/>
+            <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="5ecf-f86d-4e3f-8006" name="Character" primary="false"/>
+            <categoryLink targetId="bff2-ae16-74a8-8712" id="ef8f-54d3-4b1c-8cfe" name="Light" primary="false"/>
+            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="b054-5f64-4b30-a4c7" name="Unique" primary="false"/>
           </categoryLinks>
         </selectionEntry>
         <selectionEntry id="9054-a4c3-8387-4c76" name="Fulcrim Hand Cannon" hidden="false" collective="false" import="true" type="upgrade">
@@ -3263,6 +3267,9 @@ Corvus Corax may still Run on a turn when the Korvidine Pinions have been activa
           </costs>
           <categoryLinks>
             <categoryLink targetId="4f07-3d45-4f28-a0c6" id="3ed2-7b0f-c4c0-1f6a" primary="false" name="Independent Character"/>
+            <categoryLink targetId="ad5f-31db-8bc7-5c46" id="8b19-dc49-49cb-814d" name="Primarch" primary="false"/>
+            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="ba0f-0d41-48bc-bb81" name="Unique" primary="false"/>
+            <categoryLink targetId="59a4-7b61-600a-c457" id="dfe5-aa83-4256-a0fd" name="Skirmish" primary="false"/>
           </categoryLinks>
         </selectionEntry>
       </selectionEntries>
@@ -3561,6 +3568,11 @@ Corvus Corax may still Run on a turn when the Korvidine Pinions have been activa
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
               </costs>
+              <categoryLinks>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="d06f-28af-4f15-ac3e" name="Infantry" primary="false"/>
+                <categoryLink targetId="59a4-7b61-600a-c457" id="5358-a88f-4d36-bb8e" name="Skirmish" primary="false"/>
+                <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="e8e3-f8c1-4102-af07" name="Character" primary="false"/>
+              </categoryLinks>
             </selectionEntry>
             <selectionEntry id="2851-3859-0740-a416" name="Mor Deythan Shade w/Special Weapon" hidden="false" collective="false" import="true" type="model">
               <constraints>
@@ -3695,6 +3707,11 @@ Corvus Corax may still Run on a turn when the Korvidine Pinions have been activa
               <infoLinks>
                 <infoLink id="0dde-2e01-49d4-75c8" name="Mor Deythan Shade" targetId="f720-cd2b-5c7f-2ad4" type="profile"/>
               </infoLinks>
+              <categoryLinks>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="7b7c-b082-4c3f-bf7f" name="Infantry" primary="false"/>
+                <categoryLink targetId="59a4-7b61-600a-c457" id="7015-1371-4f3f-ac1f" name="Skirmish" primary="false"/>
+                <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="ec8a-834c-4458-b538" name="Character" primary="false"/>
+              </categoryLinks>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
@@ -3808,6 +3825,11 @@ Corvus Corax may still Run on a turn when the Korvidine Pinions have been activa
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25"/>
               </costs>
+              <categoryLinks>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="e729-3c89-4c3b-99cc" name="Infantry" primary="false"/>
+              </categoryLinks>
+              <comment>!BSC Errors from 20240328-1346
+Could not find type or subtype &apos;Skrimish&apos;</comment>
             </selectionEntry>
             <selectionEntry id="e2db-b3b2-e938-62c5" name="Mor Deythan w/Special Weapon" hidden="false" collective="false" import="true" type="model">
               <modifiers>
@@ -3910,6 +3932,11 @@ Corvus Corax may still Run on a turn when the Korvidine Pinions have been activa
               <infoLinks>
                 <infoLink id="573e-66b0-7d0a-970a" name="Mor Deythan" targetId="9e9b-1562-811d-d0bf" type="profile"/>
               </infoLinks>
+              <categoryLinks>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="c312-7a90-4083-8e3b" name="Infantry" primary="false"/>
+              </categoryLinks>
+              <comment>!BSC Errors from 20240328-1346
+Could not find type or subtype &apos;Skrimish&apos;</comment>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
@@ -4011,6 +4038,9 @@ Corvus Corax may still Run on a turn when the Korvidine Pinions have been activa
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25"/>
           </costs>
+          <categoryLinks>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="8153-e749-4fc1-969a" name="Infantry" primary="false"/>
+          </categoryLinks>
         </selectionEntry>
         <selectionEntry id="a454-113e-f900-cee3" name="Chooser of the Slain" hidden="false" collective="false" import="true" type="model">
           <modifiers>
@@ -4052,6 +4082,10 @@ Corvus Corax may still Run on a turn when the Korvidine Pinions have been activa
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="40"/>
           </costs>
+          <categoryLinks>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="b789-6e94-429d-bde1" name="Infantry" primary="false"/>
+            <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="f11f-cee8-4eb2-b332" name="Character" primary="false"/>
+          </categoryLinks>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
@@ -4260,6 +4294,9 @@ Corvus Corax may still Run on a turn when the Korvidine Pinions have been activa
           </costs>
           <categoryLinks>
             <categoryLink targetId="4f07-3d45-4f28-a0c6" id="b468-6e45-b156-899b" primary="false" name="Independent Character"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="f0b4-a4fb-4564-b6f3" name="Infantry" primary="false"/>
+            <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="3616-1340-45b1-90ce" name="Character" primary="false"/>
+            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="fc12-dbe6-46d7-b6c2" name="Unique" primary="false"/>
           </categoryLinks>
         </selectionEntry>
       </selectionEntries>
@@ -4373,6 +4410,8 @@ Additionally, if selected as part of an army that includes Corvus Corax, no mode
               </profiles>
               <categoryLinks>
                 <categoryLink id="6cf3-6064-94d9-766c" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="c8ea-60d9-45ee-b988" name="Infantry" primary="false"/>
+                <categoryLink targetId="9231-183c-b97b-63f9" id="603b-23d4-41c9-9c9f" name="Heavy" primary="false"/>
               </categoryLinks>
               <entryLinks>
                 <entryLink id="7243-41b8-68b3-d513" name="Infravisor" hidden="false" collective="false" import="true" targetId="bc5b-fcd7-aeed-e97c" type="selectionEntry">
@@ -4419,6 +4458,8 @@ Additionally, if selected as part of an army that includes Corvus Corax, no mode
             <selectionEntry id="2fd7-841f-206a-9f2b" name="Deliverer Chieftain" hidden="false" collective="false" import="true" type="model">
               <categoryLinks>
                 <categoryLink id="0e24-4422-ed3e-dec5" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="9502-4a41-4a44-9b64" name="Infantry" primary="false"/>
+                <categoryLink targetId="9231-183c-b97b-63f9" id="1eef-8bdd-45e8-8bf4" name="Heavy" primary="false"/>
               </categoryLinks>
               <entryLinks>
                 <entryLink id="000d-22ac-47f1-b8e0" name="Deliverer Melee Weapon" hidden="false" collective="false" import="true" targetId="d48a-b33b-002e-fc23" type="selectionEntryGroup"/>
@@ -4458,6 +4499,8 @@ Additionally, if selected as part of an army that includes Corvus Corax, no mode
             <selectionEntry id="1ca5-717a-5346-81c1" name="Deliverer Chieftain w/Heavy Weapon" hidden="false" collective="false" import="true" type="model">
               <categoryLinks>
                 <categoryLink id="58e3-212f-ea8d-ec37" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="19b4-0fb4-4220-a112" name="Infantry" primary="false"/>
+                <categoryLink targetId="9231-183c-b97b-63f9" id="77c2-3435-413c-97b4" name="Heavy" primary="false"/>
               </categoryLinks>
               <entryLinks>
                 <entryLink id="3af5-0c60-c79f-75ae" name="Deliverer Heavy Weapons" hidden="false" collective="false" import="true" targetId="2c85-3ae3-fbdf-2e60" type="selectionEntryGroup"/>
@@ -4527,6 +4570,10 @@ Additionally, if selected as part of an army that includes Corvus Corax, no mode
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="40"/>
               </costs>
+              <categoryLinks>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="12dd-3674-47be-9f5c" name="Infantry" primary="false"/>
+                <categoryLink targetId="9231-183c-b97b-63f9" id="5123-396c-4e98-8cf6" name="Heavy" primary="false"/>
+              </categoryLinks>
             </selectionEntry>
             <selectionEntry id="acb7-6b25-f268-1e56" name="Deliverer w/Pair of Raven&apos;s Talons" hidden="false" collective="false" import="true" type="model">
               <entryLinks>
@@ -4546,6 +4593,10 @@ Additionally, if selected as part of an army that includes Corvus Corax, no mode
               <infoLinks>
                 <infoLink id="3677-f1a2-ccdf-4e11" name="Deliverer" targetId="a312-9684-80bb-c22f" type="profile"/>
               </infoLinks>
+              <categoryLinks>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="082f-934b-47d9-b3e6" name="Infantry" primary="false"/>
+                <categoryLink targetId="9231-183c-b97b-63f9" id="c8c1-39f2-4531-a6f0" name="Heavy" primary="false"/>
+              </categoryLinks>
             </selectionEntry>
             <selectionEntry id="a74c-a81e-519d-6339" name="Deliverer w/Heavy Weapon" hidden="false" collective="false" import="true" type="model">
               <modifiers>
@@ -4573,6 +4624,10 @@ Additionally, if selected as part of an army that includes Corvus Corax, no mode
               <infoLinks>
                 <infoLink id="b553-b1cf-be43-12c1" name="Deliverer" targetId="a312-9684-80bb-c22f" type="profile"/>
               </infoLinks>
+              <categoryLinks>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="b801-4725-44d3-bb50" name="Infantry" primary="false"/>
+                <categoryLink targetId="9231-183c-b97b-63f9" id="cdb8-ec69-4aae-a755" name="Heavy" primary="false"/>
+              </categoryLinks>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>

--- a/2022 - LA - Raven Guard.cat
+++ b/2022 - LA - Raven Guard.cat
@@ -3728,7 +3728,7 @@ Corvus Corax may still Run on a turn when the Korvidine Pinions have been activa
               <profiles>
                 <profile id="9e9b-1562-811d-d0bf" name="Mor Deythan" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName="Unit">
                   <characteristics>
-                    <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Skrimish)</characteristic>
+                    <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Skirmish)</characteristic>
                     <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
                     <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
                     <characteristic name="BS" typeId="74ae-c840-0036-d244">5</characteristic>
@@ -3827,9 +3827,8 @@ Corvus Corax may still Run on a turn when the Korvidine Pinions have been activa
               </costs>
               <categoryLinks>
                 <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="e729-3c89-4c3b-99cc" name="Infantry" primary="false"/>
+                <categoryLink targetId="59a4-7b61-600a-c457" id="ee0b-6fca-48c4-9aa4" name="Skirmish" primary="false"/>
               </categoryLinks>
-              <comment>!BSC Errors from 20240328-1346
-Could not find type or subtype &apos;Skrimish&apos;</comment>
             </selectionEntry>
             <selectionEntry id="e2db-b3b2-e938-62c5" name="Mor Deythan w/Special Weapon" hidden="false" collective="false" import="true" type="model">
               <modifiers>
@@ -3934,9 +3933,8 @@ Could not find type or subtype &apos;Skrimish&apos;</comment>
               </infoLinks>
               <categoryLinks>
                 <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="c312-7a90-4083-8e3b" name="Infantry" primary="false"/>
+                <categoryLink targetId="59a4-7b61-600a-c457" id="71c2-7d24-4f43-8e9d" name="Skirmish" primary="false"/>
               </categoryLinks>
-              <comment>!BSC Errors from 20240328-1346
-Could not find type or subtype &apos;Skrimish&apos;</comment>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>

--- a/2022 - LA - Raven Guard.cat
+++ b/2022 - LA - Raven Guard.cat
@@ -2675,7 +2675,7 @@
       <categoryLinks>
         <categoryLink id="63ff-0a92-42ab-ae8c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="204c-7b0f-4fb9-b1b3" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="85e6-cb31-427c-a040" name="Line Sub-type:" hidden="false" targetId="6399-5c65-7833-1025" primary="false"/>
+        <categoryLink id="85e6-cb31-427c-a040" name="Line Sub-type" hidden="false" targetId="6399-5c65-7833-1025" primary="false"/>
         <categoryLink id="b53d-b5f0-f9fb-2f00" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -3000,7 +3000,7 @@
       <categoryLinks>
         <categoryLink id="d770-1c5b-320d-4c12" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="21b2-c021-325e-d0b3" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="74fd-26f0-cda4-cd6b" name="Light Sub-type:" hidden="false" targetId="bff2-ae16-74a8-8712" primary="false"/>
+        <categoryLink id="74fd-26f0-cda4-cd6b" name="Light Sub-type" hidden="false" targetId="bff2-ae16-74a8-8712" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="6abf-622b-dee3-f98e" name="Moritat-Prime Kaedes Nex" hidden="false" collective="false" import="true" type="model">
@@ -3134,7 +3134,7 @@
       <categoryLinks>
         <categoryLink id="d718-986e-82a3-6418" name="Jump Infantry:" hidden="false" targetId="eee8-3c7c-2762-e33e" primary="false"/>
         <categoryLink id="077f-e8dd-5f24-86e9" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="26ee-c51c-b946-63f4" name="Skirmish Sub-type:" hidden="false" targetId="59a4-7b61-600a-c457" primary="false"/>
+        <categoryLink id="26ee-c51c-b946-63f4" name="Skirmish Sub-type" hidden="false" targetId="59a4-7b61-600a-c457" primary="false"/>
         <categoryLink id="1aa4-254b-db10-45c3" name="LoW &amp; Primarchs (25% Limit)" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false"/>
       </categoryLinks>
       <selectionEntries>
@@ -3311,7 +3311,7 @@ Corvus Corax may still Run on a turn when the Korvidine Pinions have been activa
       </infoLinks>
       <categoryLinks>
         <categoryLink id="9bde-6d45-2c6d-9437" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="9b5d-cc1c-07cf-48a2" name="Skirmish Sub-type:" hidden="false" targetId="59a4-7b61-600a-c457" primary="false"/>
+        <categoryLink id="9b5d-cc1c-07cf-48a2" name="Skirmish Sub-type" hidden="false" targetId="59a4-7b61-600a-c457" primary="false"/>
         <categoryLink id="af53-7c6c-7d0b-18f1" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
@@ -4379,7 +4379,7 @@ Additionally, if selected as part of an army that includes Corvus Corax, no mode
       </infoLinks>
       <categoryLinks>
         <categoryLink id="188c-d76b-84a6-638f" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="9cc5-6040-2587-922f" name="Heavy Sub-type:" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+        <categoryLink id="9cc5-6040-2587-922f" name="Heavy Sub-type" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
         <categoryLink id="c489-7c99-cc6f-01d0" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="5877-4eb0-e84d-2158" name="Terminators:" hidden="false" targetId="bab3-f50d-3e5f-2f78" primary="false"/>
       </categoryLinks>

--- a/2022 - LA - Raven Guard.cat
+++ b/2022 - LA - Raven Guard.cat
@@ -2998,7 +2998,7 @@
         <infoLink id="6d1d-134b-6029-5438" name="Pathfinder" hidden="false" targetId="ec97-7aa8-49f5-b298" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="d770-1c5b-320d-4c12" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="d770-1c5b-320d-4c12" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="21b2-c021-325e-d0b3" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="74fd-26f0-cda4-cd6b" name="Light Sub-type" hidden="false" targetId="bff2-ae16-74a8-8712" primary="false"/>
       </categoryLinks>
@@ -3030,10 +3030,10 @@
           </costs>
           <categoryLinks>
             <categoryLink targetId="4f07-3d45-4f28-a0c6" id="bb81-a4e6-a503-56ae" primary="false" name="Independent Character"/>
-            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="78d8-58da-40b1-9b04" name="Infantry" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="78d8-58da-40b1-9b04" name="Infantry Unit Type" primary="false"/>
             <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="5ecf-f86d-4e3f-8006" name="Character" primary="false"/>
-            <categoryLink targetId="bff2-ae16-74a8-8712" id="ef8f-54d3-4b1c-8cfe" name="Light" primary="false"/>
-            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="b054-5f64-4b30-a4c7" name="Unique" primary="false"/>
+            <categoryLink targetId="bff2-ae16-74a8-8712" id="ef8f-54d3-4b1c-8cfe" name="Light Sub-type" primary="false"/>
+            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="b054-5f64-4b30-a4c7" name="Unique Sub-type" primary="false"/>
           </categoryLinks>
         </selectionEntry>
         <selectionEntry id="9054-a4c3-8387-4c76" name="Fulcrim Hand Cannon" hidden="false" collective="false" import="true" type="upgrade">
@@ -3267,9 +3267,9 @@ Corvus Corax may still Run on a turn when the Korvidine Pinions have been activa
           </costs>
           <categoryLinks>
             <categoryLink targetId="4f07-3d45-4f28-a0c6" id="3ed2-7b0f-c4c0-1f6a" primary="false" name="Independent Character"/>
-            <categoryLink targetId="ad5f-31db-8bc7-5c46" id="8b19-dc49-49cb-814d" name="Primarch" primary="false"/>
-            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="ba0f-0d41-48bc-bb81" name="Unique" primary="false"/>
-            <categoryLink targetId="59a4-7b61-600a-c457" id="dfe5-aa83-4256-a0fd" name="Skirmish" primary="false"/>
+            <categoryLink targetId="ad5f-31db-8bc7-5c46" id="8b19-dc49-49cb-814d" name="Primarch:" primary="false"/>
+            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="ba0f-0d41-48bc-bb81" name="Unique Sub-type" primary="false"/>
+            <categoryLink targetId="59a4-7b61-600a-c457" id="dfe5-aa83-4256-a0fd" name="Skirmish Sub-type" primary="false"/>
           </categoryLinks>
         </selectionEntry>
       </selectionEntries>
@@ -3310,7 +3310,7 @@ Corvus Corax may still Run on a turn when the Korvidine Pinions have been activa
         <infoLink id="c894-4d1b-4c4a-8201" name="Scout" hidden="false" targetId="aacf-9a7e-982d-b793" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="9bde-6d45-2c6d-9437" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="9bde-6d45-2c6d-9437" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="9b5d-cc1c-07cf-48a2" name="Skirmish Sub-type" hidden="false" targetId="59a4-7b61-600a-c457" primary="false"/>
         <categoryLink id="af53-7c6c-7d0b-18f1" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
       </categoryLinks>
@@ -3569,8 +3569,8 @@ Corvus Corax may still Run on a turn when the Korvidine Pinions have been activa
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
               </costs>
               <categoryLinks>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="d06f-28af-4f15-ac3e" name="Infantry" primary="false"/>
-                <categoryLink targetId="59a4-7b61-600a-c457" id="5358-a88f-4d36-bb8e" name="Skirmish" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="d06f-28af-4f15-ac3e" name="Infantry Unit Type" primary="false"/>
+                <categoryLink targetId="59a4-7b61-600a-c457" id="5358-a88f-4d36-bb8e" name="Skirmish Sub-type" primary="false"/>
                 <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="e8e3-f8c1-4102-af07" name="Character" primary="false"/>
               </categoryLinks>
             </selectionEntry>
@@ -3708,8 +3708,8 @@ Corvus Corax may still Run on a turn when the Korvidine Pinions have been activa
                 <infoLink id="0dde-2e01-49d4-75c8" name="Mor Deythan Shade" targetId="f720-cd2b-5c7f-2ad4" type="profile"/>
               </infoLinks>
               <categoryLinks>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="7b7c-b082-4c3f-bf7f" name="Infantry" primary="false"/>
-                <categoryLink targetId="59a4-7b61-600a-c457" id="7015-1371-4f3f-ac1f" name="Skirmish" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="7b7c-b082-4c3f-bf7f" name="Infantry Unit Type" primary="false"/>
+                <categoryLink targetId="59a4-7b61-600a-c457" id="7015-1371-4f3f-ac1f" name="Skirmish Sub-type" primary="false"/>
                 <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="ec8a-834c-4458-b538" name="Character" primary="false"/>
               </categoryLinks>
             </selectionEntry>
@@ -3826,8 +3826,8 @@ Corvus Corax may still Run on a turn when the Korvidine Pinions have been activa
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25"/>
               </costs>
               <categoryLinks>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="e729-3c89-4c3b-99cc" name="Infantry" primary="false"/>
-                <categoryLink targetId="59a4-7b61-600a-c457" id="ee0b-6fca-48c4-9aa4" name="Skirmish" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="e729-3c89-4c3b-99cc" name="Infantry Unit Type" primary="false"/>
+                <categoryLink targetId="59a4-7b61-600a-c457" id="ee0b-6fca-48c4-9aa4" name="Skirmish Sub-type" primary="false"/>
               </categoryLinks>
             </selectionEntry>
             <selectionEntry id="e2db-b3b2-e938-62c5" name="Mor Deythan w/Special Weapon" hidden="false" collective="false" import="true" type="model">
@@ -3932,8 +3932,8 @@ Corvus Corax may still Run on a turn when the Korvidine Pinions have been activa
                 <infoLink id="573e-66b0-7d0a-970a" name="Mor Deythan" targetId="9e9b-1562-811d-d0bf" type="profile"/>
               </infoLinks>
               <categoryLinks>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="c312-7a90-4083-8e3b" name="Infantry" primary="false"/>
-                <categoryLink targetId="59a4-7b61-600a-c457" id="71c2-7d24-4f43-8e9d" name="Skirmish" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="c312-7a90-4083-8e3b" name="Infantry Unit Type" primary="false"/>
+                <categoryLink targetId="59a4-7b61-600a-c457" id="71c2-7d24-4f43-8e9d" name="Skirmish Sub-type" primary="false"/>
               </categoryLinks>
             </selectionEntry>
           </selectionEntries>
@@ -3996,7 +3996,7 @@ Corvus Corax may still Run on a turn when the Korvidine Pinions have been activa
         </infoLink>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="cf6d-8fba-9f4c-c28b" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="cf6d-8fba-9f4c-c28b" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="ead3-4b26-1019-2b19" name="Jump Infantry:" hidden="false" targetId="eee8-3c7c-2762-e33e" primary="false"/>
         <categoryLink id="675d-d44e-ad5b-cebe" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
       </categoryLinks>
@@ -4037,7 +4037,7 @@ Corvus Corax may still Run on a turn when the Korvidine Pinions have been activa
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25"/>
           </costs>
           <categoryLinks>
-            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="8153-e749-4fc1-969a" name="Infantry" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="8153-e749-4fc1-969a" name="Infantry Unit Type" primary="false"/>
           </categoryLinks>
         </selectionEntry>
         <selectionEntry id="a454-113e-f900-cee3" name="Chooser of the Slain" hidden="false" collective="false" import="true" type="model">
@@ -4081,7 +4081,7 @@ Corvus Corax may still Run on a turn when the Korvidine Pinions have been activa
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="40"/>
           </costs>
           <categoryLinks>
-            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="b789-6e94-429d-bde1" name="Infantry" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="b789-6e94-429d-bde1" name="Infantry Unit Type" primary="false"/>
             <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="f11f-cee8-4eb2-b332" name="Character" primary="false"/>
           </categoryLinks>
         </selectionEntry>
@@ -4197,7 +4197,7 @@ Corvus Corax may still Run on a turn when the Korvidine Pinions have been activa
     </selectionEntry>
     <selectionEntry id="0e66-8311-405c-1e49" name="Strike Captain Alvarex Maun" hidden="false" collective="false" import="true" type="unit">
       <categoryLinks>
-        <categoryLink id="734e-eb71-18b5-ff92" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="734e-eb71-18b5-ff92" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="2fe0-6132-a9c3-7cc1" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
       </categoryLinks>
       <selectionEntries>
@@ -4292,9 +4292,9 @@ Corvus Corax may still Run on a turn when the Korvidine Pinions have been activa
           </costs>
           <categoryLinks>
             <categoryLink targetId="4f07-3d45-4f28-a0c6" id="b468-6e45-b156-899b" primary="false" name="Independent Character"/>
-            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="f0b4-a4fb-4564-b6f3" name="Infantry" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="f0b4-a4fb-4564-b6f3" name="Infantry Unit Type" primary="false"/>
             <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="3616-1340-45b1-90ce" name="Character" primary="false"/>
-            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="fc12-dbe6-46d7-b6c2" name="Unique" primary="false"/>
+            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="fc12-dbe6-46d7-b6c2" name="Unique Sub-type" primary="false"/>
           </categoryLinks>
         </selectionEntry>
       </selectionEntries>
@@ -4376,7 +4376,7 @@ Additionally, if selected as part of an army that includes Corvus Corax, no mode
         </infoLink>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="188c-d76b-84a6-638f" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="188c-d76b-84a6-638f" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="9cc5-6040-2587-922f" name="Heavy Sub-type" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
         <categoryLink id="c489-7c99-cc6f-01d0" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="5877-4eb0-e84d-2158" name="Terminators:" hidden="false" targetId="bab3-f50d-3e5f-2f78" primary="false"/>
@@ -4408,8 +4408,8 @@ Additionally, if selected as part of an army that includes Corvus Corax, no mode
               </profiles>
               <categoryLinks>
                 <categoryLink id="6cf3-6064-94d9-766c" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="c8ea-60d9-45ee-b988" name="Infantry" primary="false"/>
-                <categoryLink targetId="9231-183c-b97b-63f9" id="603b-23d4-41c9-9c9f" name="Heavy" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="c8ea-60d9-45ee-b988" name="Infantry Unit Type" primary="false"/>
+                <categoryLink targetId="9231-183c-b97b-63f9" id="603b-23d4-41c9-9c9f" name="Heavy Sub-type" primary="false"/>
               </categoryLinks>
               <entryLinks>
                 <entryLink id="7243-41b8-68b3-d513" name="Infravisor" hidden="false" collective="false" import="true" targetId="bc5b-fcd7-aeed-e97c" type="selectionEntry">
@@ -4456,8 +4456,8 @@ Additionally, if selected as part of an army that includes Corvus Corax, no mode
             <selectionEntry id="2fd7-841f-206a-9f2b" name="Deliverer Chieftain" hidden="false" collective="false" import="true" type="model">
               <categoryLinks>
                 <categoryLink id="0e24-4422-ed3e-dec5" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="9502-4a41-4a44-9b64" name="Infantry" primary="false"/>
-                <categoryLink targetId="9231-183c-b97b-63f9" id="1eef-8bdd-45e8-8bf4" name="Heavy" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="9502-4a41-4a44-9b64" name="Infantry Unit Type" primary="false"/>
+                <categoryLink targetId="9231-183c-b97b-63f9" id="1eef-8bdd-45e8-8bf4" name="Heavy Sub-type" primary="false"/>
               </categoryLinks>
               <entryLinks>
                 <entryLink id="000d-22ac-47f1-b8e0" name="Deliverer Melee Weapon" hidden="false" collective="false" import="true" targetId="d48a-b33b-002e-fc23" type="selectionEntryGroup"/>
@@ -4497,8 +4497,8 @@ Additionally, if selected as part of an army that includes Corvus Corax, no mode
             <selectionEntry id="1ca5-717a-5346-81c1" name="Deliverer Chieftain w/Heavy Weapon" hidden="false" collective="false" import="true" type="model">
               <categoryLinks>
                 <categoryLink id="58e3-212f-ea8d-ec37" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="19b4-0fb4-4220-a112" name="Infantry" primary="false"/>
-                <categoryLink targetId="9231-183c-b97b-63f9" id="77c2-3435-413c-97b4" name="Heavy" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="19b4-0fb4-4220-a112" name="Infantry Unit Type" primary="false"/>
+                <categoryLink targetId="9231-183c-b97b-63f9" id="77c2-3435-413c-97b4" name="Heavy Sub-type" primary="false"/>
               </categoryLinks>
               <entryLinks>
                 <entryLink id="3af5-0c60-c79f-75ae" name="Deliverer Heavy Weapons" hidden="false" collective="false" import="true" targetId="2c85-3ae3-fbdf-2e60" type="selectionEntryGroup"/>
@@ -4569,8 +4569,8 @@ Additionally, if selected as part of an army that includes Corvus Corax, no mode
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="40"/>
               </costs>
               <categoryLinks>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="12dd-3674-47be-9f5c" name="Infantry" primary="false"/>
-                <categoryLink targetId="9231-183c-b97b-63f9" id="5123-396c-4e98-8cf6" name="Heavy" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="12dd-3674-47be-9f5c" name="Infantry Unit Type" primary="false"/>
+                <categoryLink targetId="9231-183c-b97b-63f9" id="5123-396c-4e98-8cf6" name="Heavy Sub-type" primary="false"/>
               </categoryLinks>
             </selectionEntry>
             <selectionEntry id="acb7-6b25-f268-1e56" name="Deliverer w/Pair of Raven&apos;s Talons" hidden="false" collective="false" import="true" type="model">
@@ -4592,8 +4592,8 @@ Additionally, if selected as part of an army that includes Corvus Corax, no mode
                 <infoLink id="3677-f1a2-ccdf-4e11" name="Deliverer" targetId="a312-9684-80bb-c22f" type="profile"/>
               </infoLinks>
               <categoryLinks>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="082f-934b-47d9-b3e6" name="Infantry" primary="false"/>
-                <categoryLink targetId="9231-183c-b97b-63f9" id="c8c1-39f2-4531-a6f0" name="Heavy" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="082f-934b-47d9-b3e6" name="Infantry Unit Type" primary="false"/>
+                <categoryLink targetId="9231-183c-b97b-63f9" id="c8c1-39f2-4531-a6f0" name="Heavy Sub-type" primary="false"/>
               </categoryLinks>
             </selectionEntry>
             <selectionEntry id="a74c-a81e-519d-6339" name="Deliverer w/Heavy Weapon" hidden="false" collective="false" import="true" type="model">
@@ -4623,8 +4623,8 @@ Additionally, if selected as part of an army that includes Corvus Corax, no mode
                 <infoLink id="b553-b1cf-be43-12c1" name="Deliverer" targetId="a312-9684-80bb-c22f" type="profile"/>
               </infoLinks>
               <categoryLinks>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="b801-4725-44d3-bb50" name="Infantry" primary="false"/>
-                <categoryLink targetId="9231-183c-b97b-63f9" id="cdb8-ec69-4aae-a755" name="Heavy" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="b801-4725-44d3-bb50" name="Infantry Unit Type" primary="false"/>
+                <categoryLink targetId="9231-183c-b97b-63f9" id="cdb8-ec69-4aae-a755" name="Heavy Sub-type" primary="false"/>
               </categoryLinks>
             </selectionEntry>
           </selectionEntries>

--- a/2022 - LA - Salamanders.cat
+++ b/2022 - LA - Salamanders.cat
@@ -3420,6 +3420,8 @@
         <selectionEntry type="model" import="true" name="Vulkan" hidden="false" id="e40a-1808-536d-f353">
           <categoryLinks>
             <categoryLink targetId="4f07-3d45-4f28-a0c6" id="41c9-c87d-bea9-73f3" primary="false" name="Independent Character"/>
+            <categoryLink targetId="ad5f-31db-8bc7-5c46" id="daa6-8485-4d6a-8207" name="Primarch" primary="false"/>
+            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="7fa4-aeca-43b4-ac4e" name="Unique" primary="false"/>
           </categoryLinks>
           <constraints>
             <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="1934-e704-ce56-d7c8"/>
@@ -3525,6 +3527,9 @@
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="30"/>
           </costs>
+          <categoryLinks>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="bb62-25cd-4bbe-b6e6" name="Infantry" primary="false"/>
+          </categoryLinks>
         </selectionEntry>
         <selectionEntry id="59b5-2903-41d4-da1c" name="Pyroclast Warden" hidden="false" collective="false" import="true" type="model">
           <constraints>
@@ -3550,6 +3555,7 @@
           </profiles>
           <categoryLinks>
             <categoryLink id="ad9b-ee4b-9a7f-081f" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="f09a-cddf-47e0-b214" name="Infantry" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="a058-7b3e-3f47-c9eb" name="Warden Melee:" hidden="false" collective="false" import="true" defaultSelectionEntryId="3028-3f3e-8046-4a4f">
@@ -3905,6 +3911,10 @@
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="45"/>
           </costs>
+          <categoryLinks>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="0f5f-b867-4e98-bb8b" name="Infantry" primary="false"/>
+            <categoryLink targetId="9231-183c-b97b-63f9" id="cde4-155a-4a8b-8fcd" name="Heavy" primary="false"/>
+          </categoryLinks>
         </selectionEntry>
         <selectionEntry id="d8b7-2197-33f3-6668" name="Firedrake Master" hidden="false" collective="false" import="true" type="model">
           <constraints>
@@ -3930,6 +3940,8 @@
           </profiles>
           <categoryLinks>
             <categoryLink id="7493-b565-8d7b-ebe9" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="c83a-7f3f-4bc1-9024" name="Infantry" primary="false"/>
+            <categoryLink targetId="9231-183c-b97b-63f9" id="afbf-de21-465e-a2ab" name="Heavy" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="5aec-2671-da16-e919" name="1) Melee Options:" hidden="false" collective="false" import="true" defaultSelectionEntryId="c167-f4c9-6ab3-7a15">
@@ -4179,6 +4191,7 @@
         <categoryLink id="3af7-46b2-2419-4a55" name="Heavy Sub-type:" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
         <categoryLink id="d849-8fbc-0faa-8dfb" name="Dreadnought Unit-type:" hidden="false" targetId="4280-4963-02b5-e31d" primary="false"/>
         <categoryLink id="2ff0-6e13-57f0-e139" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink targetId="aa94-5c65-d1f1-46a4" id="9996-7f4e-4632-ac50" name="Unique" primary="false"/>
       </categoryLinks>
       <entryLinks>
         <entryLink id="8df9-b411-be3d-51a9" name="Dreadnought Drop Pod" hidden="false" collective="false" import="true" targetId="1ffe-82e4-12db-538d" type="selectionEntry">
@@ -4299,6 +4312,9 @@
         <selectionEntry type="model" import="true" name="Lord Chaplain Nomus Rhy&apos;Tan" hidden="false" id="69a7-8617-7dea-7762">
           <categoryLinks>
             <categoryLink targetId="4f07-3d45-4f28-a0c6" id="9f3a-4213-ba25-fb5e" primary="false" name="Independent Character"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="d0bc-ff6e-473d-80dc" name="Infantry" primary="false"/>
+            <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="68a0-6977-446a-8ed1" name="Character" primary="false"/>
+            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="9cd5-fb47-4b1f-a7cc" name="Unique" primary="false"/>
           </categoryLinks>
           <constraints>
             <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="1934-e704-ce56-d7c8"/>
@@ -4458,6 +4474,9 @@
         <selectionEntry type="model" import="true" name="Xiaphas Jurr" hidden="false" id="a4a6-3c44-93e0-6b8e">
           <categoryLinks>
             <categoryLink targetId="4f07-3d45-4f28-a0c6" id="3cc4-d304-4e2b-e0a9" primary="false" name="Independent Character"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="709f-0182-4434-8802" name="Infantry" primary="false"/>
+            <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="e4fe-2207-4786-853a" name="Character" primary="false"/>
+            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="97e7-7888-4da2-b763" name="Unique" primary="false"/>
           </categoryLinks>
           <constraints>
             <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="1934-e704-ce56-d7c8"/>
@@ -4676,6 +4695,7 @@
           </profiles>
           <categoryLinks>
             <categoryLink id="9b32-cc32-59f1-e043" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="1cac-869f-4916-abd9" name="Infantry" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="9f27-9acb-024a-9bec" name="1) One in 5 may exhange Dragonbreath Combi-Flamer for:" hidden="false" collective="false" import="true" defaultSelectionEntryId="0544-f65e-e341-201c">
@@ -4800,6 +4820,9 @@
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20"/>
               </costs>
+              <categoryLinks>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="9f05-1e21-49ab-9d95" name="Infantry" primary="false"/>
+              </categoryLinks>
             </selectionEntry>
             <selectionEntry id="1c27-7553-0365-a562" name="Adherent w/ Dragon&apos;s Beath Heavy Flamer (1 in 5)" hidden="false" collective="false" import="true" type="model">
               <modifiers>
@@ -4837,6 +4860,9 @@
               <infoLinks>
                 <infoLink id="23cb-44fa-04e8-df73" name="Adherent" targetId="0d19-141f-7ffc-3a99" type="profile"/>
               </infoLinks>
+              <categoryLinks>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="1434-771a-4a35-923f" name="Infantry" primary="false"/>
+              </categoryLinks>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
@@ -5041,6 +5067,7 @@
           </profiles>
           <categoryLinks>
             <categoryLink id="d91f-ec13-e397-df15" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="df29-c34a-4b00-b956" name="Infantry" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="2869-e1ce-ec25-9abb" name="May Exchange Chainsword for:" hidden="false" collective="false" import="true" defaultSelectionEntryId="f1bc-f7d1-33c-cf0b">
@@ -5293,6 +5320,9 @@
                   </constraints>
                 </entryLink>
               </entryLinks>
+              <categoryLinks>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="e758-6e38-43bf-9d48" name="Infantry" primary="false"/>
+              </categoryLinks>
             </selectionEntry>
             <selectionEntry id="6a08-a21f-c954-fddf" name="Sanctifier w/ Options" hidden="false" collective="false" import="true" type="model">
               <constraints>
@@ -5514,6 +5544,9 @@
                   </selectionEntryGroups>
                 </selectionEntryGroup>
               </selectionEntryGroups>
+              <categoryLinks>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="ad3d-e348-4392-b1b9" name="Infantry" primary="false"/>
+              </categoryLinks>
             </selectionEntry>
           </selectionEntries>
           <constraints>

--- a/2022 - LA - Salamanders.cat
+++ b/2022 - LA - Salamanders.cat
@@ -2986,7 +2986,7 @@
       <categoryLinks>
         <categoryLink id="63ff-0a92-42ab-ae8c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="204c-7b0f-4fb9-b1b3" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="85e6-cb31-427c-a040" name="Line Sub-type:" hidden="false" targetId="6399-5c65-7833-1025" primary="false"/>
+        <categoryLink id="85e6-cb31-427c-a040" name="Line Sub-type" hidden="false" targetId="6399-5c65-7833-1025" primary="false"/>
         <categoryLink id="589c-fa50-73d4-0b2d" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -3285,7 +3285,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="fc97-0a33-3c10-db8e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="463a-8ed4-5ea4-f05d" name="Line Sub-type:" hidden="false" targetId="6399-5c65-7833-1025" primary="false"/>
+        <categoryLink id="463a-8ed4-5ea4-f05d" name="Line Sub-type" hidden="false" targetId="6399-5c65-7833-1025" primary="false"/>
         <categoryLink id="55c4-00e8-71c9-df57" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
         <categoryLink id="4a91-da38-d2c0-f52b" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
       </categoryLinks>
@@ -3796,7 +3796,7 @@
         </infoLink>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="b47e-4128-4626-5ab1" name="Heavy Sub-type:" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+        <categoryLink id="b47e-4128-4626-5ab1" name="Heavy Sub-type" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
         <categoryLink id="0d65-1662-e010-f889" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="f28b-f86f-8c4f-ba4f" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="a1cf-3d0c-18a6-773d" name="Terminators:" hidden="false" targetId="bab3-f50d-3e5f-2f78" primary="false"/>
@@ -4188,8 +4188,8 @@
         </infoLink>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="3af7-46b2-2419-4a55" name="Heavy Sub-type:" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
-        <categoryLink id="d849-8fbc-0faa-8dfb" name="Dreadnought Unit-type:" hidden="false" targetId="4280-4963-02b5-e31d" primary="false"/>
+        <categoryLink id="3af7-46b2-2419-4a55" name="Heavy Sub-type" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+        <categoryLink id="d849-8fbc-0faa-8dfb" name="Dreadnought Unit Type" hidden="false" targetId="4280-4963-02b5-e31d" primary="false"/>
         <categoryLink id="2ff0-6e13-57f0-e139" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink targetId="aa94-5c65-d1f1-46a4" id="9996-7f4e-4632-ac50" name="Unique" primary="false"/>
       </categoryLinks>

--- a/2022 - LA - Salamanders.cat
+++ b/2022 - LA - Salamanders.cat
@@ -3420,8 +3420,8 @@
         <selectionEntry type="model" import="true" name="Vulkan" hidden="false" id="e40a-1808-536d-f353">
           <categoryLinks>
             <categoryLink targetId="4f07-3d45-4f28-a0c6" id="41c9-c87d-bea9-73f3" primary="false" name="Independent Character"/>
-            <categoryLink targetId="ad5f-31db-8bc7-5c46" id="daa6-8485-4d6a-8207" name="Primarch" primary="false"/>
-            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="7fa4-aeca-43b4-ac4e" name="Unique" primary="false"/>
+            <categoryLink targetId="ad5f-31db-8bc7-5c46" id="daa6-8485-4d6a-8207" name="Primarch:" primary="false"/>
+            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="7fa4-aeca-43b4-ac4e" name="Unique Sub-type" primary="false"/>
           </categoryLinks>
           <constraints>
             <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="1934-e704-ce56-d7c8"/>
@@ -3498,7 +3498,7 @@
         </infoLink>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="d837-e352-e6f6-6b63" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="d837-e352-e6f6-6b63" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="0f09-6dcb-5b34-c507" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
       </categoryLinks>
       <selectionEntries>
@@ -3528,7 +3528,7 @@
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="30"/>
           </costs>
           <categoryLinks>
-            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="bb62-25cd-4bbe-b6e6" name="Infantry" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="bb62-25cd-4bbe-b6e6" name="Infantry Unit Type" primary="false"/>
           </categoryLinks>
         </selectionEntry>
         <selectionEntry id="59b5-2903-41d4-da1c" name="Pyroclast Warden" hidden="false" collective="false" import="true" type="model">
@@ -3555,7 +3555,7 @@
           </profiles>
           <categoryLinks>
             <categoryLink id="ad9b-ee4b-9a7f-081f" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
-            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="f09a-cddf-47e0-b214" name="Infantry" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="f09a-cddf-47e0-b214" name="Infantry Unit Type" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="a058-7b3e-3f47-c9eb" name="Warden Melee:" hidden="false" collective="false" import="true" defaultSelectionEntryId="3028-3f3e-8046-4a4f">
@@ -3797,7 +3797,7 @@
       </infoLinks>
       <categoryLinks>
         <categoryLink id="b47e-4128-4626-5ab1" name="Heavy Sub-type" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
-        <categoryLink id="0d65-1662-e010-f889" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="0d65-1662-e010-f889" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="f28b-f86f-8c4f-ba4f" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="a1cf-3d0c-18a6-773d" name="Terminators:" hidden="false" targetId="bab3-f50d-3e5f-2f78" primary="false"/>
       </categoryLinks>
@@ -3912,8 +3912,8 @@
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="45"/>
           </costs>
           <categoryLinks>
-            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="0f5f-b867-4e98-bb8b" name="Infantry" primary="false"/>
-            <categoryLink targetId="9231-183c-b97b-63f9" id="cde4-155a-4a8b-8fcd" name="Heavy" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="0f5f-b867-4e98-bb8b" name="Infantry Unit Type" primary="false"/>
+            <categoryLink targetId="9231-183c-b97b-63f9" id="cde4-155a-4a8b-8fcd" name="Heavy Sub-type" primary="false"/>
           </categoryLinks>
         </selectionEntry>
         <selectionEntry id="d8b7-2197-33f3-6668" name="Firedrake Master" hidden="false" collective="false" import="true" type="model">
@@ -3940,8 +3940,8 @@
           </profiles>
           <categoryLinks>
             <categoryLink id="7493-b565-8d7b-ebe9" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
-            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="c83a-7f3f-4bc1-9024" name="Infantry" primary="false"/>
-            <categoryLink targetId="9231-183c-b97b-63f9" id="afbf-de21-465e-a2ab" name="Heavy" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="c83a-7f3f-4bc1-9024" name="Infantry Unit Type" primary="false"/>
+            <categoryLink targetId="9231-183c-b97b-63f9" id="afbf-de21-465e-a2ab" name="Heavy Sub-type" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="5aec-2671-da16-e919" name="1) Melee Options:" hidden="false" collective="false" import="true" defaultSelectionEntryId="c167-f4c9-6ab3-7a15">
@@ -4191,7 +4191,7 @@
         <categoryLink id="3af7-46b2-2419-4a55" name="Heavy Sub-type" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
         <categoryLink id="d849-8fbc-0faa-8dfb" name="Dreadnought Unit Type" hidden="false" targetId="4280-4963-02b5-e31d" primary="false"/>
         <categoryLink id="2ff0-6e13-57f0-e139" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink targetId="aa94-5c65-d1f1-46a4" id="9996-7f4e-4632-ac50" name="Unique" primary="false"/>
+        <categoryLink targetId="aa94-5c65-d1f1-46a4" id="9996-7f4e-4632-ac50" name="Unique Sub-type" primary="false"/>
       </categoryLinks>
       <entryLinks>
         <entryLink id="8df9-b411-be3d-51a9" name="Dreadnought Drop Pod" hidden="false" collective="false" import="true" targetId="1ffe-82e4-12db-538d" type="selectionEntry">
@@ -4281,7 +4281,7 @@
         </infoLink>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="f22c-47a5-ca44-ccdc" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="f22c-47a5-ca44-ccdc" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="b624-3e54-171d-2b09" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink targetId="3f99-ad1b-740b-862e" id="86b9-e65d-f24a-e97e" primary="false" name="The Awakening Fire (Chaplain)"/>
       </categoryLinks>
@@ -4312,9 +4312,9 @@
         <selectionEntry type="model" import="true" name="Lord Chaplain Nomus Rhy&apos;Tan" hidden="false" id="69a7-8617-7dea-7762">
           <categoryLinks>
             <categoryLink targetId="4f07-3d45-4f28-a0c6" id="9f3a-4213-ba25-fb5e" primary="false" name="Independent Character"/>
-            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="d0bc-ff6e-473d-80dc" name="Infantry" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="d0bc-ff6e-473d-80dc" name="Infantry Unit Type" primary="false"/>
             <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="68a0-6977-446a-8ed1" name="Character" primary="false"/>
-            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="9cd5-fb47-4b1f-a7cc" name="Unique" primary="false"/>
+            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="9cd5-fb47-4b1f-a7cc" name="Unique Sub-type" primary="false"/>
           </categoryLinks>
           <constraints>
             <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="1934-e704-ce56-d7c8"/>
@@ -4427,7 +4427,7 @@
         </infoLink>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="8e0a-7307-985f-50a6" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="8e0a-7307-985f-50a6" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="4585-3e1e-8e4c-4a36" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink targetId="3f99-ad1b-740b-862e" id="6c70-e974-dcd8-7193" primary="false" name="The Awakening Fire (Chaplain)"/>
       </categoryLinks>
@@ -4474,9 +4474,9 @@
         <selectionEntry type="model" import="true" name="Xiaphas Jurr" hidden="false" id="a4a6-3c44-93e0-6b8e">
           <categoryLinks>
             <categoryLink targetId="4f07-3d45-4f28-a0c6" id="3cc4-d304-4e2b-e0a9" primary="false" name="Independent Character"/>
-            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="709f-0182-4434-8802" name="Infantry" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="709f-0182-4434-8802" name="Infantry Unit Type" primary="false"/>
             <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="e4fe-2207-4786-853a" name="Character" primary="false"/>
-            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="97e7-7888-4da2-b763" name="Unique" primary="false"/>
+            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="97e7-7888-4da2-b763" name="Unique Sub-type" primary="false"/>
           </categoryLinks>
           <constraints>
             <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="1934-e704-ce56-d7c8"/>
@@ -4661,7 +4661,7 @@
       </infoLinks>
       <categoryLinks>
         <categoryLink id="3da4-aafa-38cb-08f1" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="fbce-7a28-4574-f6bb" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="fbce-7a28-4574-f6bb" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="78d3-3a4b-65dc-7a3b" name="1) Adherent Sergeant" hidden="false" collective="false" import="true" type="model">
@@ -4695,7 +4695,7 @@
           </profiles>
           <categoryLinks>
             <categoryLink id="9b32-cc32-59f1-e043" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
-            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="1cac-869f-4916-abd9" name="Infantry" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="1cac-869f-4916-abd9" name="Infantry Unit Type" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="9f27-9acb-024a-9bec" name="1) One in 5 may exhange Dragonbreath Combi-Flamer for:" hidden="false" collective="false" import="true" defaultSelectionEntryId="0544-f65e-e341-201c">
@@ -4821,7 +4821,7 @@
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20"/>
               </costs>
               <categoryLinks>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="9f05-1e21-49ab-9d95" name="Infantry" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="9f05-1e21-49ab-9d95" name="Infantry Unit Type" primary="false"/>
               </categoryLinks>
             </selectionEntry>
             <selectionEntry id="1c27-7553-0365-a562" name="Adherent w/ Dragon&apos;s Beath Heavy Flamer (1 in 5)" hidden="false" collective="false" import="true" type="model">
@@ -4861,7 +4861,7 @@
                 <infoLink id="23cb-44fa-04e8-df73" name="Adherent" targetId="0d19-141f-7ffc-3a99" type="profile"/>
               </infoLinks>
               <categoryLinks>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="1434-771a-4a35-923f" name="Infantry" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="1434-771a-4a35-923f" name="Infantry Unit Type" primary="false"/>
               </categoryLinks>
             </selectionEntry>
           </selectionEntries>
@@ -5032,7 +5032,7 @@
         <infoLink id="cfd5-a132-5c7b-3360" name="Stubborn" hidden="false" targetId="7989-1f2c-a43d-82ae" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="8702-96e8-baeb-caa9" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="8702-96e8-baeb-caa9" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="313f-a842-1ae0-a2e4" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
       </categoryLinks>
       <selectionEntries>
@@ -5067,7 +5067,7 @@
           </profiles>
           <categoryLinks>
             <categoryLink id="d91f-ec13-e397-df15" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
-            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="df29-c34a-4b00-b956" name="Infantry" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="df29-c34a-4b00-b956" name="Infantry Unit Type" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="2869-e1ce-ec25-9abb" name="May Exchange Chainsword for:" hidden="false" collective="false" import="true" defaultSelectionEntryId="f1bc-f7d1-33c-cf0b">
@@ -5321,7 +5321,7 @@
                 </entryLink>
               </entryLinks>
               <categoryLinks>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="e758-6e38-43bf-9d48" name="Infantry" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="e758-6e38-43bf-9d48" name="Infantry Unit Type" primary="false"/>
               </categoryLinks>
             </selectionEntry>
             <selectionEntry id="6a08-a21f-c954-fddf" name="Sanctifier w/ Options" hidden="false" collective="false" import="true" type="model">
@@ -5545,7 +5545,7 @@
                 </selectionEntryGroup>
               </selectionEntryGroups>
               <categoryLinks>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="ad3d-e348-4392-b1b9" name="Infantry" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="ad3d-e348-4392-b1b9" name="Infantry Unit Type" primary="false"/>
               </categoryLinks>
             </selectionEntry>
           </selectionEntries>

--- a/2022 - LA - Sons of Horus.cat
+++ b/2022 - LA - Sons of Horus.cat
@@ -3138,7 +3138,7 @@
       </infoLinks>
       <categoryLinks>
         <categoryLink id="74fd-91d7-6d1c-8edd" name="Heavy Sub-type" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
-        <categoryLink id="8cac-3a0b-8f04-2877" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="8cac-3a0b-8f04-2877" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="ed45-fc62-5dd5-769f" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
       </categoryLinks>
       <selectionEntries>
@@ -3239,8 +3239,8 @@
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20"/>
           </costs>
           <categoryLinks>
-            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="df67-8a86-46d0-852e" name="Infantry" primary="false"/>
-            <categoryLink targetId="9231-183c-b97b-63f9" id="7db6-e9e4-4ec1-89f6" name="Heavy" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="df67-8a86-46d0-852e" name="Infantry Unit Type" primary="false"/>
+            <categoryLink targetId="9231-183c-b97b-63f9" id="7db6-e9e4-4ec1-89f6" name="Heavy Sub-type" primary="false"/>
           </categoryLinks>
         </selectionEntry>
         <selectionEntry id="0ca4-f397-e1f8-2afe" name="Standard Bearer" hidden="false" collective="false" import="true" type="model">
@@ -3340,8 +3340,8 @@
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
           </costs>
           <categoryLinks>
-            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="5619-b18c-4689-9bff" name="Infantry" primary="false"/>
-            <categoryLink targetId="9231-183c-b97b-63f9" id="a2ef-174a-48f3-bd84" name="Heavy" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="5619-b18c-4689-9bff" name="Infantry Unit Type" primary="false"/>
+            <categoryLink targetId="9231-183c-b97b-63f9" id="a2ef-174a-48f3-bd84" name="Heavy Sub-type" primary="false"/>
           </categoryLinks>
         </selectionEntry>
       </selectionEntries>
@@ -3521,8 +3521,8 @@
               </costs>
               <categoryLinks>
                 <categoryLink targetId="4f07-3d45-4f28-a0c6" id="3877-3563-8980-fce4" primary="false" name="Independent Character"/>
-                <categoryLink targetId="ad5f-31db-8bc7-5c46" id="ef75-a0e0-48ff-890a" name="Primarch" primary="false"/>
-                <categoryLink targetId="aa94-5c65-d1f1-46a4" id="6c08-64d8-449c-9a43" name="Unique" primary="false"/>
+                <categoryLink targetId="ad5f-31db-8bc7-5c46" id="ef75-a0e0-48ff-890a" name="Primarch:" primary="false"/>
+                <categoryLink targetId="aa94-5c65-d1f1-46a4" id="6c08-64d8-449c-9a43" name="Unique Sub-type" primary="false"/>
               </categoryLinks>
             </selectionEntry>
           </selectionEntries>
@@ -3601,7 +3601,7 @@
       </infoLinks>
       <categoryLinks>
         <categoryLink id="4caa-933a-6c61-0c7a" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="d534-6f34-1da7-062d" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="d534-6f34-1da7-062d" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="8e5a-163d-6dcf-8f4a" name="Reaver Chieftain" hidden="false" collective="false" import="true" type="model">
@@ -3640,7 +3640,7 @@
           </profiles>
           <categoryLinks>
             <categoryLink id="9e64-6058-50b6-2676" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
-            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="9177-9911-4219-8d50" name="Infantry" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="9177-9911-4219-8d50" name="Infantry Unit Type" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="366f-f67d-382b-7a6f" name="Bolt Pistol:" hidden="false" collective="false" import="true" defaultSelectionEntryId="d4bd-a4c8-1282-0a0d">
@@ -4102,7 +4102,7 @@
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="22"/>
               </costs>
               <categoryLinks>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="de47-fcb5-4e95-b2ca" name="Infantry" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="de47-fcb5-4e95-b2ca" name="Infantry Unit Type" primary="false"/>
               </categoryLinks>
             </selectionEntry>
             <selectionEntry id="2fc2-12f4-a68f-111d" name="Reaver w/ Options" hidden="false" collective="false" import="true" type="model">
@@ -4349,7 +4349,7 @@
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="22"/>
               </costs>
               <categoryLinks>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="9573-27ed-4d67-aad8" name="Infantry" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="9573-27ed-4d67-aad8" name="Infantry Unit Type" primary="false"/>
               </categoryLinks>
             </selectionEntry>
           </selectionEntries>
@@ -4386,7 +4386,7 @@
         <constraint field="selections" scope="force" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a2fb-65c3-01b9-1e64" type="max"/>
       </constraints>
       <categoryLinks>
-        <categoryLink id="1f57-7f73-c9f6-c78c" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="1f57-7f73-c9f6-c78c" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="008c-4ae3-4bb8-7464" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="0a8b-db6e-ba23-26ec" name="Line Sub-type" hidden="false" targetId="6399-5c65-7833-1025" primary="false"/>
       </categoryLinks>
@@ -4439,10 +4439,10 @@
           </costs>
           <categoryLinks>
             <categoryLink targetId="4f07-3d45-4f28-a0c6" id="7c6b-2082-90a4-8d02" primary="false" name="Independent Character"/>
-            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="9ce6-83b2-4275-a5c3" name="Infantry" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="9ce6-83b2-4275-a5c3" name="Infantry Unit Type" primary="false"/>
             <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="aef1-2536-4908-8ed7" name="Character" primary="false"/>
-            <categoryLink targetId="6399-5c65-7833-1025" id="7fce-8ef4-43d2-a18e" name="Line" primary="false"/>
-            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="0814-d1db-46da-872f" name="Unique" primary="false"/>
+            <categoryLink targetId="6399-5c65-7833-1025" id="7fce-8ef4-43d2-a18e" name="Line Sub-type" primary="false"/>
+            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="0814-d1db-46da-872f" name="Unique Sub-type" primary="false"/>
           </categoryLinks>
         </selectionEntry>
       </selectionEntries>
@@ -4546,7 +4546,7 @@
         <infoLink id="aea7-24d3-925e-74c2" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="6cdb-94f4-0716-aa82" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="6cdb-94f4-0716-aa82" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="4897-8773-245a-fd7e" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="ea4e-2199-7ddc-8cb8" name="Terminators:" hidden="false" targetId="bab3-f50d-3e5f-2f78" primary="false"/>
       </categoryLinks>
@@ -4579,10 +4579,10 @@
         <selectionEntry type="model" import="true" name="Ezekyle Abaddon" hidden="false" id="4907-6e0d-1154-d01b">
           <categoryLinks>
             <categoryLink targetId="4f07-3d45-4f28-a0c6" id="5c67-4e64-dc0d-f2a2" primary="false" name="Independent Character"/>
-            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="38dd-9669-40e1-a5f4" name="Infantry" primary="false"/>
-            <categoryLink targetId="9231-183c-b97b-63f9" id="1205-6b1d-4e5a-ad6c" name="Heavy" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="38dd-9669-40e1-a5f4" name="Infantry Unit Type" primary="false"/>
+            <categoryLink targetId="9231-183c-b97b-63f9" id="1205-6b1d-4e5a-ad6c" name="Heavy Sub-type" primary="false"/>
             <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="4425-be8c-42e6-b0a3" name="Character" primary="false"/>
-            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="0822-f5a0-49d6-bebe" name="Unique" primary="false"/>
+            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="0822-f5a0-49d6-bebe" name="Unique Sub-type" primary="false"/>
           </categoryLinks>
           <constraints>
             <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="3f5d-e211-1f51-57bc"/>
@@ -4670,7 +4670,7 @@
         <infoLink id="1603-a22b-5c84-710e" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="fcef-9b8a-6c3f-4fbe" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="fcef-9b8a-6c3f-4fbe" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="6aca-3f5f-eceb-bb6f" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
       </categoryLinks>
       <entryLinks>
@@ -4738,8 +4738,8 @@
           <categoryLinks>
             <categoryLink targetId="4f07-3d45-4f28-a0c6" id="8740-5abd-10ae-f2f9" primary="false" name="Independent Character"/>
             <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="b7a3-8942-4b78-bcde" name="Character" primary="false"/>
-            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="0b18-9161-4070-b133" name="Unique" primary="false"/>
-            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="58df-e0c3-4737-a93a" name="Infantry" primary="false"/>
+            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="0b18-9161-4070-b133" name="Unique Sub-type" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="58df-e0c3-4737-a93a" name="Infantry Unit Type" primary="false"/>
           </categoryLinks>
           <constraints>
             <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="3f5d-e211-1f51-57bc"/>
@@ -4819,7 +4819,7 @@
       </infoLinks>
       <categoryLinks>
         <categoryLink id="705b-da26-7a7c-2f8c" name="Heavy Sub-type" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
-        <categoryLink id="9f47-8b3b-90cc-998d" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="9f47-8b3b-90cc-998d" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="5156-399a-3fcc-8ca9" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="fbc7-2ac6-fa36-63d9" name="Terminators:" hidden="false" targetId="bab3-f50d-3e5f-2f78" primary="false"/>
       </categoryLinks>
@@ -4925,8 +4925,8 @@
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="50"/>
               </costs>
               <categoryLinks>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="4bba-2670-4ef7-a2bc" name="Infantry" primary="false"/>
-                <categoryLink targetId="9231-183c-b97b-63f9" id="5fe8-f7ea-402b-9d13" name="Heavy" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="4bba-2670-4ef7-a2bc" name="Infantry Unit Type" primary="false"/>
+                <categoryLink targetId="9231-183c-b97b-63f9" id="5fe8-f7ea-402b-9d13" name="Heavy Sub-type" primary="false"/>
               </categoryLinks>
             </selectionEntry>
             <selectionEntry id="a1f2-efc6-9ff7-3323" name="Justaerin w/Heavy Weapon (1 in 5)" hidden="false" collective="false" import="true" type="model">
@@ -5013,8 +5013,8 @@
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="50"/>
               </costs>
               <categoryLinks>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="6ca1-0be0-42a8-8685" name="Infantry" primary="false"/>
-                <categoryLink targetId="9231-183c-b97b-63f9" id="e4f4-0da3-4009-bc2c" name="Heavy" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="6ca1-0be0-42a8-8685" name="Infantry Unit Type" primary="false"/>
+                <categoryLink targetId="9231-183c-b97b-63f9" id="e4f4-0da3-4009-bc2c" name="Heavy Sub-type" primary="false"/>
               </categoryLinks>
             </selectionEntry>
             <selectionEntry id="3c6e-f814-9806-3453" name="Justaerin w/Pair of Lightning Claws" hidden="false" collective="false" import="true" type="model">
@@ -5033,8 +5033,8 @@
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="55"/>
               </costs>
               <categoryLinks>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="4ba5-df65-422b-bd7d" name="Infantry" primary="false"/>
-                <categoryLink targetId="9231-183c-b97b-63f9" id="ef83-0b54-461c-a2ec" name="Heavy" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="4ba5-df65-422b-bd7d" name="Infantry Unit Type" primary="false"/>
+                <categoryLink targetId="9231-183c-b97b-63f9" id="ef83-0b54-461c-a2ec" name="Heavy Sub-type" primary="false"/>
               </categoryLinks>
             </selectionEntry>
             <selectionEntry id="3856-ef30-d865-30a6" name="Justaerin w/Pair of Lightning Claws, Grenade Harness" hidden="false" collective="false" import="true" type="model">
@@ -5062,8 +5062,8 @@
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="65"/>
               </costs>
               <categoryLinks>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="2905-7675-432a-abf6" name="Infantry" primary="false"/>
-                <categoryLink targetId="9231-183c-b97b-63f9" id="c6b8-289f-4cf3-a97b" name="Heavy" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="2905-7675-432a-abf6" name="Infantry Unit Type" primary="false"/>
+                <categoryLink targetId="9231-183c-b97b-63f9" id="c6b8-289f-4cf3-a97b" name="Heavy Sub-type" primary="false"/>
               </categoryLinks>
             </selectionEntry>
             <selectionEntry id="b02f-0bac-63d0-6dc6" name="Justaerin w/Legion Standard" hidden="true" collective="false" import="true" type="model">
@@ -5130,8 +5130,8 @@
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="65"/>
               </costs>
               <categoryLinks>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="3f71-056d-4a7d-8230" name="Infantry" primary="false"/>
-                <categoryLink targetId="9231-183c-b97b-63f9" id="f2a0-77a9-4253-9488" name="Heavy" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="3f71-056d-4a7d-8230" name="Infantry Unit Type" primary="false"/>
+                <categoryLink targetId="9231-183c-b97b-63f9" id="f2a0-77a9-4253-9488" name="Heavy Sub-type" primary="false"/>
               </categoryLinks>
             </selectionEntry>
           </selectionEntries>
@@ -5201,7 +5201,7 @@
       </infoLinks>
       <categoryLinks>
         <categoryLink id="773d-17eb-9834-2e2a" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="d4f8-7cfd-49ff-ca02" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="d4f8-7cfd-49ff-ca02" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="2095-6d87-7bf5-f840" name="The Culling Blade" hidden="false" collective="false" import="true" type="upgrade">
@@ -5244,9 +5244,9 @@
         <selectionEntry type="model" import="true" name="Tybalt Marr" hidden="false" id="da20-54b1-fdb-9659">
           <categoryLinks>
             <categoryLink targetId="4f07-3d45-4f28-a0c6" id="d42-4abd-3e06-f45" primary="false" name="Independent Character"/>
-            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="6c7d-d51d-432f-a82f" name="Infantry" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="6c7d-d51d-432f-a82f" name="Infantry Unit Type" primary="false"/>
             <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="c07e-c6fc-41e0-b0ec" name="Character" primary="false"/>
-            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="dda5-3fc8-4915-aac4" name="Unique" primary="false"/>
+            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="dda5-3fc8-4915-aac4" name="Unique Sub-type" primary="false"/>
           </categoryLinks>
           <constraints>
             <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="3f5d-e211-1f51-57bc"/>
@@ -5357,7 +5357,7 @@
       </infoLinks>
       <categoryLinks>
         <categoryLink id="38b8-bc47-ee4f-baef" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="6480-d33b-811b-a7fe" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="6480-d33b-811b-a7fe" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="ce86-cb58-16b1-219d" name="Reaver Chieftain" hidden="false" collective="false" import="true" type="model">
@@ -5396,7 +5396,7 @@
           </profiles>
           <categoryLinks>
             <categoryLink id="32f6-2c22-d0e4-c548" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
-            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="89c2-2281-4ad4-8df9" name="Infantry" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="89c2-2281-4ad4-8df9" name="Infantry Unit Type" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="4c88-3a9a-a466-eb56" name="Bolt Pistol:" hidden="false" collective="false" import="true" defaultSelectionEntryId="e645-7b6f-6e68-6d11">
@@ -5775,7 +5775,7 @@
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="30"/>
               </costs>
               <categoryLinks>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="e830-ed6a-489e-a386" name="Infantry" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="e830-ed6a-489e-a386" name="Infantry Unit Type" primary="false"/>
               </categoryLinks>
             </selectionEntry>
             <selectionEntry id="8149-8fa6-c6b9-c3db" name="Reaver w/ Options" hidden="false" collective="false" import="true" type="model">
@@ -6001,7 +6001,7 @@
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="30"/>
               </costs>
               <categoryLinks>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="15c3-5603-4d30-88c5" name="Infantry" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="15c3-5603-4d30-88c5" name="Infantry Unit Type" primary="false"/>
               </categoryLinks>
             </selectionEntry>
           </selectionEntries>
@@ -6073,7 +6073,7 @@
         <infoLink id="38e8-188d-6089-fde3" name="Traitor" hidden="false" targetId="eff2-8b0e-21da-2f0d" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="507f-c9cb-6d01-afea" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="507f-c9cb-6d01-afea" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="6416-7913-cca6-25fc" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
       </categoryLinks>
       <selectionEntries>
@@ -6153,9 +6153,9 @@
         <selectionEntry type="model" import="true" name="Vheren Ashurhaddon" hidden="false" id="e538-2349-cd08-a7fb">
           <categoryLinks>
             <categoryLink targetId="4f07-3d45-4f28-a0c6" id="3d98-f685-17f-e688" primary="false" name="Independent Character"/>
-            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="0996-6ba2-47eb-a24e" name="Infantry" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="0996-6ba2-47eb-a24e" name="Infantry Unit Type" primary="false"/>
             <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="6aca-f65f-44ee-9907" name="Character" primary="false"/>
-            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="97fa-f764-425a-8924" name="Unique" primary="false"/>
+            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="97fa-f764-425a-8924" name="Unique Sub-type" primary="false"/>
           </categoryLinks>
           <constraints>
             <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="3f5d-e211-1f51-57bc"/>

--- a/2022 - LA - Sons of Horus.cat
+++ b/2022 - LA - Sons of Horus.cat
@@ -3238,6 +3238,10 @@
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20"/>
           </costs>
+          <categoryLinks>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="df67-8a86-46d0-852e" name="Infantry" primary="false"/>
+            <categoryLink targetId="9231-183c-b97b-63f9" id="7db6-e9e4-4ec1-89f6" name="Heavy" primary="false"/>
+          </categoryLinks>
         </selectionEntry>
         <selectionEntry id="0ca4-f397-e1f8-2afe" name="Standard Bearer" hidden="false" collective="false" import="true" type="model">
           <constraints>
@@ -3335,6 +3339,10 @@
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
           </costs>
+          <categoryLinks>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="5619-b18c-4689-9bff" name="Infantry" primary="false"/>
+            <categoryLink targetId="9231-183c-b97b-63f9" id="a2ef-174a-48f3-bd84" name="Heavy" primary="false"/>
+          </categoryLinks>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
@@ -3513,6 +3521,8 @@
               </costs>
               <categoryLinks>
                 <categoryLink targetId="4f07-3d45-4f28-a0c6" id="3877-3563-8980-fce4" primary="false" name="Independent Character"/>
+                <categoryLink targetId="ad5f-31db-8bc7-5c46" id="ef75-a0e0-48ff-890a" name="Primarch" primary="false"/>
+                <categoryLink targetId="aa94-5c65-d1f1-46a4" id="6c08-64d8-449c-9a43" name="Unique" primary="false"/>
               </categoryLinks>
             </selectionEntry>
           </selectionEntries>
@@ -3630,6 +3640,7 @@
           </profiles>
           <categoryLinks>
             <categoryLink id="9e64-6058-50b6-2676" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="9177-9911-4219-8d50" name="Infantry" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="366f-f67d-382b-7a6f" name="Bolt Pistol:" hidden="false" collective="false" import="true" defaultSelectionEntryId="d4bd-a4c8-1282-0a0d">
@@ -4090,6 +4101,9 @@
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="22"/>
               </costs>
+              <categoryLinks>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="de47-fcb5-4e95-b2ca" name="Infantry" primary="false"/>
+              </categoryLinks>
             </selectionEntry>
             <selectionEntry id="2fc2-12f4-a68f-111d" name="Reaver w/ Options" hidden="false" collective="false" import="true" type="model">
               <profiles>
@@ -4334,6 +4348,9 @@
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="22"/>
               </costs>
+              <categoryLinks>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="9573-27ed-4d67-aad8" name="Infantry" primary="false"/>
+              </categoryLinks>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
@@ -4422,6 +4439,10 @@
           </costs>
           <categoryLinks>
             <categoryLink targetId="4f07-3d45-4f28-a0c6" id="7c6b-2082-90a4-8d02" primary="false" name="Independent Character"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="9ce6-83b2-4275-a5c3" name="Infantry" primary="false"/>
+            <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="aef1-2536-4908-8ed7" name="Character" primary="false"/>
+            <categoryLink targetId="6399-5c65-7833-1025" id="7fce-8ef4-43d2-a18e" name="Line" primary="false"/>
+            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="0814-d1db-46da-872f" name="Unique" primary="false"/>
           </categoryLinks>
         </selectionEntry>
       </selectionEntries>
@@ -4558,6 +4579,10 @@
         <selectionEntry type="model" import="true" name="Ezekyle Abaddon" hidden="false" id="4907-6e0d-1154-d01b">
           <categoryLinks>
             <categoryLink targetId="4f07-3d45-4f28-a0c6" id="5c67-4e64-dc0d-f2a2" primary="false" name="Independent Character"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="38dd-9669-40e1-a5f4" name="Infantry" primary="false"/>
+            <categoryLink targetId="9231-183c-b97b-63f9" id="1205-6b1d-4e5a-ad6c" name="Heavy" primary="false"/>
+            <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="4425-be8c-42e6-b0a3" name="Character" primary="false"/>
+            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="0822-f5a0-49d6-bebe" name="Unique" primary="false"/>
           </categoryLinks>
           <constraints>
             <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="3f5d-e211-1f51-57bc"/>
@@ -4712,6 +4737,8 @@
         <selectionEntry type="model" import="true" name="Garviel Loken" hidden="false" id="d27c-8394-5d94-7a7c">
           <categoryLinks>
             <categoryLink targetId="4f07-3d45-4f28-a0c6" id="8740-5abd-10ae-f2f9" primary="false" name="Independent Character"/>
+            <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="b7a3-8942-4b78-bcde" name="Character" primary="false"/>
+            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="0b18-9161-4070-b133" name="Unique" primary="false"/>
           </categoryLinks>
           <constraints>
             <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="3f5d-e211-1f51-57bc"/>
@@ -4734,6 +4761,8 @@
               </characteristics>
             </profile>
           </profiles>
+          <comment>!BSC Errors from 20240328-1346
+Could not find type or subtype &apos;&apos;</comment>
         </selectionEntry>
       </selectionEntries>
     </selectionEntry>
@@ -4896,6 +4925,10 @@
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="50"/>
               </costs>
+              <categoryLinks>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="4bba-2670-4ef7-a2bc" name="Infantry" primary="false"/>
+                <categoryLink targetId="9231-183c-b97b-63f9" id="5fe8-f7ea-402b-9d13" name="Heavy" primary="false"/>
+              </categoryLinks>
             </selectionEntry>
             <selectionEntry id="a1f2-efc6-9ff7-3323" name="Justaerin w/Heavy Weapon (1 in 5)" hidden="false" collective="false" import="true" type="model">
               <modifiers>
@@ -4980,6 +5013,10 @@
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="50"/>
               </costs>
+              <categoryLinks>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="6ca1-0be0-42a8-8685" name="Infantry" primary="false"/>
+                <categoryLink targetId="9231-183c-b97b-63f9" id="e4f4-0da3-4009-bc2c" name="Heavy" primary="false"/>
+              </categoryLinks>
             </selectionEntry>
             <selectionEntry id="3c6e-f814-9806-3453" name="Justaerin w/Pair of Lightning Claws" hidden="false" collective="false" import="true" type="model">
               <infoLinks>
@@ -4996,6 +5033,10 @@
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="55"/>
               </costs>
+              <categoryLinks>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="4ba5-df65-422b-bd7d" name="Infantry" primary="false"/>
+                <categoryLink targetId="9231-183c-b97b-63f9" id="ef83-0b54-461c-a2ec" name="Heavy" primary="false"/>
+              </categoryLinks>
             </selectionEntry>
             <selectionEntry id="3856-ef30-d865-30a6" name="Justaerin w/Pair of Lightning Claws, Grenade Harness" hidden="false" collective="false" import="true" type="model">
               <infoLinks>
@@ -5021,6 +5062,10 @@
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="65"/>
               </costs>
+              <categoryLinks>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="2905-7675-432a-abf6" name="Infantry" primary="false"/>
+                <categoryLink targetId="9231-183c-b97b-63f9" id="c6b8-289f-4cf3-a97b" name="Heavy" primary="false"/>
+              </categoryLinks>
             </selectionEntry>
             <selectionEntry id="b02f-0bac-63d0-6dc6" name="Justaerin w/Legion Standard" hidden="true" collective="false" import="true" type="model">
               <modifiers>
@@ -5085,6 +5130,10 @@
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="65"/>
               </costs>
+              <categoryLinks>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="3f71-056d-4a7d-8230" name="Infantry" primary="false"/>
+                <categoryLink targetId="9231-183c-b97b-63f9" id="f2a0-77a9-4253-9488" name="Heavy" primary="false"/>
+              </categoryLinks>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
@@ -5196,6 +5245,9 @@
         <selectionEntry type="model" import="true" name="Tybalt Marr" hidden="false" id="da20-54b1-fdb-9659">
           <categoryLinks>
             <categoryLink targetId="4f07-3d45-4f28-a0c6" id="d42-4abd-3e06-f45" primary="false" name="Independent Character"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="6c7d-d51d-432f-a82f" name="Infantry" primary="false"/>
+            <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="c07e-c6fc-41e0-b0ec" name="Character" primary="false"/>
+            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="dda5-3fc8-4915-aac4" name="Unique" primary="false"/>
           </categoryLinks>
           <constraints>
             <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="3f5d-e211-1f51-57bc"/>
@@ -5345,6 +5397,7 @@
           </profiles>
           <categoryLinks>
             <categoryLink id="32f6-2c22-d0e4-c548" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="89c2-2281-4ad4-8df9" name="Infantry" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="4c88-3a9a-a466-eb56" name="Bolt Pistol:" hidden="false" collective="false" import="true" defaultSelectionEntryId="e645-7b6f-6e68-6d11">
@@ -5722,6 +5775,9 @@
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="30"/>
               </costs>
+              <categoryLinks>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="e830-ed6a-489e-a386" name="Infantry" primary="false"/>
+              </categoryLinks>
             </selectionEntry>
             <selectionEntry id="8149-8fa6-c6b9-c3db" name="Reaver w/ Options" hidden="false" collective="false" import="true" type="model">
               <infoLinks>
@@ -5945,6 +6001,9 @@
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="30"/>
               </costs>
+              <categoryLinks>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="15c3-5603-4d30-88c5" name="Infantry" primary="false"/>
+              </categoryLinks>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
@@ -6095,6 +6154,9 @@
         <selectionEntry type="model" import="true" name="Vheren Ashurhaddon" hidden="false" id="e538-2349-cd08-a7fb">
           <categoryLinks>
             <categoryLink targetId="4f07-3d45-4f28-a0c6" id="3d98-f685-17f-e688" primary="false" name="Independent Character"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="0996-6ba2-47eb-a24e" name="Infantry" primary="false"/>
+            <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="6aca-f65f-44ee-9907" name="Character" primary="false"/>
+            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="97fa-f764-425a-8924" name="Unique" primary="false"/>
           </categoryLinks>
           <constraints>
             <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="3f5d-e211-1f51-57bc"/>

--- a/2022 - LA - Sons of Horus.cat
+++ b/2022 - LA - Sons of Horus.cat
@@ -4739,6 +4739,7 @@
             <categoryLink targetId="4f07-3d45-4f28-a0c6" id="8740-5abd-10ae-f2f9" primary="false" name="Independent Character"/>
             <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="b7a3-8942-4b78-bcde" name="Character" primary="false"/>
             <categoryLink targetId="aa94-5c65-d1f1-46a4" id="0b18-9161-4070-b133" name="Unique" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="58df-e0c3-4737-a93a" name="Infantry" primary="false"/>
           </categoryLinks>
           <constraints>
             <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="3f5d-e211-1f51-57bc"/>
@@ -4747,7 +4748,7 @@
           <profiles>
             <profile id="8c34-be7c-7bf9-5b3a" name="Garviel Loken" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName="Unit">
               <characteristics>
-                <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">(Character, Unique)</characteristic>
+                <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Character, Unique)</characteristic>
                 <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
                 <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">6</characteristic>
                 <characteristic name="BS" typeId="74ae-c840-0036-d244">6</characteristic>
@@ -4761,8 +4762,6 @@
               </characteristics>
             </profile>
           </profiles>
-          <comment>!BSC Errors from 20240328-1346
-Could not find type or subtype &apos;&apos;</comment>
         </selectionEntry>
       </selectionEntries>
     </selectionEntry>

--- a/2022 - LA - Sons of Horus.cat
+++ b/2022 - LA - Sons of Horus.cat
@@ -99,7 +99,7 @@
       <categoryLinks>
         <categoryLink id="77a5-bc2d-91c4-f76e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="e465-788c-463b-7b1c" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="fd37-d09d-cd28-82d8" name="Line Sub-type:" hidden="false" targetId="6399-5c65-7833-1025" primary="false"/>
+        <categoryLink id="fd37-d09d-cd28-82d8" name="Line Sub-type" hidden="false" targetId="6399-5c65-7833-1025" primary="false"/>
         <categoryLink id="3da2-228b-fd58-fc4e" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -2615,7 +2615,7 @@
         <categoryLink id="e12d-b822-47b3-4e92" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="317c-51b9-5bce-4d12" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
         <categoryLink id="c490-800c-2c91-6890" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="e084-90b6-7d3d-e76d" name="Line Sub-type:" hidden="false" targetId="6399-5c65-7833-1025" primary="false"/>
+        <categoryLink id="e084-90b6-7d3d-e76d" name="Line Sub-type" hidden="false" targetId="6399-5c65-7833-1025" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="88c9-c7b9-42f5-8af8" name="Nullificator Squad" hidden="true" collective="false" import="false" targetId="954d-cf8e-eefd-27a6" type="selectionEntry">
@@ -2737,7 +2737,7 @@
       <categoryLinks>
         <categoryLink id="63ff-0a92-42ab-ae8c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="204c-7b0f-4fb9-b1b3" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="85e6-cb31-427c-a040" name="Line Sub-type:" hidden="false" targetId="6399-5c65-7833-1025" primary="false"/>
+        <categoryLink id="85e6-cb31-427c-a040" name="Line Sub-type" hidden="false" targetId="6399-5c65-7833-1025" primary="false"/>
         <categoryLink id="9eec-015a-f3e7-3297" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -3137,7 +3137,7 @@
         <infoLink id="1cf2-f06c-9b38-96ea" name="Legiones Astartes (Sons of Horus)" hidden="false" targetId="f4a2-e4ca-b8b2-35a1" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="74fd-91d7-6d1c-8edd" name="Heavy Sub-type:" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+        <categoryLink id="74fd-91d7-6d1c-8edd" name="Heavy Sub-type" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
         <categoryLink id="8cac-3a0b-8f04-2877" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="ed45-fc62-5dd5-769f" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
       </categoryLinks>
@@ -4388,7 +4388,7 @@
       <categoryLinks>
         <categoryLink id="1f57-7f73-c9f6-c78c" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="008c-4ae3-4bb8-7464" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="0a8b-db6e-ba23-26ec" name="Line Sub-type:" hidden="false" targetId="6399-5c65-7833-1025" primary="false"/>
+        <categoryLink id="0a8b-db6e-ba23-26ec" name="Line Sub-type" hidden="false" targetId="6399-5c65-7833-1025" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="e879-1248-f5b3-ae24" name="Maloghurst the Twisted" hidden="false" collective="false" import="true" type="model">
@@ -4819,7 +4819,7 @@ Could not find type or subtype &apos;&apos;</comment>
         </infoLink>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="705b-da26-7a7c-2f8c" name="Heavy Sub-type:" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+        <categoryLink id="705b-da26-7a7c-2f8c" name="Heavy Sub-type" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
         <categoryLink id="9f47-8b3b-90cc-998d" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="5156-399a-3fcc-8ca9" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="fbc7-2ac6-fa36-63d9" name="Terminators:" hidden="false" targetId="bab3-f50d-3e5f-2f78" primary="false"/>

--- a/2022 - LA - Space Wolves.cat
+++ b/2022 - LA - Space Wolves.cat
@@ -3049,6 +3049,9 @@
           </costs>
           <categoryLinks>
             <categoryLink targetId="4f07-3d45-4f28-a0c6" id="fd7d-e734-6979-d2a4" primary="false" name="Independent Character"/>
+            <categoryLink targetId="ad5f-31db-8bc7-5c46" id="5f3e-13ac-47a0-b146" name="Primarch" primary="false"/>
+            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="0f1e-52d9-4b5d-8b1e" name="Unique" primary="false"/>
+            <categoryLink targetId="59a4-7b61-600a-c457" id="aab0-c0c0-4d3d-b4c9" name="Skirmish" primary="false"/>
           </categoryLinks>
         </selectionEntry>
         <selectionEntry id="3533-53d6-976c-05f1" name="The Armour Elavagar" hidden="false" collective="false" import="true" type="upgrade">
@@ -3285,6 +3288,12 @@
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="50"/>
           </costs>
+          <categoryLinks>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="f586-7723-4869-9c4e" name="Infantry" primary="false"/>
+            <categoryLink targetId="59a4-7b61-600a-c457" id="375e-213c-4450-9443" name="Skirmish" primary="false"/>
+            <categoryLink targetId="bff2-ae16-74a8-8712" id="d009-4084-4f20-8700" name="Light" primary="false"/>
+            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="ef0e-f11f-4fa9-984a" name="Unique" primary="false"/>
+          </categoryLinks>
         </selectionEntry>
         <selectionEntry id="35f2-f7ef-b668-1962" name="Geri" hidden="false" collective="false" import="true" type="model">
           <constraints>
@@ -3354,6 +3363,12 @@
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="50"/>
           </costs>
+          <categoryLinks>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="92b6-397b-47de-9a4a" name="Infantry" primary="false"/>
+            <categoryLink targetId="59a4-7b61-600a-c457" id="7152-13c6-48e0-ab77" name="Skirmish" primary="false"/>
+            <categoryLink targetId="bff2-ae16-74a8-8712" id="d720-5b75-4086-bd2d" name="Light" primary="false"/>
+            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="5f8a-78ed-42ca-b79a" name="Unique" primary="false"/>
+          </categoryLinks>
         </selectionEntry>
       </selectionEntries>
       <costs>
@@ -3409,6 +3424,10 @@
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="30"/>
           </costs>
+          <categoryLinks>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="7b22-4ae0-4931-974f" name="Infantry" primary="false"/>
+            <categoryLink targetId="9231-183c-b97b-63f9" id="f189-4475-4364-8a8b" name="Heavy" primary="false"/>
+          </categoryLinks>
         </selectionEntry>
         <selectionEntry id="8fbd-8f9c-1880-dc48" name="Ymira Class Stasis Bombs" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
@@ -3818,6 +3837,10 @@
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="45"/>
           </costs>
+          <categoryLinks>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="d6ca-c116-42de-982f" name="Infantry" primary="false"/>
+            <categoryLink targetId="9231-183c-b97b-63f9" id="1a9f-8668-4a48-85c9" name="Heavy" primary="false"/>
+          </categoryLinks>
         </selectionEntry>
         <selectionEntry id="9977-8907-aebb-d864" name="Thegn" hidden="false" collective="false" import="true" type="model">
           <constraints>
@@ -3843,6 +3866,8 @@
           </profiles>
           <categoryLinks>
             <categoryLink id="72ed-7d96-0940-a70d" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="41d7-52dc-49fd-91bf" name="Infantry" primary="false"/>
+            <categoryLink targetId="9231-183c-b97b-63f9" id="e9a0-4cda-44d1-a6a4" name="Heavy" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="123a-39a8-1b6e-8e3e" name="1st Melee Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="6d1f-4f34-170b-58a9">
@@ -4188,6 +4213,9 @@
           </profiles>
           <categoryLinks>
             <categoryLink id="a17a-08c9-3929-eb98" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="7b1c-b1f1-4409-a6fb" name="Infantry" primary="false"/>
+            <categoryLink targetId="59a4-7b61-600a-c457" id="0f9d-32b5-4044-aa1b" name="Skirmish" primary="false"/>
+            <categoryLink targetId="6399-5c65-7833-1025" id="6e84-4afa-45be-bad5" name="Line" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="b309-5e5b-0e38-3a11" name="3) May exchange his Bolt Pistol and Fenrisian Axe for:" hidden="false" collective="false" import="true">
@@ -4518,6 +4546,11 @@
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="12"/>
               </costs>
+              <categoryLinks>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="096b-1361-422c-877d" name="Infantry" primary="false"/>
+                <categoryLink targetId="59a4-7b61-600a-c457" id="0945-f0fc-4fab-8eb2" name="Skirmish" primary="false"/>
+                <categoryLink targetId="6399-5c65-7833-1025" id="c312-23cd-46ef-bdce" name="Line" primary="false"/>
+              </categoryLinks>
             </selectionEntry>
             <selectionEntry id="859f-9945-1a77-2d77" name="Grey Slayer w/Combat Shield, Power Axe" hidden="false" collective="false" import="true" type="model">
               <constraints>
@@ -4543,6 +4576,11 @@
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="17"/>
               </costs>
+              <categoryLinks>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="24fa-69c6-4faa-a5e0" name="Infantry" primary="false"/>
+                <categoryLink targetId="59a4-7b61-600a-c457" id="95b4-74fe-4387-a009" name="Skirmish" primary="false"/>
+                <categoryLink targetId="6399-5c65-7833-1025" id="75e5-5518-4bf4-8625" name="Line" primary="false"/>
+              </categoryLinks>
             </selectionEntry>
             <selectionEntry id="ed00-a72f-bbb4-429d" name="Grey Slayer w/Bolter, Power Sword" hidden="false" collective="false" import="true" type="model">
               <constraints>
@@ -4607,6 +4645,11 @@
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="12"/>
               </costs>
+              <categoryLinks>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="d12e-b0e9-491e-b0f6" name="Infantry" primary="false"/>
+                <categoryLink targetId="59a4-7b61-600a-c457" id="6c35-5f65-49d5-aca2" name="Skirmish" primary="false"/>
+                <categoryLink targetId="6399-5c65-7833-1025" id="5606-81f3-4d7e-9a50" name="Line" primary="false"/>
+              </categoryLinks>
             </selectionEntry>
             <selectionEntry id="fc48-8eea-bc4e-f014" name="Grey Slayer w/ Options" hidden="false" collective="false" import="true" type="model">
               <infoLinks>
@@ -4787,6 +4830,11 @@
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="12"/>
               </costs>
+              <categoryLinks>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="5757-e299-4a82-949b" name="Infantry" primary="false"/>
+                <categoryLink targetId="59a4-7b61-600a-c457" id="af4a-67f1-4879-b561" name="Skirmish" primary="false"/>
+                <categoryLink targetId="6399-5c65-7833-1025" id="5563-6509-48aa-87d2" name="Line" primary="false"/>
+              </categoryLinks>
             </selectionEntry>
             <selectionEntry id="c830-ff75-317f-45c1" name="Grey Slayer w/Bolter, Power Axe" hidden="false" collective="false" import="true" type="model">
               <constraints>
@@ -4840,6 +4888,11 @@
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="12"/>
               </costs>
+              <categoryLinks>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="03d8-643d-4473-a665" name="Infantry" primary="false"/>
+                <categoryLink targetId="59a4-7b61-600a-c457" id="11b7-b5ef-4bb3-b1b5" name="Skirmish" primary="false"/>
+                <categoryLink targetId="6399-5c65-7833-1025" id="95cc-2bd3-4d05-bae5" name="Line" primary="false"/>
+              </categoryLinks>
             </selectionEntry>
             <selectionEntry id="98f2-784e-6eeb-9940" name="Grey Slayer w/Bolter, Power Maul" hidden="false" collective="false" import="true" type="model">
               <constraints>
@@ -4893,6 +4946,11 @@
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="12"/>
               </costs>
+              <categoryLinks>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="e753-7f0c-445c-8fdd" name="Infantry" primary="false"/>
+                <categoryLink targetId="59a4-7b61-600a-c457" id="c93e-5045-4555-9f37" name="Skirmish" primary="false"/>
+                <categoryLink targetId="6399-5c65-7833-1025" id="64db-432e-413d-8b27" name="Line" primary="false"/>
+              </categoryLinks>
             </selectionEntry>
             <selectionEntry id="31e0-f58c-85d7-d5f2" name="Grey Slayer w/Bolter, Fenrisian Axe" hidden="false" collective="false" import="true" type="model">
               <constraints>
@@ -4946,6 +5004,11 @@
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="12"/>
               </costs>
+              <categoryLinks>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="c22f-b2e7-4cce-8a3f" name="Infantry" primary="false"/>
+                <categoryLink targetId="59a4-7b61-600a-c457" id="f9e4-9ea8-411b-8fed" name="Skirmish" primary="false"/>
+                <categoryLink targetId="6399-5c65-7833-1025" id="08d7-c87a-4118-bad0" name="Line" primary="false"/>
+              </categoryLinks>
             </selectionEntry>
             <selectionEntry id="cc8a-51a3-99db-3e78" name="Grey Slayer w/Bolter, Power Lance" hidden="false" collective="false" import="true" type="model">
               <constraints>
@@ -4999,6 +5062,11 @@
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="12"/>
               </costs>
+              <categoryLinks>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="1968-31d0-4c7b-af8a" name="Infantry" primary="false"/>
+                <categoryLink targetId="59a4-7b61-600a-c457" id="a125-d469-495e-9387" name="Skirmish" primary="false"/>
+                <categoryLink targetId="6399-5c65-7833-1025" id="e2a5-a386-4d5f-8361" name="Line" primary="false"/>
+              </categoryLinks>
             </selectionEntry>
             <selectionEntry id="1f48-0084-7908-cc26" name="Grey Slayer w/Combat Shield, Power Maul" hidden="false" collective="false" import="true" type="model">
               <constraints>
@@ -5024,6 +5092,11 @@
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="17"/>
               </costs>
+              <categoryLinks>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="5158-70d8-4c8a-ba94" name="Infantry" primary="false"/>
+                <categoryLink targetId="59a4-7b61-600a-c457" id="8f8b-7762-482d-a86e" name="Skirmish" primary="false"/>
+                <categoryLink targetId="6399-5c65-7833-1025" id="2a0c-14f0-4aac-b792" name="Line" primary="false"/>
+              </categoryLinks>
             </selectionEntry>
             <selectionEntry id="bd6a-c128-08d2-8627" name="Grey Slayer w/Combat Shield, Power Lance" hidden="false" collective="false" import="true" type="model">
               <constraints>
@@ -5049,6 +5122,11 @@
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="17"/>
               </costs>
+              <categoryLinks>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="80c0-8993-4262-acad" name="Infantry" primary="false"/>
+                <categoryLink targetId="59a4-7b61-600a-c457" id="ab52-76f6-4db0-9fde" name="Skirmish" primary="false"/>
+                <categoryLink targetId="6399-5c65-7833-1025" id="a5a3-d7e8-4b52-ac93" name="Line" primary="false"/>
+              </categoryLinks>
             </selectionEntry>
             <selectionEntry id="0f4d-43c5-f0bd-ea25" name="Grey Slayer w/Combat Shield, Power Sword" hidden="false" collective="false" import="true" type="model">
               <constraints>
@@ -5074,6 +5152,11 @@
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="17"/>
               </costs>
+              <categoryLinks>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="e666-6ef1-417c-9e96" name="Infantry" primary="false"/>
+                <categoryLink targetId="59a4-7b61-600a-c457" id="19f0-50b2-4c49-862c" name="Skirmish" primary="false"/>
+                <categoryLink targetId="6399-5c65-7833-1025" id="a189-103b-40bb-ac90" name="Line" primary="false"/>
+              </categoryLinks>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
@@ -5179,6 +5262,9 @@
           </profiles>
           <categoryLinks>
             <categoryLink id="45f3-17a2-f2de-7958" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="1d9c-92fe-478a-a643" name="Infantry" primary="false"/>
+            <categoryLink targetId="59a4-7b61-600a-c457" id="844d-397e-49c3-a5a6" name="Skirmish" primary="false"/>
+            <categoryLink targetId="6399-5c65-7833-1025" id="26ec-836d-45e8-a7dd" name="Line" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="a31a-a800-9e97-7e77" name="4) Wargear" hidden="false" collective="false" import="true">
@@ -5533,6 +5619,11 @@
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="14"/>
               </costs>
+              <categoryLinks>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="b1f9-fadf-4c95-9b1a" name="Infantry" primary="false"/>
+                <categoryLink targetId="59a4-7b61-600a-c457" id="4164-eb0a-4b39-8f33" name="Skirmish" primary="false"/>
+                <categoryLink targetId="6399-5c65-7833-1025" id="3fc1-9c2c-4fa6-8294" name="Line" primary="false"/>
+              </categoryLinks>
             </selectionEntry>
             <selectionEntry id="7861-5220-928a-3c81" name="Grey Stalker w/ Power Axe" hidden="false" collective="false" import="true" type="model">
               <constraints>
@@ -5555,6 +5646,11 @@
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="12"/>
               </costs>
+              <categoryLinks>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="4785-777b-42b1-b020" name="Infantry" primary="false"/>
+                <categoryLink targetId="59a4-7b61-600a-c457" id="f742-304a-4da7-85f9" name="Skirmish" primary="false"/>
+                <categoryLink targetId="6399-5c65-7833-1025" id="3333-0c87-400f-a4c3" name="Line" primary="false"/>
+              </categoryLinks>
             </selectionEntry>
             <selectionEntry id="fcdb-5adc-1d89-aac7" name="Grey Stalker w/ Power Lance" hidden="false" collective="false" import="true" type="model">
               <constraints>
@@ -5577,6 +5673,11 @@
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="12"/>
               </costs>
+              <categoryLinks>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="5169-7878-47dd-aa9c" name="Infantry" primary="false"/>
+                <categoryLink targetId="59a4-7b61-600a-c457" id="e951-b299-406f-acaf" name="Skirmish" primary="false"/>
+                <categoryLink targetId="6399-5c65-7833-1025" id="28e5-3ae2-44f1-bde5" name="Line" primary="false"/>
+              </categoryLinks>
             </selectionEntry>
             <selectionEntry id="b157-449e-0ddb-6d47" name="Grey Stalker w/ Power Maul" hidden="false" collective="false" import="true" type="model">
               <constraints>
@@ -5599,6 +5700,11 @@
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="12"/>
               </costs>
+              <categoryLinks>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="afe9-29f6-4537-bedb" name="Infantry" primary="false"/>
+                <categoryLink targetId="59a4-7b61-600a-c457" id="c5ca-37c3-4a92-a619" name="Skirmish" primary="false"/>
+                <categoryLink targetId="6399-5c65-7833-1025" id="833e-1c75-4dbc-be11" name="Line" primary="false"/>
+              </categoryLinks>
             </selectionEntry>
             <selectionEntry id="af66-5795-41ff-afdb" name="Grey Stalker w/ Power Sword" hidden="false" collective="false" import="true" type="model">
               <constraints>
@@ -5621,6 +5727,11 @@
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="12"/>
               </costs>
+              <categoryLinks>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="fa83-75a5-4b4e-955b" name="Infantry" primary="false"/>
+                <categoryLink targetId="59a4-7b61-600a-c457" id="d101-dfed-495b-aa13" name="Skirmish" primary="false"/>
+                <categoryLink targetId="6399-5c65-7833-1025" id="868f-6f7e-4763-8ec1" name="Line" primary="false"/>
+              </categoryLinks>
             </selectionEntry>
             <selectionEntry id="a482-de3c-4324-a64f" name="Grey Stalker w/ Options" hidden="false" collective="false" import="true" type="model">
               <infoLinks>
@@ -5909,6 +6020,11 @@
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="12"/>
               </costs>
+              <categoryLinks>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="df30-d7ef-4f9a-8430" name="Infantry" primary="false"/>
+                <categoryLink targetId="59a4-7b61-600a-c457" id="5581-c7a3-464f-9bb2" name="Skirmish" primary="false"/>
+                <categoryLink targetId="6399-5c65-7833-1025" id="1197-0cee-4633-86ee" name="Line" primary="false"/>
+              </categoryLinks>
             </selectionEntry>
             <selectionEntry id="2472-8f6f-6df0-19b9" name="Grey Stalker w/ Chainsword" hidden="false" collective="false" import="true" type="model">
               <constraints>
@@ -5928,6 +6044,11 @@
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="12"/>
               </costs>
+              <categoryLinks>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="9e1f-8e0a-4903-9e92" name="Infantry" primary="false"/>
+                <categoryLink targetId="59a4-7b61-600a-c457" id="701e-d113-445a-b46b" name="Skirmish" primary="false"/>
+                <categoryLink targetId="6399-5c65-7833-1025" id="0915-d800-467b-a0cb" name="Line" primary="false"/>
+              </categoryLinks>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
@@ -6075,6 +6196,10 @@
           </costs>
           <categoryLinks>
             <categoryLink targetId="4f07-3d45-4f28-a0c6" id="bfba-adcf-27b4-9484" primary="false" name="Independent Character"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="e393-7152-4420-93c4" name="Infantry" primary="false"/>
+            <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="cc67-a257-4587-9f07" name="Character" primary="false"/>
+            <categoryLink targetId="59a4-7b61-600a-c457" id="a746-96da-4946-8642" name="Skirmish" primary="false"/>
+            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="5953-e3dd-4bb2-96dd" name="Unique" primary="false"/>
           </categoryLinks>
         </selectionEntry>
       </selectionEntries>
@@ -6208,6 +6333,9 @@
           </costs>
           <categoryLinks>
             <categoryLink targetId="4f07-3d45-4f28-a0c6" id="98fb-909-f3fc-d3ac" primary="false" name="Independent Character"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="ee34-9234-4936-9c2d" name="Infantry" primary="false"/>
+            <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="b91c-b9cf-4eb4-ac2e" name="Character" primary="false"/>
+            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="40d6-cca8-4a3d-9ad7" name="Unique" primary="false"/>
           </categoryLinks>
         </selectionEntry>
       </selectionEntries>
@@ -6284,6 +6412,9 @@
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15"/>
           </costs>
+          <categoryLinks>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="a61a-c1fb-4dcb-a91a" name="Infantry" primary="false"/>
+          </categoryLinks>
         </selectionEntry>
         <selectionEntry id="0a7d-31ab-699e-1377" name="Hunt-master" hidden="false" collective="false" import="true" type="model">
           <constraints>
@@ -6316,6 +6447,7 @@
           </profiles>
           <categoryLinks>
             <categoryLink id="4660-da5d-c2a4-9da0" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="5353-ae48-478f-a300" name="Infantry" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="7f67-db6e-5008-8432" name="4) May take:" hidden="false" collective="false" import="true">
@@ -6725,6 +6857,11 @@
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5"/>
           </costs>
+          <categoryLinks>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="66b7-1cfc-4dec-85aa" name="Infantry" primary="false"/>
+            <categoryLink targetId="bff2-ae16-74a8-8712" id="0920-eaad-4184-81f0" name="Light" primary="false"/>
+            <categoryLink targetId="59a4-7b61-600a-c457" id="8eff-bf5e-46a8-8f4c" name="Skirmish" primary="false"/>
+          </categoryLinks>
         </selectionEntry>
         <selectionEntry id="aabc-e789-59be-d5a0" name="Claws" hidden="false" collective="false" import="true" type="upgrade">
           <profiles>

--- a/2022 - LA - Space Wolves.cat
+++ b/2022 - LA - Space Wolves.cat
@@ -2707,7 +2707,7 @@
       <categoryLinks>
         <categoryLink id="63ff-0a92-42ab-ae8c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="204c-7b0f-4fb9-b1b3" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="85e6-cb31-427c-a040" name="Line Sub-type:" hidden="false" targetId="6399-5c65-7833-1025" primary="false"/>
+        <categoryLink id="85e6-cb31-427c-a040" name="Line Sub-type" hidden="false" targetId="6399-5c65-7833-1025" primary="false"/>
         <categoryLink id="0e83-d847-9c24-8a81" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -3010,7 +3010,7 @@
       </infoLinks>
       <categoryLinks>
         <categoryLink id="935c-5280-2665-ebbe" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="94c4-d1c1-31a4-0cce" name="Skirmish Sub-type:" hidden="false" targetId="59a4-7b61-600a-c457" primary="false"/>
+        <categoryLink id="94c4-d1c1-31a4-0cce" name="Skirmish Sub-type" hidden="false" targetId="59a4-7b61-600a-c457" primary="false"/>
         <categoryLink id="0a97-1c28-655b-6262" name="LoW &amp; Primarchs (25% Limit)" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false"/>
       </categoryLinks>
       <selectionEntries>
@@ -3205,9 +3205,9 @@
         </rule>
       </rules>
       <categoryLinks>
-        <categoryLink id="a231-01f6-2c07-1d34" name="Skirmish Sub-type:" hidden="false" targetId="59a4-7b61-600a-c457" primary="false"/>
+        <categoryLink id="a231-01f6-2c07-1d34" name="Skirmish Sub-type" hidden="false" targetId="59a4-7b61-600a-c457" primary="false"/>
         <categoryLink id="aa46-1901-68ca-1c6f" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="e1f3-747e-4b46-0a8e" name="Light Sub-type:" hidden="false" targetId="bff2-ae16-74a8-8712" primary="false"/>
+        <categoryLink id="e1f3-747e-4b46-0a8e" name="Light Sub-type" hidden="false" targetId="bff2-ae16-74a8-8712" primary="false"/>
         <categoryLink id="f919-6f26-e787-b770" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
       </categoryLinks>
       <selectionEntries>
@@ -3395,7 +3395,7 @@
       </infoLinks>
       <categoryLinks>
         <categoryLink id="e579-d4c0-6f64-2eb2" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="1ebc-e9e5-35d4-88c3" name="Heavy Sub-type:" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+        <categoryLink id="1ebc-e9e5-35d4-88c3" name="Heavy Sub-type" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
         <categoryLink id="81a2-f758-8265-d1a6" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
       </categoryLinks>
       <selectionEntries>
@@ -3680,7 +3680,7 @@
         </infoLink>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="2ee4-2abc-3c87-55e6" name="Heavy Sub-type:" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+        <categoryLink id="2ee4-2abc-3c87-55e6" name="Heavy Sub-type" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
         <categoryLink id="7469-45b8-1b62-5427" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="0ef2-5d12-a22c-7300" name="Terminators:" hidden="false" targetId="bab3-f50d-3e5f-2f78" primary="false"/>
         <categoryLink id="38da-50e3-302b-8975" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
@@ -4178,8 +4178,8 @@
       <categoryLinks>
         <categoryLink id="bbe7-7ff2-451e-b829" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="b448-e7f9-63a5-1209" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="1b8f-457a-d55c-4e91" name="Skirmish Sub-type:" hidden="false" targetId="59a4-7b61-600a-c457" primary="false"/>
-        <categoryLink id="1d25-440b-a838-dfd4" name="Line Sub-type:" hidden="false" targetId="6399-5c65-7833-1025" primary="false"/>
+        <categoryLink id="1b8f-457a-d55c-4e91" name="Skirmish Sub-type" hidden="false" targetId="59a4-7b61-600a-c457" primary="false"/>
+        <categoryLink id="1d25-440b-a838-dfd4" name="Line Sub-type" hidden="false" targetId="6399-5c65-7833-1025" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="2429-5700-81ec-f055" name="Huscarl" hidden="false" collective="false" import="true" type="model">
@@ -5227,8 +5227,8 @@
       <categoryLinks>
         <categoryLink id="b526-a925-98fa-3c1b" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="4d9c-b591-869f-72e1" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="cebe-84b9-86a9-ad58" name="Skirmish Sub-type:" hidden="false" targetId="59a4-7b61-600a-c457" primary="false"/>
-        <categoryLink id="b50f-33ce-bd61-3d78" name="Line Sub-type:" hidden="false" targetId="6399-5c65-7833-1025" primary="false"/>
+        <categoryLink id="cebe-84b9-86a9-ad58" name="Skirmish Sub-type" hidden="false" targetId="59a4-7b61-600a-c457" primary="false"/>
+        <categoryLink id="b50f-33ce-bd61-3d78" name="Line Sub-type" hidden="false" targetId="6399-5c65-7833-1025" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="de06-5384-4447-33ee" name="Huscarl" hidden="false" collective="false" import="true" type="model">
@@ -6083,7 +6083,7 @@
       </constraints>
       <categoryLinks>
         <categoryLink id="d60f-4d22-ec3a-4ff4" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="d837-ea6b-4c27-6d28" name="Skirmish Sub-type:" hidden="false" targetId="59a4-7b61-600a-c457" primary="false"/>
+        <categoryLink id="d837-ea6b-4c27-6d28" name="Skirmish Sub-type" hidden="false" targetId="59a4-7b61-600a-c457" primary="false"/>
         <categoryLink id="630f-3af2-6436-6e5f" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
       </categoryLinks>
       <selectionEntries>
@@ -6827,8 +6827,8 @@
       </rules>
       <categoryLinks>
         <categoryLink id="cd15-57a2-eb52-ba6e" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="3fa3-2b6b-9450-df23" name="Skirmish Sub-type:" hidden="false" targetId="59a4-7b61-600a-c457" primary="false"/>
-        <categoryLink id="902c-d0fe-d4c8-5002" name="Light Sub-type:" hidden="false" targetId="bff2-ae16-74a8-8712" primary="false"/>
+        <categoryLink id="3fa3-2b6b-9450-df23" name="Skirmish Sub-type" hidden="false" targetId="59a4-7b61-600a-c457" primary="false"/>
+        <categoryLink id="902c-d0fe-d4c8-5002" name="Light Sub-type" hidden="false" targetId="bff2-ae16-74a8-8712" primary="false"/>
         <categoryLink id="a83a-860c-9cb5-1471" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
       </categoryLinks>
       <selectionEntries>

--- a/2022 - LA - Space Wolves.cat
+++ b/2022 - LA - Space Wolves.cat
@@ -3049,9 +3049,9 @@
           </costs>
           <categoryLinks>
             <categoryLink targetId="4f07-3d45-4f28-a0c6" id="fd7d-e734-6979-d2a4" primary="false" name="Independent Character"/>
-            <categoryLink targetId="ad5f-31db-8bc7-5c46" id="5f3e-13ac-47a0-b146" name="Primarch" primary="false"/>
-            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="0f1e-52d9-4b5d-8b1e" name="Unique" primary="false"/>
-            <categoryLink targetId="59a4-7b61-600a-c457" id="aab0-c0c0-4d3d-b4c9" name="Skirmish" primary="false"/>
+            <categoryLink targetId="ad5f-31db-8bc7-5c46" id="5f3e-13ac-47a0-b146" name="Primarch:" primary="false"/>
+            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="0f1e-52d9-4b5d-8b1e" name="Unique Sub-type" primary="false"/>
+            <categoryLink targetId="59a4-7b61-600a-c457" id="aab0-c0c0-4d3d-b4c9" name="Skirmish Sub-type" primary="false"/>
           </categoryLinks>
         </selectionEntry>
         <selectionEntry id="3533-53d6-976c-05f1" name="The Armour Elavagar" hidden="false" collective="false" import="true" type="upgrade">
@@ -3208,7 +3208,7 @@
         <categoryLink id="a231-01f6-2c07-1d34" name="Skirmish Sub-type" hidden="false" targetId="59a4-7b61-600a-c457" primary="false"/>
         <categoryLink id="aa46-1901-68ca-1c6f" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="e1f3-747e-4b46-0a8e" name="Light Sub-type" hidden="false" targetId="bff2-ae16-74a8-8712" primary="false"/>
-        <categoryLink id="f919-6f26-e787-b770" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="f919-6f26-e787-b770" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="cdb9-9230-2585-94c5" name="Freki" hidden="false" collective="false" import="true" type="model">
@@ -3289,10 +3289,10 @@
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="50"/>
           </costs>
           <categoryLinks>
-            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="f586-7723-4869-9c4e" name="Infantry" primary="false"/>
-            <categoryLink targetId="59a4-7b61-600a-c457" id="375e-213c-4450-9443" name="Skirmish" primary="false"/>
-            <categoryLink targetId="bff2-ae16-74a8-8712" id="d009-4084-4f20-8700" name="Light" primary="false"/>
-            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="ef0e-f11f-4fa9-984a" name="Unique" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="f586-7723-4869-9c4e" name="Infantry Unit Type" primary="false"/>
+            <categoryLink targetId="59a4-7b61-600a-c457" id="375e-213c-4450-9443" name="Skirmish Sub-type" primary="false"/>
+            <categoryLink targetId="bff2-ae16-74a8-8712" id="d009-4084-4f20-8700" name="Light Sub-type" primary="false"/>
+            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="ef0e-f11f-4fa9-984a" name="Unique Sub-type" primary="false"/>
           </categoryLinks>
         </selectionEntry>
         <selectionEntry id="35f2-f7ef-b668-1962" name="Geri" hidden="false" collective="false" import="true" type="model">
@@ -3364,10 +3364,10 @@
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="50"/>
           </costs>
           <categoryLinks>
-            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="92b6-397b-47de-9a4a" name="Infantry" primary="false"/>
-            <categoryLink targetId="59a4-7b61-600a-c457" id="7152-13c6-48e0-ab77" name="Skirmish" primary="false"/>
-            <categoryLink targetId="bff2-ae16-74a8-8712" id="d720-5b75-4086-bd2d" name="Light" primary="false"/>
-            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="5f8a-78ed-42ca-b79a" name="Unique" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="92b6-397b-47de-9a4a" name="Infantry Unit Type" primary="false"/>
+            <categoryLink targetId="59a4-7b61-600a-c457" id="7152-13c6-48e0-ab77" name="Skirmish Sub-type" primary="false"/>
+            <categoryLink targetId="bff2-ae16-74a8-8712" id="d720-5b75-4086-bd2d" name="Light Sub-type" primary="false"/>
+            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="5f8a-78ed-42ca-b79a" name="Unique Sub-type" primary="false"/>
           </categoryLinks>
         </selectionEntry>
       </selectionEntries>
@@ -3394,7 +3394,7 @@
         <infoLink id="0fbd-20ec-9b4a-b6ae" name="Stubborn" hidden="false" targetId="7989-1f2c-a43d-82ae" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="e579-d4c0-6f64-2eb2" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="e579-d4c0-6f64-2eb2" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="1ebc-e9e5-35d4-88c3" name="Heavy Sub-type" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
         <categoryLink id="81a2-f758-8265-d1a6" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
       </categoryLinks>
@@ -3425,8 +3425,8 @@
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="30"/>
           </costs>
           <categoryLinks>
-            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="7b22-4ae0-4931-974f" name="Infantry" primary="false"/>
-            <categoryLink targetId="9231-183c-b97b-63f9" id="f189-4475-4364-8a8b" name="Heavy" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="7b22-4ae0-4931-974f" name="Infantry Unit Type" primary="false"/>
+            <categoryLink targetId="9231-183c-b97b-63f9" id="f189-4475-4364-8a8b" name="Heavy Sub-type" primary="false"/>
           </categoryLinks>
         </selectionEntry>
         <selectionEntry id="8fbd-8f9c-1880-dc48" name="Ymira Class Stasis Bombs" hidden="false" collective="false" import="true" type="upgrade">
@@ -3681,7 +3681,7 @@
       </infoLinks>
       <categoryLinks>
         <categoryLink id="2ee4-2abc-3c87-55e6" name="Heavy Sub-type" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
-        <categoryLink id="7469-45b8-1b62-5427" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="7469-45b8-1b62-5427" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="0ef2-5d12-a22c-7300" name="Terminators:" hidden="false" targetId="bab3-f50d-3e5f-2f78" primary="false"/>
         <categoryLink id="38da-50e3-302b-8975" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
       </categoryLinks>
@@ -3838,8 +3838,8 @@
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="45"/>
           </costs>
           <categoryLinks>
-            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="d6ca-c116-42de-982f" name="Infantry" primary="false"/>
-            <categoryLink targetId="9231-183c-b97b-63f9" id="1a9f-8668-4a48-85c9" name="Heavy" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="d6ca-c116-42de-982f" name="Infantry Unit Type" primary="false"/>
+            <categoryLink targetId="9231-183c-b97b-63f9" id="1a9f-8668-4a48-85c9" name="Heavy Sub-type" primary="false"/>
           </categoryLinks>
         </selectionEntry>
         <selectionEntry id="9977-8907-aebb-d864" name="Thegn" hidden="false" collective="false" import="true" type="model">
@@ -3866,8 +3866,8 @@
           </profiles>
           <categoryLinks>
             <categoryLink id="72ed-7d96-0940-a70d" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
-            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="41d7-52dc-49fd-91bf" name="Infantry" primary="false"/>
-            <categoryLink targetId="9231-183c-b97b-63f9" id="e9a0-4cda-44d1-a6a4" name="Heavy" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="41d7-52dc-49fd-91bf" name="Infantry Unit Type" primary="false"/>
+            <categoryLink targetId="9231-183c-b97b-63f9" id="e9a0-4cda-44d1-a6a4" name="Heavy Sub-type" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="123a-39a8-1b6e-8e3e" name="1st Melee Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="6d1f-4f34-170b-58a9">
@@ -4176,7 +4176,7 @@
         </infoLink>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="bbe7-7ff2-451e-b829" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="bbe7-7ff2-451e-b829" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="b448-e7f9-63a5-1209" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="1b8f-457a-d55c-4e91" name="Skirmish Sub-type" hidden="false" targetId="59a4-7b61-600a-c457" primary="false"/>
         <categoryLink id="1d25-440b-a838-dfd4" name="Line Sub-type" hidden="false" targetId="6399-5c65-7833-1025" primary="false"/>
@@ -4213,9 +4213,9 @@
           </profiles>
           <categoryLinks>
             <categoryLink id="a17a-08c9-3929-eb98" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
-            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="7b1c-b1f1-4409-a6fb" name="Infantry" primary="false"/>
-            <categoryLink targetId="59a4-7b61-600a-c457" id="0f9d-32b5-4044-aa1b" name="Skirmish" primary="false"/>
-            <categoryLink targetId="6399-5c65-7833-1025" id="6e84-4afa-45be-bad5" name="Line" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="7b1c-b1f1-4409-a6fb" name="Infantry Unit Type" primary="false"/>
+            <categoryLink targetId="59a4-7b61-600a-c457" id="0f9d-32b5-4044-aa1b" name="Skirmish Sub-type" primary="false"/>
+            <categoryLink targetId="6399-5c65-7833-1025" id="6e84-4afa-45be-bad5" name="Line Sub-type" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="b309-5e5b-0e38-3a11" name="3) May exchange his Bolt Pistol and Fenrisian Axe for:" hidden="false" collective="false" import="true">
@@ -4547,9 +4547,9 @@
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="12"/>
               </costs>
               <categoryLinks>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="096b-1361-422c-877d" name="Infantry" primary="false"/>
-                <categoryLink targetId="59a4-7b61-600a-c457" id="0945-f0fc-4fab-8eb2" name="Skirmish" primary="false"/>
-                <categoryLink targetId="6399-5c65-7833-1025" id="c312-23cd-46ef-bdce" name="Line" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="096b-1361-422c-877d" name="Infantry Unit Type" primary="false"/>
+                <categoryLink targetId="59a4-7b61-600a-c457" id="0945-f0fc-4fab-8eb2" name="Skirmish Sub-type" primary="false"/>
+                <categoryLink targetId="6399-5c65-7833-1025" id="c312-23cd-46ef-bdce" name="Line Sub-type" primary="false"/>
               </categoryLinks>
             </selectionEntry>
             <selectionEntry id="859f-9945-1a77-2d77" name="Grey Slayer w/Combat Shield, Power Axe" hidden="false" collective="false" import="true" type="model">
@@ -4577,9 +4577,9 @@
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="17"/>
               </costs>
               <categoryLinks>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="24fa-69c6-4faa-a5e0" name="Infantry" primary="false"/>
-                <categoryLink targetId="59a4-7b61-600a-c457" id="95b4-74fe-4387-a009" name="Skirmish" primary="false"/>
-                <categoryLink targetId="6399-5c65-7833-1025" id="75e5-5518-4bf4-8625" name="Line" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="24fa-69c6-4faa-a5e0" name="Infantry Unit Type" primary="false"/>
+                <categoryLink targetId="59a4-7b61-600a-c457" id="95b4-74fe-4387-a009" name="Skirmish Sub-type" primary="false"/>
+                <categoryLink targetId="6399-5c65-7833-1025" id="75e5-5518-4bf4-8625" name="Line Sub-type" primary="false"/>
               </categoryLinks>
             </selectionEntry>
             <selectionEntry id="ed00-a72f-bbb4-429d" name="Grey Slayer w/Bolter, Power Sword" hidden="false" collective="false" import="true" type="model">
@@ -4646,9 +4646,9 @@
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="12"/>
               </costs>
               <categoryLinks>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="d12e-b0e9-491e-b0f6" name="Infantry" primary="false"/>
-                <categoryLink targetId="59a4-7b61-600a-c457" id="6c35-5f65-49d5-aca2" name="Skirmish" primary="false"/>
-                <categoryLink targetId="6399-5c65-7833-1025" id="5606-81f3-4d7e-9a50" name="Line" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="d12e-b0e9-491e-b0f6" name="Infantry Unit Type" primary="false"/>
+                <categoryLink targetId="59a4-7b61-600a-c457" id="6c35-5f65-49d5-aca2" name="Skirmish Sub-type" primary="false"/>
+                <categoryLink targetId="6399-5c65-7833-1025" id="5606-81f3-4d7e-9a50" name="Line Sub-type" primary="false"/>
               </categoryLinks>
             </selectionEntry>
             <selectionEntry id="fc48-8eea-bc4e-f014" name="Grey Slayer w/ Options" hidden="false" collective="false" import="true" type="model">
@@ -4831,9 +4831,9 @@
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="12"/>
               </costs>
               <categoryLinks>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="5757-e299-4a82-949b" name="Infantry" primary="false"/>
-                <categoryLink targetId="59a4-7b61-600a-c457" id="af4a-67f1-4879-b561" name="Skirmish" primary="false"/>
-                <categoryLink targetId="6399-5c65-7833-1025" id="5563-6509-48aa-87d2" name="Line" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="5757-e299-4a82-949b" name="Infantry Unit Type" primary="false"/>
+                <categoryLink targetId="59a4-7b61-600a-c457" id="af4a-67f1-4879-b561" name="Skirmish Sub-type" primary="false"/>
+                <categoryLink targetId="6399-5c65-7833-1025" id="5563-6509-48aa-87d2" name="Line Sub-type" primary="false"/>
               </categoryLinks>
             </selectionEntry>
             <selectionEntry id="c830-ff75-317f-45c1" name="Grey Slayer w/Bolter, Power Axe" hidden="false" collective="false" import="true" type="model">
@@ -4889,9 +4889,9 @@
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="12"/>
               </costs>
               <categoryLinks>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="03d8-643d-4473-a665" name="Infantry" primary="false"/>
-                <categoryLink targetId="59a4-7b61-600a-c457" id="11b7-b5ef-4bb3-b1b5" name="Skirmish" primary="false"/>
-                <categoryLink targetId="6399-5c65-7833-1025" id="95cc-2bd3-4d05-bae5" name="Line" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="03d8-643d-4473-a665" name="Infantry Unit Type" primary="false"/>
+                <categoryLink targetId="59a4-7b61-600a-c457" id="11b7-b5ef-4bb3-b1b5" name="Skirmish Sub-type" primary="false"/>
+                <categoryLink targetId="6399-5c65-7833-1025" id="95cc-2bd3-4d05-bae5" name="Line Sub-type" primary="false"/>
               </categoryLinks>
             </selectionEntry>
             <selectionEntry id="98f2-784e-6eeb-9940" name="Grey Slayer w/Bolter, Power Maul" hidden="false" collective="false" import="true" type="model">
@@ -4947,9 +4947,9 @@
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="12"/>
               </costs>
               <categoryLinks>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="e753-7f0c-445c-8fdd" name="Infantry" primary="false"/>
-                <categoryLink targetId="59a4-7b61-600a-c457" id="c93e-5045-4555-9f37" name="Skirmish" primary="false"/>
-                <categoryLink targetId="6399-5c65-7833-1025" id="64db-432e-413d-8b27" name="Line" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="e753-7f0c-445c-8fdd" name="Infantry Unit Type" primary="false"/>
+                <categoryLink targetId="59a4-7b61-600a-c457" id="c93e-5045-4555-9f37" name="Skirmish Sub-type" primary="false"/>
+                <categoryLink targetId="6399-5c65-7833-1025" id="64db-432e-413d-8b27" name="Line Sub-type" primary="false"/>
               </categoryLinks>
             </selectionEntry>
             <selectionEntry id="31e0-f58c-85d7-d5f2" name="Grey Slayer w/Bolter, Fenrisian Axe" hidden="false" collective="false" import="true" type="model">
@@ -5005,9 +5005,9 @@
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="12"/>
               </costs>
               <categoryLinks>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="c22f-b2e7-4cce-8a3f" name="Infantry" primary="false"/>
-                <categoryLink targetId="59a4-7b61-600a-c457" id="f9e4-9ea8-411b-8fed" name="Skirmish" primary="false"/>
-                <categoryLink targetId="6399-5c65-7833-1025" id="08d7-c87a-4118-bad0" name="Line" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="c22f-b2e7-4cce-8a3f" name="Infantry Unit Type" primary="false"/>
+                <categoryLink targetId="59a4-7b61-600a-c457" id="f9e4-9ea8-411b-8fed" name="Skirmish Sub-type" primary="false"/>
+                <categoryLink targetId="6399-5c65-7833-1025" id="08d7-c87a-4118-bad0" name="Line Sub-type" primary="false"/>
               </categoryLinks>
             </selectionEntry>
             <selectionEntry id="cc8a-51a3-99db-3e78" name="Grey Slayer w/Bolter, Power Lance" hidden="false" collective="false" import="true" type="model">
@@ -5063,9 +5063,9 @@
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="12"/>
               </costs>
               <categoryLinks>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="1968-31d0-4c7b-af8a" name="Infantry" primary="false"/>
-                <categoryLink targetId="59a4-7b61-600a-c457" id="a125-d469-495e-9387" name="Skirmish" primary="false"/>
-                <categoryLink targetId="6399-5c65-7833-1025" id="e2a5-a386-4d5f-8361" name="Line" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="1968-31d0-4c7b-af8a" name="Infantry Unit Type" primary="false"/>
+                <categoryLink targetId="59a4-7b61-600a-c457" id="a125-d469-495e-9387" name="Skirmish Sub-type" primary="false"/>
+                <categoryLink targetId="6399-5c65-7833-1025" id="e2a5-a386-4d5f-8361" name="Line Sub-type" primary="false"/>
               </categoryLinks>
             </selectionEntry>
             <selectionEntry id="1f48-0084-7908-cc26" name="Grey Slayer w/Combat Shield, Power Maul" hidden="false" collective="false" import="true" type="model">
@@ -5093,9 +5093,9 @@
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="17"/>
               </costs>
               <categoryLinks>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="5158-70d8-4c8a-ba94" name="Infantry" primary="false"/>
-                <categoryLink targetId="59a4-7b61-600a-c457" id="8f8b-7762-482d-a86e" name="Skirmish" primary="false"/>
-                <categoryLink targetId="6399-5c65-7833-1025" id="2a0c-14f0-4aac-b792" name="Line" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="5158-70d8-4c8a-ba94" name="Infantry Unit Type" primary="false"/>
+                <categoryLink targetId="59a4-7b61-600a-c457" id="8f8b-7762-482d-a86e" name="Skirmish Sub-type" primary="false"/>
+                <categoryLink targetId="6399-5c65-7833-1025" id="2a0c-14f0-4aac-b792" name="Line Sub-type" primary="false"/>
               </categoryLinks>
             </selectionEntry>
             <selectionEntry id="bd6a-c128-08d2-8627" name="Grey Slayer w/Combat Shield, Power Lance" hidden="false" collective="false" import="true" type="model">
@@ -5123,9 +5123,9 @@
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="17"/>
               </costs>
               <categoryLinks>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="80c0-8993-4262-acad" name="Infantry" primary="false"/>
-                <categoryLink targetId="59a4-7b61-600a-c457" id="ab52-76f6-4db0-9fde" name="Skirmish" primary="false"/>
-                <categoryLink targetId="6399-5c65-7833-1025" id="a5a3-d7e8-4b52-ac93" name="Line" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="80c0-8993-4262-acad" name="Infantry Unit Type" primary="false"/>
+                <categoryLink targetId="59a4-7b61-600a-c457" id="ab52-76f6-4db0-9fde" name="Skirmish Sub-type" primary="false"/>
+                <categoryLink targetId="6399-5c65-7833-1025" id="a5a3-d7e8-4b52-ac93" name="Line Sub-type" primary="false"/>
               </categoryLinks>
             </selectionEntry>
             <selectionEntry id="0f4d-43c5-f0bd-ea25" name="Grey Slayer w/Combat Shield, Power Sword" hidden="false" collective="false" import="true" type="model">
@@ -5153,9 +5153,9 @@
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="17"/>
               </costs>
               <categoryLinks>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="e666-6ef1-417c-9e96" name="Infantry" primary="false"/>
-                <categoryLink targetId="59a4-7b61-600a-c457" id="19f0-50b2-4c49-862c" name="Skirmish" primary="false"/>
-                <categoryLink targetId="6399-5c65-7833-1025" id="a189-103b-40bb-ac90" name="Line" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="e666-6ef1-417c-9e96" name="Infantry Unit Type" primary="false"/>
+                <categoryLink targetId="59a4-7b61-600a-c457" id="19f0-50b2-4c49-862c" name="Skirmish Sub-type" primary="false"/>
+                <categoryLink targetId="6399-5c65-7833-1025" id="a189-103b-40bb-ac90" name="Line Sub-type" primary="false"/>
               </categoryLinks>
             </selectionEntry>
           </selectionEntries>
@@ -5225,7 +5225,7 @@
         </infoLink>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="b526-a925-98fa-3c1b" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="b526-a925-98fa-3c1b" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="4d9c-b591-869f-72e1" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="cebe-84b9-86a9-ad58" name="Skirmish Sub-type" hidden="false" targetId="59a4-7b61-600a-c457" primary="false"/>
         <categoryLink id="b50f-33ce-bd61-3d78" name="Line Sub-type" hidden="false" targetId="6399-5c65-7833-1025" primary="false"/>
@@ -5262,9 +5262,9 @@
           </profiles>
           <categoryLinks>
             <categoryLink id="45f3-17a2-f2de-7958" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
-            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="1d9c-92fe-478a-a643" name="Infantry" primary="false"/>
-            <categoryLink targetId="59a4-7b61-600a-c457" id="844d-397e-49c3-a5a6" name="Skirmish" primary="false"/>
-            <categoryLink targetId="6399-5c65-7833-1025" id="26ec-836d-45e8-a7dd" name="Line" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="1d9c-92fe-478a-a643" name="Infantry Unit Type" primary="false"/>
+            <categoryLink targetId="59a4-7b61-600a-c457" id="844d-397e-49c3-a5a6" name="Skirmish Sub-type" primary="false"/>
+            <categoryLink targetId="6399-5c65-7833-1025" id="26ec-836d-45e8-a7dd" name="Line Sub-type" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="a31a-a800-9e97-7e77" name="4) Wargear" hidden="false" collective="false" import="true">
@@ -5620,9 +5620,9 @@
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="14"/>
               </costs>
               <categoryLinks>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="b1f9-fadf-4c95-9b1a" name="Infantry" primary="false"/>
-                <categoryLink targetId="59a4-7b61-600a-c457" id="4164-eb0a-4b39-8f33" name="Skirmish" primary="false"/>
-                <categoryLink targetId="6399-5c65-7833-1025" id="3fc1-9c2c-4fa6-8294" name="Line" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="b1f9-fadf-4c95-9b1a" name="Infantry Unit Type" primary="false"/>
+                <categoryLink targetId="59a4-7b61-600a-c457" id="4164-eb0a-4b39-8f33" name="Skirmish Sub-type" primary="false"/>
+                <categoryLink targetId="6399-5c65-7833-1025" id="3fc1-9c2c-4fa6-8294" name="Line Sub-type" primary="false"/>
               </categoryLinks>
             </selectionEntry>
             <selectionEntry id="7861-5220-928a-3c81" name="Grey Stalker w/ Power Axe" hidden="false" collective="false" import="true" type="model">
@@ -5647,9 +5647,9 @@
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="12"/>
               </costs>
               <categoryLinks>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="4785-777b-42b1-b020" name="Infantry" primary="false"/>
-                <categoryLink targetId="59a4-7b61-600a-c457" id="f742-304a-4da7-85f9" name="Skirmish" primary="false"/>
-                <categoryLink targetId="6399-5c65-7833-1025" id="3333-0c87-400f-a4c3" name="Line" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="4785-777b-42b1-b020" name="Infantry Unit Type" primary="false"/>
+                <categoryLink targetId="59a4-7b61-600a-c457" id="f742-304a-4da7-85f9" name="Skirmish Sub-type" primary="false"/>
+                <categoryLink targetId="6399-5c65-7833-1025" id="3333-0c87-400f-a4c3" name="Line Sub-type" primary="false"/>
               </categoryLinks>
             </selectionEntry>
             <selectionEntry id="fcdb-5adc-1d89-aac7" name="Grey Stalker w/ Power Lance" hidden="false" collective="false" import="true" type="model">
@@ -5674,9 +5674,9 @@
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="12"/>
               </costs>
               <categoryLinks>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="5169-7878-47dd-aa9c" name="Infantry" primary="false"/>
-                <categoryLink targetId="59a4-7b61-600a-c457" id="e951-b299-406f-acaf" name="Skirmish" primary="false"/>
-                <categoryLink targetId="6399-5c65-7833-1025" id="28e5-3ae2-44f1-bde5" name="Line" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="5169-7878-47dd-aa9c" name="Infantry Unit Type" primary="false"/>
+                <categoryLink targetId="59a4-7b61-600a-c457" id="e951-b299-406f-acaf" name="Skirmish Sub-type" primary="false"/>
+                <categoryLink targetId="6399-5c65-7833-1025" id="28e5-3ae2-44f1-bde5" name="Line Sub-type" primary="false"/>
               </categoryLinks>
             </selectionEntry>
             <selectionEntry id="b157-449e-0ddb-6d47" name="Grey Stalker w/ Power Maul" hidden="false" collective="false" import="true" type="model">
@@ -5701,9 +5701,9 @@
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="12"/>
               </costs>
               <categoryLinks>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="afe9-29f6-4537-bedb" name="Infantry" primary="false"/>
-                <categoryLink targetId="59a4-7b61-600a-c457" id="c5ca-37c3-4a92-a619" name="Skirmish" primary="false"/>
-                <categoryLink targetId="6399-5c65-7833-1025" id="833e-1c75-4dbc-be11" name="Line" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="afe9-29f6-4537-bedb" name="Infantry Unit Type" primary="false"/>
+                <categoryLink targetId="59a4-7b61-600a-c457" id="c5ca-37c3-4a92-a619" name="Skirmish Sub-type" primary="false"/>
+                <categoryLink targetId="6399-5c65-7833-1025" id="833e-1c75-4dbc-be11" name="Line Sub-type" primary="false"/>
               </categoryLinks>
             </selectionEntry>
             <selectionEntry id="af66-5795-41ff-afdb" name="Grey Stalker w/ Power Sword" hidden="false" collective="false" import="true" type="model">
@@ -5728,9 +5728,9 @@
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="12"/>
               </costs>
               <categoryLinks>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="fa83-75a5-4b4e-955b" name="Infantry" primary="false"/>
-                <categoryLink targetId="59a4-7b61-600a-c457" id="d101-dfed-495b-aa13" name="Skirmish" primary="false"/>
-                <categoryLink targetId="6399-5c65-7833-1025" id="868f-6f7e-4763-8ec1" name="Line" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="fa83-75a5-4b4e-955b" name="Infantry Unit Type" primary="false"/>
+                <categoryLink targetId="59a4-7b61-600a-c457" id="d101-dfed-495b-aa13" name="Skirmish Sub-type" primary="false"/>
+                <categoryLink targetId="6399-5c65-7833-1025" id="868f-6f7e-4763-8ec1" name="Line Sub-type" primary="false"/>
               </categoryLinks>
             </selectionEntry>
             <selectionEntry id="a482-de3c-4324-a64f" name="Grey Stalker w/ Options" hidden="false" collective="false" import="true" type="model">
@@ -6021,9 +6021,9 @@
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="12"/>
               </costs>
               <categoryLinks>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="df30-d7ef-4f9a-8430" name="Infantry" primary="false"/>
-                <categoryLink targetId="59a4-7b61-600a-c457" id="5581-c7a3-464f-9bb2" name="Skirmish" primary="false"/>
-                <categoryLink targetId="6399-5c65-7833-1025" id="1197-0cee-4633-86ee" name="Line" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="df30-d7ef-4f9a-8430" name="Infantry Unit Type" primary="false"/>
+                <categoryLink targetId="59a4-7b61-600a-c457" id="5581-c7a3-464f-9bb2" name="Skirmish Sub-type" primary="false"/>
+                <categoryLink targetId="6399-5c65-7833-1025" id="1197-0cee-4633-86ee" name="Line Sub-type" primary="false"/>
               </categoryLinks>
             </selectionEntry>
             <selectionEntry id="2472-8f6f-6df0-19b9" name="Grey Stalker w/ Chainsword" hidden="false" collective="false" import="true" type="model">
@@ -6045,9 +6045,9 @@
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="12"/>
               </costs>
               <categoryLinks>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="9e1f-8e0a-4903-9e92" name="Infantry" primary="false"/>
-                <categoryLink targetId="59a4-7b61-600a-c457" id="701e-d113-445a-b46b" name="Skirmish" primary="false"/>
-                <categoryLink targetId="6399-5c65-7833-1025" id="0915-d800-467b-a0cb" name="Line" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="9e1f-8e0a-4903-9e92" name="Infantry Unit Type" primary="false"/>
+                <categoryLink targetId="59a4-7b61-600a-c457" id="701e-d113-445a-b46b" name="Skirmish Sub-type" primary="false"/>
+                <categoryLink targetId="6399-5c65-7833-1025" id="0915-d800-467b-a0cb" name="Line Sub-type" primary="false"/>
               </categoryLinks>
             </selectionEntry>
           </selectionEntries>
@@ -6082,7 +6082,7 @@
         <constraint field="selections" scope="roster" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="855f-f43d-fd08-ea00" type="max"/>
       </constraints>
       <categoryLinks>
-        <categoryLink id="d60f-4d22-ec3a-4ff4" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="d60f-4d22-ec3a-4ff4" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="d837-ea6b-4c27-6d28" name="Skirmish Sub-type" hidden="false" targetId="59a4-7b61-600a-c457" primary="false"/>
         <categoryLink id="630f-3af2-6436-6e5f" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
       </categoryLinks>
@@ -6196,10 +6196,10 @@
           </costs>
           <categoryLinks>
             <categoryLink targetId="4f07-3d45-4f28-a0c6" id="bfba-adcf-27b4-9484" primary="false" name="Independent Character"/>
-            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="e393-7152-4420-93c4" name="Infantry" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="e393-7152-4420-93c4" name="Infantry Unit Type" primary="false"/>
             <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="cc67-a257-4587-9f07" name="Character" primary="false"/>
-            <categoryLink targetId="59a4-7b61-600a-c457" id="a746-96da-4946-8642" name="Skirmish" primary="false"/>
-            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="5953-e3dd-4bb2-96dd" name="Unique" primary="false"/>
+            <categoryLink targetId="59a4-7b61-600a-c457" id="a746-96da-4946-8642" name="Skirmish Sub-type" primary="false"/>
+            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="5953-e3dd-4bb2-96dd" name="Unique Sub-type" primary="false"/>
           </categoryLinks>
         </selectionEntry>
       </selectionEntries>
@@ -6233,7 +6233,7 @@
         <constraint field="selections" scope="roster" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c89d-e03f-7b36-7045" type="max"/>
       </constraints>
       <categoryLinks>
-        <categoryLink id="0638-55ed-3f00-f7e8" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="0638-55ed-3f00-f7e8" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="1e3f-2a84-0c72-44c8" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="b2ea-ff2e-17d8-7c33" name="Terminators:" hidden="false" targetId="bab3-f50d-3e5f-2f78" primary="false"/>
       </categoryLinks>
@@ -6333,9 +6333,9 @@
           </costs>
           <categoryLinks>
             <categoryLink targetId="4f07-3d45-4f28-a0c6" id="98fb-909-f3fc-d3ac" primary="false" name="Independent Character"/>
-            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="ee34-9234-4936-9c2d" name="Infantry" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="ee34-9234-4936-9c2d" name="Infantry Unit Type" primary="false"/>
             <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="b91c-b9cf-4eb4-ac2e" name="Character" primary="false"/>
-            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="40d6-cca8-4a3d-9ad7" name="Unique" primary="false"/>
+            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="40d6-cca8-4a3d-9ad7" name="Unique Sub-type" primary="false"/>
           </categoryLinks>
         </selectionEntry>
       </selectionEntries>
@@ -6384,7 +6384,7 @@
       </infoLinks>
       <categoryLinks>
         <categoryLink id="74d4-672b-5d83-787e" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="6ea9-87ae-dad3-a06a" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="6ea9-87ae-dad3-a06a" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="57d5-858f-5248-0053" name="Hunters" hidden="false" collective="false" import="true" type="model">
@@ -6413,7 +6413,7 @@
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15"/>
           </costs>
           <categoryLinks>
-            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="a61a-c1fb-4dcb-a91a" name="Infantry" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="a61a-c1fb-4dcb-a91a" name="Infantry Unit Type" primary="false"/>
           </categoryLinks>
         </selectionEntry>
         <selectionEntry id="0a7d-31ab-699e-1377" name="Hunt-master" hidden="false" collective="false" import="true" type="model">
@@ -6447,7 +6447,7 @@
           </profiles>
           <categoryLinks>
             <categoryLink id="4660-da5d-c2a4-9da0" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
-            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="5353-ae48-478f-a300" name="Infantry" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="5353-ae48-478f-a300" name="Infantry Unit Type" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="7f67-db6e-5008-8432" name="4) May take:" hidden="false" collective="false" import="true">
@@ -6829,7 +6829,7 @@
         <categoryLink id="cd15-57a2-eb52-ba6e" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="3fa3-2b6b-9450-df23" name="Skirmish Sub-type" hidden="false" targetId="59a4-7b61-600a-c457" primary="false"/>
         <categoryLink id="902c-d0fe-d4c8-5002" name="Light Sub-type" hidden="false" targetId="bff2-ae16-74a8-8712" primary="false"/>
-        <categoryLink id="a83a-860c-9cb5-1471" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="a83a-860c-9cb5-1471" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="5b26-1509-991d-f166" name="Fenrisian Wolf" hidden="false" collective="false" import="true" type="model">
@@ -6858,9 +6858,9 @@
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5"/>
           </costs>
           <categoryLinks>
-            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="66b7-1cfc-4dec-85aa" name="Infantry" primary="false"/>
-            <categoryLink targetId="bff2-ae16-74a8-8712" id="0920-eaad-4184-81f0" name="Light" primary="false"/>
-            <categoryLink targetId="59a4-7b61-600a-c457" id="8eff-bf5e-46a8-8f4c" name="Skirmish" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="66b7-1cfc-4dec-85aa" name="Infantry Unit Type" primary="false"/>
+            <categoryLink targetId="bff2-ae16-74a8-8712" id="0920-eaad-4184-81f0" name="Light Sub-type" primary="false"/>
+            <categoryLink targetId="59a4-7b61-600a-c457" id="8eff-bf5e-46a8-8f4c" name="Skirmish Sub-type" primary="false"/>
           </categoryLinks>
         </selectionEntry>
         <selectionEntry id="aabc-e789-59be-d5a0" name="Claws" hidden="false" collective="false" import="true" type="upgrade">

--- a/2022 - LA - Thousand Sons.cat
+++ b/2022 - LA - Thousand Sons.cat
@@ -3316,7 +3316,7 @@
           <profiles>
             <profile id="0492-c094-882d-9108" name="Castellax - Achea" publicationId="09c5-eeae-f398-b653" page="266" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName="Unit">
               <characteristics>
-                <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Automata (Psy -automata, Psyker)</characteristic>
+                <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Automata (Psy-automata, Psyker)</characteristic>
                 <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
                 <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">3</characteristic>
                 <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
@@ -3349,8 +3349,8 @@
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="140"/>
           </costs>
-          <comment>!BSC Errors from 20240328-1346
-Could not find type or subtype &apos;Psy -automata&apos;</comment>
+          <comment>!BSC Errors from 20240330-1529
+Could not find type or subtype &apos;Psy-automata&apos;</comment>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>

--- a/2022 - LA - Thousand Sons.cat
+++ b/2022 - LA - Thousand Sons.cat
@@ -3023,7 +3023,7 @@
         </infoLink>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="4f4b-14a1-2bc3-0dae" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="4f4b-14a1-2bc3-0dae" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="280a-d3f2-d095-83c1" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="adbf-ca76-7b97-3526" name="Skirmish Sub-type" hidden="false" targetId="59a4-7b61-600a-c457" primary="false"/>
         <categoryLink id="5e1a-c5d0-2524-ec10" name="Light Sub-type" hidden="false" targetId="bff2-ae16-74a8-8712" primary="false"/>
@@ -3055,8 +3055,8 @@
             <categoryLink id="70dd-9240-a310-b1da" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
             <categoryLink id="44c0-6cc5-6fea-0efa" name="Light Sub-type" hidden="false" targetId="bff2-ae16-74a8-8712" primary="false"/>
             <categoryLink id="075a-42ce-300a-8b4f" name="Skirmish Sub-type" hidden="false" targetId="59a4-7b61-600a-c457" primary="false"/>
-            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="247d-a9ca-433f-88f2" name="Infantry" primary="false"/>
-            <categoryLink targetId="6e0c-29ba-a445-8321" id="1a1c-e25c-46e3-a2e6" name="Psyker" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="247d-a9ca-433f-88f2" name="Infantry Unit Type" primary="false"/>
+            <categoryLink targetId="6e0c-29ba-a445-8321" id="1a1c-e25c-46e3-a2e6" name="Psyker:" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="a00a-9922-6df6-38d1" name="May take any:" hidden="false" collective="false" import="true">
@@ -3125,8 +3125,8 @@
           <categoryLinks>
             <categoryLink id="e865-2752-163b-293f" name="Light Sub-type" hidden="false" targetId="bff2-ae16-74a8-8712" primary="false"/>
             <categoryLink id="ef7e-6a43-4e20-d68e" name="Skirmish Sub-type" hidden="false" targetId="59a4-7b61-600a-c457" primary="false"/>
-            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="1eb2-86fe-41aa-af68" name="Infantry" primary="false"/>
-            <categoryLink targetId="6e0c-29ba-a445-8321" id="5dd8-0395-4781-a13a" name="Psyker" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="1eb2-86fe-41aa-af68" name="Infantry Unit Type" primary="false"/>
+            <categoryLink targetId="6e0c-29ba-a445-8321" id="5dd8-0395-4781-a13a" name="Psyker:" primary="false"/>
           </categoryLinks>
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25"/>
@@ -3344,13 +3344,11 @@
           </infoLinks>
           <categoryLinks>
             <categoryLink id="b81a-622a-27d1-2522" name="Automata Unit Type" hidden="false" targetId="d8ab-8e21-e193-63ba" primary="false"/>
-            <categoryLink targetId="6e0c-29ba-a445-8321" id="c918-733e-4420-9874" name="Psyker" primary="false"/>
+            <categoryLink targetId="6e0c-29ba-a445-8321" id="c918-733e-4420-9874" name="Psyker:" primary="false"/>
           </categoryLinks>
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="140"/>
           </costs>
-          <comment>!BSC Errors from 20240330-1529
-Could not find type or subtype &apos;Psy-automata&apos;</comment>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
@@ -3467,7 +3465,7 @@ Could not find type or subtype &apos;Psy-automata&apos;</comment>
           </infoLinks>
           <categoryLinks>
             <categoryLink id="7e1b-a2cc-89f8-3824" name="Dreadnought Unit Type" hidden="false" targetId="4280-4963-02b5-e31d" primary="false"/>
-            <categoryLink targetId="6e0c-29ba-a445-8321" id="7ca7-8674-4f41-a40e" name="Psyker" primary="false"/>
+            <categoryLink targetId="6e0c-29ba-a445-8321" id="7ca7-8674-4f41-a40e" name="Psyker:" primary="false"/>
           </categoryLinks>
           <selectionEntries>
             <selectionEntry id="51f2-4b7a-a6c0-08e7" name="Minor Arcana" hidden="false" collective="false" import="true" type="upgrade">
@@ -3693,7 +3691,7 @@ Could not find type or subtype &apos;Psy-automata&apos;</comment>
         <infoLink id="003c-d933-e89e-dc9c" name="Legiones Astartes (Thousand Sons)" hidden="false" targetId="2377-1d73-44bc-fee2" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="68e3-d5fc-41b5-8cf7" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="68e3-d5fc-41b5-8cf7" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="83a3-0ef9-edb4-003d" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
       </categoryLinks>
       <selectionEntries>
@@ -3730,10 +3728,10 @@ Could not find type or subtype &apos;Psy-automata&apos;</comment>
           </infoLinks>
           <categoryLinks>
             <categoryLink id="6ca9-7834-d332-aa0c" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
-            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="9978-ec07-4ad2-9373" name="Infantry" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="9978-ec07-4ad2-9373" name="Infantry Unit Type" primary="false"/>
             <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="7553-7b9e-41be-b7e3" name="Character" primary="false"/>
-            <categoryLink targetId="6e0c-29ba-a445-8321" id="618d-0fa7-49f4-b216" name="Psyker" primary="false"/>
-            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="df7e-627e-4720-90e3" name="Unique" primary="false"/>
+            <categoryLink targetId="6e0c-29ba-a445-8321" id="618d-0fa7-49f4-b216" name="Psyker:" primary="false"/>
+            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="df7e-627e-4720-90e3" name="Unique Sub-type" primary="false"/>
           </categoryLinks>
           <selectionEntries>
             <selectionEntry id="c609-1504-8ba4-2a09" name="Psychic powers" hidden="false" collective="false" import="true" type="upgrade">
@@ -3932,7 +3930,7 @@ Could not find type or subtype &apos;Psy-automata&apos;</comment>
         <constraint field="selections" scope="roster" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a3eb-f7d1-c04f-1aff" type="max"/>
       </constraints>
       <categoryLinks>
-        <categoryLink id="d7b8-d408-02a0-260a" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="d7b8-d408-02a0-260a" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="6fb7-0274-47e5-c469" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
       </categoryLinks>
       <selectionEntries>
@@ -3975,9 +3973,9 @@ Could not find type or subtype &apos;Psy-automata&apos;</comment>
           <categoryLinks>
             <categoryLink id="2725-e4f0-1cf8-6f29" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
             <categoryLink id="7672-7fc0-3907-9518" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
-            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="9f3b-94ea-42b2-a678" name="Infantry" primary="false"/>
-            <categoryLink targetId="6e0c-29ba-a445-8321" id="4711-ec25-4585-94c3" name="Psyker" primary="false"/>
-            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="86da-b6ac-4742-838a" name="Unique" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="9f3b-94ea-42b2-a678" name="Infantry Unit Type" primary="false"/>
+            <categoryLink targetId="6e0c-29ba-a445-8321" id="4711-ec25-4585-94c3" name="Psyker:" primary="false"/>
+            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="86da-b6ac-4742-838a" name="Unique Sub-type" primary="false"/>
           </categoryLinks>
           <selectionEntries>
             <selectionEntry id="ba7a-2388-5475-2ff6" name="Master-crafted Asphyx Bolt Pistol" hidden="false" collective="false" import="true" type="upgrade">
@@ -4138,7 +4136,7 @@ Could not find type or subtype &apos;Psy-automata&apos;</comment>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="ee57-776c-ef90-1f77" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="3066-9075-b4df-8684" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="3066-9075-b4df-8684" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="ea5b-1965-f2b0-cd0d" name="Heavy Sub-type" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
         <categoryLink id="4863-5593-dedb-fb54" name="Terminators:" hidden="false" targetId="bab3-f50d-3e5f-2f78" primary="false"/>
       </categoryLinks>
@@ -4167,9 +4165,9 @@ Could not find type or subtype &apos;Psy-automata&apos;</comment>
           </profiles>
           <categoryLinks>
             <categoryLink id="9a2f-0507-13a4-8ac8" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
-            <categoryLink id="7c63-0f76-63cb-2c82" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-            <categoryLink targetId="9231-183c-b97b-63f9" id="78a2-b12d-41fd-be4e" name="Heavy" primary="false"/>
-            <categoryLink targetId="6e0c-29ba-a445-8321" id="b889-9663-4168-8042" name="Psyker" primary="false"/>
+            <categoryLink id="7c63-0f76-63cb-2c82" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+            <categoryLink targetId="9231-183c-b97b-63f9" id="78a2-b12d-41fd-be4e" name="Heavy Sub-type" primary="false"/>
+            <categoryLink targetId="6e0c-29ba-a445-8321" id="b889-9663-4168-8042" name="Psyker:" primary="false"/>
           </categoryLinks>
           <selectionEntries>
             <selectionEntry id="a14c-93c1-d16e-d057" name="Psychic Discipline" hidden="false" collective="false" import="true" type="upgrade">
@@ -4276,9 +4274,9 @@ Could not find type or subtype &apos;Psy-automata&apos;</comment>
             </profile>
           </profiles>
           <categoryLinks>
-            <categoryLink id="9e82-d5b4-dc5f-8930" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-            <categoryLink targetId="9231-183c-b97b-63f9" id="6ef0-cc6b-4287-9378" name="Heavy" primary="false"/>
-            <categoryLink targetId="6e0c-29ba-a445-8321" id="433b-b17a-4798-bd39" name="Psyker" primary="false"/>
+            <categoryLink id="9e82-d5b4-dc5f-8930" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+            <categoryLink targetId="9231-183c-b97b-63f9" id="6ef0-cc6b-4287-9378" name="Heavy Sub-type" primary="false"/>
+            <categoryLink targetId="6e0c-29ba-a445-8321" id="433b-b17a-4798-bd39" name="Psyker:" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="f89b-c4b5-a9c7-f49a" name="Melee Weapon Option:" hidden="false" collective="false" import="true" defaultSelectionEntryId="68ba-9107-dc08-5e20">
@@ -4429,7 +4427,7 @@ Could not find type or subtype &apos;Psy-automata&apos;</comment>
         <infoLink id="bb41-1a39-e46f-158a" name="Legiones Astartes (Thousand Sons)" hidden="false" targetId="2377-1d73-44bc-fee2" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="55f4-4cab-9cec-c75d" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="55f4-4cab-9cec-c75d" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="ae48-095c-6184-34bf" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
       </categoryLinks>
       <selectionEntries>
@@ -4456,8 +4454,8 @@ Could not find type or subtype &apos;Psy-automata&apos;</comment>
             </profile>
           </profiles>
           <categoryLinks>
-            <categoryLink id="ecbe-a6e3-dabb-49b6" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-            <categoryLink targetId="6e0c-29ba-a445-8321" id="1901-aadd-40a0-a622" name="Psyker" primary="false"/>
+            <categoryLink id="ecbe-a6e3-dabb-49b6" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+            <categoryLink targetId="6e0c-29ba-a445-8321" id="1901-aadd-40a0-a622" name="Psyker:" primary="false"/>
           </categoryLinks>
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="24"/>
@@ -4493,9 +4491,9 @@ Could not find type or subtype &apos;Psy-automata&apos;</comment>
             </profile>
           </profiles>
           <categoryLinks>
-            <categoryLink id="8145-7dfb-29b1-e3c5" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+            <categoryLink id="8145-7dfb-29b1-e3c5" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
             <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="e06c-479a-434e-9d24" name="Character" primary="false"/>
-            <categoryLink targetId="6e0c-29ba-a445-8321" id="2021-c374-40d5-8fbd" name="Psyker" primary="false"/>
+            <categoryLink targetId="6e0c-29ba-a445-8321" id="2021-c374-40d5-8fbd" name="Psyker:" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="21dd-b84f-2e92-d62a" name="May take:" hidden="false" collective="false" import="true">
@@ -5000,9 +4998,9 @@ Could not find type or subtype &apos;Psy-automata&apos;</comment>
           </profiles>
           <categoryLinks>
             <categoryLink id="52c9-da65-e6a8-1946" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
-            <categoryLink targetId="ad5f-31db-8bc7-5c46" id="9200-a29f-4cbe-8913" name="Primarch" primary="false"/>
-            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="f253-fa23-4f9a-9fc7" name="Unique" primary="false"/>
-            <categoryLink targetId="6e0c-29ba-a445-8321" id="e78d-2679-4918-bc5f" name="Psyker" primary="false"/>
+            <categoryLink targetId="ad5f-31db-8bc7-5c46" id="9200-a29f-4cbe-8913" name="Primarch:" primary="false"/>
+            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="f253-fa23-4f9a-9fc7" name="Unique Sub-type" primary="false"/>
+            <categoryLink targetId="6e0c-29ba-a445-8321" id="e78d-2679-4918-bc5f" name="Psyker:" primary="false"/>
           </categoryLinks>
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
@@ -5052,7 +5050,7 @@ Could not find type or subtype &apos;Psy-automata&apos;</comment>
         </profile>
       </profiles>
       <categoryLinks>
-        <categoryLink id="af81-7294-801f-6ca9" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="af81-7294-801f-6ca9" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="da52-1de8-5089-fd73" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
       </categoryLinks>
       <selectionEntries>
@@ -5098,8 +5096,8 @@ Additionally, a unit that includes any models with this special rule may not be 
           </infoLinks>
           <categoryLinks>
             <categoryLink id="800e-13a8-47de-1127" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
-            <categoryLink id="3f06-e271-542a-0eda" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-            <categoryLink targetId="6e0c-29ba-a445-8321" id="9f0f-53ff-43eb-9f49" name="Psyker" primary="false"/>
+            <categoryLink id="3f06-e271-542a-0eda" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+            <categoryLink targetId="6e0c-29ba-a445-8321" id="9f0f-53ff-43eb-9f49" name="Psyker:" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="f524-7b20-49ef-df28" name="1) May take one of the following weapons" hidden="false" collective="false" import="true">
@@ -5265,8 +5263,8 @@ Additionally, a unit that includes any models with this special rule may not be 
             </profile>
           </profiles>
           <categoryLinks>
-            <categoryLink id="71de-96dc-adfa-47e5" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-            <categoryLink targetId="6e0c-29ba-a445-8321" id="fe1f-2e90-4d44-8a60" name="Psyker" primary="false"/>
+            <categoryLink id="71de-96dc-adfa-47e5" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+            <categoryLink targetId="6e0c-29ba-a445-8321" id="fe1f-2e90-4d44-8a60" name="Psyker:" primary="false"/>
           </categoryLinks>
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10"/>

--- a/2022 - LA - Thousand Sons.cat
+++ b/2022 - LA - Thousand Sons.cat
@@ -3055,6 +3055,8 @@
             <categoryLink id="70dd-9240-a310-b1da" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
             <categoryLink id="44c0-6cc5-6fea-0efa" name="Light Sub-type:" hidden="false" targetId="bff2-ae16-74a8-8712" primary="false"/>
             <categoryLink id="075a-42ce-300a-8b4f" name="Skirmish Sub-type:" hidden="false" targetId="59a4-7b61-600a-c457" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="247d-a9ca-433f-88f2" name="Infantry" primary="false"/>
+            <categoryLink targetId="6e0c-29ba-a445-8321" id="1a1c-e25c-46e3-a2e6" name="Psyker" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="a00a-9922-6df6-38d1" name="May take any:" hidden="false" collective="false" import="true">
@@ -3123,6 +3125,8 @@
           <categoryLinks>
             <categoryLink id="e865-2752-163b-293f" name="Light Sub-type:" hidden="false" targetId="bff2-ae16-74a8-8712" primary="false"/>
             <categoryLink id="ef7e-6a43-4e20-d68e" name="Skirmish Sub-type:" hidden="false" targetId="59a4-7b61-600a-c457" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="1eb2-86fe-41aa-af68" name="Infantry" primary="false"/>
+            <categoryLink targetId="6e0c-29ba-a445-8321" id="5dd8-0395-4781-a13a" name="Psyker" primary="false"/>
           </categoryLinks>
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25"/>
@@ -3340,10 +3344,13 @@
           </infoLinks>
           <categoryLinks>
             <categoryLink id="b81a-622a-27d1-2522" name="Automata Unit-type:" hidden="false" targetId="d8ab-8e21-e193-63ba" primary="false"/>
+            <categoryLink targetId="6e0c-29ba-a445-8321" id="c918-733e-4420-9874" name="Psyker" primary="false"/>
           </categoryLinks>
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="140"/>
           </costs>
+          <comment>!BSC Errors from 20240328-1346
+Could not find type or subtype &apos;Psy -automata&apos;</comment>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
@@ -3460,6 +3467,7 @@
           </infoLinks>
           <categoryLinks>
             <categoryLink id="7e1b-a2cc-89f8-3824" name="Dreadnought Unit-type:" hidden="false" targetId="4280-4963-02b5-e31d" primary="false"/>
+            <categoryLink targetId="6e0c-29ba-a445-8321" id="7ca7-8674-4f41-a40e" name="Psyker" primary="false"/>
           </categoryLinks>
           <selectionEntries>
             <selectionEntry id="51f2-4b7a-a6c0-08e7" name="Minor Arcana" hidden="false" collective="false" import="true" type="upgrade">
@@ -3722,6 +3730,10 @@
           </infoLinks>
           <categoryLinks>
             <categoryLink id="6ca9-7834-d332-aa0c" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="9978-ec07-4ad2-9373" name="Infantry" primary="false"/>
+            <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="7553-7b9e-41be-b7e3" name="Character" primary="false"/>
+            <categoryLink targetId="6e0c-29ba-a445-8321" id="618d-0fa7-49f4-b216" name="Psyker" primary="false"/>
+            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="df7e-627e-4720-90e3" name="Unique" primary="false"/>
           </categoryLinks>
           <selectionEntries>
             <selectionEntry id="c609-1504-8ba4-2a09" name="Psychic powers" hidden="false" collective="false" import="true" type="upgrade">
@@ -3963,6 +3975,9 @@
           <categoryLinks>
             <categoryLink id="2725-e4f0-1cf8-6f29" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
             <categoryLink id="7672-7fc0-3907-9518" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="9f3b-94ea-42b2-a678" name="Infantry" primary="false"/>
+            <categoryLink targetId="6e0c-29ba-a445-8321" id="4711-ec25-4585-94c3" name="Psyker" primary="false"/>
+            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="86da-b6ac-4742-838a" name="Unique" primary="false"/>
           </categoryLinks>
           <selectionEntries>
             <selectionEntry id="ba7a-2388-5475-2ff6" name="Master-crafted Asphyx Bolt Pistol" hidden="false" collective="false" import="true" type="upgrade">
@@ -4153,6 +4168,8 @@
           <categoryLinks>
             <categoryLink id="9a2f-0507-13a4-8ac8" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
             <categoryLink id="7c63-0f76-63cb-2c82" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+            <categoryLink targetId="9231-183c-b97b-63f9" id="78a2-b12d-41fd-be4e" name="Heavy" primary="false"/>
+            <categoryLink targetId="6e0c-29ba-a445-8321" id="b889-9663-4168-8042" name="Psyker" primary="false"/>
           </categoryLinks>
           <selectionEntries>
             <selectionEntry id="a14c-93c1-d16e-d057" name="Psychic Discipline" hidden="false" collective="false" import="true" type="upgrade">
@@ -4260,6 +4277,8 @@
           </profiles>
           <categoryLinks>
             <categoryLink id="9e82-d5b4-dc5f-8930" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+            <categoryLink targetId="9231-183c-b97b-63f9" id="6ef0-cc6b-4287-9378" name="Heavy" primary="false"/>
+            <categoryLink targetId="6e0c-29ba-a445-8321" id="433b-b17a-4798-bd39" name="Psyker" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="f89b-c4b5-a9c7-f49a" name="Melee Weapon Option:" hidden="false" collective="false" import="true" defaultSelectionEntryId="68ba-9107-dc08-5e20">
@@ -4438,6 +4457,7 @@
           </profiles>
           <categoryLinks>
             <categoryLink id="ecbe-a6e3-dabb-49b6" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+            <categoryLink targetId="6e0c-29ba-a445-8321" id="1901-aadd-40a0-a622" name="Psyker" primary="false"/>
           </categoryLinks>
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="24"/>
@@ -4474,6 +4494,8 @@
           </profiles>
           <categoryLinks>
             <categoryLink id="8145-7dfb-29b1-e3c5" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+            <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="e06c-479a-434e-9d24" name="Character" primary="false"/>
+            <categoryLink targetId="6e0c-29ba-a445-8321" id="2021-c374-40d5-8fbd" name="Psyker" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="21dd-b84f-2e92-d62a" name="May take:" hidden="false" collective="false" import="true">
@@ -4978,6 +5000,9 @@
           </profiles>
           <categoryLinks>
             <categoryLink id="52c9-da65-e6a8-1946" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
+            <categoryLink targetId="ad5f-31db-8bc7-5c46" id="9200-a29f-4cbe-8913" name="Primarch" primary="false"/>
+            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="f253-fa23-4f9a-9fc7" name="Unique" primary="false"/>
+            <categoryLink targetId="6e0c-29ba-a445-8321" id="e78d-2679-4918-bc5f" name="Psyker" primary="false"/>
           </categoryLinks>
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
@@ -5074,6 +5099,7 @@ Additionally, a unit that includes any models with this special rule may not be 
           <categoryLinks>
             <categoryLink id="800e-13a8-47de-1127" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
             <categoryLink id="3f06-e271-542a-0eda" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+            <categoryLink targetId="6e0c-29ba-a445-8321" id="9f0f-53ff-43eb-9f49" name="Psyker" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="f524-7b20-49ef-df28" name="1) May take one of the following weapons" hidden="false" collective="false" import="true">
@@ -5240,6 +5266,7 @@ Additionally, a unit that includes any models with this special rule may not be 
           </profiles>
           <categoryLinks>
             <categoryLink id="71de-96dc-adfa-47e5" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+            <categoryLink targetId="6e0c-29ba-a445-8321" id="fe1f-2e90-4d44-8a60" name="Psyker" primary="false"/>
           </categoryLinks>
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10"/>

--- a/2022 - LA - Thousand Sons.cat
+++ b/2022 - LA - Thousand Sons.cat
@@ -2680,7 +2680,7 @@
       <categoryLinks>
         <categoryLink id="63ff-0a92-42ab-ae8c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="204c-7b0f-4fb9-b1b3" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="85e6-cb31-427c-a040" name="Line Sub-type:" hidden="false" targetId="6399-5c65-7833-1025" primary="false"/>
+        <categoryLink id="85e6-cb31-427c-a040" name="Line Sub-type" hidden="false" targetId="6399-5c65-7833-1025" primary="false"/>
         <categoryLink id="4297-dea3-a5d5-a5b1" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -3025,8 +3025,8 @@
       <categoryLinks>
         <categoryLink id="4f4b-14a1-2bc3-0dae" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="280a-d3f2-d095-83c1" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="adbf-ca76-7b97-3526" name="Skirmish Sub-type:" hidden="false" targetId="59a4-7b61-600a-c457" primary="false"/>
-        <categoryLink id="5e1a-c5d0-2524-ec10" name="Light Sub-type:" hidden="false" targetId="bff2-ae16-74a8-8712" primary="false"/>
+        <categoryLink id="adbf-ca76-7b97-3526" name="Skirmish Sub-type" hidden="false" targetId="59a4-7b61-600a-c457" primary="false"/>
+        <categoryLink id="5e1a-c5d0-2524-ec10" name="Light Sub-type" hidden="false" targetId="bff2-ae16-74a8-8712" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="f786-ea3b-93e3-b24c" name="Ammitara Fate" hidden="false" collective="false" import="true" type="model">
@@ -3053,8 +3053,8 @@
           </profiles>
           <categoryLinks>
             <categoryLink id="70dd-9240-a310-b1da" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
-            <categoryLink id="44c0-6cc5-6fea-0efa" name="Light Sub-type:" hidden="false" targetId="bff2-ae16-74a8-8712" primary="false"/>
-            <categoryLink id="075a-42ce-300a-8b4f" name="Skirmish Sub-type:" hidden="false" targetId="59a4-7b61-600a-c457" primary="false"/>
+            <categoryLink id="44c0-6cc5-6fea-0efa" name="Light Sub-type" hidden="false" targetId="bff2-ae16-74a8-8712" primary="false"/>
+            <categoryLink id="075a-42ce-300a-8b4f" name="Skirmish Sub-type" hidden="false" targetId="59a4-7b61-600a-c457" primary="false"/>
             <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="247d-a9ca-433f-88f2" name="Infantry" primary="false"/>
             <categoryLink targetId="6e0c-29ba-a445-8321" id="1a1c-e25c-46e3-a2e6" name="Psyker" primary="false"/>
           </categoryLinks>
@@ -3123,8 +3123,8 @@
             </profile>
           </profiles>
           <categoryLinks>
-            <categoryLink id="e865-2752-163b-293f" name="Light Sub-type:" hidden="false" targetId="bff2-ae16-74a8-8712" primary="false"/>
-            <categoryLink id="ef7e-6a43-4e20-d68e" name="Skirmish Sub-type:" hidden="false" targetId="59a4-7b61-600a-c457" primary="false"/>
+            <categoryLink id="e865-2752-163b-293f" name="Light Sub-type" hidden="false" targetId="bff2-ae16-74a8-8712" primary="false"/>
+            <categoryLink id="ef7e-6a43-4e20-d68e" name="Skirmish Sub-type" hidden="false" targetId="59a4-7b61-600a-c457" primary="false"/>
             <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="1eb2-86fe-41aa-af68" name="Infantry" primary="false"/>
             <categoryLink targetId="6e0c-29ba-a445-8321" id="5dd8-0395-4781-a13a" name="Psyker" primary="false"/>
           </categoryLinks>
@@ -3287,7 +3287,7 @@
         <infoLink id="e9dd-447e-a8de-1ddb" name="Legiones Astartes (Thousand Sons)" hidden="false" targetId="2377-1d73-44bc-fee2" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="c1ad-3434-2f99-5b24" name="Automata Unit-type:" hidden="false" targetId="d8ab-8e21-e193-63ba" primary="false"/>
+        <categoryLink id="c1ad-3434-2f99-5b24" name="Automata Unit Type" hidden="false" targetId="d8ab-8e21-e193-63ba" primary="false"/>
         <categoryLink id="02a9-7e5a-890d-2cf8" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
       </categoryLinks>
       <selectionEntries>
@@ -3343,7 +3343,7 @@
             </infoLink>
           </infoLinks>
           <categoryLinks>
-            <categoryLink id="b81a-622a-27d1-2522" name="Automata Unit-type:" hidden="false" targetId="d8ab-8e21-e193-63ba" primary="false"/>
+            <categoryLink id="b81a-622a-27d1-2522" name="Automata Unit Type" hidden="false" targetId="d8ab-8e21-e193-63ba" primary="false"/>
             <categoryLink targetId="6e0c-29ba-a445-8321" id="c918-733e-4420-9874" name="Psyker" primary="false"/>
           </categoryLinks>
           <costs>
@@ -3424,7 +3424,7 @@ Could not find type or subtype &apos;Psy -automata&apos;</comment>
         <infoLink id="1082-9f2c-235b-5cfd" name="Legiones Astartes (Thousand Sons)" hidden="false" targetId="2377-1d73-44bc-fee2" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="b5d7-81e8-c908-4d38" name="Dreadnought Unit-type:" hidden="false" targetId="4280-4963-02b5-e31d" primary="false"/>
+        <categoryLink id="b5d7-81e8-c908-4d38" name="Dreadnought Unit Type" hidden="false" targetId="4280-4963-02b5-e31d" primary="false"/>
         <categoryLink id="051f-84da-a459-4760" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
       </categoryLinks>
       <selectionEntries>
@@ -3466,7 +3466,7 @@ Could not find type or subtype &apos;Psy -automata&apos;</comment>
             </infoLink>
           </infoLinks>
           <categoryLinks>
-            <categoryLink id="7e1b-a2cc-89f8-3824" name="Dreadnought Unit-type:" hidden="false" targetId="4280-4963-02b5-e31d" primary="false"/>
+            <categoryLink id="7e1b-a2cc-89f8-3824" name="Dreadnought Unit Type" hidden="false" targetId="4280-4963-02b5-e31d" primary="false"/>
             <categoryLink targetId="6e0c-29ba-a445-8321" id="7ca7-8674-4f41-a40e" name="Psyker" primary="false"/>
           </categoryLinks>
           <selectionEntries>
@@ -4139,7 +4139,7 @@ Could not find type or subtype &apos;Psy -automata&apos;</comment>
       <categoryLinks>
         <categoryLink id="ee57-776c-ef90-1f77" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="3066-9075-b4df-8684" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="ea5b-1965-f2b0-cd0d" name="Heavy Sub-type:" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+        <categoryLink id="ea5b-1965-f2b0-cd0d" name="Heavy Sub-type" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
         <categoryLink id="4863-5593-dedb-fb54" name="Terminators:" hidden="false" targetId="bab3-f50d-3e5f-2f78" primary="false"/>
       </categoryLinks>
       <selectionEntries>

--- a/2022 - LA - Ultramarines.cat
+++ b/2022 - LA - Ultramarines.cat
@@ -3031,8 +3031,8 @@
           </costs>
           <categoryLinks>
             <categoryLink targetId="4f07-3d45-4f28-a0c6" id="48ba-ba6b-4998-4650" primary="false" name="Independent Character"/>
-            <categoryLink targetId="ad5f-31db-8bc7-5c46" id="9d31-dcd6-4f71-8176" name="Primarch" primary="false"/>
-            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="5390-df0f-4ca0-9f5a" name="Unique" primary="false"/>
+            <categoryLink targetId="ad5f-31db-8bc7-5c46" id="9d31-dcd6-4f71-8176" name="Primarch:" primary="false"/>
+            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="5390-df0f-4ca0-9f5a" name="Unique Sub-type" primary="false"/>
           </categoryLinks>
         </selectionEntry>
         <selectionEntry id="ee3b-2513-7839-c14b" name="The Armour of Reason" hidden="false" collective="false" import="true" type="upgrade">
@@ -3174,7 +3174,7 @@
       </rules>
       <categoryLinks>
         <categoryLink id="c1fb-3d4b-27f5-b426" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="2515-1c11-b0e3-ede9" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="2515-1c11-b0e3-ede9" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="f8fc-6ad9-18f9-52bb" name="Heavy Sub-type" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
         <categoryLink id="2939-9165-c065-999f" name="Line Sub-type" hidden="false" targetId="6399-5c65-7833-1025" primary="false"/>
       </categoryLinks>
@@ -3278,9 +3278,9 @@
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="30"/>
               </costs>
               <categoryLinks>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="69f6-f1f7-4e32-9043" name="Infantry" primary="false"/>
-                <categoryLink targetId="6399-5c65-7833-1025" id="42b2-2c9b-4493-8ba4" name="Line" primary="false"/>
-                <categoryLink targetId="9231-183c-b97b-63f9" id="0c2f-386c-4cae-b5e7" name="Heavy" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="69f6-f1f7-4e32-9043" name="Infantry Unit Type" primary="false"/>
+                <categoryLink targetId="6399-5c65-7833-1025" id="42b2-2c9b-4493-8ba4" name="Line Sub-type" primary="false"/>
+                <categoryLink targetId="9231-183c-b97b-63f9" id="0c2f-386c-4cae-b5e7" name="Heavy Sub-type" primary="false"/>
                 <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="6161-c590-4d99-8571" name="Character" primary="false"/>
               </categoryLinks>
             </selectionEntry>
@@ -3306,9 +3306,9 @@
                 <infoLink name="Suzerain" hidden="false" type="profile" id="82e5-c9d6-b73e-be28" targetId="3514-22be-3c77-f1d7"/>
               </infoLinks>
               <categoryLinks>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="b032-e4c5-4fc6-9c6b" name="Infantry" primary="false"/>
-                <categoryLink targetId="6399-5c65-7833-1025" id="c412-17b7-45a5-8eb2" name="Line" primary="false"/>
-                <categoryLink targetId="9231-183c-b97b-63f9" id="6f15-3b37-4fa9-b821" name="Heavy" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="b032-e4c5-4fc6-9c6b" name="Infantry Unit Type" primary="false"/>
+                <categoryLink targetId="6399-5c65-7833-1025" id="c412-17b7-45a5-8eb2" name="Line Sub-type" primary="false"/>
+                <categoryLink targetId="9231-183c-b97b-63f9" id="6f15-3b37-4fa9-b821" name="Heavy Sub-type" primary="false"/>
                 <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="e8e6-efde-4cf3-a882" name="Character" primary="false"/>
               </categoryLinks>
             </selectionEntry>
@@ -3337,9 +3337,9 @@
                 <infoLink name="Suzerain" hidden="false" type="profile" id="371a-fa0-a81-f6fc" targetId="3514-22be-3c77-f1d7"/>
               </infoLinks>
               <categoryLinks>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="2033-2f8f-46fc-afc5" name="Infantry" primary="false"/>
-                <categoryLink targetId="6399-5c65-7833-1025" id="8b16-10b0-4cf0-9f3e" name="Line" primary="false"/>
-                <categoryLink targetId="9231-183c-b97b-63f9" id="963b-a8ca-449c-b52a" name="Heavy" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="2033-2f8f-46fc-afc5" name="Infantry Unit Type" primary="false"/>
+                <categoryLink targetId="6399-5c65-7833-1025" id="8b16-10b0-4cf0-9f3e" name="Line Sub-type" primary="false"/>
+                <categoryLink targetId="9231-183c-b97b-63f9" id="963b-a8ca-449c-b52a" name="Heavy Sub-type" primary="false"/>
                 <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="068b-a390-4934-a1b7" name="Character" primary="false"/>
               </categoryLinks>
             </selectionEntry>
@@ -3365,9 +3365,9 @@
                 <infoLink name="Suzerain" hidden="false" type="profile" id="5510-b560-7d5f-dfb9" targetId="3514-22be-3c77-f1d7"/>
               </infoLinks>
               <categoryLinks>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="9bcd-2de3-4d20-a23f" name="Infantry" primary="false"/>
-                <categoryLink targetId="6399-5c65-7833-1025" id="b8d2-5634-4e08-b5e7" name="Line" primary="false"/>
-                <categoryLink targetId="9231-183c-b97b-63f9" id="0bae-78ac-44f9-b71b" name="Heavy" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="9bcd-2de3-4d20-a23f" name="Infantry Unit Type" primary="false"/>
+                <categoryLink targetId="6399-5c65-7833-1025" id="b8d2-5634-4e08-b5e7" name="Line Sub-type" primary="false"/>
+                <categoryLink targetId="9231-183c-b97b-63f9" id="0bae-78ac-44f9-b71b" name="Heavy Sub-type" primary="false"/>
                 <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="0604-e002-43a0-a2bc" name="Character" primary="false"/>
               </categoryLinks>
             </selectionEntry>
@@ -3410,9 +3410,9 @@
                     <infoLink name="Suzerain" hidden="false" type="profile" id="99f6-2332-dc2f-e054" targetId="3514-22be-3c77-f1d7"/>
                   </infoLinks>
                   <categoryLinks>
-                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="b7e8-01dc-4bd5-9e08" name="Infantry" primary="false"/>
-                    <categoryLink targetId="6399-5c65-7833-1025" id="8708-28d4-4092-be77" name="Line" primary="false"/>
-                    <categoryLink targetId="9231-183c-b97b-63f9" id="9bc9-c435-4b26-aa4d" name="Heavy" primary="false"/>
+                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="b7e8-01dc-4bd5-9e08" name="Infantry Unit Type" primary="false"/>
+                    <categoryLink targetId="6399-5c65-7833-1025" id="8708-28d4-4092-be77" name="Line Sub-type" primary="false"/>
+                    <categoryLink targetId="9231-183c-b97b-63f9" id="9bc9-c435-4b26-aa4d" name="Heavy Sub-type" primary="false"/>
                     <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="3567-c7db-4ab4-8681" name="Character" primary="false"/>
                   </categoryLinks>
                 </selectionEntry>
@@ -3438,9 +3438,9 @@
                     <infoLink name="Suzerain" hidden="false" type="profile" id="a79b-e7a9-4c6-d2f3" targetId="3514-22be-3c77-f1d7"/>
                   </infoLinks>
                   <categoryLinks>
-                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="4520-1730-44d5-9844" name="Infantry" primary="false"/>
-                    <categoryLink targetId="6399-5c65-7833-1025" id="e504-c3f9-4281-a25c" name="Line" primary="false"/>
-                    <categoryLink targetId="9231-183c-b97b-63f9" id="8521-5079-4cc0-8b20" name="Heavy" primary="false"/>
+                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="4520-1730-44d5-9844" name="Infantry Unit Type" primary="false"/>
+                    <categoryLink targetId="6399-5c65-7833-1025" id="e504-c3f9-4281-a25c" name="Line Sub-type" primary="false"/>
+                    <categoryLink targetId="9231-183c-b97b-63f9" id="8521-5079-4cc0-8b20" name="Heavy Sub-type" primary="false"/>
                     <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="648d-2eaf-4e91-944a" name="Character" primary="false"/>
                   </categoryLinks>
                 </selectionEntry>
@@ -3531,7 +3531,7 @@
       </infoLinks>
       <categoryLinks>
         <categoryLink id="18bd-fce6-63db-d58d" name="Heavy Sub-type" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
-        <categoryLink id="f8aa-a104-90eb-b32f" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="f8aa-a104-90eb-b32f" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="a5b1-bdaf-421c-1167" name="Line Sub-type" hidden="false" targetId="6399-5c65-7833-1025" primary="false"/>
         <categoryLink id="9d2c-fdc3-3b78-373f" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
       </categoryLinks>
@@ -3639,10 +3639,10 @@
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
           </costs>
           <categoryLinks>
-            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="8da4-2bed-4957-9350" name="Infantry" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="8da4-2bed-4957-9350" name="Infantry Unit Type" primary="false"/>
             <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="c93c-3605-4aea-bc8a" name="Character" primary="false"/>
-            <categoryLink targetId="9231-183c-b97b-63f9" id="e2fe-a815-480e-9b4d" name="Heavy" primary="false"/>
-            <categoryLink targetId="6399-5c65-7833-1025" id="6d0f-ad38-4861-a14a" name="Line" primary="false"/>
+            <categoryLink targetId="9231-183c-b97b-63f9" id="e2fe-a815-480e-9b4d" name="Heavy Sub-type" primary="false"/>
+            <categoryLink targetId="6399-5c65-7833-1025" id="6d0f-ad38-4861-a14a" name="Line Sub-type" primary="false"/>
           </categoryLinks>
         </selectionEntry>
       </selectionEntries>
@@ -3749,9 +3749,9 @@
                 <infoLink name="Praetorian" hidden="false" type="profile" id="c790-504d-cdfc-860c" targetId="8b1d-ca41-c9a6-32bc"/>
               </infoLinks>
               <categoryLinks>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="d473-6167-4007-a9b0" name="Infantry" primary="false"/>
-                <categoryLink targetId="9231-183c-b97b-63f9" id="21cc-7c80-4ac0-b0db" name="Heavy" primary="false"/>
-                <categoryLink targetId="6399-5c65-7833-1025" id="d4dd-d52c-4358-a481" name="Line" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="d473-6167-4007-a9b0" name="Infantry Unit Type" primary="false"/>
+                <categoryLink targetId="9231-183c-b97b-63f9" id="21cc-7c80-4ac0-b0db" name="Heavy Sub-type" primary="false"/>
+                <categoryLink targetId="6399-5c65-7833-1025" id="d4dd-d52c-4358-a481" name="Line Sub-type" primary="false"/>
               </categoryLinks>
             </selectionEntry>
             <selectionEntry id="6a92-6844-79a1-6513" name="Praetorian w/Legatine Axe (1 in 5)" hidden="false" collective="false" import="true" type="model">
@@ -3786,9 +3786,9 @@
                 <infoLink name="Praetorian" hidden="false" type="profile" id="17b3-d41e-29b-3eb5" targetId="8b1d-ca41-c9a6-32bc"/>
               </infoLinks>
               <categoryLinks>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="cad3-7680-49f8-bfe9" name="Infantry" primary="false"/>
-                <categoryLink targetId="9231-183c-b97b-63f9" id="a299-6339-455b-a968" name="Heavy" primary="false"/>
-                <categoryLink targetId="6399-5c65-7833-1025" id="ebd2-2682-4037-a353" name="Line" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="cad3-7680-49f8-bfe9" name="Infantry Unit Type" primary="false"/>
+                <categoryLink targetId="9231-183c-b97b-63f9" id="a299-6339-455b-a968" name="Heavy Sub-type" primary="false"/>
+                <categoryLink targetId="6399-5c65-7833-1025" id="ebd2-2682-4037-a353" name="Line Sub-type" primary="false"/>
               </categoryLinks>
             </selectionEntry>
           </selectionEntries>
@@ -3840,7 +3840,7 @@
         </infoLink>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="d762-cd12-7679-e649" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="d762-cd12-7679-e649" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="51d5-8c99-7bfa-92f8" name="Terminators:" hidden="false" targetId="bab3-f50d-3e5f-2f78" primary="false"/>
         <categoryLink id="07ca-16ef-6bbf-515a" name="Heavy Sub-type" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
         <categoryLink id="e47f-ba3e-879c-88fd" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
@@ -3870,8 +3870,8 @@
           </profiles>
           <categoryLinks>
             <categoryLink id="cea8-d359-a93d-931f" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
-            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="785e-2b76-4a7a-8768" name="Infantry" primary="false"/>
-            <categoryLink targetId="9231-183c-b97b-63f9" id="d83c-e765-4c61-8576" name="Heavy" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="785e-2b76-4a7a-8768" name="Infantry Unit Type" primary="false"/>
+            <categoryLink targetId="9231-183c-b97b-63f9" id="d83c-e765-4c61-8576" name="Heavy Sub-type" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="7df2-f403-dfa4-a651" name="May Exchange Peritarch Targeter for:" hidden="false" collective="false" import="true" defaultSelectionEntryId="a41b-40b9-9a26-aa8d">
@@ -4033,8 +4033,8 @@
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="55"/>
               </costs>
               <categoryLinks>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="40be-a88c-4850-b016" name="Infantry" primary="false"/>
-                <categoryLink targetId="9231-183c-b97b-63f9" id="49ce-2789-442b-82e0" name="Heavy" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="40be-a88c-4850-b016" name="Infantry Unit Type" primary="false"/>
+                <categoryLink targetId="9231-183c-b97b-63f9" id="49ce-2789-442b-82e0" name="Heavy Sub-type" primary="false"/>
               </categoryLinks>
             </selectionEntry>
             <selectionEntry id="6209-7e08-1c9f-f440" name="Fulmentarus Terminator w/Power Axe" hidden="false" collective="false" import="true" type="model">
@@ -4059,8 +4059,8 @@
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="55"/>
               </costs>
               <categoryLinks>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="452d-8bd5-4f32-ae5b" name="Infantry" primary="false"/>
-                <categoryLink targetId="9231-183c-b97b-63f9" id="fece-eade-4c1f-8512" name="Heavy" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="452d-8bd5-4f32-ae5b" name="Infantry Unit Type" primary="false"/>
+                <categoryLink targetId="9231-183c-b97b-63f9" id="fece-eade-4c1f-8512" name="Heavy Sub-type" primary="false"/>
               </categoryLinks>
             </selectionEntry>
             <selectionEntry id="e38f-329f-6a2f-2c17" name="Fulmentarus Terminator w/Power Lance" hidden="false" collective="false" import="true" type="model">
@@ -4085,8 +4085,8 @@
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="55"/>
               </costs>
               <categoryLinks>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="0acf-c5a6-4520-8e67" name="Infantry" primary="false"/>
-                <categoryLink targetId="9231-183c-b97b-63f9" id="0e1e-4207-4246-b40a" name="Heavy" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="0acf-c5a6-4520-8e67" name="Infantry Unit Type" primary="false"/>
+                <categoryLink targetId="9231-183c-b97b-63f9" id="0e1e-4207-4246-b40a" name="Heavy Sub-type" primary="false"/>
               </categoryLinks>
             </selectionEntry>
             <selectionEntry id="5b75-16e1-76fc-2db1" name="Fulmentarus Terminator w/Power Maul" hidden="false" collective="false" import="true" type="model">
@@ -4111,8 +4111,8 @@
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="55"/>
               </costs>
               <categoryLinks>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="c8fe-5599-44f0-a994" name="Infantry" primary="false"/>
-                <categoryLink targetId="9231-183c-b97b-63f9" id="444e-9b3c-45df-9fe4" name="Heavy" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="c8fe-5599-44f0-a994" name="Infantry Unit Type" primary="false"/>
+                <categoryLink targetId="9231-183c-b97b-63f9" id="444e-9b3c-45df-9fe4" name="Heavy Sub-type" primary="false"/>
               </categoryLinks>
             </selectionEntry>
             <selectionEntry id="24b1-c85f-8c31-36d7" name="Fulmentarus Terminator w/Power Fist" hidden="false" collective="false" import="true" type="model">
@@ -4137,8 +4137,8 @@
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="60"/>
               </costs>
               <categoryLinks>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="c143-8217-4ee3-98ad" name="Infantry" primary="false"/>
-                <categoryLink targetId="9231-183c-b97b-63f9" id="da4f-389e-4eea-9ae7" name="Heavy" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="c143-8217-4ee3-98ad" name="Infantry Unit Type" primary="false"/>
+                <categoryLink targetId="9231-183c-b97b-63f9" id="da4f-389e-4eea-9ae7" name="Heavy Sub-type" primary="false"/>
               </categoryLinks>
             </selectionEntry>
             <selectionEntry id="e153-e0b3-912e-b6b8" name="Fulmentarus Terminator w/Chainfist" hidden="false" collective="false" import="true" type="model">
@@ -4177,8 +4177,8 @@
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="65"/>
               </costs>
               <categoryLinks>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="66c0-9cf5-48d8-8841" name="Infantry" primary="false"/>
-                <categoryLink targetId="9231-183c-b97b-63f9" id="6123-4914-41a0-b6ad" name="Heavy" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="66c0-9cf5-48d8-8841" name="Infantry Unit Type" primary="false"/>
+                <categoryLink targetId="9231-183c-b97b-63f9" id="6123-4914-41a0-b6ad" name="Heavy Sub-type" primary="false"/>
               </categoryLinks>
             </selectionEntry>
             <selectionEntry id="a1f1-302f-9f92-6f0b" name="Fulmentarus Terminator w/Peritarch Targeter" hidden="false" collective="false" import="true" type="model" defaultAmount="4">
@@ -4203,8 +4203,8 @@
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="55"/>
               </costs>
               <categoryLinks>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="e05d-4383-4f5c-b188" name="Infantry" primary="false"/>
-                <categoryLink targetId="9231-183c-b97b-63f9" id="c0df-86c9-48e4-899c" name="Heavy" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="e05d-4383-4f5c-b188" name="Infantry Unit Type" primary="false"/>
+                <categoryLink targetId="9231-183c-b97b-63f9" id="c0df-86c9-48e4-899c" name="Heavy Sub-type" primary="false"/>
               </categoryLinks>
             </selectionEntry>
           </selectionEntries>
@@ -4233,7 +4233,7 @@
         <constraint field="selections" scope="roster" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="764d-4747-9a62-0219" type="max"/>
       </constraints>
       <categoryLinks>
-        <categoryLink id="c823-19f8-80ae-939b" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="c823-19f8-80ae-939b" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="8ea4-d107-ba41-10c3" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
       </categoryLinks>
       <selectionEntries>
@@ -4280,9 +4280,9 @@
           </costs>
           <categoryLinks>
             <categoryLink targetId="4f07-3d45-4f28-a0c6" id="c037-24cc-5c73-a60" primary="false" name="Independent Character"/>
-            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="ab95-75b1-4c03-8ff8" name="Infantry" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="ab95-75b1-4c03-8ff8" name="Infantry Unit Type" primary="false"/>
             <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="6e92-d12a-4cda-a418" name="Character" primary="false"/>
-            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="cb1f-cbc3-405e-8edc" name="Unique" primary="false"/>
+            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="cb1f-cbc3-405e-8edc" name="Unique Sub-type" primary="false"/>
           </categoryLinks>
         </selectionEntry>
         <selectionEntry id="24b6-8803-d0a2-10ff" name="Phaethon" hidden="false" collective="false" import="true" type="upgrade">
@@ -4422,8 +4422,8 @@
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
           </costs>
           <categoryLinks>
-            <categoryLink targetId="4280-4963-02b5-e31d" id="8c61-22fc-4031-9192" name="Dreadnought" primary="false"/>
-            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="950e-23dc-4c78-b13e" name="Unique" primary="false"/>
+            <categoryLink targetId="4280-4963-02b5-e31d" id="8c61-22fc-4031-9192" name="Dreadnought Unit Type" primary="false"/>
+            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="950e-23dc-4c78-b13e" name="Unique Sub-type" primary="false"/>
           </categoryLinks>
         </selectionEntry>
       </selectionEntries>
@@ -4508,7 +4508,7 @@
         <infoLink id="d481-c887-6aaa-1612" name="Chosen Warriors" hidden="false" targetId="13d1-9270-6539-08ed" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="64a6-866c-d4f5-f6df" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="64a6-866c-d4f5-f6df" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="0fa2-0756-6373-2c2a" name="Jump Infantry:" hidden="false" targetId="eee8-3c7c-2762-e33e" primary="false"/>
         <categoryLink id="cbae-7580-9e8f-7512" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
       </categoryLinks>
@@ -4537,7 +4537,7 @@
           </profiles>
           <categoryLinks>
             <categoryLink id="2a72-86f0-130e-7ebe" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
-            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="e13e-4f21-4b02-9fa4" name="Infantry" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="e13e-4f21-4b02-9fa4" name="Infantry Unit Type" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="f41b-c392-66ce-3dfa" name="1) Melee Options" hidden="false" collective="false" import="true" defaultSelectionEntryId="a887-9d78-c1e4-8ceb">
@@ -4685,7 +4685,7 @@
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25"/>
               </costs>
               <categoryLinks>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="af02-ccab-4f73-98c0" name="Infantry" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="af02-ccab-4f73-98c0" name="Infantry Unit Type" primary="false"/>
               </categoryLinks>
             </selectionEntry>
             <selectionEntry id="ea36-9644-7d23-b95f" name="Locutarus w/Special Pistol" hidden="false" collective="false" import="true" type="model">
@@ -4739,7 +4739,7 @@
                 <infoLink id="5a10-84e2-6ebf-db4f" name="Locutarus" targetId="a006-002c-28d1-bc61" type="profile"/>
               </infoLinks>
               <categoryLinks>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="3277-6246-449f-97f9" name="Infantry" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="3277-6246-449f-97f9" name="Infantry Unit Type" primary="false"/>
               </categoryLinks>
             </selectionEntry>
           </selectionEntries>
@@ -4786,7 +4786,7 @@
         <infoLink id="2a20-3379-5a88-7066" name="Bitter Duty" hidden="false" targetId="d1b8-31da-c53c-4fe2" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="dab5-4ae9-9a89-dbb7" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="dab5-4ae9-9a89-dbb7" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="ba64-c048-fbe1-1eec" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
       </categoryLinks>
       <selectionEntries>
@@ -4821,7 +4821,7 @@
           </profiles>
           <categoryLinks>
             <categoryLink id="aa98-3308-c2e0-fbd2" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
-            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="52e3-745d-431d-bf83" name="Infantry" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="52e3-745d-431d-bf83" name="Infantry Unit Type" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="3d76-9955-751a-735e" name="2) May take:" hidden="false" collective="false" import="true">
@@ -5120,7 +5120,7 @@
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15"/>
               </costs>
               <categoryLinks>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="81d8-0b71-4ed7-a678" name="Infantry" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="81d8-0b71-4ed7-a678" name="Infantry Unit Type" primary="false"/>
               </categoryLinks>
             </selectionEntry>
             <selectionEntry id="e674-2512-0b17-2208" name="Nemesis Destroyer w/Heavy Weapon" hidden="false" collective="false" import="true" type="model">
@@ -5208,7 +5208,7 @@
                 <infoLink name="Nemesis Destroyer" hidden="false" type="profile" id="843d-b83f-3df4-cbc1" targetId="1a33-dcc3-f511-6a0d"/>
               </infoLinks>
               <categoryLinks>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="1384-3a65-412b-b640" name="Infantry" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="1384-3a65-412b-b640" name="Infantry Unit Type" primary="false"/>
               </categoryLinks>
             </selectionEntry>
           </selectionEntries>

--- a/2022 - LA - Ultramarines.cat
+++ b/2022 - LA - Ultramarines.cat
@@ -2695,7 +2695,7 @@
       <categoryLinks>
         <categoryLink id="63ff-0a92-42ab-ae8c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="204c-7b0f-4fb9-b1b3" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="85e6-cb31-427c-a040" name="Line Sub-type:" hidden="false" targetId="6399-5c65-7833-1025" primary="false"/>
+        <categoryLink id="85e6-cb31-427c-a040" name="Line Sub-type" hidden="false" targetId="6399-5c65-7833-1025" primary="false"/>
         <categoryLink id="1132-dd05-eea0-2bae" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -3175,8 +3175,8 @@
       <categoryLinks>
         <categoryLink id="c1fb-3d4b-27f5-b426" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="2515-1c11-b0e3-ede9" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="f8fc-6ad9-18f9-52bb" name="Heavy Sub-type:" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
-        <categoryLink id="2939-9165-c065-999f" name="Line Sub-type:" hidden="false" targetId="6399-5c65-7833-1025" primary="false"/>
+        <categoryLink id="f8fc-6ad9-18f9-52bb" name="Heavy Sub-type" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+        <categoryLink id="2939-9165-c065-999f" name="Line Sub-type" hidden="false" targetId="6399-5c65-7833-1025" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="3062-8ad4-10a2-9744" name="2) Dedicated Transport:" hidden="false" collective="false" import="true">
@@ -3530,9 +3530,9 @@
         </infoLink>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="18bd-fce6-63db-d58d" name="Heavy Sub-type:" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+        <categoryLink id="18bd-fce6-63db-d58d" name="Heavy Sub-type" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
         <categoryLink id="f8aa-a104-90eb-b32f" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="a5b1-bdaf-421c-1167" name="Line Sub-type:" hidden="false" targetId="6399-5c65-7833-1025" primary="false"/>
+        <categoryLink id="a5b1-bdaf-421c-1167" name="Line Sub-type" hidden="false" targetId="6399-5c65-7833-1025" primary="false"/>
         <categoryLink id="9d2c-fdc3-3b78-373f" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
       </categoryLinks>
       <selectionEntries>
@@ -3842,7 +3842,7 @@
       <categoryLinks>
         <categoryLink id="d762-cd12-7679-e649" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="51d5-8c99-7bfa-92f8" name="Terminators:" hidden="false" targetId="bab3-f50d-3e5f-2f78" primary="false"/>
-        <categoryLink id="07ca-16ef-6bbf-515a" name="Heavy Sub-type:" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+        <categoryLink id="07ca-16ef-6bbf-515a" name="Heavy Sub-type" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
         <categoryLink id="e47f-ba3e-879c-88fd" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
       </categoryLinks>
       <selectionEntries>
@@ -4392,7 +4392,7 @@
         </infoLink>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="2e8a-b2ef-e4fc-cf8d" name="Dreadnought Unit-type:" hidden="false" targetId="4280-4963-02b5-e31d" primary="false"/>
+        <categoryLink id="2e8a-b2ef-e4fc-cf8d" name="Dreadnought Unit Type" hidden="false" targetId="4280-4963-02b5-e31d" primary="false"/>
         <categoryLink id="6c25-0ad5-bf61-85dd" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
       </categoryLinks>
       <selectionEntries>

--- a/2022 - LA - Ultramarines.cat
+++ b/2022 - LA - Ultramarines.cat
@@ -3031,6 +3031,8 @@
           </costs>
           <categoryLinks>
             <categoryLink targetId="4f07-3d45-4f28-a0c6" id="48ba-ba6b-4998-4650" primary="false" name="Independent Character"/>
+            <categoryLink targetId="ad5f-31db-8bc7-5c46" id="9d31-dcd6-4f71-8176" name="Primarch" primary="false"/>
+            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="5390-df0f-4ca0-9f5a" name="Unique" primary="false"/>
           </categoryLinks>
         </selectionEntry>
         <selectionEntry id="ee3b-2513-7839-c14b" name="The Armour of Reason" hidden="false" collective="false" import="true" type="upgrade">
@@ -3275,6 +3277,12 @@
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="30"/>
               </costs>
+              <categoryLinks>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="69f6-f1f7-4e32-9043" name="Infantry" primary="false"/>
+                <categoryLink targetId="6399-5c65-7833-1025" id="42b2-2c9b-4493-8ba4" name="Line" primary="false"/>
+                <categoryLink targetId="9231-183c-b97b-63f9" id="0c2f-386c-4cae-b5e7" name="Heavy" primary="false"/>
+                <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="6161-c590-4d99-8571" name="Character" primary="false"/>
+              </categoryLinks>
             </selectionEntry>
             <selectionEntry id="5790-aef9-aa7d-9ec4" name="Suzerain w/Bolt Pistol &amp; Thunder Hammer" hidden="false" collective="false" import="true" type="model">
               <entryLinks>
@@ -3297,6 +3305,12 @@
               <infoLinks>
                 <infoLink name="Suzerain" hidden="false" type="profile" id="82e5-c9d6-b73e-be28" targetId="3514-22be-3c77-f1d7"/>
               </infoLinks>
+              <categoryLinks>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="b032-e4c5-4fc6-9c6b" name="Infantry" primary="false"/>
+                <categoryLink targetId="6399-5c65-7833-1025" id="c412-17b7-45a5-8eb2" name="Line" primary="false"/>
+                <categoryLink targetId="9231-183c-b97b-63f9" id="6f15-3b37-4fa9-b821" name="Heavy" primary="false"/>
+                <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="e8e6-efde-4cf3-a882" name="Character" primary="false"/>
+              </categoryLinks>
             </selectionEntry>
             <selectionEntry id="2859-846d-8545-752c" name="Suzerain w/Plasma Pistol &amp; Legatine Axe" hidden="false" collective="false" import="true" type="model">
               <entryLinks>
@@ -3322,6 +3336,12 @@
               <infoLinks>
                 <infoLink name="Suzerain" hidden="false" type="profile" id="371a-fa0-a81-f6fc" targetId="3514-22be-3c77-f1d7"/>
               </infoLinks>
+              <categoryLinks>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="2033-2f8f-46fc-afc5" name="Infantry" primary="false"/>
+                <categoryLink targetId="6399-5c65-7833-1025" id="8b16-10b0-4cf0-9f3e" name="Line" primary="false"/>
+                <categoryLink targetId="9231-183c-b97b-63f9" id="963b-a8ca-449c-b52a" name="Heavy" primary="false"/>
+                <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="068b-a390-4934-a1b7" name="Character" primary="false"/>
+              </categoryLinks>
             </selectionEntry>
             <selectionEntry id="276d-8bc1-5949-baa7" name="Suzerain w/Plasma Pistol &amp; Thunder Hammer" hidden="false" collective="false" import="true" type="model">
               <entryLinks>
@@ -3344,6 +3364,12 @@
               <infoLinks>
                 <infoLink name="Suzerain" hidden="false" type="profile" id="5510-b560-7d5f-dfb9" targetId="3514-22be-3c77-f1d7"/>
               </infoLinks>
+              <categoryLinks>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="9bcd-2de3-4d20-a23f" name="Infantry" primary="false"/>
+                <categoryLink targetId="6399-5c65-7833-1025" id="b8d2-5634-4e08-b5e7" name="Line" primary="false"/>
+                <categoryLink targetId="9231-183c-b97b-63f9" id="0bae-78ac-44f9-b71b" name="Heavy" primary="false"/>
+                <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="0604-e002-43a0-a2bc" name="Character" primary="false"/>
+              </categoryLinks>
             </selectionEntry>
           </selectionEntries>
           <selectionEntryGroups>
@@ -3383,6 +3409,12 @@
                   <infoLinks>
                     <infoLink name="Suzerain" hidden="false" type="profile" id="99f6-2332-dc2f-e054" targetId="3514-22be-3c77-f1d7"/>
                   </infoLinks>
+                  <categoryLinks>
+                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="b7e8-01dc-4bd5-9e08" name="Infantry" primary="false"/>
+                    <categoryLink targetId="6399-5c65-7833-1025" id="8708-28d4-4092-be77" name="Line" primary="false"/>
+                    <categoryLink targetId="9231-183c-b97b-63f9" id="9bc9-c435-4b26-aa4d" name="Heavy" primary="false"/>
+                    <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="3567-c7db-4ab4-8681" name="Character" primary="false"/>
+                  </categoryLinks>
                 </selectionEntry>
                 <selectionEntry id="1b60-c439-0b96-10cf" name="Suzerain w/Legion Standard &amp; Thunder Hammer" hidden="false" collective="false" import="true" type="model">
                   <entryLinks>
@@ -3405,6 +3437,12 @@
                   <infoLinks>
                     <infoLink name="Suzerain" hidden="false" type="profile" id="a79b-e7a9-4c6-d2f3" targetId="3514-22be-3c77-f1d7"/>
                   </infoLinks>
+                  <categoryLinks>
+                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="4520-1730-44d5-9844" name="Infantry" primary="false"/>
+                    <categoryLink targetId="6399-5c65-7833-1025" id="e504-c3f9-4281-a25c" name="Line" primary="false"/>
+                    <categoryLink targetId="9231-183c-b97b-63f9" id="8521-5079-4cc0-8b20" name="Heavy" primary="false"/>
+                    <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="648d-2eaf-4e91-944a" name="Character" primary="false"/>
+                  </categoryLinks>
                 </selectionEntry>
               </selectionEntries>
             </selectionEntryGroup>
@@ -3600,6 +3638,12 @@
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
           </costs>
+          <categoryLinks>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="8da4-2bed-4957-9350" name="Infantry" primary="false"/>
+            <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="c93c-3605-4aea-bc8a" name="Character" primary="false"/>
+            <categoryLink targetId="9231-183c-b97b-63f9" id="e2fe-a815-480e-9b4d" name="Heavy" primary="false"/>
+            <categoryLink targetId="6399-5c65-7833-1025" id="6d0f-ad38-4861-a14a" name="Line" primary="false"/>
+          </categoryLinks>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
@@ -3704,6 +3748,11 @@
               <infoLinks>
                 <infoLink name="Praetorian" hidden="false" type="profile" id="c790-504d-cdfc-860c" targetId="8b1d-ca41-c9a6-32bc"/>
               </infoLinks>
+              <categoryLinks>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="d473-6167-4007-a9b0" name="Infantry" primary="false"/>
+                <categoryLink targetId="9231-183c-b97b-63f9" id="21cc-7c80-4ac0-b0db" name="Heavy" primary="false"/>
+                <categoryLink targetId="6399-5c65-7833-1025" id="d4dd-d52c-4358-a481" name="Line" primary="false"/>
+              </categoryLinks>
             </selectionEntry>
             <selectionEntry id="6a92-6844-79a1-6513" name="Praetorian w/Legatine Axe (1 in 5)" hidden="false" collective="false" import="true" type="model">
               <modifiers>
@@ -3736,6 +3785,11 @@
               <infoLinks>
                 <infoLink name="Praetorian" hidden="false" type="profile" id="17b3-d41e-29b-3eb5" targetId="8b1d-ca41-c9a6-32bc"/>
               </infoLinks>
+              <categoryLinks>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="cad3-7680-49f8-bfe9" name="Infantry" primary="false"/>
+                <categoryLink targetId="9231-183c-b97b-63f9" id="a299-6339-455b-a968" name="Heavy" primary="false"/>
+                <categoryLink targetId="6399-5c65-7833-1025" id="ebd2-2682-4037-a353" name="Line" primary="false"/>
+              </categoryLinks>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
@@ -3816,6 +3870,8 @@
           </profiles>
           <categoryLinks>
             <categoryLink id="cea8-d359-a93d-931f" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="785e-2b76-4a7a-8768" name="Infantry" primary="false"/>
+            <categoryLink targetId="9231-183c-b97b-63f9" id="d83c-e765-4c61-8576" name="Heavy" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="7df2-f403-dfa4-a651" name="May Exchange Peritarch Targeter for:" hidden="false" collective="false" import="true" defaultSelectionEntryId="a41b-40b9-9a26-aa8d">
@@ -3976,6 +4032,10 @@
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="55"/>
               </costs>
+              <categoryLinks>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="40be-a88c-4850-b016" name="Infantry" primary="false"/>
+                <categoryLink targetId="9231-183c-b97b-63f9" id="49ce-2789-442b-82e0" name="Heavy" primary="false"/>
+              </categoryLinks>
             </selectionEntry>
             <selectionEntry id="6209-7e08-1c9f-f440" name="Fulmentarus Terminator w/Power Axe" hidden="false" collective="false" import="true" type="model">
               <infoLinks>
@@ -3998,6 +4058,10 @@
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="55"/>
               </costs>
+              <categoryLinks>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="452d-8bd5-4f32-ae5b" name="Infantry" primary="false"/>
+                <categoryLink targetId="9231-183c-b97b-63f9" id="fece-eade-4c1f-8512" name="Heavy" primary="false"/>
+              </categoryLinks>
             </selectionEntry>
             <selectionEntry id="e38f-329f-6a2f-2c17" name="Fulmentarus Terminator w/Power Lance" hidden="false" collective="false" import="true" type="model">
               <infoLinks>
@@ -4020,6 +4084,10 @@
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="55"/>
               </costs>
+              <categoryLinks>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="0acf-c5a6-4520-8e67" name="Infantry" primary="false"/>
+                <categoryLink targetId="9231-183c-b97b-63f9" id="0e1e-4207-4246-b40a" name="Heavy" primary="false"/>
+              </categoryLinks>
             </selectionEntry>
             <selectionEntry id="5b75-16e1-76fc-2db1" name="Fulmentarus Terminator w/Power Maul" hidden="false" collective="false" import="true" type="model">
               <infoLinks>
@@ -4042,6 +4110,10 @@
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="55"/>
               </costs>
+              <categoryLinks>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="c8fe-5599-44f0-a994" name="Infantry" primary="false"/>
+                <categoryLink targetId="9231-183c-b97b-63f9" id="444e-9b3c-45df-9fe4" name="Heavy" primary="false"/>
+              </categoryLinks>
             </selectionEntry>
             <selectionEntry id="24b1-c85f-8c31-36d7" name="Fulmentarus Terminator w/Power Fist" hidden="false" collective="false" import="true" type="model">
               <infoLinks>
@@ -4064,6 +4136,10 @@
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="60"/>
               </costs>
+              <categoryLinks>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="c143-8217-4ee3-98ad" name="Infantry" primary="false"/>
+                <categoryLink targetId="9231-183c-b97b-63f9" id="da4f-389e-4eea-9ae7" name="Heavy" primary="false"/>
+              </categoryLinks>
             </selectionEntry>
             <selectionEntry id="e153-e0b3-912e-b6b8" name="Fulmentarus Terminator w/Chainfist" hidden="false" collective="false" import="true" type="model">
               <profiles>
@@ -4100,6 +4176,10 @@
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="65"/>
               </costs>
+              <categoryLinks>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="66c0-9cf5-48d8-8841" name="Infantry" primary="false"/>
+                <categoryLink targetId="9231-183c-b97b-63f9" id="6123-4914-41a0-b6ad" name="Heavy" primary="false"/>
+              </categoryLinks>
             </selectionEntry>
             <selectionEntry id="a1f1-302f-9f92-6f0b" name="Fulmentarus Terminator w/Peritarch Targeter" hidden="false" collective="false" import="true" type="model" defaultAmount="4">
               <infoLinks>
@@ -4122,6 +4202,10 @@
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="55"/>
               </costs>
+              <categoryLinks>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="e05d-4383-4f5c-b188" name="Infantry" primary="false"/>
+                <categoryLink targetId="9231-183c-b97b-63f9" id="c0df-86c9-48e4-899c" name="Heavy" primary="false"/>
+              </categoryLinks>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
@@ -4196,6 +4280,9 @@
           </costs>
           <categoryLinks>
             <categoryLink targetId="4f07-3d45-4f28-a0c6" id="c037-24cc-5c73-a60" primary="false" name="Independent Character"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="ab95-75b1-4c03-8ff8" name="Infantry" primary="false"/>
+            <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="6e92-d12a-4cda-a418" name="Character" primary="false"/>
+            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="cb1f-cbc3-405e-8edc" name="Unique" primary="false"/>
           </categoryLinks>
         </selectionEntry>
         <selectionEntry id="24b6-8803-d0a2-10ff" name="Phaethon" hidden="false" collective="false" import="true" type="upgrade">
@@ -4334,6 +4421,10 @@
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
           </costs>
+          <categoryLinks>
+            <categoryLink targetId="4280-4963-02b5-e31d" id="8c61-22fc-4031-9192" name="Dreadnought" primary="false"/>
+            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="950e-23dc-4c78-b13e" name="Unique" primary="false"/>
+          </categoryLinks>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
@@ -4446,6 +4537,7 @@
           </profiles>
           <categoryLinks>
             <categoryLink id="2a72-86f0-130e-7ebe" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="e13e-4f21-4b02-9fa4" name="Infantry" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="f41b-c392-66ce-3dfa" name="1) Melee Options" hidden="false" collective="false" import="true" defaultSelectionEntryId="a887-9d78-c1e4-8ceb">
@@ -4592,6 +4684,9 @@
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25"/>
               </costs>
+              <categoryLinks>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="af02-ccab-4f73-98c0" name="Infantry" primary="false"/>
+              </categoryLinks>
             </selectionEntry>
             <selectionEntry id="ea36-9644-7d23-b95f" name="Locutarus w/Special Pistol" hidden="false" collective="false" import="true" type="model">
               <modifiers>
@@ -4643,6 +4738,9 @@
               <infoLinks>
                 <infoLink id="5a10-84e2-6ebf-db4f" name="Locutarus" targetId="a006-002c-28d1-bc61" type="profile"/>
               </infoLinks>
+              <categoryLinks>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="3277-6246-449f-97f9" name="Infantry" primary="false"/>
+              </categoryLinks>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
@@ -4723,6 +4821,7 @@
           </profiles>
           <categoryLinks>
             <categoryLink id="aa98-3308-c2e0-fbd2" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="52e3-745d-431d-bf83" name="Infantry" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="3d76-9955-751a-735e" name="2) May take:" hidden="false" collective="false" import="true">
@@ -5020,6 +5119,9 @@
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15"/>
               </costs>
+              <categoryLinks>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="81d8-0b71-4ed7-a678" name="Infantry" primary="false"/>
+              </categoryLinks>
             </selectionEntry>
             <selectionEntry id="e674-2512-0b17-2208" name="Nemesis Destroyer w/Heavy Weapon" hidden="false" collective="false" import="true" type="model">
               <modifiers>
@@ -5105,6 +5207,9 @@
               <infoLinks>
                 <infoLink name="Nemesis Destroyer" hidden="false" type="profile" id="843d-b83f-3df4-cbc1" targetId="1a33-dcc3-f511-6a0d"/>
               </infoLinks>
+              <categoryLinks>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="1384-3a65-412b-b640" name="Infantry" primary="false"/>
+              </categoryLinks>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>

--- a/2022 - LA - White Scars.cat
+++ b/2022 - LA - White Scars.cat
@@ -3325,6 +3325,11 @@
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="40"/>
           </costs>
+          <categoryLinks>
+            <categoryLink targetId="6d79-a3e4-381f-7b0f" id="f2a4-a57d-43bd-a463" name="Cavalry" primary="false"/>
+            <categoryLink targetId="4303-1348-cce4-9501" id="17b4-98ba-4c4e-b1f8" name="Antigrav" primary="false"/>
+            <categoryLink targetId="9231-183c-b97b-63f9" id="24c6-0df2-4271-8855" name="Heavy" primary="false"/>
+          </categoryLinks>
         </selectionEntry>
         <selectionEntry id="b55b-c197-71d3-9c84" name="Golden Keshig Champion" hidden="false" collective="false" import="true" type="model">
           <constraints>
@@ -3357,6 +3362,9 @@
           </profiles>
           <categoryLinks>
             <categoryLink id="597d-1cf2-1be6-94af" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
+            <categoryLink targetId="6d79-a3e4-381f-7b0f" id="3025-56da-43cd-97be" name="Cavalry" primary="false"/>
+            <categoryLink targetId="4303-1348-cce4-9501" id="affb-9e7b-4c2f-ab96" name="Antigrav" primary="false"/>
+            <categoryLink targetId="9231-183c-b97b-63f9" id="321a-157d-4010-a05e" name="Heavy" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="8126-aa08-3eb9-d49d" name="May exchange their Chainsword for:" hidden="false" collective="false" import="true" defaultSelectionEntryId="a0d6-d7e7-83b1-cb65">
@@ -3817,6 +3825,11 @@
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="105"/>
           </costs>
+          <categoryLinks>
+            <categoryLink targetId="6d79-a3e4-381f-7b0f" id="165e-190a-4285-a324" name="Cavalry" primary="false"/>
+            <categoryLink targetId="4303-1348-cce4-9501" id="12fb-ed4d-4c30-84e5" name="Antigrav" primary="false"/>
+            <categoryLink targetId="9231-183c-b97b-63f9" id="6a15-ae28-4ae7-9122" name="Heavy" primary="false"/>
+          </categoryLinks>
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
@@ -4035,6 +4048,11 @@
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="16"/>
           </costs>
+          <categoryLinks>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="3ae9-79f9-4d59-8c07" name="Infantry" primary="false"/>
+            <categoryLink targetId="bff2-ae16-74a8-8712" id="bbdd-912e-4b0a-abb9" name="Light" primary="false"/>
+            <categoryLink targetId="59a4-7b61-600a-c457" id="ebc5-72df-4893-ad1a" name="Skirmish" primary="false"/>
+          </categoryLinks>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
@@ -4194,6 +4212,7 @@
           </profiles>
           <categoryLinks>
             <categoryLink id="1aef-0993-2400-9738" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="7ec5-6879-4a27-9ce6" name="Infantry" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="cc84-4808-e998-b656" name="1) Melee Options:" hidden="false" collective="false" import="true" defaultSelectionEntryId="4487-dbf4-fc92-9e1a">
@@ -4339,6 +4358,9 @@
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20"/>
           </costs>
+          <categoryLinks>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="c6c6-025d-4c96-a0b2" name="Infantry" primary="false"/>
+          </categoryLinks>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
@@ -4550,6 +4572,9 @@
         <selectionEntry type="model" import="true" name="Qin Xa" hidden="false" id="bdec-21c5-bf4a-3a95">
           <categoryLinks>
             <categoryLink targetId="4f07-3d45-4f28-a0c6" id="5a83-c56c-2fb-706c" primary="false" name="Independent Character"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="cd92-f94b-4aad-aa70" name="Infantry" primary="false"/>
+            <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="7f85-91e2-4383-b5ff" name="Character" primary="false"/>
+            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="73d6-30bf-4e7b-969b" name="Unique" primary="false"/>
           </categoryLinks>
           <constraints>
             <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="8cf2-a0c1-6adf-958b"/>
@@ -4696,6 +4721,9 @@
         <selectionEntry type="model" import="true" name="Tsolmon Khan" hidden="false" id="7dd4-df27-9afb-f0af">
           <categoryLinks>
             <categoryLink targetId="4f07-3d45-4f28-a0c6" id="6721-afa5-62e2-e507" primary="false" name="Independent Character"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="d837-114a-4fae-aa6c" name="Infantry" primary="false"/>
+            <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="73f8-f1a2-4672-b5c9" name="Character" primary="false"/>
+            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="5db4-6dd5-4f45-8c86" name="Unique" primary="false"/>
           </categoryLinks>
           <constraints>
             <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="8cf2-a0c1-6adf-958b"/>
@@ -4922,6 +4950,9 @@
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
               </costs>
+              <categoryLinks>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="1588-88d7-472d-8984" name="Infantry" primary="false"/>
+              </categoryLinks>
             </selectionEntry>
             <selectionEntry id="ece0-e3d7-d62d-aafe" name="Tartaros Standard Bearer w/Ranged Weapon" hidden="false" collective="false" import="true" type="model">
               <profiles>
@@ -4968,6 +4999,9 @@
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
               </costs>
+              <categoryLinks>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="089a-a37a-4893-8a55" name="Infantry" primary="false"/>
+              </categoryLinks>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
@@ -5013,6 +5047,9 @@
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="40"/>
               </costs>
+              <categoryLinks>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="accf-1f82-4b01-8329" name="Infantry" primary="false"/>
+              </categoryLinks>
             </selectionEntry>
             <selectionEntry id="1568-ca7f-fba1-e742" name="Tartaros Chosen" hidden="false" collective="false" import="true" type="model">
               <profiles>
@@ -5039,6 +5076,9 @@
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="30"/>
               </costs>
+              <categoryLinks>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="86bb-bcca-486a-836a" name="Infantry" primary="false"/>
+              </categoryLinks>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
@@ -5223,6 +5263,8 @@ May join units that include models with the Cavalry Unit Type despite the usual 
         <selectionEntry type="model" import="true" name="Jaghatai Khan" hidden="false" id="657b-383e-85ed-781b">
           <categoryLinks>
             <categoryLink targetId="4f07-3d45-4f28-a0c6" id="69ca-446a-2911-eb68" primary="false" name="Independent Character"/>
+            <categoryLink targetId="ad5f-31db-8bc7-5c46" id="00fc-e1f5-46cf-acff" name="Primarch" primary="false"/>
+            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="b35e-71d6-4a43-8ec0" name="Unique" primary="false"/>
           </categoryLinks>
           <constraints>
             <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="8cf2-a0c1-6adf-958b"/>

--- a/2022 - LA - White Scars.cat
+++ b/2022 - LA - White Scars.cat
@@ -3326,9 +3326,9 @@
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="40"/>
           </costs>
           <categoryLinks>
-            <categoryLink targetId="6d79-a3e4-381f-7b0f" id="f2a4-a57d-43bd-a463" name="Cavalry" primary="false"/>
-            <categoryLink targetId="4303-1348-cce4-9501" id="17b4-98ba-4c4e-b1f8" name="Antigrav" primary="false"/>
-            <categoryLink targetId="9231-183c-b97b-63f9" id="24c6-0df2-4271-8855" name="Heavy" primary="false"/>
+            <categoryLink targetId="6d79-a3e4-381f-7b0f" id="f2a4-a57d-43bd-a463" name="Cavalry Unit Type" primary="false"/>
+            <categoryLink targetId="4303-1348-cce4-9501" id="17b4-98ba-4c4e-b1f8" name="Antigrav Sub-type" primary="false"/>
+            <categoryLink targetId="9231-183c-b97b-63f9" id="24c6-0df2-4271-8855" name="Heavy Sub-type" primary="false"/>
           </categoryLinks>
         </selectionEntry>
         <selectionEntry id="b55b-c197-71d3-9c84" name="Golden Keshig Champion" hidden="false" collective="false" import="true" type="model">
@@ -3362,9 +3362,9 @@
           </profiles>
           <categoryLinks>
             <categoryLink id="597d-1cf2-1be6-94af" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
-            <categoryLink targetId="6d79-a3e4-381f-7b0f" id="3025-56da-43cd-97be" name="Cavalry" primary="false"/>
-            <categoryLink targetId="4303-1348-cce4-9501" id="affb-9e7b-4c2f-ab96" name="Antigrav" primary="false"/>
-            <categoryLink targetId="9231-183c-b97b-63f9" id="321a-157d-4010-a05e" name="Heavy" primary="false"/>
+            <categoryLink targetId="6d79-a3e4-381f-7b0f" id="3025-56da-43cd-97be" name="Cavalry Unit Type" primary="false"/>
+            <categoryLink targetId="4303-1348-cce4-9501" id="affb-9e7b-4c2f-ab96" name="Antigrav Sub-type" primary="false"/>
+            <categoryLink targetId="9231-183c-b97b-63f9" id="321a-157d-4010-a05e" name="Heavy Sub-type" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="8126-aa08-3eb9-d49d" name="May exchange their Chainsword for:" hidden="false" collective="false" import="true" defaultSelectionEntryId="a0d6-d7e7-83b1-cb65">
@@ -3550,7 +3550,7 @@
         <infoLink id="578a-d59c-9c57-a23c" name="Kharash" hidden="false" targetId="71fa-da0d-0056-9072" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="3eca-813c-b5fa-62bb" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="3eca-813c-b5fa-62bb" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="3cb7-2f9b-6a21-e130" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
       </categoryLinks>
       <selectionEntries>
@@ -3826,9 +3826,9 @@
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="105"/>
           </costs>
           <categoryLinks>
-            <categoryLink targetId="6d79-a3e4-381f-7b0f" id="165e-190a-4285-a324" name="Cavalry" primary="false"/>
-            <categoryLink targetId="4303-1348-cce4-9501" id="12fb-ed4d-4c30-84e5" name="Antigrav" primary="false"/>
-            <categoryLink targetId="9231-183c-b97b-63f9" id="6a15-ae28-4ae7-9122" name="Heavy" primary="false"/>
+            <categoryLink targetId="6d79-a3e4-381f-7b0f" id="165e-190a-4285-a324" name="Cavalry Unit Type" primary="false"/>
+            <categoryLink targetId="4303-1348-cce4-9501" id="12fb-ed4d-4c30-84e5" name="Antigrav Sub-type" primary="false"/>
+            <categoryLink targetId="9231-183c-b97b-63f9" id="6a15-ae28-4ae7-9122" name="Heavy Sub-type" primary="false"/>
           </categoryLinks>
         </selectionEntry>
       </selectionEntries>
@@ -3891,7 +3891,7 @@
       </infoLinks>
       <categoryLinks>
         <categoryLink id="0f7c-1949-3208-41d9" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="9534-1164-ded8-a7e0" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="9534-1164-ded8-a7e0" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="2201-4a07-ab90-f50f" name="Light Sub-type" hidden="false" targetId="bff2-ae16-74a8-8712" primary="false"/>
         <categoryLink id="3f32-f496-6141-bad9" name="Skirmish Sub-type" hidden="false" targetId="59a4-7b61-600a-c457" primary="false"/>
       </categoryLinks>
@@ -3927,7 +3927,7 @@
           </profiles>
           <categoryLinks>
             <categoryLink id="a649-b82b-acf1-3bc8" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
-            <categoryLink id="b8fc-c2a0-ad60-21ba" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+            <categoryLink id="b8fc-c2a0-ad60-21ba" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
             <categoryLink id="1f48-ae0c-22f4-235c" name="Light Sub-type" hidden="false" targetId="bff2-ae16-74a8-8712" primary="false"/>
             <categoryLink id="3df5-3e2a-1236-5e80" name="Skirmish Sub-type" hidden="false" targetId="59a4-7b61-600a-c457" primary="false"/>
           </categoryLinks>
@@ -4049,9 +4049,9 @@
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="16"/>
           </costs>
           <categoryLinks>
-            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="3ae9-79f9-4d59-8c07" name="Infantry" primary="false"/>
-            <categoryLink targetId="bff2-ae16-74a8-8712" id="bbdd-912e-4b0a-abb9" name="Light" primary="false"/>
-            <categoryLink targetId="59a4-7b61-600a-c457" id="ebc5-72df-4893-ad1a" name="Skirmish" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="3ae9-79f9-4d59-8c07" name="Infantry Unit Type" primary="false"/>
+            <categoryLink targetId="bff2-ae16-74a8-8712" id="bbdd-912e-4b0a-abb9" name="Light Sub-type" primary="false"/>
+            <categoryLink targetId="59a4-7b61-600a-c457" id="ebc5-72df-4893-ad1a" name="Skirmish Sub-type" primary="false"/>
           </categoryLinks>
         </selectionEntry>
       </selectionEntries>
@@ -4173,7 +4173,7 @@
       </infoLinks>
       <categoryLinks>
         <categoryLink id="8607-29a7-0dba-bd62" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="cb68-2347-61ae-4a0b" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="cb68-2347-61ae-4a0b" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="5102-02bb-c8d6-56d6" name="Death&apos;s Champion" publicationId="09b3-d525-cdea-260c" page="11" hidden="false" collective="false" import="true" type="model">
@@ -4212,7 +4212,7 @@
           </profiles>
           <categoryLinks>
             <categoryLink id="1aef-0993-2400-9738" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
-            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="7ec5-6879-4a27-9ce6" name="Infantry" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="7ec5-6879-4a27-9ce6" name="Infantry Unit Type" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="cc84-4808-e998-b656" name="1) Melee Options:" hidden="false" collective="false" import="true" defaultSelectionEntryId="4487-dbf4-fc92-9e1a">
@@ -4359,7 +4359,7 @@
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20"/>
           </costs>
           <categoryLinks>
-            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="c6c6-025d-4c96-a0b2" name="Infantry" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="c6c6-025d-4c96-a0b2" name="Infantry Unit Type" primary="false"/>
           </categoryLinks>
         </selectionEntry>
       </selectionEntries>
@@ -4529,7 +4529,7 @@
       <categoryLinks>
         <categoryLink id="54e2-d6ae-9451-cef4" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="e3e9-8ad6-46b0-b979" name="Terminators:" hidden="false" targetId="bab3-f50d-3e5f-2f78" primary="false"/>
-        <categoryLink id="b6ea-20c7-9037-cfba" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="b6ea-20c7-9037-cfba" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="a42b-18eb-0912-d5fc" name="The Tails of the Dragon" hidden="false" collective="false" import="true" type="upgrade">
@@ -4572,9 +4572,9 @@
         <selectionEntry type="model" import="true" name="Qin Xa" hidden="false" id="bdec-21c5-bf4a-3a95">
           <categoryLinks>
             <categoryLink targetId="4f07-3d45-4f28-a0c6" id="5a83-c56c-2fb-706c" primary="false" name="Independent Character"/>
-            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="cd92-f94b-4aad-aa70" name="Infantry" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="cd92-f94b-4aad-aa70" name="Infantry Unit Type" primary="false"/>
             <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="7f85-91e2-4383-b5ff" name="Character" primary="false"/>
-            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="73d6-30bf-4e7b-969b" name="Unique" primary="false"/>
+            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="73d6-30bf-4e7b-969b" name="Unique Sub-type" primary="false"/>
           </categoryLinks>
           <constraints>
             <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="8cf2-a0c1-6adf-958b"/>
@@ -4721,9 +4721,9 @@
         <selectionEntry type="model" import="true" name="Tsolmon Khan" hidden="false" id="7dd4-df27-9afb-f0af">
           <categoryLinks>
             <categoryLink targetId="4f07-3d45-4f28-a0c6" id="6721-afa5-62e2-e507" primary="false" name="Independent Character"/>
-            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="d837-114a-4fae-aa6c" name="Infantry" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="d837-114a-4fae-aa6c" name="Infantry Unit Type" primary="false"/>
             <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="73f8-f1a2-4672-b5c9" name="Character" primary="false"/>
-            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="5db4-6dd5-4f45-8c86" name="Unique" primary="false"/>
+            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="5db4-6dd5-4f45-8c86" name="Unique Sub-type" primary="false"/>
           </categoryLinks>
           <constraints>
             <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="8cf2-a0c1-6adf-958b"/>
@@ -4855,7 +4855,7 @@
       <categoryLinks>
         <categoryLink id="0020-4301-b8cb-e152" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="1bd4-4a45-a9d6-fc0c" name="Terminators:" hidden="false" targetId="bab3-f50d-3e5f-2f78" primary="false"/>
-        <categoryLink id="86cc-121b-a65c-422a" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="86cc-121b-a65c-422a" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="db53-d618-c96b-4a8c" name="Dedicated Transport" hidden="false" collective="false" import="true">
@@ -4951,7 +4951,7 @@
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
               </costs>
               <categoryLinks>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="1588-88d7-472d-8984" name="Infantry" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="1588-88d7-472d-8984" name="Infantry Unit Type" primary="false"/>
               </categoryLinks>
             </selectionEntry>
             <selectionEntry id="ece0-e3d7-d62d-aafe" name="Tartaros Standard Bearer w/Ranged Weapon" hidden="false" collective="false" import="true" type="model">
@@ -5000,7 +5000,7 @@
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
               </costs>
               <categoryLinks>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="089a-a37a-4893-8a55" name="Infantry" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="089a-a37a-4893-8a55" name="Infantry Unit Type" primary="false"/>
               </categoryLinks>
             </selectionEntry>
           </selectionEntries>
@@ -5048,7 +5048,7 @@
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="40"/>
               </costs>
               <categoryLinks>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="accf-1f82-4b01-8329" name="Infantry" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="accf-1f82-4b01-8329" name="Infantry Unit Type" primary="false"/>
               </categoryLinks>
             </selectionEntry>
             <selectionEntry id="1568-ca7f-fba1-e742" name="Tartaros Chosen" hidden="false" collective="false" import="true" type="model">
@@ -5077,7 +5077,7 @@
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="30"/>
               </costs>
               <categoryLinks>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="86bb-bcca-486a-836a" name="Infantry" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="86bb-bcca-486a-836a" name="Infantry Unit Type" primary="false"/>
               </categoryLinks>
             </selectionEntry>
           </selectionEntries>
@@ -5263,8 +5263,8 @@ May join units that include models with the Cavalry Unit Type despite the usual 
         <selectionEntry type="model" import="true" name="Jaghatai Khan" hidden="false" id="657b-383e-85ed-781b">
           <categoryLinks>
             <categoryLink targetId="4f07-3d45-4f28-a0c6" id="69ca-446a-2911-eb68" primary="false" name="Independent Character"/>
-            <categoryLink targetId="ad5f-31db-8bc7-5c46" id="00fc-e1f5-46cf-acff" name="Primarch" primary="false"/>
-            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="b35e-71d6-4a43-8ec0" name="Unique" primary="false"/>
+            <categoryLink targetId="ad5f-31db-8bc7-5c46" id="00fc-e1f5-46cf-acff" name="Primarch:" primary="false"/>
+            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="b35e-71d6-4a43-8ec0" name="Unique Sub-type" primary="false"/>
           </categoryLinks>
           <constraints>
             <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="8cf2-a0c1-6adf-958b"/>

--- a/2022 - LA - White Scars.cat
+++ b/2022 - LA - White Scars.cat
@@ -2888,7 +2888,7 @@
       <categoryLinks>
         <categoryLink id="63ff-0a92-42ab-ae8c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="204c-7b0f-4fb9-b1b3" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="85e6-cb31-427c-a040" name="Line Sub-type:" hidden="false" targetId="6399-5c65-7833-1025" primary="false"/>
+        <categoryLink id="85e6-cb31-427c-a040" name="Line Sub-type" hidden="false" targetId="6399-5c65-7833-1025" primary="false"/>
         <categoryLink id="6c98-a1d5-a715-057d" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -3174,7 +3174,7 @@
           <comment>template_id_ff9f-01cb-41b9-800e</comment>
         </categoryLink>
         <categoryLink id="ed2b-3736-8e9d-7051" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="e803-81d6-72fc-283c" name="Line Sub-type:" hidden="false" targetId="6399-5c65-7833-1025" primary="false"/>
+        <categoryLink id="e803-81d6-72fc-283c" name="Line Sub-type" hidden="false" targetId="6399-5c65-7833-1025" primary="false"/>
         <categoryLink id="4a5a-10ef-bc04-b211" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -3289,8 +3289,8 @@
       </infoLinks>
       <categoryLinks>
         <categoryLink id="4083-4f2a-5da9-39f9" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="b4a8-ec8a-7485-af38" name="Cavalry Unit-type:" hidden="false" targetId="6d79-a3e4-381f-7b0f" primary="false"/>
-        <categoryLink id="7dc2-f06d-83d7-3f15" name="Heavy Sub-type:" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+        <categoryLink id="b4a8-ec8a-7485-af38" name="Cavalry Unit Type" hidden="false" targetId="6d79-a3e4-381f-7b0f" primary="false"/>
+        <categoryLink id="7dc2-f06d-83d7-3f15" name="Heavy Sub-type" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="c46b-3bf0-77df-39bb" name="Golden Keshig Rider" hidden="false" collective="false" import="true" type="model">
@@ -3777,8 +3777,8 @@
         <infoLink id="f543-146d-d77f-dd23" name="Hit &amp; Run" hidden="false" targetId="5986-e960-d432-affd" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="74d4-f605-7461-db43" name="Cavalry Unit-type:" hidden="false" targetId="6d79-a3e4-381f-7b0f" primary="false"/>
-        <categoryLink id="ce3b-6d6a-0eca-ace7" name="Heavy Sub-type:" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+        <categoryLink id="74d4-f605-7461-db43" name="Cavalry Unit Type" hidden="false" targetId="6d79-a3e4-381f-7b0f" primary="false"/>
+        <categoryLink id="ce3b-6d6a-0eca-ace7" name="Heavy Sub-type" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
         <categoryLink id="0b3c-e0ff-0485-b240" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="059a-9e08-d32a-bc1f" name="Deep Strike:" hidden="false" targetId="0d4f-ff28-d819-a512" primary="false"/>
       </categoryLinks>
@@ -3892,8 +3892,8 @@
       <categoryLinks>
         <categoryLink id="0f7c-1949-3208-41d9" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="9534-1164-ded8-a7e0" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="2201-4a07-ab90-f50f" name="Light Sub-type:" hidden="false" targetId="bff2-ae16-74a8-8712" primary="false"/>
-        <categoryLink id="3f32-f496-6141-bad9" name="Skirmish Sub-type:" hidden="false" targetId="59a4-7b61-600a-c457" primary="false"/>
+        <categoryLink id="2201-4a07-ab90-f50f" name="Light Sub-type" hidden="false" targetId="bff2-ae16-74a8-8712" primary="false"/>
+        <categoryLink id="3f32-f496-6141-bad9" name="Skirmish Sub-type" hidden="false" targetId="59a4-7b61-600a-c457" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="3726-92d5-2afe-1f1e" name="Falcon&apos;s Claws Champion" publicationId="817a-6288-e016-7469" hidden="false" collective="false" import="true" type="model">
@@ -3928,8 +3928,8 @@
           <categoryLinks>
             <categoryLink id="a649-b82b-acf1-3bc8" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
             <categoryLink id="b8fc-c2a0-ad60-21ba" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-            <categoryLink id="1f48-ae0c-22f4-235c" name="Light Sub-type:" hidden="false" targetId="bff2-ae16-74a8-8712" primary="false"/>
-            <categoryLink id="3df5-3e2a-1236-5e80" name="Skirmish Sub-type:" hidden="false" targetId="59a4-7b61-600a-c457" primary="false"/>
+            <categoryLink id="1f48-ae0c-22f4-235c" name="Light Sub-type" hidden="false" targetId="bff2-ae16-74a8-8712" primary="false"/>
+            <categoryLink id="3df5-3e2a-1236-5e80" name="Skirmish Sub-type" hidden="false" targetId="59a4-7b61-600a-c457" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="c141-ae35-dee5-390a" name="May take:" hidden="false" collective="false" import="true">

--- a/2022 - LA - Word Bearers.cat
+++ b/2022 - LA - Word Bearers.cat
@@ -3386,7 +3386,7 @@
         <infoLink id="5720-f12e-d335-bd3d" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="8bb5-03cb-13d0-5b68" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="8bb5-03cb-13d0-5b68" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="01a3-36e3-0dee-8337" name="Corrupted Sub-type" hidden="false" targetId="9055-7410-8ffd-b8e7" primary="false"/>
         <categoryLink id="9fc7-089c-acfd-0f40" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
       </categoryLinks>
@@ -3432,7 +3432,7 @@
               </profiles>
               <categoryLinks>
                 <categoryLink id="c88d-b283-6386-016b" name="Corrupted Sub-type" hidden="false" targetId="9055-7410-8ffd-b8e7" primary="false"/>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="6f32-8270-4972-8a48" name="Infantry" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="6f32-8270-4972-8a48" name="Infantry Unit Type" primary="false"/>
               </categoryLinks>
               <selectionEntryGroups>
                 <selectionEntryGroup id="47f2-5642-9947-fbc6" name="Tainted Talons:" hidden="false" collective="false" import="true" defaultSelectionEntryId="adbd-f29d-b757-04ce">
@@ -3492,7 +3492,7 @@
               </constraints>
               <categoryLinks>
                 <categoryLink id="6301-3df0-f6f7-94de" name="Corrupted Sub-type" hidden="false" targetId="9055-7410-8ffd-b8e7" primary="false"/>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="e3f3-2749-4f3a-9cca" name="Infantry" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="e3f3-2749-4f3a-9cca" name="Infantry Unit Type" primary="false"/>
               </categoryLinks>
               <entryLinks>
                 <entryLink id="3ddc-e26e-9a11-849f" name="Boltspitter" hidden="false" collective="false" import="true" targetId="8bd9-2a5f-22bc-735b" type="selectionEntry">
@@ -3534,7 +3534,7 @@
               </constraints>
               <categoryLinks>
                 <categoryLink id="0e5d-ec08-8f11-ae1e" name="Corrupted Sub-type" hidden="false" targetId="9055-7410-8ffd-b8e7" primary="false"/>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="22e3-6e1d-4a69-9892" name="Infantry" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="22e3-6e1d-4a69-9892" name="Infantry Unit Type" primary="false"/>
               </categoryLinks>
               <selectionEntryGroups>
                 <selectionEntryGroup id="7899-13c5-6501-32ec" name="Boltspitter:" hidden="false" collective="false" import="true" defaultSelectionEntryId="0c17-733c-f154-1b4d">
@@ -3613,7 +3613,7 @@
               </constraints>
               <categoryLinks>
                 <categoryLink id="2922-5ff8-d70b-c7da" name="Corrupted Sub-type" hidden="false" targetId="9055-7410-8ffd-b8e7" primary="false"/>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="6e92-a123-4e33-ab13" name="Infantry" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="6e92-a123-4e33-ab13" name="Infantry Unit Type" primary="false"/>
               </categoryLinks>
               <selectionEntryGroups>
                 <selectionEntryGroup id="253c-61a1-03b8-e9e3" name="Boltspitter:" hidden="false" collective="false" import="true" defaultSelectionEntryId="ea17-2c81-7fc5-15eb">
@@ -3899,9 +3899,9 @@ In addition, once per battle, one friendly unit composed entirely of models with
               </costs>
               <categoryLinks>
                 <categoryLink targetId="4f07-3d45-4f28-a0c6" id="6bb3-8da4-9b06-76e6" primary="false" name="Independent Character"/>
-                <categoryLink targetId="ad5f-31db-8bc7-5c46" id="775b-a750-4dd1-8079" name="Primarch" primary="false"/>
-                <categoryLink targetId="6e0c-29ba-a445-8321" id="75fb-ffd3-4e64-b372" name="Psyker" primary="false"/>
-                <categoryLink targetId="aa94-5c65-d1f1-46a4" id="8a1e-4ed1-4ed4-82d8" name="Unique" primary="false"/>
+                <categoryLink targetId="ad5f-31db-8bc7-5c46" id="775b-a750-4dd1-8079" name="Primarch:" primary="false"/>
+                <categoryLink targetId="6e0c-29ba-a445-8321" id="75fb-ffd3-4e64-b372" name="Psyker:" primary="false"/>
+                <categoryLink targetId="aa94-5c65-d1f1-46a4" id="8a1e-4ed1-4ed4-82d8" name="Unique Sub-type" primary="false"/>
               </categoryLinks>
             </selectionEntry>
             <selectionEntry id="86f6-6646-2bef-31ee" name="Lorgar Transfigured" hidden="false" collective="false" import="true" type="upgrade">
@@ -3997,7 +3997,7 @@ In addition, once per battle, one friendly unit composed entirely of models with
         <infoLink id="09ec-48df-a675-66ec" name="Stubborn" hidden="false" targetId="7989-1f2c-a43d-82ae" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="768a-11a0-1cb1-d896" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="768a-11a0-1cb1-d896" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="75a1-c482-1a18-e139" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="1937-18d3-3af6-806c" name="Heavy Sub-type" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
         <categoryLink id="fd96-34a3-5cd2-680a" name="Jump Infantry:" hidden="false" targetId="eee8-3c7c-2762-e33e" primary="false"/>
@@ -4034,8 +4034,8 @@ In addition, once per battle, one friendly unit composed entirely of models with
           </profiles>
           <categoryLinks>
             <categoryLink id="1092-6e5f-5e97-f956" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
-            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="0643-b4fd-40a3-b577" name="Infantry" primary="false"/>
-            <categoryLink targetId="9231-183c-b97b-63f9" id="f6ea-a424-46a7-b943" name="Heavy" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="0643-b4fd-40a3-b577" name="Infantry Unit Type" primary="false"/>
+            <categoryLink targetId="9231-183c-b97b-63f9" id="f6ea-a424-46a7-b943" name="Heavy Sub-type" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="d4d3-c315-f02b-1c9c" name="1) Pistol Options:" hidden="false" collective="false" import="true" defaultSelectionEntryId="0496-d93a-e5cb-12a5">
@@ -4151,8 +4151,8 @@ In addition, once per battle, one friendly unit composed entirely of models with
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20"/>
           </costs>
           <categoryLinks>
-            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="7972-5dad-4d92-b00e" name="Infantry" primary="false"/>
-            <categoryLink targetId="9231-183c-b97b-63f9" id="1c9d-2988-4181-822f" name="Heavy" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="7972-5dad-4d92-b00e" name="Infantry Unit Type" primary="false"/>
+            <categoryLink targetId="9231-183c-b97b-63f9" id="1c9d-2988-4181-822f" name="Heavy Sub-type" primary="false"/>
           </categoryLinks>
         </selectionEntry>
       </selectionEntries>
@@ -4373,7 +4373,7 @@ In addition, once per battle, one friendly unit composed entirely of models with
       </infoLinks>
       <categoryLinks>
         <categoryLink id="12b2-c421-a2f1-8907" name="Corrupted Sub-type" hidden="false" targetId="9055-7410-8ffd-b8e7" primary="false"/>
-        <categoryLink id="f886-4ca2-1868-07e2" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="f886-4ca2-1868-07e2" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="52a9-15b7-149f-b6d7" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
       </categoryLinks>
       <selectionEntries>
@@ -4488,7 +4488,7 @@ In addition, once per battle, one friendly unit composed entirely of models with
         </infoLink>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="a847-6e8a-66a4-fa17" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="a847-6e8a-66a4-fa17" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="c096-bb42-1c27-67a6" name="Corrupted Sub-type" hidden="false" targetId="9055-7410-8ffd-b8e7" primary="false"/>
         <categoryLink targetId="11f2-472f-c1d1-9ae9" id="6cc0-6682-2cc0-cd4c" primary="false" name="Legiones Astartes"/>
       </categoryLinks>
@@ -4533,10 +4533,10 @@ Argel Tal may still Run while using this special rule, if he would normally be a
         <selectionEntry type="model" import="true" name="Argel Tal" hidden="false" id="3407-6707-e02-bedf">
           <categoryLinks>
             <categoryLink targetId="4f07-3d45-4f28-a0c6" id="fa1b-510e-429e-c6b0" primary="false" name="Independent Character"/>
-            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="6e6b-5cc0-4118-9b87" name="Infantry" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="6e6b-5cc0-4118-9b87" name="Infantry Unit Type" primary="false"/>
             <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="6b3d-b8dc-4790-91af" name="Character" primary="false"/>
-            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="d96a-abba-4722-949a" name="Unique" primary="false"/>
-            <categoryLink targetId="9055-7410-8ffd-b8e7" id="e7e8-61df-4d0a-9aae" name="Corrupted" primary="false"/>
+            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="d96a-abba-4722-949a" name="Unique Sub-type" primary="false"/>
+            <categoryLink targetId="9055-7410-8ffd-b8e7" id="e7e8-61df-4d0a-9aae" name="Corrupted Sub-type" primary="false"/>
           </categoryLinks>
           <constraints>
             <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="dab-773e-53e4-ed58"/>
@@ -4625,7 +4625,7 @@ Psychic Weapon</description>
         <infoLink id="a94d-4b88-ece7-d111" name="Fearless" hidden="false" targetId="b48c-d7e1-2a83-2f5b" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="d3d0-99c4-cb4c-969c" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="d3d0-99c4-cb4c-969c" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="9acc-39e7-b768-439f" name="Corrupted Sub-type" hidden="false" targetId="9055-7410-8ffd-b8e7" primary="false"/>
         <categoryLink id="c6bf-c6ef-ae4a-4995" name="Psyker:" hidden="false" targetId="6e0c-29ba-a445-8321" primary="false"/>
         <categoryLink targetId="11f2-472f-c1d1-9ae9" id="8cd9-d390-1cf-5dad" primary="false" name="Legiones Astartes"/>
@@ -4685,11 +4685,11 @@ Psychic Weapon</description>
         <selectionEntry type="model" import="true" name="High Chaplain Erebus" hidden="false" id="c5f8-1709-fb44-a64d">
           <categoryLinks>
             <categoryLink targetId="4f07-3d45-4f28-a0c6" id="12d1-da56-374b-314b" primary="false" name="Independent Character"/>
-            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="3272-a69e-43a4-ad33" name="Infantry" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="3272-a69e-43a4-ad33" name="Infantry Unit Type" primary="false"/>
             <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="9bd7-ceea-417a-b36f" name="Character" primary="false"/>
-            <categoryLink targetId="6e0c-29ba-a445-8321" id="914b-2107-4e00-bbd1" name="Psyker" primary="false"/>
-            <categoryLink targetId="9055-7410-8ffd-b8e7" id="2bd7-64e2-4a1b-ae71" name="Corrupted" primary="false"/>
-            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="1edc-bd42-4666-9a99" name="Unique" primary="false"/>
+            <categoryLink targetId="6e0c-29ba-a445-8321" id="914b-2107-4e00-bbd1" name="Psyker:" primary="false"/>
+            <categoryLink targetId="9055-7410-8ffd-b8e7" id="2bd7-64e2-4a1b-ae71" name="Corrupted Sub-type" primary="false"/>
+            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="1edc-bd42-4666-9a99" name="Unique Sub-type" primary="false"/>
           </categoryLinks>
           <constraints>
             <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="dab-773e-53e4-ed58"/>
@@ -4881,11 +4881,11 @@ Psychic Weapon</description>
         <selectionEntry type="model" import="true" name="Kor Phaeron" hidden="false" id="935d-7774-dfc9-7e13">
           <categoryLinks>
             <categoryLink targetId="4f07-3d45-4f28-a0c6" id="693d-3d37-afc4-1696" primary="false" name="Independent Character"/>
-            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="c62b-38d5-47ae-9ff6" name="Infantry" primary="false"/>
-            <categoryLink targetId="9231-183c-b97b-63f9" id="af6e-afdc-4988-84bb" name="Heavy" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="c62b-38d5-47ae-9ff6" name="Infantry Unit Type" primary="false"/>
+            <categoryLink targetId="9231-183c-b97b-63f9" id="af6e-afdc-4988-84bb" name="Heavy Sub-type" primary="false"/>
             <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="ed0b-4165-4e09-89f9" name="Character" primary="false"/>
-            <categoryLink targetId="9055-7410-8ffd-b8e7" id="4909-258a-4e8d-9a47" name="Corrupted" primary="false"/>
-            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="537a-0f7c-4f7d-82d0" name="Unique" primary="false"/>
+            <categoryLink targetId="9055-7410-8ffd-b8e7" id="4909-258a-4e8d-9a47" name="Corrupted Sub-type" primary="false"/>
+            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="537a-0f7c-4f7d-82d0" name="Unique Sub-type" primary="false"/>
           </categoryLinks>
           <constraints>
             <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="dab-773e-53e4-ed58"/>
@@ -4951,7 +4951,7 @@ Threatening Entreaties - Kor Phaeron and the unit he has joined gain the Fearles
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="125"/>
       </costs>
       <categoryLinks>
-        <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="b4ae-65a-479b-cdc1" primary="false" name="Infantry:"/>
+        <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="b4ae-65a-479b-cdc1" primary="false" name="Infantry Unit Type"/>
         <categoryLink targetId="9055-7410-8ffd-b8e7" id="1c2-3805-b6f8-8b1b" primary="false" name="Corrupted Sub-type"/>
         <categoryLink targetId="11f2-472f-c1d1-9ae9" id="cbe2-a552-1e8b-9dc7" primary="false" name="Legiones Astartes"/>
       </categoryLinks>
@@ -4980,7 +4980,7 @@ as the Aetheric Lightning Psychic Weapon</description>
         <infoLink id="8932-28c5-60c8-9155" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="cd36-7aef-4bad-b59e" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="cd36-7aef-4bad-b59e" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="9ace-0389-f30c-2062" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="d74c-384e-1128-4d7a" name="Corrupted Sub-type" hidden="false" targetId="9055-7410-8ffd-b8e7" primary="false"/>
       </categoryLinks>
@@ -5042,11 +5042,11 @@ as the Aetheric Lightning Psychic Weapon</description>
         <selectionEntry type="model" import="true" name="Zardu Layak" hidden="false" id="1233-5b3f-d481-f723">
           <categoryLinks>
             <categoryLink targetId="4f07-3d45-4f28-a0c6" id="48b1-6791-8fa5-66f4" primary="false" name="Independent Character"/>
-            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="fcac-69dd-41ad-b46c" name="Infantry" primary="false"/>
-            <categoryLink targetId="9055-7410-8ffd-b8e7" id="b62a-9d51-43f8-912c" name="Corrupted" primary="false"/>
-            <categoryLink targetId="6e0c-29ba-a445-8321" id="bc28-66b0-468e-b7e4" name="Psyker" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="fcac-69dd-41ad-b46c" name="Infantry Unit Type" primary="false"/>
+            <categoryLink targetId="9055-7410-8ffd-b8e7" id="b62a-9d51-43f8-912c" name="Corrupted Sub-type" primary="false"/>
+            <categoryLink targetId="6e0c-29ba-a445-8321" id="bc28-66b0-468e-b7e4" name="Psyker:" primary="false"/>
             <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="3ea5-dc60-4066-86ed" name="Character" primary="false"/>
-            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="4282-edf7-4c8f-8223" name="Unique" primary="false"/>
+            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="4282-edf7-4c8f-8223" name="Unique Sub-type" primary="false"/>
           </categoryLinks>
           <constraints>
             <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="dab-773e-53e4-ed58"/>
@@ -5151,7 +5151,7 @@ as the Aetheric Lightning Psychic Weapon</description>
       </rules>
       <categoryLinks>
         <categoryLink id="5aff-13d0-9bfc-03ef" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="c840-64ca-a73b-7f3c" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="c840-64ca-a73b-7f3c" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="9229-d848-0adf-91c7" name="2) Procurants" hidden="false" collective="false" import="true" defaultSelectionEntryId="9c94-e8e3-2c5a-6f24">
@@ -5213,7 +5213,7 @@ as the Aetheric Lightning Psychic Weapon</description>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15"/>
               </costs>
               <categoryLinks>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="b592-f1dd-41a1-a498" name="Infantry" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="b592-f1dd-41a1-a498" name="Infantry Unit Type" primary="false"/>
               </categoryLinks>
             </selectionEntry>
           </selectionEntries>
@@ -5272,7 +5272,7 @@ as the Aetheric Lightning Psychic Weapon</description>
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="30"/>
                   </costs>
                   <categoryLinks>
-                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="6b86-6cf1-4c62-b0b1" name="Infantry" primary="false"/>
+                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="6b86-6cf1-4c62-b0b1" name="Infantry Unit Type" primary="false"/>
                   </categoryLinks>
                 </selectionEntry>
                 <selectionEntry id="7aa9-1e13-3b38-84f5" name="Procurant w/Chainsword &amp; Hand Flamer" hidden="false" collective="false" import="true" type="model">
@@ -5297,7 +5297,7 @@ as the Aetheric Lightning Psychic Weapon</description>
                     <infoLink id="141c-23a2-e6ac-4eb8" name="Procurant" targetId="a7bb-abb3-af34-587d" type="profile"/>
                   </infoLinks>
                   <categoryLinks>
-                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="d695-5e06-4838-93d2" name="Infantry" primary="false"/>
+                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="d695-5e06-4838-93d2" name="Infantry Unit Type" primary="false"/>
                   </categoryLinks>
                 </selectionEntry>
                 <selectionEntry id="4c19-9c4c-1370-f9f2" name="Procurant w/Chainsword &amp; Plasma Pistol" hidden="false" collective="false" import="true" type="model">
@@ -5322,7 +5322,7 @@ as the Aetheric Lightning Psychic Weapon</description>
                     <infoLink id="46b8-23ae-ab0c-c735" name="Procurant" targetId="a7bb-abb3-af34-587d" type="profile"/>
                   </infoLinks>
                   <categoryLinks>
-                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="596e-15b5-429f-a9b2" name="Infantry" primary="false"/>
+                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="596e-15b5-429f-a9b2" name="Infantry Unit Type" primary="false"/>
                   </categoryLinks>
                 </selectionEntry>
                 <selectionEntry id="23cb-25e0-acbf-1185" name="Procurant w/Power Fist &amp; Hand Flamer" hidden="false" collective="false" import="true" type="model">
@@ -5347,7 +5347,7 @@ as the Aetheric Lightning Psychic Weapon</description>
                     <infoLink id="28f6-ce6d-08ea-191d" name="Procurant" targetId="a7bb-abb3-af34-587d" type="profile"/>
                   </infoLinks>
                   <categoryLinks>
-                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="0ea6-9418-4f0c-bf29" name="Infantry" primary="false"/>
+                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="0ea6-9418-4f0c-bf29" name="Infantry Unit Type" primary="false"/>
                   </categoryLinks>
                 </selectionEntry>
                 <selectionEntry id="b608-957e-2fdb-6765" name="Procurant w/Power Fist &amp; Plasma Pistol" hidden="false" collective="false" import="true" type="model">
@@ -5372,7 +5372,7 @@ as the Aetheric Lightning Psychic Weapon</description>
                     <infoLink id="3b42-aa7d-a68d-55e4" name="Procurant" targetId="a7bb-abb3-af34-587d" type="profile"/>
                   </infoLinks>
                   <categoryLinks>
-                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="54d8-d87a-428b-9adf" name="Infantry" primary="false"/>
+                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="54d8-d87a-428b-9adf" name="Infantry Unit Type" primary="false"/>
                   </categoryLinks>
                 </selectionEntry>
               </selectionEntries>
@@ -5422,7 +5422,7 @@ as the Aetheric Lightning Psychic Weapon</description>
               </profiles>
               <categoryLinks>
                 <categoryLink id="ba79-3660-600e-be94" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="55ff-c79c-4487-9d6c" name="Infantry" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="55ff-c79c-4487-9d6c" name="Infantry Unit Type" primary="false"/>
               </categoryLinks>
               <selectionEntryGroups>
                 <selectionEntryGroup id="3726-fec2-17d5-252e" name="Bolt Pistol" hidden="false" collective="false" import="true" defaultSelectionEntryId="c070-b1c9-3fa9-996a">

--- a/2022 - LA - Word Bearers.cat
+++ b/2022 - LA - Word Bearers.cat
@@ -3432,6 +3432,7 @@
               </profiles>
               <categoryLinks>
                 <categoryLink id="c88d-b283-6386-016b" name="Corrupted Sub-type:" hidden="false" targetId="9055-7410-8ffd-b8e7" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="6f32-8270-4972-8a48" name="Infantry" primary="false"/>
               </categoryLinks>
               <selectionEntryGroups>
                 <selectionEntryGroup id="47f2-5642-9947-fbc6" name="Tainted Talons:" hidden="false" collective="false" import="true" defaultSelectionEntryId="adbd-f29d-b757-04ce">
@@ -3491,6 +3492,7 @@
               </constraints>
               <categoryLinks>
                 <categoryLink id="6301-3df0-f6f7-94de" name="Corrupted Sub-type:" hidden="false" targetId="9055-7410-8ffd-b8e7" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="e3f3-2749-4f3a-9cca" name="Infantry" primary="false"/>
               </categoryLinks>
               <entryLinks>
                 <entryLink id="3ddc-e26e-9a11-849f" name="Boltspitter" hidden="false" collective="false" import="true" targetId="8bd9-2a5f-22bc-735b" type="selectionEntry">
@@ -3532,6 +3534,7 @@
               </constraints>
               <categoryLinks>
                 <categoryLink id="0e5d-ec08-8f11-ae1e" name="Corrupted Sub-type:" hidden="false" targetId="9055-7410-8ffd-b8e7" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="22e3-6e1d-4a69-9892" name="Infantry" primary="false"/>
               </categoryLinks>
               <selectionEntryGroups>
                 <selectionEntryGroup id="7899-13c5-6501-32ec" name="Boltspitter:" hidden="false" collective="false" import="true" defaultSelectionEntryId="0c17-733c-f154-1b4d">
@@ -3610,6 +3613,7 @@
               </constraints>
               <categoryLinks>
                 <categoryLink id="2922-5ff8-d70b-c7da" name="Corrupted Sub-type:" hidden="false" targetId="9055-7410-8ffd-b8e7" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="6e92-a123-4e33-ab13" name="Infantry" primary="false"/>
               </categoryLinks>
               <selectionEntryGroups>
                 <selectionEntryGroup id="253c-61a1-03b8-e9e3" name="Boltspitter:" hidden="false" collective="false" import="true" defaultSelectionEntryId="ea17-2c81-7fc5-15eb">
@@ -3895,6 +3899,9 @@ In addition, once per battle, one friendly unit composed entirely of models with
               </costs>
               <categoryLinks>
                 <categoryLink targetId="4f07-3d45-4f28-a0c6" id="6bb3-8da4-9b06-76e6" primary="false" name="Independent Character"/>
+                <categoryLink targetId="ad5f-31db-8bc7-5c46" id="775b-a750-4dd1-8079" name="Primarch" primary="false"/>
+                <categoryLink targetId="6e0c-29ba-a445-8321" id="75fb-ffd3-4e64-b372" name="Psyker" primary="false"/>
+                <categoryLink targetId="aa94-5c65-d1f1-46a4" id="8a1e-4ed1-4ed4-82d8" name="Unique" primary="false"/>
               </categoryLinks>
             </selectionEntry>
             <selectionEntry id="86f6-6646-2bef-31ee" name="Lorgar Transfigured" hidden="false" collective="false" import="true" type="upgrade">
@@ -4027,6 +4034,8 @@ In addition, once per battle, one friendly unit composed entirely of models with
           </profiles>
           <categoryLinks>
             <categoryLink id="1092-6e5f-5e97-f956" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="0643-b4fd-40a3-b577" name="Infantry" primary="false"/>
+            <categoryLink targetId="9231-183c-b97b-63f9" id="f6ea-a424-46a7-b943" name="Heavy" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="d4d3-c315-f02b-1c9c" name="1) Pistol Options:" hidden="false" collective="false" import="true" defaultSelectionEntryId="0496-d93a-e5cb-12a5">
@@ -4141,6 +4150,10 @@ In addition, once per battle, one friendly unit composed entirely of models with
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20"/>
           </costs>
+          <categoryLinks>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="7972-5dad-4d92-b00e" name="Infantry" primary="false"/>
+            <categoryLink targetId="9231-183c-b97b-63f9" id="1c9d-2988-4181-822f" name="Heavy" primary="false"/>
+          </categoryLinks>
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
@@ -4520,6 +4533,10 @@ Argel Tal may still Run while using this special rule, if he would normally be a
         <selectionEntry type="model" import="true" name="Argel Tal" hidden="false" id="3407-6707-e02-bedf">
           <categoryLinks>
             <categoryLink targetId="4f07-3d45-4f28-a0c6" id="fa1b-510e-429e-c6b0" primary="false" name="Independent Character"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="6e6b-5cc0-4118-9b87" name="Infantry" primary="false"/>
+            <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="6b3d-b8dc-4790-91af" name="Character" primary="false"/>
+            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="d96a-abba-4722-949a" name="Unique" primary="false"/>
+            <categoryLink targetId="9055-7410-8ffd-b8e7" id="e7e8-61df-4d0a-9aae" name="Corrupted" primary="false"/>
           </categoryLinks>
           <constraints>
             <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="dab-773e-53e4-ed58"/>
@@ -4668,6 +4685,11 @@ Psychic Weapon</description>
         <selectionEntry type="model" import="true" name="High Chaplain Erebus" hidden="false" id="c5f8-1709-fb44-a64d">
           <categoryLinks>
             <categoryLink targetId="4f07-3d45-4f28-a0c6" id="12d1-da56-374b-314b" primary="false" name="Independent Character"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="3272-a69e-43a4-ad33" name="Infantry" primary="false"/>
+            <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="9bd7-ceea-417a-b36f" name="Character" primary="false"/>
+            <categoryLink targetId="6e0c-29ba-a445-8321" id="914b-2107-4e00-bbd1" name="Psyker" primary="false"/>
+            <categoryLink targetId="9055-7410-8ffd-b8e7" id="2bd7-64e2-4a1b-ae71" name="Corrupted" primary="false"/>
+            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="1edc-bd42-4666-9a99" name="Unique" primary="false"/>
           </categoryLinks>
           <constraints>
             <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="dab-773e-53e4-ed58"/>
@@ -4859,6 +4881,11 @@ Psychic Weapon</description>
         <selectionEntry type="model" import="true" name="Kor Phaeron" hidden="false" id="935d-7774-dfc9-7e13">
           <categoryLinks>
             <categoryLink targetId="4f07-3d45-4f28-a0c6" id="693d-3d37-afc4-1696" primary="false" name="Independent Character"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="c62b-38d5-47ae-9ff6" name="Infantry" primary="false"/>
+            <categoryLink targetId="9231-183c-b97b-63f9" id="af6e-afdc-4988-84bb" name="Heavy" primary="false"/>
+            <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="ed0b-4165-4e09-89f9" name="Character" primary="false"/>
+            <categoryLink targetId="9055-7410-8ffd-b8e7" id="4909-258a-4e8d-9a47" name="Corrupted" primary="false"/>
+            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="537a-0f7c-4f7d-82d0" name="Unique" primary="false"/>
           </categoryLinks>
           <constraints>
             <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="dab-773e-53e4-ed58"/>
@@ -5015,6 +5042,11 @@ as the Aetheric Lightning Psychic Weapon</description>
         <selectionEntry type="model" import="true" name="Zardu Layak" hidden="false" id="1233-5b3f-d481-f723">
           <categoryLinks>
             <categoryLink targetId="4f07-3d45-4f28-a0c6" id="48b1-6791-8fa5-66f4" primary="false" name="Independent Character"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="fcac-69dd-41ad-b46c" name="Infantry" primary="false"/>
+            <categoryLink targetId="9055-7410-8ffd-b8e7" id="b62a-9d51-43f8-912c" name="Corrupted" primary="false"/>
+            <categoryLink targetId="6e0c-29ba-a445-8321" id="bc28-66b0-468e-b7e4" name="Psyker" primary="false"/>
+            <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="3ea5-dc60-4066-86ed" name="Character" primary="false"/>
+            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="4282-edf7-4c8f-8223" name="Unique" primary="false"/>
           </categoryLinks>
           <constraints>
             <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="dab-773e-53e4-ed58"/>
@@ -5180,6 +5212,9 @@ as the Aetheric Lightning Psychic Weapon</description>
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15"/>
               </costs>
+              <categoryLinks>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="b592-f1dd-41a1-a498" name="Infantry" primary="false"/>
+              </categoryLinks>
             </selectionEntry>
           </selectionEntries>
           <selectionEntryGroups>
@@ -5236,6 +5271,9 @@ as the Aetheric Lightning Psychic Weapon</description>
                   <costs>
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="30"/>
                   </costs>
+                  <categoryLinks>
+                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="6b86-6cf1-4c62-b0b1" name="Infantry" primary="false"/>
+                  </categoryLinks>
                 </selectionEntry>
                 <selectionEntry id="7aa9-1e13-3b38-84f5" name="Procurant w/Chainsword &amp; Hand Flamer" hidden="false" collective="false" import="true" type="model">
                   <entryLinks>
@@ -5258,6 +5296,9 @@ as the Aetheric Lightning Psychic Weapon</description>
                   <infoLinks>
                     <infoLink id="141c-23a2-e6ac-4eb8" name="Procurant" targetId="a7bb-abb3-af34-587d" type="profile"/>
                   </infoLinks>
+                  <categoryLinks>
+                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="d695-5e06-4838-93d2" name="Infantry" primary="false"/>
+                  </categoryLinks>
                 </selectionEntry>
                 <selectionEntry id="4c19-9c4c-1370-f9f2" name="Procurant w/Chainsword &amp; Plasma Pistol" hidden="false" collective="false" import="true" type="model">
                   <entryLinks>
@@ -5280,6 +5321,9 @@ as the Aetheric Lightning Psychic Weapon</description>
                   <infoLinks>
                     <infoLink id="46b8-23ae-ab0c-c735" name="Procurant" targetId="a7bb-abb3-af34-587d" type="profile"/>
                   </infoLinks>
+                  <categoryLinks>
+                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="596e-15b5-429f-a9b2" name="Infantry" primary="false"/>
+                  </categoryLinks>
                 </selectionEntry>
                 <selectionEntry id="23cb-25e0-acbf-1185" name="Procurant w/Power Fist &amp; Hand Flamer" hidden="false" collective="false" import="true" type="model">
                   <entryLinks>
@@ -5302,6 +5346,9 @@ as the Aetheric Lightning Psychic Weapon</description>
                   <infoLinks>
                     <infoLink id="28f6-ce6d-08ea-191d" name="Procurant" targetId="a7bb-abb3-af34-587d" type="profile"/>
                   </infoLinks>
+                  <categoryLinks>
+                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="0ea6-9418-4f0c-bf29" name="Infantry" primary="false"/>
+                  </categoryLinks>
                 </selectionEntry>
                 <selectionEntry id="b608-957e-2fdb-6765" name="Procurant w/Power Fist &amp; Plasma Pistol" hidden="false" collective="false" import="true" type="model">
                   <entryLinks>
@@ -5324,6 +5371,9 @@ as the Aetheric Lightning Psychic Weapon</description>
                   <infoLinks>
                     <infoLink id="3b42-aa7d-a68d-55e4" name="Procurant" targetId="a7bb-abb3-af34-587d" type="profile"/>
                   </infoLinks>
+                  <categoryLinks>
+                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="54d8-d87a-428b-9adf" name="Infantry" primary="false"/>
+                  </categoryLinks>
                 </selectionEntry>
               </selectionEntries>
             </selectionEntryGroup>
@@ -5372,6 +5422,7 @@ as the Aetheric Lightning Psychic Weapon</description>
               </profiles>
               <categoryLinks>
                 <categoryLink id="ba79-3660-600e-be94" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="55ff-c79c-4487-9d6c" name="Infantry" primary="false"/>
               </categoryLinks>
               <selectionEntryGroups>
                 <selectionEntryGroup id="3726-fec2-17d5-252e" name="Bolt Pistol" hidden="false" collective="false" import="true" defaultSelectionEntryId="c070-b1c9-3fa9-996a">

--- a/2022 - LA - Word Bearers.cat
+++ b/2022 - LA - Word Bearers.cat
@@ -2734,7 +2734,7 @@
       <categoryLinks>
         <categoryLink id="63ff-0a92-42ab-ae8c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="204c-7b0f-4fb9-b1b3" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="85e6-cb31-427c-a040" name="Line Sub-type:" hidden="false" targetId="6399-5c65-7833-1025" primary="false"/>
+        <categoryLink id="85e6-cb31-427c-a040" name="Line Sub-type" hidden="false" targetId="6399-5c65-7833-1025" primary="false"/>
         <categoryLink id="fe0b-e9e6-91cf-83e2" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -3387,7 +3387,7 @@
       </infoLinks>
       <categoryLinks>
         <categoryLink id="8bb5-03cb-13d0-5b68" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="01a3-36e3-0dee-8337" name="Corrupted Sub-type:" hidden="false" targetId="9055-7410-8ffd-b8e7" primary="false"/>
+        <categoryLink id="01a3-36e3-0dee-8337" name="Corrupted Sub-type" hidden="false" targetId="9055-7410-8ffd-b8e7" primary="false"/>
         <categoryLink id="9fc7-089c-acfd-0f40" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
@@ -3431,7 +3431,7 @@
                 </profile>
               </profiles>
               <categoryLinks>
-                <categoryLink id="c88d-b283-6386-016b" name="Corrupted Sub-type:" hidden="false" targetId="9055-7410-8ffd-b8e7" primary="false"/>
+                <categoryLink id="c88d-b283-6386-016b" name="Corrupted Sub-type" hidden="false" targetId="9055-7410-8ffd-b8e7" primary="false"/>
                 <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="6f32-8270-4972-8a48" name="Infantry" primary="false"/>
               </categoryLinks>
               <selectionEntryGroups>
@@ -3491,7 +3491,7 @@
                 <constraint field="selections" scope="parent" value="10" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4ead-43c2-d3d5-b42c" type="max"/>
               </constraints>
               <categoryLinks>
-                <categoryLink id="6301-3df0-f6f7-94de" name="Corrupted Sub-type:" hidden="false" targetId="9055-7410-8ffd-b8e7" primary="false"/>
+                <categoryLink id="6301-3df0-f6f7-94de" name="Corrupted Sub-type" hidden="false" targetId="9055-7410-8ffd-b8e7" primary="false"/>
                 <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="e3f3-2749-4f3a-9cca" name="Infantry" primary="false"/>
               </categoryLinks>
               <entryLinks>
@@ -3533,7 +3533,7 @@
                 <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6d16-a540-deb6-3415" type="max"/>
               </constraints>
               <categoryLinks>
-                <categoryLink id="0e5d-ec08-8f11-ae1e" name="Corrupted Sub-type:" hidden="false" targetId="9055-7410-8ffd-b8e7" primary="false"/>
+                <categoryLink id="0e5d-ec08-8f11-ae1e" name="Corrupted Sub-type" hidden="false" targetId="9055-7410-8ffd-b8e7" primary="false"/>
                 <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="22e3-6e1d-4a69-9892" name="Infantry" primary="false"/>
               </categoryLinks>
               <selectionEntryGroups>
@@ -3612,7 +3612,7 @@
                 <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="69fc-c9bd-3575-3cbd" type="max"/>
               </constraints>
               <categoryLinks>
-                <categoryLink id="2922-5ff8-d70b-c7da" name="Corrupted Sub-type:" hidden="false" targetId="9055-7410-8ffd-b8e7" primary="false"/>
+                <categoryLink id="2922-5ff8-d70b-c7da" name="Corrupted Sub-type" hidden="false" targetId="9055-7410-8ffd-b8e7" primary="false"/>
                 <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="6e92-a123-4e33-ab13" name="Infantry" primary="false"/>
               </categoryLinks>
               <selectionEntryGroups>
@@ -3999,7 +3999,7 @@ In addition, once per battle, one friendly unit composed entirely of models with
       <categoryLinks>
         <categoryLink id="768a-11a0-1cb1-d896" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="75a1-c482-1a18-e139" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="1937-18d3-3af6-806c" name="Heavy Sub-type:" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+        <categoryLink id="1937-18d3-3af6-806c" name="Heavy Sub-type" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
         <categoryLink id="fd96-34a3-5cd2-680a" name="Jump Infantry:" hidden="false" targetId="eee8-3c7c-2762-e33e" primary="false"/>
       </categoryLinks>
       <selectionEntries>
@@ -4255,9 +4255,9 @@ In addition, once per battle, one friendly unit composed entirely of models with
         </infoLink>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="384c-208d-03b6-bd42" name="Corrupted Sub-type:" hidden="false" targetId="9055-7410-8ffd-b8e7" primary="false"/>
+        <categoryLink id="384c-208d-03b6-bd42" name="Corrupted Sub-type" hidden="false" targetId="9055-7410-8ffd-b8e7" primary="false"/>
         <categoryLink id="03be-92b3-01a3-c1ff" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="e23d-5f58-c4d7-7506" name="Dreadnought Unit-type:" hidden="false" targetId="4280-4963-02b5-e31d" primary="false"/>
+        <categoryLink id="e23d-5f58-c4d7-7506" name="Dreadnought Unit Type" hidden="false" targetId="4280-4963-02b5-e31d" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="41a2-9e23-99ea-0e6d" name="Exchange Warpfire cannon for:" hidden="false" collective="false" import="true" defaultSelectionEntryId="ed3c-bdac-aec7-ab09">
@@ -4372,7 +4372,7 @@ In addition, once per battle, one friendly unit composed entirely of models with
         <infoLink id="80b6-d93b-76ac-ef8e" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="12b2-c421-a2f1-8907" name="Corrupted Sub-type:" hidden="false" targetId="9055-7410-8ffd-b8e7" primary="false"/>
+        <categoryLink id="12b2-c421-a2f1-8907" name="Corrupted Sub-type" hidden="false" targetId="9055-7410-8ffd-b8e7" primary="false"/>
         <categoryLink id="f886-4ca2-1868-07e2" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="52a9-15b7-149f-b6d7" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
       </categoryLinks>
@@ -4489,7 +4489,7 @@ In addition, once per battle, one friendly unit composed entirely of models with
       </infoLinks>
       <categoryLinks>
         <categoryLink id="a847-6e8a-66a4-fa17" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="c096-bb42-1c27-67a6" name="Corrupted Sub-type:" hidden="false" targetId="9055-7410-8ffd-b8e7" primary="false"/>
+        <categoryLink id="c096-bb42-1c27-67a6" name="Corrupted Sub-type" hidden="false" targetId="9055-7410-8ffd-b8e7" primary="false"/>
         <categoryLink targetId="11f2-472f-c1d1-9ae9" id="6cc0-6682-2cc0-cd4c" primary="false" name="Legiones Astartes"/>
       </categoryLinks>
       <selectionEntries>
@@ -4626,7 +4626,7 @@ Psychic Weapon</description>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="d3d0-99c4-cb4c-969c" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="9acc-39e7-b768-439f" name="Corrupted Sub-type:" hidden="false" targetId="9055-7410-8ffd-b8e7" primary="false"/>
+        <categoryLink id="9acc-39e7-b768-439f" name="Corrupted Sub-type" hidden="false" targetId="9055-7410-8ffd-b8e7" primary="false"/>
         <categoryLink id="c6bf-c6ef-ae4a-4995" name="Psyker:" hidden="false" targetId="6e0c-29ba-a445-8321" primary="false"/>
         <categoryLink targetId="11f2-472f-c1d1-9ae9" id="8cd9-d390-1cf-5dad" primary="false" name="Legiones Astartes"/>
       </categoryLinks>
@@ -4952,7 +4952,7 @@ Threatening Entreaties - Kor Phaeron and the unit he has joined gain the Fearles
       </costs>
       <categoryLinks>
         <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="b4ae-65a-479b-cdc1" primary="false" name="Infantry:"/>
-        <categoryLink targetId="9055-7410-8ffd-b8e7" id="1c2-3805-b6f8-8b1b" primary="false" name="Corrupted Sub-type:"/>
+        <categoryLink targetId="9055-7410-8ffd-b8e7" id="1c2-3805-b6f8-8b1b" primary="false" name="Corrupted Sub-type"/>
         <categoryLink targetId="11f2-472f-c1d1-9ae9" id="cbe2-a552-1e8b-9dc7" primary="false" name="Legiones Astartes"/>
       </categoryLinks>
     </selectionEntry>
@@ -4982,7 +4982,7 @@ as the Aetheric Lightning Psychic Weapon</description>
       <categoryLinks>
         <categoryLink id="cd36-7aef-4bad-b59e" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="9ace-0389-f30c-2062" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="d74c-384e-1128-4d7a" name="Corrupted Sub-type:" hidden="false" targetId="9055-7410-8ffd-b8e7" primary="false"/>
+        <categoryLink id="d74c-384e-1128-4d7a" name="Corrupted Sub-type" hidden="false" targetId="9055-7410-8ffd-b8e7" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="2bac-34cb-8346-fc49" name="The Azurda Char&apos;is" hidden="false" collective="false" import="true" type="upgrade">
@@ -5610,7 +5610,7 @@ as the Aetheric Lightning Psychic Weapon</description>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="7d80-70a7-dba9-1c46" name="Daemon Unit-type:" hidden="false" targetId="e699-d9cd-e68e-46d9" primary="false"/>
+        <categoryLink id="7d80-70a7-dba9-1c46" name="Daemon Unit Type" hidden="false" targetId="e699-d9cd-e68e-46d9" primary="false"/>
         <categoryLink id="bda0-69f3-9a67-867f" name="Bound Sub-type" hidden="false" targetId="40f3-05e8-5ddc-636a" primary="false"/>
       </categoryLinks>
       <entryLinks>
@@ -5631,7 +5631,7 @@ as the Aetheric Lightning Psychic Weapon</description>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="79f6-f16e-4baa-1c37" name="Daemon Unit-type:" hidden="false" targetId="e699-d9cd-e68e-46d9" primary="false"/>
+        <categoryLink id="79f6-f16e-4baa-1c37" name="Daemon Unit Type" hidden="false" targetId="e699-d9cd-e68e-46d9" primary="false"/>
         <categoryLink id="2c84-da60-2762-c184" name="Bound Sub-type" hidden="false" targetId="40f3-05e8-5ddc-636a" primary="false"/>
       </categoryLinks>
       <entryLinks>
@@ -5647,7 +5647,7 @@ as the Aetheric Lightning Psychic Weapon</description>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20"/>
       </costs>
       <categoryLinks>
-        <categoryLink targetId="e699-d9cd-e68e-46d9" id="48cc-b473-1a79-be8c" primary="false" name="Daemon Unit-type:"/>
+        <categoryLink targetId="e699-d9cd-e68e-46d9" id="48cc-b473-1a79-be8c" primary="false" name="Daemon Unit Type"/>
       </categoryLinks>
       <entryLinks>
         <entryLink import="true" name="Daemon Beasts" hidden="false" type="selectionEntryGroup" id="b39c-e914-bea9-2003" targetId="8d09-1913-b79f-5c35"/>
@@ -5697,7 +5697,7 @@ as the Aetheric Lightning Psychic Weapon</description>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15"/>
       </costs>
       <categoryLinks>
-        <categoryLink targetId="e699-d9cd-e68e-46d9" id="bc68-8fc2-6f1a-9183" primary="false" name="Daemon Unit-type:"/>
+        <categoryLink targetId="e699-d9cd-e68e-46d9" id="bc68-8fc2-6f1a-9183" primary="false" name="Daemon Unit Type"/>
       </categoryLinks>
       <entryLinks>
         <entryLink import="true" name="Daemon Brute" hidden="false" type="selectionEntry" id="f0e3-7d1f-1f4d-ed7b" targetId="e3e-4f46-2300-a35"/>
@@ -5741,7 +5741,7 @@ as the Aetheric Lightning Psychic Weapon</description>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Greater Ruinstorm Daemon Beast (Lorgar)" hidden="false" id="59d-9e40-117a-7a34">
       <categoryLinks>
-        <categoryLink targetId="e699-d9cd-e68e-46d9" id="f5ce-e236-b5a1-66b4" primary="false" name="Daemon Unit-type:"/>
+        <categoryLink targetId="e699-d9cd-e68e-46d9" id="f5ce-e236-b5a1-66b4" primary="false" name="Daemon Unit Type"/>
       </categoryLinks>
       <infoLinks>
         <infoLink id="2b72-655d-a776-8d5" name="Traitor" hidden="false" targetId="eff2-8b0e-21da-2f0d" type="rule"/>
@@ -5788,7 +5788,7 @@ as the Aetheric Lightning Psychic Weapon</description>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Ruinstorm Daemon Behemoth (Lorgar)" hidden="false" id="6344-7863-4f0b-deaa">
       <categoryLinks>
-        <categoryLink targetId="e699-d9cd-e68e-46d9" id="6e1b-ee35-4c8a-fd38" primary="false" name="Daemon Unit-type:"/>
+        <categoryLink targetId="e699-d9cd-e68e-46d9" id="6e1b-ee35-4c8a-fd38" primary="false" name="Daemon Unit Type"/>
       </categoryLinks>
       <infoLinks>
         <infoLink id="b17d-c4a8-8ce4-4b5f" name="Traitor" hidden="false" targetId="eff2-8b0e-21da-2f0d" type="rule"/>
@@ -5842,7 +5842,7 @@ as the Aetheric Lightning Psychic Weapon</description>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Ruinstorm Daemon Cavalry (Lorgar)" hidden="false" id="f2d-471c-3b99-1752">
       <categoryLinks>
-        <categoryLink targetId="e699-d9cd-e68e-46d9" id="c8c4-6415-5261-6ead" primary="false" name="Daemon Unit-type:"/>
+        <categoryLink targetId="e699-d9cd-e68e-46d9" id="c8c4-6415-5261-6ead" primary="false" name="Daemon Unit Type"/>
       </categoryLinks>
       <infoLinks>
         <infoLink id="ebc7-6015-e730-7897" name="Traitor" hidden="false" targetId="eff2-8b0e-21da-2f0d" type="rule"/>
@@ -5872,7 +5872,7 @@ as the Aetheric Lightning Psychic Weapon</description>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Ruinstorm Daemon Harbinger (Lorgar/Erebus)" hidden="false" id="8599-a03d-8af7-4ba1">
       <categoryLinks>
-        <categoryLink targetId="e699-d9cd-e68e-46d9" id="53d3-afc9-2661-13ec" primary="false" name="Daemon Unit-type:"/>
+        <categoryLink targetId="e699-d9cd-e68e-46d9" id="53d3-afc9-2661-13ec" primary="false" name="Daemon Unit Type"/>
       </categoryLinks>
       <infoLinks>
         <infoLink id="bbf7-b35d-7a50-b5d5" name="Traitor" hidden="false" targetId="eff2-8b0e-21da-2f0d" type="rule"/>
@@ -5895,7 +5895,7 @@ as the Aetheric Lightning Psychic Weapon</description>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Ruinstorm Daemon Hierarch (Lorgar/Erebus)" hidden="false" id="e9d5-f180-aedf-521b">
       <categoryLinks>
-        <categoryLink targetId="e699-d9cd-e68e-46d9" id="2a0a-a768-c8f2-3324" primary="false" name="Daemon Unit-type:"/>
+        <categoryLink targetId="e699-d9cd-e68e-46d9" id="2a0a-a768-c8f2-3324" primary="false" name="Daemon Unit Type"/>
         <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="2f84-e203-3535-72b5" primary="false" name="Character"/>
       </categoryLinks>
       <infoLinks>
@@ -5952,7 +5952,7 @@ as the Aetheric Lightning Psychic Weapon</description>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Ruinstorm Daemon Harriers (Lorgar)" hidden="false" id="8c8f-683c-4690-4c3c">
       <categoryLinks>
-        <categoryLink targetId="e699-d9cd-e68e-46d9" id="7fd5-6b88-af84-bef0" primary="false" name="Daemon Unit-type:"/>
+        <categoryLink targetId="e699-d9cd-e68e-46d9" id="7fd5-6b88-af84-bef0" primary="false" name="Daemon Unit Type"/>
       </categoryLinks>
       <infoLinks>
         <infoLink id="a5e9-89f4-2704-53fe" name="Traitor" hidden="false" targetId="eff2-8b0e-21da-2f0d" type="rule"/>
@@ -5987,8 +5987,8 @@ as the Aetheric Lightning Psychic Weapon</description>
     </selectionEntry>
     <selectionEntry type="unit" import="false" name="Ruinstorm Lesser Daemons (Lorgar)" hidden="false" id="1aef-763e-42a7-b78f">
       <categoryLinks>
-        <categoryLink targetId="e699-d9cd-e68e-46d9" id="23a3-c4d7-8831-3eb2" primary="false" name="Daemon Unit-type:"/>
-        <categoryLink targetId="6399-5c65-7833-1025" id="ae29-4f5d-f3dd-402e" primary="false" name="Line Sub-type:"/>
+        <categoryLink targetId="e699-d9cd-e68e-46d9" id="23a3-c4d7-8831-3eb2" primary="false" name="Daemon Unit Type"/>
+        <categoryLink targetId="6399-5c65-7833-1025" id="ae29-4f5d-f3dd-402e" primary="false" name="Line Sub-type"/>
       </categoryLinks>
       <infoLinks>
         <infoLink id="f636-8cf-71e0-b493" name="Traitor" hidden="false" targetId="eff2-8b0e-21da-2f0d" type="rule"/>
@@ -6035,9 +6035,9 @@ as the Aetheric Lightning Psychic Weapon</description>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Ruinstorm Daemon Swarms (Lorgar)" hidden="false" id="646-b4d8-aea6-60a0">
       <categoryLinks>
-        <categoryLink targetId="e699-d9cd-e68e-46d9" id="b7e9-9709-82e1-ffd4" primary="false" name="Daemon Unit-type:"/>
-        <categoryLink targetId="6399-5c65-7833-1025" id="39ee-bc17-dcb4-d386" primary="false" name="Line Sub-type:"/>
-        <categoryLink targetId="59a4-7b61-600a-c457" id="a692-da86-b596-2a3b" primary="false" name="Skirmish Sub-type:"/>
+        <categoryLink targetId="e699-d9cd-e68e-46d9" id="b7e9-9709-82e1-ffd4" primary="false" name="Daemon Unit Type"/>
+        <categoryLink targetId="6399-5c65-7833-1025" id="39ee-bc17-dcb4-d386" primary="false" name="Line Sub-type"/>
+        <categoryLink targetId="59a4-7b61-600a-c457" id="a692-da86-b596-2a3b" primary="false" name="Skirmish Sub-type"/>
       </categoryLinks>
       <infoLinks>
         <infoLink id="8f7c-636-d15e-b4ef" name="Traitor" hidden="false" targetId="eff2-8b0e-21da-2f0d" type="rule"/>
@@ -6063,8 +6063,8 @@ as the Aetheric Lightning Psychic Weapon</description>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Ruinstorm Daemon Sovereign (Lorgar/Erebus)" hidden="false" id="e0f2-1da3-accb-7ac2">
       <categoryLinks>
-        <categoryLink targetId="e699-d9cd-e68e-46d9" id="f2b9-2820-94e3-a6b9" primary="false" name="Daemon Unit-type:"/>
-        <categoryLink targetId="7d95-f9d1-440a-67bd" id="e4b-18cd-9de8-5814" primary="false" name="Monstrous Sub-type:"/>
+        <categoryLink targetId="e699-d9cd-e68e-46d9" id="f2b9-2820-94e3-a6b9" primary="false" name="Daemon Unit Type"/>
+        <categoryLink targetId="7d95-f9d1-440a-67bd" id="e4b-18cd-9de8-5814" primary="false" name="Monstrous Sub-type"/>
         <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="a5e1-3abd-adf9-6e46" primary="false" name="Character"/>
       </categoryLinks>
       <infoLinks>

--- a/2022 - LA - World Eaters.cat
+++ b/2022 - LA - World Eaters.cat
@@ -3053,7 +3053,7 @@
       </infoLinks>
       <categoryLinks>
         <categoryLink id="5c3d-505d-be3a-0021" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="ee5e-db50-34f8-2da8" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="ee5e-db50-34f8-2da8" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="bb97-5922-24bd-d6ca" name="Blood Bonded" hidden="false" collective="false" import="true" type="model">
@@ -3087,7 +3087,7 @@
           </profiles>
           <categoryLinks>
             <categoryLink id="4669-76c5-d1bf-0aaf" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
-            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="4858-2d5b-438c-887c" name="Infantry" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="4858-2d5b-438c-887c" name="Infantry Unit Type" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="8446-e737-b3cc-945c" name="Melee Options:" hidden="false" collective="false" import="true" defaultSelectionEntryId="0fb2-28ae-2339-eeb5">
@@ -3256,7 +3256,7 @@
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15"/>
               </costs>
               <categoryLinks>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="e864-73f4-4eac-8089" name="Infantry" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="e864-73f4-4eac-8089" name="Infantry Unit Type" primary="false"/>
               </categoryLinks>
             </selectionEntry>
             <selectionEntry id="34ff-115f-b2ad-9c40" name="Ravager w/ Heavy Weapon (1 in every 5)" hidden="false" collective="false" import="true" type="model">
@@ -3358,7 +3358,7 @@
                 <infoLink name="Ravager" hidden="false" type="profile" id="b4dd-5bcc-668f-365a" targetId="2b72-66e9-2e1c-797c"/>
               </infoLinks>
               <categoryLinks>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="fdf7-5bcf-44da-bc04" name="Infantry" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="fdf7-5bcf-44da-bc04" name="Infantry Unit Type" primary="false"/>
               </categoryLinks>
             </selectionEntry>
             <selectionEntry id="b2c4-34be-a4a0-03ee" name="Ravager w/Excoriator Chainaxe" hidden="false" collective="false" import="true" type="model">
@@ -3386,7 +3386,7 @@
                 <infoLink name="Ravager" hidden="false" type="profile" id="cb8e-660-d8de-5fd5" targetId="2b72-66e9-2e1c-797c"/>
               </infoLinks>
               <categoryLinks>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="748b-2a05-40c7-bb4d" name="Infantry" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="748b-2a05-40c7-bb4d" name="Infantry Unit Type" primary="false"/>
               </categoryLinks>
             </selectionEntry>
             <selectionEntry id="5eb0-975c-8626-1f99" name="Ravager w/Meteor Hammer" hidden="false" collective="false" import="true" type="model">
@@ -3414,7 +3414,7 @@
                 <infoLink name="Ravager" hidden="false" type="profile" id="5a5c-8cf1-3ada-b0da" targetId="2b72-66e9-2e1c-797c"/>
               </infoLinks>
               <categoryLinks>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="fc39-ad6c-49b8-9b3a" name="Infantry" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="fc39-ad6c-49b8-9b3a" name="Infantry Unit Type" primary="false"/>
               </categoryLinks>
             </selectionEntry>
             <selectionEntry id="c247-33d8-5da1-c5fd" name="Ravager w/Two Falax Blades" hidden="false" collective="false" import="true" type="model">
@@ -3442,7 +3442,7 @@
                 <infoLink name="Ravager" hidden="false" type="profile" id="781a-1127-db6d-73cc" targetId="2b72-66e9-2e1c-797c"/>
               </infoLinks>
               <categoryLinks>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="e5f0-46da-4c71-b1bc" name="Infantry" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="e5f0-46da-4c71-b1bc" name="Infantry Unit Type" primary="false"/>
               </categoryLinks>
             </selectionEntry>
             <selectionEntry id="51a0-5dd3-f296-2d25" name="Ravager w/Barb-Hook Lash" hidden="false" collective="false" import="true" type="model">
@@ -3470,7 +3470,7 @@
                 <infoLink name="Ravager" hidden="false" type="profile" id="6f8b-d67e-29e4-6996" targetId="2b72-66e9-2e1c-797c"/>
               </infoLinks>
               <categoryLinks>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="539b-4fb6-44cb-bff2" name="Infantry" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="539b-4fb6-44cb-bff2" name="Infantry Unit Type" primary="false"/>
               </categoryLinks>
             </selectionEntry>
             <selectionEntry id="b0a9-c7ec-cf42-ee1a" name="Ravager w/Chainaxe" hidden="false" collective="false" import="true" type="model">
@@ -3501,7 +3501,7 @@
                 <infoLink name="Ravager" hidden="false" type="profile" id="5c7f-1c16-2339-a1b3" targetId="2b72-66e9-2e1c-797c"/>
               </infoLinks>
               <categoryLinks>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="33f4-b544-47c6-9d4e" name="Infantry" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="33f4-b544-47c6-9d4e" name="Infantry Unit Type" primary="false"/>
               </categoryLinks>
             </selectionEntry>
           </selectionEntries>
@@ -3572,7 +3572,7 @@
         </infoLink>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="6018-e91b-ef03-2ee3" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="6018-e91b-ef03-2ee3" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="66fc-9632-84b0-aa90" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
       </categoryLinks>
       <selectionEntries>
@@ -3611,9 +3611,9 @@
         <selectionEntry type="model" import="true" name="Shabran Darr" hidden="false" id="8b51-4189-994a-459c">
           <categoryLinks>
             <categoryLink targetId="4f07-3d45-4f28-a0c6" id="6642-9b2c-cc5a-4f62" primary="false" name="Independent Character"/>
-            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="bcbf-c141-4371-b0dd" name="Infantry" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="bcbf-c141-4371-b0dd" name="Infantry Unit Type" primary="false"/>
             <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="0914-c2ec-412a-b256" name="Character" primary="false"/>
-            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="1859-53ae-4e6d-89ae" name="Unique" primary="false"/>
+            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="1859-53ae-4e6d-89ae" name="Unique Sub-type" primary="false"/>
           </categoryLinks>
           <constraints>
             <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="867-990a-65b-ab7d"/>
@@ -3740,7 +3740,7 @@
       </infoLinks>
       <categoryLinks>
         <categoryLink id="dac3-55aa-0d1b-36b7" name="Heavy Sub-type" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
-        <categoryLink id="cf1c-50e5-11f5-a5c0" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="cf1c-50e5-11f5-a5c0" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="080b-8aab-b802-323a" name="Terminators:" hidden="false" targetId="bab3-f50d-3e5f-2f78" primary="false"/>
         <categoryLink id="4259-2c1a-9160-12f3" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
       </categoryLinks>
@@ -3769,8 +3769,8 @@
           </profiles>
           <categoryLinks>
             <categoryLink id="e96c-7be7-50c9-2e1d" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
-            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="1fb3-b0eb-4d62-997c" name="Infantry" primary="false"/>
-            <categoryLink targetId="9231-183c-b97b-63f9" id="442c-8149-4f89-8bcd" name="Heavy" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="1fb3-b0eb-4d62-997c" name="Infantry Unit Type" primary="false"/>
+            <categoryLink targetId="9231-183c-b97b-63f9" id="442c-8149-4f89-8bcd" name="Heavy Sub-type" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="a999-8d13-e96f-b721" name="Weapon Options" hidden="false" collective="false" import="true" defaultSelectionEntryId="83ef-25d3-f484-916e">
@@ -3947,7 +3947,7 @@
               </profiles>
               <categoryLinks>
                 <categoryLink id="3350-d90c-ee36-ecdb" name="Heavy Sub-type" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="6ea4-c054-4d0c-a8f5" name="Infantry" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="6ea4-c054-4d0c-a8f5" name="Infantry Unit Type" primary="false"/>
               </categoryLinks>
               <entryLinks>
                 <entryLink id="0dba-da69-d791-9dfa" name="Pair of Lightning Claws" hidden="false" collective="false" import="true" targetId="405f-030d-0343-ade8" type="selectionEntry">
@@ -3964,7 +3964,7 @@
             <selectionEntry id="7916-ca80-5a20-cfbb" name="Red Butcher (Pair of Power Axes)" hidden="false" collective="false" import="true" type="model">
               <categoryLinks>
                 <categoryLink id="1a75-21e4-e926-1808" name="Heavy Sub-type" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="cbce-ba50-45a3-a493" name="Infantry" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="cbce-ba50-45a3-a493" name="Infantry Unit Type" primary="false"/>
               </categoryLinks>
               <entryLinks>
                 <entryLink id="29a6-069f-4daa-a55a" name="Power Axe" hidden="false" collective="false" import="true" targetId="ef98-66ac-fcaf-c15d" type="selectionEntry">
@@ -3987,7 +3987,7 @@
             <selectionEntry id="f307-35b7-3b94-91a6" name="Red Butcher (Power Axe &amp; Combi-Bolter)" hidden="false" collective="false" import="true" type="model">
               <categoryLinks>
                 <categoryLink id="bdb6-5467-8aaf-75a8" name="Heavy Sub-type" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="52bb-ca25-4fa0-82e4" name="Infantry" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="52bb-ca25-4fa0-82e4" name="Infantry Unit Type" primary="false"/>
               </categoryLinks>
               <entryLinks>
                 <entryLink id="fa41-1e69-487d-b1ae" name="Combi-Bolter" hidden="false" collective="false" import="true" targetId="0f3d-c07c-7a7e-d534" type="selectionEntry">
@@ -4076,7 +4076,7 @@
       </infoLinks>
       <categoryLinks>
         <categoryLink id="27fd-7bde-4c05-e9f2" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="56af-118e-8128-ae96" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="56af-118e-8128-ae96" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="2ef5-6070-0e71-2776" name="Infantry Only" hidden="false" targetId="db6f-0311-834c-e6ff" primary="false"/>
       </categoryLinks>
       <selectionEntries>
@@ -4111,7 +4111,7 @@
           </profiles>
           <categoryLinks>
             <categoryLink id="922f-b976-ade5-4768" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
-            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="5244-b491-48ad-8351" name="Infantry" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="5244-b491-48ad-8351" name="Infantry Unit Type" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="0100-9dff-9956-9429" name="1) Melee Choice:" hidden="false" collective="false" import="true" defaultSelectionEntryId="40be-76c5-f7cd-772d">
@@ -4325,7 +4325,7 @@
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="22"/>
               </costs>
               <categoryLinks>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="fa7e-d0a9-4b94-8875" name="Infantry" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="fa7e-d0a9-4b94-8875" name="Infantry Unit Type" primary="false"/>
               </categoryLinks>
             </selectionEntry>
             <selectionEntry id="0b24-339a-5ddf-2a79" name="Rampager w/Barb-Hook Lash" hidden="false" collective="false" import="true" type="model">
@@ -4350,7 +4350,7 @@
                 <infoLink id="8956-2749-056d-0471" name="Rampager" targetId="ee6c-d04f-7553-d244" type="profile"/>
               </infoLinks>
               <categoryLinks>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="af16-64dd-4f84-a25a" name="Infantry" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="af16-64dd-4f84-a25a" name="Infantry Unit Type" primary="false"/>
               </categoryLinks>
             </selectionEntry>
             <selectionEntry id="3899-2854-4fd9-0cb2" name="Rampager w/Excoriator Chainaxe" hidden="false" collective="false" import="true" type="model">
@@ -4375,7 +4375,7 @@
                 <infoLink id="b7b4-1906-7c02-957c" name="Rampager" targetId="ee6c-d04f-7553-d244" type="profile"/>
               </infoLinks>
               <categoryLinks>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="f027-64b2-4f1f-b987" name="Infantry" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="f027-64b2-4f1f-b987" name="Infantry Unit Type" primary="false"/>
               </categoryLinks>
             </selectionEntry>
             <selectionEntry id="95de-f8f7-2d72-a4cd" name="Rampager w/Two Falax Blade" hidden="false" collective="false" import="true" type="model">
@@ -4403,7 +4403,7 @@
                 <infoLink id="6d34-d492-9160-1a86" name="Rampager" targetId="ee6c-d04f-7553-d244" type="profile"/>
               </infoLinks>
               <categoryLinks>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="0fba-2eeb-4033-96de" name="Infantry" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="0fba-2eeb-4033-96de" name="Infantry Unit Type" primary="false"/>
               </categoryLinks>
             </selectionEntry>
             <selectionEntry id="0a53-f8b4-252e-5c23" name="Rampager w/Meteor Hammer" hidden="false" collective="false" import="true" type="model">
@@ -4428,7 +4428,7 @@
                 <infoLink id="94f8-1ea3-03ed-90e7" name="Rampager" targetId="ee6c-d04f-7553-d244" type="profile"/>
               </infoLinks>
               <categoryLinks>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="6505-c327-493c-a3cf" name="Infantry" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="6505-c327-493c-a3cf" name="Infantry Unit Type" primary="false"/>
               </categoryLinks>
             </selectionEntry>
           </selectionEntries>
@@ -4611,8 +4611,8 @@
         <selectionEntry type="model" import="true" name="Angron" hidden="false" id="609e-d127-8155-f471">
           <categoryLinks>
             <categoryLink targetId="4f07-3d45-4f28-a0c6" id="6641-24c8-ae1f-4633" primary="false" name="Independent Character"/>
-            <categoryLink targetId="ad5f-31db-8bc7-5c46" id="220c-a163-47cd-85ce" name="Primarch" primary="false"/>
-            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="c3a3-30f4-41ea-aeef" name="Unique" primary="false"/>
+            <categoryLink targetId="ad5f-31db-8bc7-5c46" id="220c-a163-47cd-85ce" name="Primarch:" primary="false"/>
+            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="c3a3-30f4-41ea-aeef" name="Unique Sub-type" primary="false"/>
           </categoryLinks>
           <constraints>
             <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="867-990a-65b-ab7d"/>
@@ -4685,7 +4685,7 @@
         <infoLink id="b04b-077c-a729-1a77" name="Legiones Astartes (World Eaters)" hidden="false" targetId="405d-019f-9ef6-423c" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="9218-c0cc-8dc7-a683" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="9218-c0cc-8dc7-a683" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="58d8-8eda-8902-2a74" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink targetId="b81a-8f4a-ff50-ef99" id="6990-d385-815e-4427" primary="false" name="Primus Medicae"/>
       </categoryLinks>
@@ -4716,9 +4716,9 @@
         <selectionEntry type="model" import="true" name="Gahlan Surlak" hidden="false" id="5685-4f6b-eb83-ba22">
           <categoryLinks>
             <categoryLink targetId="4f07-3d45-4f28-a0c6" id="f768-c27b-57ba-b2a6" primary="false" name="Independent Character"/>
-            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="0a36-e4cd-48b9-9afd" name="Infantry" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="0a36-e4cd-48b9-9afd" name="Infantry Unit Type" primary="false"/>
             <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="8b6a-5dd8-4247-b435" name="Character" primary="false"/>
-            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="d064-f6ab-40e2-b89d" name="Unique" primary="false"/>
+            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="d064-f6ab-40e2-b89d" name="Unique Sub-type" primary="false"/>
           </categoryLinks>
           <constraints>
             <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="867-990a-65b-ab7d"/>
@@ -4825,7 +4825,7 @@
       </infoLinks>
       <categoryLinks>
         <categoryLink id="6d76-7591-3f6a-4f2c" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="2e2e-a670-504f-7861" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="2e2e-a670-504f-7861" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="3017-90ed-f8d5-20fb" name="Melee Weapon" hidden="false" collective="false" import="true">
@@ -4949,9 +4949,9 @@
         <selectionEntry type="model" import="true" name="Khârn the Bloody" hidden="false" id="6dd3-d166-c125-c354">
           <categoryLinks>
             <categoryLink targetId="4f07-3d45-4f28-a0c6" id="1152-3d1-9b16-dc4b" primary="false" name="Independent Character"/>
-            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="4d2a-1bf7-4788-a1b6" name="Infantry" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="4d2a-1bf7-4788-a1b6" name="Infantry Unit Type" primary="false"/>
             <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="805b-dffb-4c9c-8bbd" name="Character" primary="false"/>
-            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="df03-64ee-4075-b597" name="Unique" primary="false"/>
+            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="df03-64ee-4075-b597" name="Unique Sub-type" primary="false"/>
           </categoryLinks>
           <constraints>
             <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="867-990a-65b-ab7d"/>

--- a/2022 - LA - World Eaters.cat
+++ b/2022 - LA - World Eaters.cat
@@ -2694,7 +2694,7 @@
       <categoryLinks>
         <categoryLink id="63ff-0a92-42ab-ae8c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="204c-7b0f-4fb9-b1b3" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="85e6-cb31-427c-a040" name="Line Sub-type:" hidden="false" targetId="6399-5c65-7833-1025" primary="false"/>
+        <categoryLink id="85e6-cb31-427c-a040" name="Line Sub-type" hidden="false" targetId="6399-5c65-7833-1025" primary="false"/>
         <categoryLink id="8197-2ef4-84d5-a84a" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -3739,7 +3739,7 @@
         <infoLink id="9f9a-d927-04d9-579a" name="Ravening Madmen" hidden="false" targetId="1864-f270-d462-ecb5" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="dac3-55aa-0d1b-36b7" name="Heavy Sub-type:" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+        <categoryLink id="dac3-55aa-0d1b-36b7" name="Heavy Sub-type" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
         <categoryLink id="cf1c-50e5-11f5-a5c0" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="080b-8aab-b802-323a" name="Terminators:" hidden="false" targetId="bab3-f50d-3e5f-2f78" primary="false"/>
         <categoryLink id="4259-2c1a-9160-12f3" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
@@ -3946,7 +3946,7 @@
                 </profile>
               </profiles>
               <categoryLinks>
-                <categoryLink id="3350-d90c-ee36-ecdb" name="Heavy Sub-type:" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+                <categoryLink id="3350-d90c-ee36-ecdb" name="Heavy Sub-type" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
                 <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="6ea4-c054-4d0c-a8f5" name="Infantry" primary="false"/>
               </categoryLinks>
               <entryLinks>
@@ -3963,7 +3963,7 @@
             </selectionEntry>
             <selectionEntry id="7916-ca80-5a20-cfbb" name="Red Butcher (Pair of Power Axes)" hidden="false" collective="false" import="true" type="model">
               <categoryLinks>
-                <categoryLink id="1a75-21e4-e926-1808" name="Heavy Sub-type:" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+                <categoryLink id="1a75-21e4-e926-1808" name="Heavy Sub-type" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
                 <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="cbce-ba50-45a3-a493" name="Infantry" primary="false"/>
               </categoryLinks>
               <entryLinks>
@@ -3986,7 +3986,7 @@
             </selectionEntry>
             <selectionEntry id="f307-35b7-3b94-91a6" name="Red Butcher (Power Axe &amp; Combi-Bolter)" hidden="false" collective="false" import="true" type="model">
               <categoryLinks>
-                <categoryLink id="bdb6-5467-8aaf-75a8" name="Heavy Sub-type:" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+                <categoryLink id="bdb6-5467-8aaf-75a8" name="Heavy Sub-type" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
                 <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="52bb-ca25-4fa0-82e4" name="Infantry" primary="false"/>
               </categoryLinks>
               <entryLinks>
@@ -4787,7 +4787,7 @@
           <profiles>
             <profile id="622f-954e-3ea4-4c59" name="Abhorrent Augmentations" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
               <characteristics>
-                <characteristic name="Text" typeId="c68e-2cda-b67b-baca">If Gahlan Surlak is chosen as the army&apos;s Warlord, before any models are deployed the controlling player may choose up to a total of three Legion Tactical Squads and Legion Despoiler Squads from the same Detachment as Gahlan Surlak to have Abhorrent Augmentations. These units gain Bitter Duty special rules along with +1 to their Strength characteristic, but suffer -1 to their BS and lose the Heart of the Legion special rule and Line Unit Sub-Type. In addition, an army whose Warlord is Gahlan Surlak may make an additional Reaction in the opposing player’s Movement phase, as long as Gahlan Surlak has not been removed as a casualty.</characteristic>
+                <characteristic name="Text" typeId="c68e-2cda-b67b-baca">If Gahlan Surlak is chosen as the army&apos;s Warlord, before any models are deployed the controlling player may choose up to a total of three Legion Tactical Squads and Legion Despoiler Squads from the same Detachment as Gahlan Surlak to have Abhorrent Augmentations. These units gain Bitter Duty special rules along with +1 to their Strength characteristic, but suffer -1 to their BS and lose the Heart of the Legion special rule and Line Unit Sub-type. In addition, an army whose Warlord is Gahlan Surlak may make an additional Reaction in the opposing player’s Movement phase, as long as Gahlan Surlak has not been removed as a casualty.</characteristic>
               </characteristics>
             </profile>
           </profiles>

--- a/2022 - LA - World Eaters.cat
+++ b/2022 - LA - World Eaters.cat
@@ -3087,6 +3087,7 @@
           </profiles>
           <categoryLinks>
             <categoryLink id="4669-76c5-d1bf-0aaf" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="4858-2d5b-438c-887c" name="Infantry" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="8446-e737-b3cc-945c" name="Melee Options:" hidden="false" collective="false" import="true" defaultSelectionEntryId="0fb2-28ae-2339-eeb5">
@@ -3254,6 +3255,9 @@
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15"/>
               </costs>
+              <categoryLinks>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="e864-73f4-4eac-8089" name="Infantry" primary="false"/>
+              </categoryLinks>
             </selectionEntry>
             <selectionEntry id="34ff-115f-b2ad-9c40" name="Ravager w/ Heavy Weapon (1 in every 5)" hidden="false" collective="false" import="true" type="model">
               <modifiers>
@@ -3353,6 +3357,9 @@
               <infoLinks>
                 <infoLink name="Ravager" hidden="false" type="profile" id="b4dd-5bcc-668f-365a" targetId="2b72-66e9-2e1c-797c"/>
               </infoLinks>
+              <categoryLinks>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="fdf7-5bcf-44da-bc04" name="Infantry" primary="false"/>
+              </categoryLinks>
             </selectionEntry>
             <selectionEntry id="b2c4-34be-a4a0-03ee" name="Ravager w/Excoriator Chainaxe" hidden="false" collective="false" import="true" type="model">
               <constraints>
@@ -3378,6 +3385,9 @@
               <infoLinks>
                 <infoLink name="Ravager" hidden="false" type="profile" id="cb8e-660-d8de-5fd5" targetId="2b72-66e9-2e1c-797c"/>
               </infoLinks>
+              <categoryLinks>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="748b-2a05-40c7-bb4d" name="Infantry" primary="false"/>
+              </categoryLinks>
             </selectionEntry>
             <selectionEntry id="5eb0-975c-8626-1f99" name="Ravager w/Meteor Hammer" hidden="false" collective="false" import="true" type="model">
               <constraints>
@@ -3403,6 +3413,9 @@
               <infoLinks>
                 <infoLink name="Ravager" hidden="false" type="profile" id="5a5c-8cf1-3ada-b0da" targetId="2b72-66e9-2e1c-797c"/>
               </infoLinks>
+              <categoryLinks>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="fc39-ad6c-49b8-9b3a" name="Infantry" primary="false"/>
+              </categoryLinks>
             </selectionEntry>
             <selectionEntry id="c247-33d8-5da1-c5fd" name="Ravager w/Two Falax Blades" hidden="false" collective="false" import="true" type="model">
               <constraints>
@@ -3428,6 +3441,9 @@
               <infoLinks>
                 <infoLink name="Ravager" hidden="false" type="profile" id="781a-1127-db6d-73cc" targetId="2b72-66e9-2e1c-797c"/>
               </infoLinks>
+              <categoryLinks>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="e5f0-46da-4c71-b1bc" name="Infantry" primary="false"/>
+              </categoryLinks>
             </selectionEntry>
             <selectionEntry id="51a0-5dd3-f296-2d25" name="Ravager w/Barb-Hook Lash" hidden="false" collective="false" import="true" type="model">
               <constraints>
@@ -3453,6 +3469,9 @@
               <infoLinks>
                 <infoLink name="Ravager" hidden="false" type="profile" id="6f8b-d67e-29e4-6996" targetId="2b72-66e9-2e1c-797c"/>
               </infoLinks>
+              <categoryLinks>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="539b-4fb6-44cb-bff2" name="Infantry" primary="false"/>
+              </categoryLinks>
             </selectionEntry>
             <selectionEntry id="b0a9-c7ec-cf42-ee1a" name="Ravager w/Chainaxe" hidden="false" collective="false" import="true" type="model">
               <constraints>
@@ -3481,6 +3500,9 @@
               <infoLinks>
                 <infoLink name="Ravager" hidden="false" type="profile" id="5c7f-1c16-2339-a1b3" targetId="2b72-66e9-2e1c-797c"/>
               </infoLinks>
+              <categoryLinks>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="33f4-b544-47c6-9d4e" name="Infantry" primary="false"/>
+              </categoryLinks>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
@@ -3589,6 +3611,9 @@
         <selectionEntry type="model" import="true" name="Shabran Darr" hidden="false" id="8b51-4189-994a-459c">
           <categoryLinks>
             <categoryLink targetId="4f07-3d45-4f28-a0c6" id="6642-9b2c-cc5a-4f62" primary="false" name="Independent Character"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="bcbf-c141-4371-b0dd" name="Infantry" primary="false"/>
+            <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="0914-c2ec-412a-b256" name="Character" primary="false"/>
+            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="1859-53ae-4e6d-89ae" name="Unique" primary="false"/>
           </categoryLinks>
           <constraints>
             <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="867-990a-65b-ab7d"/>
@@ -3744,6 +3769,8 @@
           </profiles>
           <categoryLinks>
             <categoryLink id="e96c-7be7-50c9-2e1d" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="1fb3-b0eb-4d62-997c" name="Infantry" primary="false"/>
+            <categoryLink targetId="9231-183c-b97b-63f9" id="442c-8149-4f89-8bcd" name="Heavy" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="a999-8d13-e96f-b721" name="Weapon Options" hidden="false" collective="false" import="true" defaultSelectionEntryId="83ef-25d3-f484-916e">
@@ -3920,6 +3947,7 @@
               </profiles>
               <categoryLinks>
                 <categoryLink id="3350-d90c-ee36-ecdb" name="Heavy Sub-type:" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="6ea4-c054-4d0c-a8f5" name="Infantry" primary="false"/>
               </categoryLinks>
               <entryLinks>
                 <entryLink id="0dba-da69-d791-9dfa" name="Pair of Lightning Claws" hidden="false" collective="false" import="true" targetId="405f-030d-0343-ade8" type="selectionEntry">
@@ -3936,6 +3964,7 @@
             <selectionEntry id="7916-ca80-5a20-cfbb" name="Red Butcher (Pair of Power Axes)" hidden="false" collective="false" import="true" type="model">
               <categoryLinks>
                 <categoryLink id="1a75-21e4-e926-1808" name="Heavy Sub-type:" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="cbce-ba50-45a3-a493" name="Infantry" primary="false"/>
               </categoryLinks>
               <entryLinks>
                 <entryLink id="29a6-069f-4daa-a55a" name="Power Axe" hidden="false" collective="false" import="true" targetId="ef98-66ac-fcaf-c15d" type="selectionEntry">
@@ -3958,6 +3987,7 @@
             <selectionEntry id="f307-35b7-3b94-91a6" name="Red Butcher (Power Axe &amp; Combi-Bolter)" hidden="false" collective="false" import="true" type="model">
               <categoryLinks>
                 <categoryLink id="bdb6-5467-8aaf-75a8" name="Heavy Sub-type:" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="52bb-ca25-4fa0-82e4" name="Infantry" primary="false"/>
               </categoryLinks>
               <entryLinks>
                 <entryLink id="fa41-1e69-487d-b1ae" name="Combi-Bolter" hidden="false" collective="false" import="true" targetId="0f3d-c07c-7a7e-d534" type="selectionEntry">
@@ -4081,6 +4111,7 @@
           </profiles>
           <categoryLinks>
             <categoryLink id="922f-b976-ade5-4768" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="5244-b491-48ad-8351" name="Infantry" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="0100-9dff-9956-9429" name="1) Melee Choice:" hidden="false" collective="false" import="true" defaultSelectionEntryId="40be-76c5-f7cd-772d">
@@ -4293,6 +4324,9 @@
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="22"/>
               </costs>
+              <categoryLinks>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="fa7e-d0a9-4b94-8875" name="Infantry" primary="false"/>
+              </categoryLinks>
             </selectionEntry>
             <selectionEntry id="0b24-339a-5ddf-2a79" name="Rampager w/Barb-Hook Lash" hidden="false" collective="false" import="true" type="model">
               <entryLinks>
@@ -4315,6 +4349,9 @@
               <infoLinks>
                 <infoLink id="8956-2749-056d-0471" name="Rampager" targetId="ee6c-d04f-7553-d244" type="profile"/>
               </infoLinks>
+              <categoryLinks>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="af16-64dd-4f84-a25a" name="Infantry" primary="false"/>
+              </categoryLinks>
             </selectionEntry>
             <selectionEntry id="3899-2854-4fd9-0cb2" name="Rampager w/Excoriator Chainaxe" hidden="false" collective="false" import="true" type="model">
               <entryLinks>
@@ -4337,6 +4374,9 @@
               <infoLinks>
                 <infoLink id="b7b4-1906-7c02-957c" name="Rampager" targetId="ee6c-d04f-7553-d244" type="profile"/>
               </infoLinks>
+              <categoryLinks>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="f027-64b2-4f1f-b987" name="Infantry" primary="false"/>
+              </categoryLinks>
             </selectionEntry>
             <selectionEntry id="95de-f8f7-2d72-a4cd" name="Rampager w/Two Falax Blade" hidden="false" collective="false" import="true" type="model">
               <entryLinks>
@@ -4362,6 +4402,9 @@
               <infoLinks>
                 <infoLink id="6d34-d492-9160-1a86" name="Rampager" targetId="ee6c-d04f-7553-d244" type="profile"/>
               </infoLinks>
+              <categoryLinks>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="0fba-2eeb-4033-96de" name="Infantry" primary="false"/>
+              </categoryLinks>
             </selectionEntry>
             <selectionEntry id="0a53-f8b4-252e-5c23" name="Rampager w/Meteor Hammer" hidden="false" collective="false" import="true" type="model">
               <entryLinks>
@@ -4384,6 +4427,9 @@
               <infoLinks>
                 <infoLink id="94f8-1ea3-03ed-90e7" name="Rampager" targetId="ee6c-d04f-7553-d244" type="profile"/>
               </infoLinks>
+              <categoryLinks>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="6505-c327-493c-a3cf" name="Infantry" primary="false"/>
+              </categoryLinks>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
@@ -4565,6 +4611,8 @@
         <selectionEntry type="model" import="true" name="Angron" hidden="false" id="609e-d127-8155-f471">
           <categoryLinks>
             <categoryLink targetId="4f07-3d45-4f28-a0c6" id="6641-24c8-ae1f-4633" primary="false" name="Independent Character"/>
+            <categoryLink targetId="ad5f-31db-8bc7-5c46" id="220c-a163-47cd-85ce" name="Primarch" primary="false"/>
+            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="c3a3-30f4-41ea-aeef" name="Unique" primary="false"/>
           </categoryLinks>
           <constraints>
             <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="867-990a-65b-ab7d"/>
@@ -4668,6 +4716,9 @@
         <selectionEntry type="model" import="true" name="Gahlan Surlak" hidden="false" id="5685-4f6b-eb83-ba22">
           <categoryLinks>
             <categoryLink targetId="4f07-3d45-4f28-a0c6" id="f768-c27b-57ba-b2a6" primary="false" name="Independent Character"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="0a36-e4cd-48b9-9afd" name="Infantry" primary="false"/>
+            <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="8b6a-5dd8-4247-b435" name="Character" primary="false"/>
+            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="d064-f6ab-40e2-b89d" name="Unique" primary="false"/>
           </categoryLinks>
           <constraints>
             <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="867-990a-65b-ab7d"/>
@@ -4898,6 +4949,9 @@
         <selectionEntry type="model" import="true" name="Khârn the Bloody" hidden="false" id="6dd3-d166-c125-c354">
           <categoryLinks>
             <categoryLink targetId="4f07-3d45-4f28-a0c6" id="1152-3d1-9b16-dc4b" primary="false" name="Independent Character"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="4d2a-1bf7-4788-a1b6" name="Infantry" primary="false"/>
+            <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="805b-dffb-4c9c-8bbd" name="Character" primary="false"/>
+            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="df03-64ee-4075-b597" name="Unique" primary="false"/>
           </categoryLinks>
           <constraints>
             <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="867-990a-65b-ab7d"/>

--- a/2022 - LA Template.cattemplate
+++ b/2022 - LA Template.cattemplate
@@ -1924,7 +1924,7 @@
       <categoryLinks>
         <categoryLink id="63ff-0a92-42ab-ae8c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="204c-7b0f-4fb9-b1b3" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="85e6-cb31-427c-a040" name="Line Sub-type:" hidden="false" targetId="6399-5c65-7833-1025" primary="false"/>
+        <categoryLink id="85e6-cb31-427c-a040" name="Line Sub-type" hidden="false" targetId="6399-5c65-7833-1025" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="60e9-649a-41dc-8dd7" name="Proteus Land Speeder Squadron" hidden="true" collective="false" import="false" targetId="a736-43ca-ed95-a08f" type="selectionEntry">

--- a/2022 - LI - Assassins.cat
+++ b/2022 - LI - Assassins.cat
@@ -33,8 +33,8 @@
       </infoLinks>
       <categoryLinks>
         <categoryLink id="0023-51b9-50b3-c66b" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
-        <categoryLink id="94df-4b0f-221f-9acc" name="Assassin Sub-Type" hidden="false" targetId="d615-c0e4-6d17-107e" primary="false"/>
-        <categoryLink id="1125-32ee-cd21-10ad" name="Light Sub-type:" hidden="false" targetId="bff2-ae16-74a8-8712" primary="false"/>
+        <categoryLink id="94df-4b0f-221f-9acc" name="Assassin Sub-type" hidden="false" targetId="d615-c0e4-6d17-107e" primary="false"/>
+        <categoryLink id="1125-32ee-cd21-10ad" name="Light Sub-type" hidden="false" targetId="bff2-ae16-74a8-8712" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="4605-a7c6-6a68-ec1e" name="Nemesil Blade" publicationId="15a4-fc68-502d-48a9" page="121" hidden="false" collective="false" import="true" type="upgrade">
@@ -198,9 +198,9 @@
         <infoLink id="e951-696e-2fa2-f0f5" name="Loyalist" hidden="false" targetId="d1de-a45d-2b9b-c878" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="8736-0e38-60c0-a7d2" name="Assassin Sub-Type" hidden="false" targetId="d615-c0e4-6d17-107e" primary="false"/>
+        <categoryLink id="8736-0e38-60c0-a7d2" name="Assassin Sub-type" hidden="false" targetId="d615-c0e4-6d17-107e" primary="false"/>
         <categoryLink id="8e50-e745-191c-11f7" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
-        <categoryLink id="43eb-dd2c-5380-66c3" name="Light Sub-type:" hidden="false" targetId="bff2-ae16-74a8-8712" primary="false"/>
+        <categoryLink id="43eb-dd2c-5380-66c3" name="Light Sub-type" hidden="false" targetId="bff2-ae16-74a8-8712" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="8092-57ee-d254-5e3f" name="Polymorphine" publicationId="15a4-fc68-502d-48a9" page="117" hidden="false" collective="false" import="true" type="upgrade">
@@ -330,9 +330,9 @@ during the battle. Once a unit or model with polymorphine has made a Shootin gAt
         </infoLink>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="edc8-fbd6-fbfa-8d87" name="Assassin Sub-Type" hidden="false" targetId="d615-c0e4-6d17-107e" primary="false"/>
+        <categoryLink id="edc8-fbd6-fbfa-8d87" name="Assassin Sub-type" hidden="false" targetId="d615-c0e4-6d17-107e" primary="false"/>
         <categoryLink id="83c9-6e6a-ce45-7fff" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
-        <categoryLink id="0d61-9b1f-333c-a79c" name="Light Sub-type:" hidden="false" targetId="bff2-ae16-74a8-8712" primary="false"/>
+        <categoryLink id="0d61-9b1f-333c-a79c" name="Light Sub-type" hidden="false" targetId="bff2-ae16-74a8-8712" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="343f-f172-a3ec-18d6" name="Life Drain" publicationId="15a4-fc68-502d-48a9" page="115" hidden="false" collective="false" import="true" type="upgrade">
@@ -457,8 +457,8 @@ during the battle. Once a unit or model with polymorphine has made a Shootin gAt
       </infoLinks>
       <categoryLinks>
         <categoryLink id="3e59-53b2-2e89-e5c7" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
-        <categoryLink id="69ba-0f69-445b-99f6" name="Assassin Sub-Type" hidden="false" targetId="d615-c0e4-6d17-107e" primary="false"/>
-        <categoryLink id="45be-a56e-8444-b334" name="Light Sub-type:" hidden="false" targetId="bff2-ae16-74a8-8712" primary="false"/>
+        <categoryLink id="69ba-0f69-445b-99f6" name="Assassin Sub-type" hidden="false" targetId="d615-c0e4-6d17-107e" primary="false"/>
+        <categoryLink id="45be-a56e-8444-b334" name="Light Sub-type" hidden="false" targetId="bff2-ae16-74a8-8712" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="e7c1-7582-465c-6542" name="Neuro-Gauntlet" publicationId="15a4-fc68-502d-48a9" page="119" hidden="false" collective="false" import="true" type="upgrade">
@@ -576,8 +576,8 @@ during the battle. Once a unit or model with polymorphine has made a Shootin gAt
       </infoLinks>
       <categoryLinks>
         <categoryLink id="cf7b-537c-daed-5b1e" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
-        <categoryLink id="11f6-34ac-6bd1-8a46" name="Assassin Sub-Type" hidden="false" targetId="d615-c0e4-6d17-107e" primary="false"/>
-        <categoryLink id="70b1-d663-0455-a3fc" name="Light Sub-type:" hidden="false" targetId="bff2-ae16-74a8-8712" primary="false"/>
+        <categoryLink id="11f6-34ac-6bd1-8a46" name="Assassin Sub-type" hidden="false" targetId="d615-c0e4-6d17-107e" primary="false"/>
+        <categoryLink id="70b1-d663-0455-a3fc" name="Light Sub-type" hidden="false" targetId="bff2-ae16-74a8-8712" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="67ea-0ed0-690f-55ea" name="Auspectre" publicationId="15a4-fc68-502d-48a9" page="125" hidden="false" collective="false" import="true" type="upgrade">
@@ -692,8 +692,8 @@ during the battle. Once a unit or model with polymorphine has made a Shootin gAt
       </infoLinks>
       <categoryLinks>
         <categoryLink id="f41a-599a-1e9e-1289" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
-        <categoryLink id="af81-910a-0980-d3d5" name="Light Sub-type:" hidden="false" targetId="bff2-ae16-74a8-8712" primary="false"/>
-        <categoryLink id="a7ff-4c2b-2817-d539" name="Assassin Sub-Type" hidden="false" targetId="d615-c0e4-6d17-107e" primary="false"/>
+        <categoryLink id="af81-910a-0980-d3d5" name="Light Sub-type" hidden="false" targetId="bff2-ae16-74a8-8712" primary="false"/>
+        <categoryLink id="a7ff-4c2b-2817-d539" name="Assassin Sub-type" hidden="false" targetId="d615-c0e4-6d17-107e" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="d4a2-3b7d-d05c-9fbe" name="Hookfang" publicationId="15a4-fc68-502d-48a9" page="123" hidden="false" collective="false" import="true" type="upgrade">
@@ -809,9 +809,9 @@ during the battle. Once a unit or model with polymorphine has made a Shootin gAt
         <infoLink id="dc32-2874-4392-4656" name="Loyalist" hidden="false" targetId="d1de-a45d-2b9b-c878" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="ecba-9e48-4f6e-0883" name="Assassin Sub-Type" hidden="false" targetId="d615-c0e4-6d17-107e" primary="false"/>
+        <categoryLink id="ecba-9e48-4f6e-0883" name="Assassin Sub-type" hidden="false" targetId="d615-c0e4-6d17-107e" primary="false"/>
         <categoryLink id="d053-1453-82f9-2ae1" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
-        <categoryLink id="e3c3-53e1-a9f3-3e8f" name="Light Sub-type:" hidden="false" targetId="bff2-ae16-74a8-8712" primary="false"/>
+        <categoryLink id="e3c3-53e1-a9f3-3e8f" name="Light Sub-type" hidden="false" targetId="bff2-ae16-74a8-8712" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="a213-2600-430b-2658" name="Exitus Rifle" publicationId="15a4-fc68-502d-48a9" page="114" hidden="false" collective="false" import="true" type="upgrade">
@@ -987,8 +987,8 @@ during the battle. Once a unit or model with polymorphine has made a Shootin gAt
       </infoLinks>
       <categoryLinks>
         <categoryLink id="8829-ecd8-cdc1-f140" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
-        <categoryLink id="33f2-aa45-7deb-abf8" name="Assassin Sub-Type" hidden="false" targetId="d615-c0e4-6d17-107e" primary="false"/>
-        <categoryLink id="09f7-774f-a43e-1915" name="Light Sub-type:" hidden="false" targetId="bff2-ae16-74a8-8712" primary="false"/>
+        <categoryLink id="33f2-aa45-7deb-abf8" name="Assassin Sub-type" hidden="false" targetId="d615-c0e4-6d17-107e" primary="false"/>
+        <categoryLink id="09f7-774f-a43e-1915" name="Light Sub-type" hidden="false" targetId="bff2-ae16-74a8-8712" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="94c3-d0e6-238f-efe2" name="Transmutative armaments" publicationId="53a4-0d21-2f8a-2c45" page="222" hidden="false" collective="false" import="true" type="upgrade">

--- a/2022 - LI - Assassins.cat
+++ b/2022 - LI - Assassins.cat
@@ -1099,7 +1099,7 @@ during the battle. Once a unit or model with polymorphine has made a Shootin gAt
         <categoryLink id="d64e-6627-e31b-2078" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
         <categoryLink id="c8f3-eaeb-92cd-5ce7" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
         <categoryLink id="2e0f-9678-8a0e-11a3" name="Psyker:" hidden="false" targetId="6e0c-29ba-a445-8321" primary="false"/>
-        <categoryLink id="cdb9-dc11-9ec4-0dc3" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="cdb9-dc11-9ec4-0dc3" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink name="SA or IM Unit" hidden="false" id="7b8c-7663-47e3-9877" targetId="4aca-2849-7f41-0200" primary="false"/>
       </categoryLinks>
       <selectionEntries>
@@ -1208,8 +1208,8 @@ during the battle. Once a unit or model with polymorphine has made a Shootin gAt
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="50"/>
           </costs>
           <categoryLinks>
-            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="ce53-662b-4263-ad85" name="Infantry" primary="false"/>
-            <categoryLink targetId="6e0c-29ba-a445-8321" id="ab9a-0292-4736-8fbd" name="Psyker" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="ce53-662b-4263-ad85" name="Infantry Unit Type" primary="false"/>
+            <categoryLink targetId="6e0c-29ba-a445-8321" id="ab9a-0292-4736-8fbd" name="Psyker:" primary="false"/>
             <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="34ac-92b7-4e84-950c" name="Character" primary="false"/>
           </categoryLinks>
         </selectionEntry>
@@ -1222,7 +1222,7 @@ during the battle. Once a unit or model with polymorphine has made a Shootin gAt
       <categoryLinks>
         <categoryLink id="dc64-e9e2-d847-5412" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
         <categoryLink id="2719-41d2-0b7e-3d7c" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
-        <categoryLink id="b1b0-58ac-7135-1e01" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="b1b0-58ac-7135-1e01" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="63ce-413c-6c5d-d9ce" name="Psyker:" hidden="false" targetId="6e0c-29ba-a445-8321" primary="false"/>
         <categoryLink name="SA or IM Unit" hidden="false" id="ef08-18fb-c93e-7fb4" targetId="4aca-2849-7f41-0200" primary="false"/>
       </categoryLinks>
@@ -1313,11 +1313,9 @@ during the battle. Once a unit or model with polymorphine has made a Shootin gAt
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="50"/>
           </costs>
           <categoryLinks>
-            <categoryLink targetId="6e0c-29ba-a445-8321" id="115e-3c4a-4823-aac1" name="Psyker" primary="false"/>
+            <categoryLink targetId="6e0c-29ba-a445-8321" id="115e-3c4a-4823-aac1" name="Psyker:" primary="false"/>
             <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="7633-3b2c-4627-96ff" name="Character" primary="false"/>
           </categoryLinks>
-          <comment>!BSC Errors from 20240328-1346
-Could not find type or subtype &apos;Expeditionary Navigator: Infantry&apos;</comment>
         </selectionEntry>
       </selectionEntries>
       <costs>
@@ -1377,7 +1375,7 @@ Could not find type or subtype &apos;Expeditionary Navigator: Infantry&apos;</co
       </infoLinks>
       <categoryLinks>
         <categoryLink id="106a-6fa4-41be-881" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
-        <categoryLink id="c89-5fcb-2ef3-89d8" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="c89-5fcb-2ef3-89d8" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="e353-952c-5733-c446" name="Libertas" hidden="false" collective="false" import="true" type="upgrade">
@@ -1489,10 +1487,10 @@ Could not find type or subtype &apos;Expeditionary Navigator: Infantry&apos;</co
       </infoLinks>
       <categoryLinks>
         <categoryLink id="e009-cda0-797d-647c" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
-        <categoryLink id="6013-f7e4-2e03-af0d" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="6013-f7e4-2e03-af0d" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="625b-8688-7e5b-4478" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="2b3b-ba1c-4d3a-8762" name="Character" primary="false"/>
-        <categoryLink targetId="aa94-5c65-d1f1-46a4" id="3226-b723-4302-a1e6" name="Unique" primary="false"/>
+        <categoryLink targetId="aa94-5c65-d1f1-46a4" id="3226-b723-4302-a1e6" name="Unique Sub-type" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="7a6e-ff13-9c39-ff1d" name="The Aegis Argentum" publicationId="d0df-7166-5cd3-89fd" page="7" hidden="false" collective="false" import="true" type="upgrade">

--- a/2022 - LI - Assassins.cat
+++ b/2022 - LI - Assassins.cat
@@ -1207,6 +1207,11 @@ during the battle. Once a unit or model with polymorphine has made a Shootin gAt
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="50"/>
           </costs>
+          <categoryLinks>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="ce53-662b-4263-ad85" name="Infantry" primary="false"/>
+            <categoryLink targetId="6e0c-29ba-a445-8321" id="ab9a-0292-4736-8fbd" name="Psyker" primary="false"/>
+            <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="34ac-92b7-4e84-950c" name="Character" primary="false"/>
+          </categoryLinks>
         </selectionEntry>
       </selectionEntries>
       <costs>
@@ -1307,6 +1312,12 @@ during the battle. Once a unit or model with polymorphine has made a Shootin gAt
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="50"/>
           </costs>
+          <categoryLinks>
+            <categoryLink targetId="6e0c-29ba-a445-8321" id="115e-3c4a-4823-aac1" name="Psyker" primary="false"/>
+            <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="7633-3b2c-4627-96ff" name="Character" primary="false"/>
+          </categoryLinks>
+          <comment>!BSC Errors from 20240328-1346
+Could not find type or subtype &apos;Expeditionary Navigator: Infantry&apos;</comment>
         </selectionEntry>
       </selectionEntries>
       <costs>
@@ -1480,6 +1491,8 @@ during the battle. Once a unit or model with polymorphine has made a Shootin gAt
         <categoryLink id="e009-cda0-797d-647c" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
         <categoryLink id="6013-f7e4-2e03-af0d" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="625b-8688-7e5b-4478" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="2b3b-ba1c-4d3a-8762" name="Character" primary="false"/>
+        <categoryLink targetId="aa94-5c65-d1f1-46a4" id="3226-b723-4302-a1e6" name="Unique" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="7a6e-ff13-9c39-ff1d" name="The Aegis Argentum" publicationId="d0df-7166-5cd3-89fd" page="7" hidden="false" collective="false" import="true" type="upgrade">

--- a/2022 - LI - Custodes.cat
+++ b/2022 - LI - Custodes.cat
@@ -598,9 +598,9 @@
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="300"/>
           </costs>
           <categoryLinks>
-            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="270d-7c35-492d-91ea" name="Infantry" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="270d-7c35-492d-91ea" name="Infantry Unit Type" primary="false"/>
             <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="6c9f-2c47-4a4e-826b" name="Character" primary="false"/>
-            <categoryLink targetId="59a4-7b61-600a-c457" id="3246-87ee-4b0f-83bd" name="Skirmish" primary="false"/>
+            <categoryLink targetId="59a4-7b61-600a-c457" id="3246-87ee-4b0f-83bd" name="Skirmish Sub-type" primary="false"/>
           </categoryLinks>
         </selectionEntry>
       </selectionEntries>
@@ -857,8 +857,8 @@
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="70"/>
           </costs>
           <categoryLinks>
-            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="ab03-271b-4a46-8fbe" name="Infantry" primary="false"/>
-            <categoryLink targetId="59a4-7b61-600a-c457" id="277d-c69d-4366-b678" name="Skirmish" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="ab03-271b-4a46-8fbe" name="Infantry Unit Type" primary="false"/>
+            <categoryLink targetId="59a4-7b61-600a-c457" id="277d-c69d-4366-b678" name="Skirmish Sub-type" primary="false"/>
           </categoryLinks>
         </selectionEntry>
       </selectionEntries>
@@ -919,7 +919,7 @@
         <categoryLink id="5797-77fd-47c1-3b72" name="Legio Custodes" hidden="false" targetId="ccca-a9de-0cd9-f8be" primary="false"/>
         <categoryLink id="5977-631d-7dc9-bf7e" name="Skirmish Sub-type" hidden="false" targetId="59a4-7b61-600a-c457" primary="false"/>
         <categoryLink id="408b-7ea1-2f7e-fa1b" name="Heavy Sub-type" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
-        <categoryLink id="c43b-ac00-e293-42ed" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="c43b-ac00-e293-42ed" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="e35e-3b4a-634c-27c7" name="Aquilon Terminator" hidden="false" collective="false" import="true" defaultSelectionEntryId="3b03-cf93-c721-4c45">
@@ -953,9 +953,9 @@
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="105"/>
               </costs>
               <categoryLinks>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="1717-d305-46c3-b9db" name="Infantry" primary="false"/>
-                <categoryLink targetId="59a4-7b61-600a-c457" id="7a15-4716-4682-ace4" name="Skirmish" primary="false"/>
-                <categoryLink targetId="9231-183c-b97b-63f9" id="b3db-8bb1-478e-a1d0" name="Heavy" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="1717-d305-46c3-b9db" name="Infantry Unit Type" primary="false"/>
+                <categoryLink targetId="59a4-7b61-600a-c457" id="7a15-4716-4682-ace4" name="Skirmish Sub-type" primary="false"/>
+                <categoryLink targetId="9231-183c-b97b-63f9" id="b3db-8bb1-478e-a1d0" name="Heavy Sub-type" primary="false"/>
               </categoryLinks>
             </selectionEntry>
             <selectionEntry id="e6d8-b264-6ebb-213d" name="Aquilon w/ Solarite Power Gauntlet &amp; Infernus Firepike" hidden="false" collective="false" import="true" type="model">
@@ -983,9 +983,9 @@
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="105"/>
               </costs>
               <categoryLinks>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="0786-707b-41e9-ad37" name="Infantry" primary="false"/>
-                <categoryLink targetId="59a4-7b61-600a-c457" id="ff4d-4592-4033-82bc" name="Skirmish" primary="false"/>
-                <categoryLink targetId="9231-183c-b97b-63f9" id="1492-8e5b-4e97-95b7" name="Heavy" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="0786-707b-41e9-ad37" name="Infantry Unit Type" primary="false"/>
+                <categoryLink targetId="59a4-7b61-600a-c457" id="ff4d-4592-4033-82bc" name="Skirmish Sub-type" primary="false"/>
+                <categoryLink targetId="9231-183c-b97b-63f9" id="1492-8e5b-4e97-95b7" name="Heavy Sub-type" primary="false"/>
               </categoryLinks>
             </selectionEntry>
             <selectionEntry id="f5f5-d024-af1b-83c5" name="Aquilon w/ Solarite Power Talon &amp; Twin-Linked Adrathic Destructor" hidden="false" collective="false" import="true" type="model">
@@ -1013,9 +1013,9 @@
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="105"/>
               </costs>
               <categoryLinks>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="0563-3cce-4af3-bc5b" name="Infantry" primary="false"/>
-                <categoryLink targetId="59a4-7b61-600a-c457" id="6602-c3bf-45e0-b497" name="Skirmish" primary="false"/>
-                <categoryLink targetId="9231-183c-b97b-63f9" id="9b7c-798b-444b-bc5b" name="Heavy" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="0563-3cce-4af3-bc5b" name="Infantry Unit Type" primary="false"/>
+                <categoryLink targetId="59a4-7b61-600a-c457" id="6602-c3bf-45e0-b497" name="Skirmish Sub-type" primary="false"/>
+                <categoryLink targetId="9231-183c-b97b-63f9" id="9b7c-798b-444b-bc5b" name="Heavy Sub-type" primary="false"/>
               </categoryLinks>
             </selectionEntry>
             <selectionEntry id="3b03-cf93-c721-4c45" name="Aquilon w/ Solarite Power Gauntlet &amp; Lastrum Storm Bolter" hidden="false" collective="false" import="true" type="model">
@@ -1043,9 +1043,9 @@
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="90"/>
               </costs>
               <categoryLinks>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="37ff-49bb-483d-b0b4" name="Infantry" primary="false"/>
-                <categoryLink targetId="59a4-7b61-600a-c457" id="9683-593f-4cdb-a0f7" name="Skirmish" primary="false"/>
-                <categoryLink targetId="9231-183c-b97b-63f9" id="4af5-c5e5-47f4-bec4" name="Heavy" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="37ff-49bb-483d-b0b4" name="Infantry Unit Type" primary="false"/>
+                <categoryLink targetId="59a4-7b61-600a-c457" id="9683-593f-4cdb-a0f7" name="Skirmish Sub-type" primary="false"/>
+                <categoryLink targetId="9231-183c-b97b-63f9" id="4af5-c5e5-47f4-bec4" name="Heavy Sub-type" primary="false"/>
               </categoryLinks>
             </selectionEntry>
             <selectionEntry id="b50a-3dc9-3a90-c15c" name="Aquilon w/ Solarite Power Gauntlet &amp; Solarite Power Talon" hidden="false" collective="false" import="true" type="model">
@@ -1073,9 +1073,9 @@
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="90"/>
               </costs>
               <categoryLinks>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="d2df-32e1-4084-b94d" name="Infantry" primary="false"/>
-                <categoryLink targetId="59a4-7b61-600a-c457" id="3b30-6fbc-4091-9a84" name="Skirmish" primary="false"/>
-                <categoryLink targetId="9231-183c-b97b-63f9" id="3af8-be5b-4e1e-9d08" name="Heavy" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="d2df-32e1-4084-b94d" name="Infantry Unit Type" primary="false"/>
+                <categoryLink targetId="59a4-7b61-600a-c457" id="3b30-6fbc-4091-9a84" name="Skirmish Sub-type" primary="false"/>
+                <categoryLink targetId="9231-183c-b97b-63f9" id="3af8-be5b-4e1e-9d08" name="Heavy Sub-type" primary="false"/>
               </categoryLinks>
             </selectionEntry>
             <selectionEntry id="e10f-e6da-6a20-ae01" name="Aquilon w/ Solarite Power Talon &amp; Infernus Firepike" hidden="false" collective="false" import="true" type="model">
@@ -1103,9 +1103,9 @@
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="105"/>
               </costs>
               <categoryLinks>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="b998-3e8b-401b-b1c8" name="Infantry" primary="false"/>
-                <categoryLink targetId="59a4-7b61-600a-c457" id="50b3-d135-4068-8f1e" name="Skirmish" primary="false"/>
-                <categoryLink targetId="9231-183c-b97b-63f9" id="735f-c51f-4e77-80fb" name="Heavy" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="b998-3e8b-401b-b1c8" name="Infantry Unit Type" primary="false"/>
+                <categoryLink targetId="59a4-7b61-600a-c457" id="50b3-d135-4068-8f1e" name="Skirmish Sub-type" primary="false"/>
+                <categoryLink targetId="9231-183c-b97b-63f9" id="735f-c51f-4e77-80fb" name="Heavy Sub-type" primary="false"/>
               </categoryLinks>
             </selectionEntry>
             <selectionEntry id="02d3-2f77-69a4-b0a5" name="Aquilon w/ Solarite 2X Power Talons" hidden="false" collective="false" import="true" type="model">
@@ -1141,9 +1141,9 @@
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="90"/>
               </costs>
               <categoryLinks>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="7915-2833-41ff-8788" name="Infantry" primary="false"/>
-                <categoryLink targetId="59a4-7b61-600a-c457" id="1dfe-1969-4f68-85b2" name="Skirmish" primary="false"/>
-                <categoryLink targetId="9231-183c-b97b-63f9" id="89d1-c1a9-47f9-96a2" name="Heavy" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="7915-2833-41ff-8788" name="Infantry Unit Type" primary="false"/>
+                <categoryLink targetId="59a4-7b61-600a-c457" id="1dfe-1969-4f68-85b2" name="Skirmish Sub-type" primary="false"/>
+                <categoryLink targetId="9231-183c-b97b-63f9" id="89d1-c1a9-47f9-96a2" name="Heavy Sub-type" primary="false"/>
               </categoryLinks>
             </selectionEntry>
             <selectionEntry id="68d9-52e0-0e62-e879" name="Aquilon w/ Solarite Power Talon &amp; Lastrum Storm Bolter" hidden="false" collective="false" import="true" type="model">
@@ -1171,9 +1171,9 @@
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="90"/>
               </costs>
               <categoryLinks>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="a9ef-6b90-4daa-9b24" name="Infantry" primary="false"/>
-                <categoryLink targetId="59a4-7b61-600a-c457" id="bdec-23b6-414a-a92c" name="Skirmish" primary="false"/>
-                <categoryLink targetId="9231-183c-b97b-63f9" id="643b-f5cc-49e5-943f" name="Heavy" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="a9ef-6b90-4daa-9b24" name="Infantry Unit Type" primary="false"/>
+                <categoryLink targetId="59a4-7b61-600a-c457" id="bdec-23b6-414a-a92c" name="Skirmish Sub-type" primary="false"/>
+                <categoryLink targetId="9231-183c-b97b-63f9" id="643b-f5cc-49e5-943f" name="Heavy Sub-type" primary="false"/>
               </categoryLinks>
             </selectionEntry>
           </selectionEntries>
@@ -1237,9 +1237,9 @@
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="45"/>
               </costs>
               <categoryLinks>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="e660-5ba3-449b-9ccb" name="Infantry" primary="false"/>
-                <categoryLink targetId="59a4-7b61-600a-c457" id="cc43-8b08-466c-882f" name="Skirmish" primary="false"/>
-                <categoryLink targetId="6399-5c65-7833-1025" id="0594-48ea-42e3-8f54" name="Line" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="e660-5ba3-449b-9ccb" name="Infantry Unit Type" primary="false"/>
+                <categoryLink targetId="59a4-7b61-600a-c457" id="cc43-8b08-466c-882f" name="Skirmish Sub-type" primary="false"/>
+                <categoryLink targetId="6399-5c65-7833-1025" id="0594-48ea-42e3-8f54" name="Line Sub-type" primary="false"/>
               </categoryLinks>
             </selectionEntry>
             <selectionEntry id="7546-51fe-0073-06fd" name="Custodian Guard w/ Pyrihite Spear" hidden="false" collective="false" import="true" type="model">
@@ -1261,9 +1261,9 @@
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="60"/>
               </costs>
               <categoryLinks>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="2241-cc7c-4a37-b6ba" name="Infantry" primary="false"/>
-                <categoryLink targetId="59a4-7b61-600a-c457" id="81ea-873e-4713-9174" name="Skirmish" primary="false"/>
-                <categoryLink targetId="6399-5c65-7833-1025" id="284c-b0cf-41e3-b944" name="Line" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="2241-cc7c-4a37-b6ba" name="Infantry Unit Type" primary="false"/>
+                <categoryLink targetId="59a4-7b61-600a-c457" id="81ea-873e-4713-9174" name="Skirmish Sub-type" primary="false"/>
+                <categoryLink targetId="6399-5c65-7833-1025" id="284c-b0cf-41e3-b944" name="Line Sub-type" primary="false"/>
               </categoryLinks>
             </selectionEntry>
             <selectionEntry id="be52-52ce-b2cf-bf20" name="Custodian Guard w/ Adrasite Spear" hidden="false" collective="false" import="true" type="model">
@@ -1299,9 +1299,9 @@
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="55"/>
               </costs>
               <categoryLinks>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="6ebc-04f0-4e7f-972b" name="Infantry" primary="false"/>
-                <categoryLink targetId="59a4-7b61-600a-c457" id="21b9-7a14-4716-b76e" name="Skirmish" primary="false"/>
-                <categoryLink targetId="6399-5c65-7833-1025" id="26b2-3b14-4b5a-93f8" name="Line" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="6ebc-04f0-4e7f-972b" name="Infantry Unit Type" primary="false"/>
+                <categoryLink targetId="59a4-7b61-600a-c457" id="21b9-7a14-4716-b76e" name="Skirmish Sub-type" primary="false"/>
+                <categoryLink targetId="6399-5c65-7833-1025" id="26b2-3b14-4b5a-93f8" name="Line Sub-type" primary="false"/>
               </categoryLinks>
             </selectionEntry>
             <selectionEntry id="0a74-0ea1-da5f-e3b7" name="Custodian Guard w/ Guardian Axe" hidden="false" collective="false" import="true" type="model">
@@ -1323,9 +1323,9 @@
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="45"/>
               </costs>
               <categoryLinks>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="fa94-6cd3-475f-b602" name="Infantry" primary="false"/>
-                <categoryLink targetId="59a4-7b61-600a-c457" id="60ac-062c-4e45-8ecf" name="Skirmish" primary="false"/>
-                <categoryLink targetId="6399-5c65-7833-1025" id="51c1-5156-4832-9209" name="Line" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="fa94-6cd3-475f-b602" name="Infantry Unit Type" primary="false"/>
+                <categoryLink targetId="59a4-7b61-600a-c457" id="60ac-062c-4e45-8ecf" name="Skirmish Sub-type" primary="false"/>
+                <categoryLink targetId="6399-5c65-7833-1025" id="51c1-5156-4832-9209" name="Line Sub-type" primary="false"/>
               </categoryLinks>
             </selectionEntry>
           </selectionEntries>
@@ -1346,9 +1346,9 @@
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="65"/>
                   </costs>
                   <categoryLinks>
-                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="c536-00ec-4746-b115" name="Infantry" primary="false"/>
-                    <categoryLink targetId="59a4-7b61-600a-c457" id="4937-3cd2-4b62-90e8" name="Skirmish" primary="false"/>
-                    <categoryLink targetId="6399-5c65-7833-1025" id="4f9e-0628-4b21-9bb7" name="Line" primary="false"/>
+                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="c536-00ec-4746-b115" name="Infantry Unit Type" primary="false"/>
+                    <categoryLink targetId="59a4-7b61-600a-c457" id="4937-3cd2-4b62-90e8" name="Skirmish Sub-type" primary="false"/>
+                    <categoryLink targetId="6399-5c65-7833-1025" id="4f9e-0628-4b21-9bb7" name="Line Sub-type" primary="false"/>
                   </categoryLinks>
                 </selectionEntry>
                 <selectionEntry id="8dc5-b5d6-e154-a8eb" name="Custodian Guard w/ Master-Crafted Power Lance &amp; Vexilla" hidden="false" collective="false" import="true" type="model">
@@ -1362,9 +1362,9 @@
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="60"/>
                   </costs>
                   <categoryLinks>
-                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="6b19-48bf-4987-941d" name="Infantry" primary="false"/>
-                    <categoryLink targetId="59a4-7b61-600a-c457" id="af4c-53c7-4453-8d5d" name="Skirmish" primary="false"/>
-                    <categoryLink targetId="6399-5c65-7833-1025" id="063c-bd1e-42c5-ae76" name="Line" primary="false"/>
+                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="6b19-48bf-4987-941d" name="Infantry Unit Type" primary="false"/>
+                    <categoryLink targetId="59a4-7b61-600a-c457" id="af4c-53c7-4453-8d5d" name="Skirmish Sub-type" primary="false"/>
+                    <categoryLink targetId="6399-5c65-7833-1025" id="063c-bd1e-42c5-ae76" name="Line Sub-type" primary="false"/>
                   </categoryLinks>
                 </selectionEntry>
                 <selectionEntry id="8de9-3bdc-c580-b9aa" name="Custodian Guard w/ Master-Crafted Power Maul &amp; Vexilla" hidden="false" collective="false" import="true" type="model">
@@ -1378,9 +1378,9 @@
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="60"/>
                   </costs>
                   <categoryLinks>
-                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="4fb3-3830-4fd1-8334" name="Infantry" primary="false"/>
-                    <categoryLink targetId="59a4-7b61-600a-c457" id="e7eb-ad61-403b-83d6" name="Skirmish" primary="false"/>
-                    <categoryLink targetId="6399-5c65-7833-1025" id="380f-a690-491b-91a5" name="Line" primary="false"/>
+                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="4fb3-3830-4fd1-8334" name="Infantry Unit Type" primary="false"/>
+                    <categoryLink targetId="59a4-7b61-600a-c457" id="e7eb-ad61-403b-83d6" name="Skirmish Sub-type" primary="false"/>
+                    <categoryLink targetId="6399-5c65-7833-1025" id="380f-a690-491b-91a5" name="Line Sub-type" primary="false"/>
                   </categoryLinks>
                 </selectionEntry>
                 <selectionEntry id="67fb-8d60-68ee-2fae" name="Custodian Guard w/ Master-Crafted Power Axe &amp; Vexilla" hidden="false" collective="false" import="true" type="model">
@@ -1394,9 +1394,9 @@
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="60"/>
                   </costs>
                   <categoryLinks>
-                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="c788-f6ed-4b5d-9fe9" name="Infantry" primary="false"/>
-                    <categoryLink targetId="59a4-7b61-600a-c457" id="1be0-a4a9-41d8-a144" name="Skirmish" primary="false"/>
-                    <categoryLink targetId="6399-5c65-7833-1025" id="97d1-7508-4349-8a74" name="Line" primary="false"/>
+                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="c788-f6ed-4b5d-9fe9" name="Infantry Unit Type" primary="false"/>
+                    <categoryLink targetId="59a4-7b61-600a-c457" id="1be0-a4a9-41d8-a144" name="Skirmish Sub-type" primary="false"/>
+                    <categoryLink targetId="6399-5c65-7833-1025" id="97d1-7508-4349-8a74" name="Line Sub-type" primary="false"/>
                   </categoryLinks>
                 </selectionEntry>
                 <selectionEntry id="8497-6360-cc95-acf2" name="Custodian Guard w/ Master-Crafted Power Sword &amp; Vexilla" hidden="false" collective="false" import="true" type="model">
@@ -1489,9 +1489,9 @@
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="55"/>
               </costs>
               <categoryLinks>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="4937-4abe-42c3-9b43" name="Infantry" primary="false"/>
-                <categoryLink targetId="59a4-7b61-600a-c457" id="7862-ef98-422d-b2a1" name="Skirmish" primary="false"/>
-                <categoryLink targetId="6399-5c65-7833-1025" id="3e83-08d3-46d0-8aad" name="Line" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="4937-4abe-42c3-9b43" name="Infantry Unit Type" primary="false"/>
+                <categoryLink targetId="59a4-7b61-600a-c457" id="7862-ef98-422d-b2a1" name="Skirmish Sub-type" primary="false"/>
+                <categoryLink targetId="6399-5c65-7833-1025" id="3e83-08d3-46d0-8aad" name="Line Sub-type" primary="false"/>
               </categoryLinks>
             </selectionEntry>
             <selectionEntry id="fb12-f008-703b-3f30" name="Sentinel Guard w/ Solarite Power Gauntlet &amp; Shield" hidden="false" collective="false" import="true" type="model">
@@ -1516,9 +1516,9 @@
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="75"/>
               </costs>
               <categoryLinks>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="74d0-d192-4038-b9a5" name="Infantry" primary="false"/>
-                <categoryLink targetId="59a4-7b61-600a-c457" id="e77a-e42a-4984-b3d5" name="Skirmish" primary="false"/>
-                <categoryLink targetId="6399-5c65-7833-1025" id="2b10-84be-4be8-9df4" name="Line" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="74d0-d192-4038-b9a5" name="Infantry Unit Type" primary="false"/>
+                <categoryLink targetId="59a4-7b61-600a-c457" id="e77a-e42a-4984-b3d5" name="Skirmish Sub-type" primary="false"/>
+                <categoryLink targetId="6399-5c65-7833-1025" id="2b10-84be-4be8-9df4" name="Line Sub-type" primary="false"/>
               </categoryLinks>
             </selectionEntry>
             <selectionEntry id="2906-1c80-a8ed-6672" name="Sentinel Guard w/ Sentinel Warblade &amp; Shield" hidden="false" collective="false" import="true" type="model">
@@ -1557,9 +1557,9 @@
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="45"/>
               </costs>
               <categoryLinks>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="4aa6-3cd4-4213-b3b5" name="Infantry" primary="false"/>
-                <categoryLink targetId="59a4-7b61-600a-c457" id="1e1b-c299-46ee-8441" name="Skirmish" primary="false"/>
-                <categoryLink targetId="6399-5c65-7833-1025" id="92ad-d1c4-47e2-966b" name="Line" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="4aa6-3cd4-4213-b3b5" name="Infantry Unit Type" primary="false"/>
+                <categoryLink targetId="59a4-7b61-600a-c457" id="1e1b-c299-46ee-8441" name="Skirmish Sub-type" primary="false"/>
+                <categoryLink targetId="6399-5c65-7833-1025" id="92ad-d1c4-47e2-966b" name="Line Sub-type" primary="false"/>
               </categoryLinks>
             </selectionEntry>
           </selectionEntries>
@@ -1594,9 +1594,9 @@
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="65"/>
                   </costs>
                   <categoryLinks>
-                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="5b42-1678-4051-ba8b" name="Infantry" primary="false"/>
-                    <categoryLink targetId="59a4-7b61-600a-c457" id="9693-fe77-4a7a-a24f" name="Skirmish" primary="false"/>
-                    <categoryLink targetId="6399-5c65-7833-1025" id="67c4-b35f-4315-8f86" name="Line" primary="false"/>
+                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="5b42-1678-4051-ba8b" name="Infantry Unit Type" primary="false"/>
+                    <categoryLink targetId="59a4-7b61-600a-c457" id="9693-fe77-4a7a-a24f" name="Skirmish Sub-type" primary="false"/>
+                    <categoryLink targetId="6399-5c65-7833-1025" id="67c4-b35f-4315-8f86" name="Line Sub-type" primary="false"/>
                   </categoryLinks>
                 </selectionEntry>
                 <selectionEntry id="3665-6d98-26e6-ef50" name="Sentinel Guard w/ Solarite Power Gauntlet &amp; Vexilla" hidden="false" collective="false" import="true" type="model">
@@ -1624,9 +1624,9 @@
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="85"/>
                   </costs>
                   <categoryLinks>
-                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="a5c0-775d-413f-a48c" name="Infantry" primary="false"/>
-                    <categoryLink targetId="59a4-7b61-600a-c457" id="3212-e18f-45a7-8524" name="Skirmish" primary="false"/>
-                    <categoryLink targetId="6399-5c65-7833-1025" id="4cde-612a-4737-aea4" name="Line" primary="false"/>
+                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="a5c0-775d-413f-a48c" name="Infantry Unit Type" primary="false"/>
+                    <categoryLink targetId="59a4-7b61-600a-c457" id="3212-e18f-45a7-8524" name="Skirmish Sub-type" primary="false"/>
+                    <categoryLink targetId="6399-5c65-7833-1025" id="4cde-612a-4737-aea4" name="Line Sub-type" primary="false"/>
                   </categoryLinks>
                 </selectionEntry>
                 <selectionEntry id="bf33-5019-fe30-a70a" name="Sentinel Guard w/ Sentinel Warblade &amp; Vexilla" hidden="false" collective="false" import="true" type="model">
@@ -1654,9 +1654,9 @@
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="55"/>
                   </costs>
                   <categoryLinks>
-                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="f62e-b918-41c2-a4c8" name="Infantry" primary="false"/>
-                    <categoryLink targetId="59a4-7b61-600a-c457" id="6de7-6eaa-45ee-8555" name="Skirmish" primary="false"/>
-                    <categoryLink targetId="6399-5c65-7833-1025" id="ce3c-fe94-42e0-85d8" name="Line" primary="false"/>
+                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="f62e-b918-41c2-a4c8" name="Infantry Unit Type" primary="false"/>
+                    <categoryLink targetId="59a4-7b61-600a-c457" id="6de7-6eaa-45ee-8555" name="Skirmish Sub-type" primary="false"/>
+                    <categoryLink targetId="6399-5c65-7833-1025" id="ce3c-fe94-42e0-85d8" name="Line Sub-type" primary="false"/>
                   </categoryLinks>
                 </selectionEntry>
               </selectionEntries>
@@ -1795,9 +1795,9 @@
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="85"/>
               </costs>
               <categoryLinks>
-                <categoryLink targetId="6d79-a3e4-381f-7b0f" id="d7ef-d039-4f6a-817e" name="Cavalry" primary="false"/>
-                <categoryLink targetId="59a4-7b61-600a-c457" id="4387-e6d6-4ebc-9521" name="Skirmish" primary="false"/>
-                <categoryLink targetId="4303-1348-cce4-9501" id="df36-422e-47d4-a220" name="Antigrav" primary="false"/>
+                <categoryLink targetId="6d79-a3e4-381f-7b0f" id="d7ef-d039-4f6a-817e" name="Cavalry Unit Type" primary="false"/>
+                <categoryLink targetId="59a4-7b61-600a-c457" id="4387-e6d6-4ebc-9521" name="Skirmish Sub-type" primary="false"/>
+                <categoryLink targetId="4303-1348-cce4-9501" id="df36-422e-47d4-a220" name="Antigrav Sub-type" primary="false"/>
               </categoryLinks>
             </selectionEntry>
             <selectionEntry id="bc7b-9471-b7b9-dbd9" name="Agamatus with Adrathic Devastator" hidden="false" collective="false" import="true" type="model">
@@ -1833,9 +1833,9 @@
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="100"/>
               </costs>
               <categoryLinks>
-                <categoryLink targetId="6d79-a3e4-381f-7b0f" id="d296-4bff-4b3e-8122" name="Cavalry" primary="false"/>
-                <categoryLink targetId="59a4-7b61-600a-c457" id="1c18-6ff4-4530-a4f5" name="Skirmish" primary="false"/>
-                <categoryLink targetId="4303-1348-cce4-9501" id="1f94-0641-494f-b5b9" name="Antigrav" primary="false"/>
+                <categoryLink targetId="6d79-a3e4-381f-7b0f" id="d296-4bff-4b3e-8122" name="Cavalry Unit Type" primary="false"/>
+                <categoryLink targetId="59a4-7b61-600a-c457" id="1c18-6ff4-4530-a4f5" name="Skirmish Sub-type" primary="false"/>
+                <categoryLink targetId="4303-1348-cce4-9501" id="1f94-0641-494f-b5b9" name="Antigrav Sub-type" primary="false"/>
               </categoryLinks>
             </selectionEntry>
             <selectionEntry id="c410-e50f-8751-bda1" name="Agamatus with Twin-linked Corvae Las-Pulser" hidden="false" collective="false" import="true" type="model">
@@ -1857,9 +1857,9 @@
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="120"/>
               </costs>
               <categoryLinks>
-                <categoryLink targetId="6d79-a3e4-381f-7b0f" id="5f9a-fd30-4383-a618" name="Cavalry" primary="false"/>
-                <categoryLink targetId="59a4-7b61-600a-c457" id="4f19-5cfd-4e2c-8d79" name="Skirmish" primary="false"/>
-                <categoryLink targetId="4303-1348-cce4-9501" id="6174-1f99-441f-8b19" name="Antigrav" primary="false"/>
+                <categoryLink targetId="6d79-a3e4-381f-7b0f" id="5f9a-fd30-4383-a618" name="Cavalry Unit Type" primary="false"/>
+                <categoryLink targetId="59a4-7b61-600a-c457" id="4f19-5cfd-4e2c-8d79" name="Skirmish Sub-type" primary="false"/>
+                <categoryLink targetId="4303-1348-cce4-9501" id="6174-1f99-441f-8b19" name="Antigrav Sub-type" primary="false"/>
               </categoryLinks>
             </selectionEntry>
           </selectionEntries>
@@ -1926,8 +1926,8 @@
               <categoryLinks>
                 <categoryLink id="01f1-f064-5384-5dfb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
                 <categoryLink id="cb6c-c2b2-8add-13da" name="Legio Custodes" hidden="false" targetId="ccca-a9de-0cd9-f8be" primary="false"/>
-                <categoryLink targetId="e2b6-b770-784c-9e95" id="3a06-5a51-4d5a-bb88" name="Vehicle" primary="false"/>
-                <categoryLink targetId="0ea2-efb5-b7af-226e" id="73d4-ef2e-4a7f-8174" name="Fast" primary="false"/>
+                <categoryLink targetId="e2b6-b770-784c-9e95" id="3a06-5a51-4d5a-bb88" name="Vehicle:" primary="false"/>
+                <categoryLink targetId="0ea2-efb5-b7af-226e" id="73d4-ef2e-4a7f-8174" name="Fast Sub-type" primary="false"/>
                 <categoryLink targetId="6a28-17c5-8117-d99c" id="1e0c-9088-493b-a54f" name="Skimmer" primary="false"/>
               </categoryLinks>
               <entryLinks>
@@ -1961,8 +1961,8 @@
               <categoryLinks>
                 <categoryLink id="77f0-b604-ed69-9dec" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
                 <categoryLink id="8f99-1140-18b2-45d4" name="Legio Custodes" hidden="false" targetId="ccca-a9de-0cd9-f8be" primary="false"/>
-                <categoryLink targetId="e2b6-b770-784c-9e95" id="5f6b-405e-4f27-9aa7" name="Vehicle" primary="false"/>
-                <categoryLink targetId="0ea2-efb5-b7af-226e" id="4f54-94a5-453c-ba79" name="Fast" primary="false"/>
+                <categoryLink targetId="e2b6-b770-784c-9e95" id="5f6b-405e-4f27-9aa7" name="Vehicle:" primary="false"/>
+                <categoryLink targetId="0ea2-efb5-b7af-226e" id="4f54-94a5-453c-ba79" name="Fast Sub-type" primary="false"/>
                 <categoryLink targetId="6a28-17c5-8117-d99c" id="f24d-aeed-4d71-83c6" name="Skimmer" primary="false"/>
               </categoryLinks>
               <entryLinks>
@@ -2219,8 +2219,8 @@
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="50"/>
               </costs>
               <categoryLinks>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="ba9c-7001-461e-a6c4" name="Infantry" primary="false"/>
-                <categoryLink targetId="59a4-7b61-600a-c457" id="573e-d2eb-43ab-b20a" name="Skirmish" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="ba9c-7001-461e-a6c4" name="Infantry Unit Type" primary="false"/>
+                <categoryLink targetId="59a4-7b61-600a-c457" id="573e-d2eb-43ab-b20a" name="Skirmish Sub-type" primary="false"/>
               </categoryLinks>
             </selectionEntry>
             <selectionEntry id="c1a4-cce9-495b-1a0c" name="Sentinal Guard w/ Magisterium Vexilla and Adrathic Destructor" hidden="false" collective="false" import="true" type="upgrade">
@@ -3487,9 +3487,9 @@ the Front Armour during the same Phase.�</characteristic>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="200"/>
       </costs>
       <categoryLinks>
-        <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="d98d-b8eb-44ff-8da1" name="Infantry" primary="false"/>
+        <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="d98d-b8eb-44ff-8da1" name="Infantry Unit Type" primary="false"/>
         <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="f11c-181e-4062-a315" name="Character" primary="false"/>
-        <categoryLink targetId="59a4-7b61-600a-c457" id="b212-6891-4c2a-af63" name="Skirmish" primary="false"/>
+        <categoryLink targetId="59a4-7b61-600a-c457" id="b212-6891-4c2a-af63" name="Skirmish Sub-type" primary="false"/>
       </categoryLinks>
     </selectionEntry>
     <selectionEntry id="abad-0b02-cb27-28b3" name="Contemptor-Achillus Dreadnought" hidden="false" collective="false" import="true" type="model">
@@ -3721,7 +3721,7 @@ the Front Armour during the same Phase.�</characteristic>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="235"/>
       </costs>
       <categoryLinks>
-        <categoryLink targetId="4280-4963-02b5-e31d" id="2226-9c28-4c15-81e7" name="Dreadnought" primary="false"/>
+        <categoryLink targetId="4280-4963-02b5-e31d" id="2226-9c28-4c15-81e7" name="Dreadnought Unit Type" primary="false"/>
       </categoryLinks>
     </selectionEntry>
     <selectionEntry id="7cf8-3f52-2876-60e9" name="Venatari Jump Harness" publicationId="15a4-fc68-502d-48a9" page="159" hidden="false" collective="false" import="true" type="upgrade">
@@ -3883,8 +3883,8 @@ During a Reaction made in any Phase, a player may not choose to activate a model
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="225"/>
       </costs>
       <categoryLinks>
-        <categoryLink targetId="e2b6-b770-784c-9e95" id="ac91-afc2-4416-bf1f" name="Vehicle" primary="false"/>
-        <categoryLink targetId="4303-1348-cce4-9501" id="4e11-29e7-4774-a2ab" name="Antigrav" primary="false"/>
+        <categoryLink targetId="e2b6-b770-784c-9e95" id="ac91-afc2-4416-bf1f" name="Vehicle:" primary="false"/>
+        <categoryLink targetId="4303-1348-cce4-9501" id="4e11-29e7-4774-a2ab" name="Antigrav Sub-type" primary="false"/>
       </categoryLinks>
     </selectionEntry>
     <selectionEntry id="6526-bdfb-4ebe-6e0a" name="Orion Assault Dropship" hidden="false" collective="false" import="true" type="model">
@@ -3940,13 +3940,11 @@ During a Reaction made in any Phase, a player may not choose to activate a model
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="600"/>
       </costs>
       <categoryLinks>
-        <categoryLink targetId="e2b6-b770-784c-9e95" id="b8f4-59d9-4dc6-85b0" name="Vehicle" primary="false"/>
-        <categoryLink targetId="4e84-2d57-4986-2b23" id="dc1b-369d-4476-8b34" name="Flyer" primary="false"/>
-        <categoryLink targetId="3a7a-8bb7-b0d3-e2e7" id="cdee-8d6e-4d99-81b6" name="Hover" primary="false"/>
-        <categoryLink targetId="7f9b-c5ed-7edb-02dc" id="a526-c481-4d11-9f79" name="Lumbering" primary="false"/>
+        <categoryLink targetId="e2b6-b770-784c-9e95" id="b8f4-59d9-4dc6-85b0" name="Vehicle:" primary="false"/>
+        <categoryLink targetId="4e84-2d57-4986-2b23" id="dc1b-369d-4476-8b34" name="Flyer Sub-type" primary="false"/>
+        <categoryLink targetId="3a7a-8bb7-b0d3-e2e7" id="cdee-8d6e-4d99-81b6" name="Hover Sub-type" primary="false"/>
+        <categoryLink targetId="7f9b-c5ed-7edb-02dc" id="a526-c481-4d11-9f79" name="Lumbering Sub-type" primary="false"/>
       </categoryLinks>
-      <comment>!BSC Errors from 20240328-1346
-Could not find type or subtype &apos;Transpor&apos;</comment>
     </selectionEntry>
     <selectionEntry id="aa0c-15a3-9d4b-ac47" name="Ares Gunship" hidden="false" collective="false" import="true" type="model">
       <profiles>
@@ -4019,10 +4017,10 @@ Could not find type or subtype &apos;Transpor&apos;</comment>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="650"/>
       </costs>
       <categoryLinks>
-        <categoryLink targetId="e2b6-b770-784c-9e95" id="432d-cbb5-47c4-8267" name="Vehicle" primary="false"/>
-        <categoryLink targetId="4e84-2d57-4986-2b23" id="24f0-d6f5-4140-a5d1" name="Flyer" primary="false"/>
-        <categoryLink targetId="3a7a-8bb7-b0d3-e2e7" id="55ac-eadd-47bf-b853" name="Hover" primary="false"/>
-        <categoryLink targetId="7f9b-c5ed-7edb-02dc" id="a7ad-2abb-426d-8981" name="Lumbering" primary="false"/>
+        <categoryLink targetId="e2b6-b770-784c-9e95" id="432d-cbb5-47c4-8267" name="Vehicle:" primary="false"/>
+        <categoryLink targetId="4e84-2d57-4986-2b23" id="24f0-d6f5-4140-a5d1" name="Flyer Sub-type" primary="false"/>
+        <categoryLink targetId="3a7a-8bb7-b0d3-e2e7" id="55ac-eadd-47bf-b853" name="Hover Sub-type" primary="false"/>
+        <categoryLink targetId="7f9b-c5ed-7edb-02dc" id="a7ad-2abb-426d-8981" name="Lumbering Sub-type" primary="false"/>
       </categoryLinks>
     </selectionEntry>
     <selectionEntry id="2357-23af-0317-1a79" name="Adrastus Bolt Caliver" hidden="false" collective="false" import="true" type="upgrade">

--- a/2022 - LI - Custodes.cat
+++ b/2022 - LI - Custodes.cat
@@ -597,6 +597,11 @@
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="300"/>
           </costs>
+          <categoryLinks>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="270d-7c35-492d-91ea" name="Infantry" primary="false"/>
+            <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="6c9f-2c47-4a4e-826b" name="Character" primary="false"/>
+            <categoryLink targetId="59a4-7b61-600a-c457" id="3246-87ee-4b0f-83bd" name="Skirmish" primary="false"/>
+          </categoryLinks>
         </selectionEntry>
       </selectionEntries>
       <costs>
@@ -851,6 +856,10 @@
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="70"/>
           </costs>
+          <categoryLinks>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="ab03-271b-4a46-8fbe" name="Infantry" primary="false"/>
+            <categoryLink targetId="59a4-7b61-600a-c457" id="277d-c69d-4366-b678" name="Skirmish" primary="false"/>
+          </categoryLinks>
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
@@ -943,6 +952,11 @@
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="105"/>
               </costs>
+              <categoryLinks>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="1717-d305-46c3-b9db" name="Infantry" primary="false"/>
+                <categoryLink targetId="59a4-7b61-600a-c457" id="7a15-4716-4682-ace4" name="Skirmish" primary="false"/>
+                <categoryLink targetId="9231-183c-b97b-63f9" id="b3db-8bb1-478e-a1d0" name="Heavy" primary="false"/>
+              </categoryLinks>
             </selectionEntry>
             <selectionEntry id="e6d8-b264-6ebb-213d" name="Aquilon w/ Solarite Power Gauntlet &amp; Infernus Firepike" hidden="false" collective="false" import="true" type="model">
               <constraints>
@@ -968,6 +982,11 @@
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="105"/>
               </costs>
+              <categoryLinks>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="0786-707b-41e9-ad37" name="Infantry" primary="false"/>
+                <categoryLink targetId="59a4-7b61-600a-c457" id="ff4d-4592-4033-82bc" name="Skirmish" primary="false"/>
+                <categoryLink targetId="9231-183c-b97b-63f9" id="1492-8e5b-4e97-95b7" name="Heavy" primary="false"/>
+              </categoryLinks>
             </selectionEntry>
             <selectionEntry id="f5f5-d024-af1b-83c5" name="Aquilon w/ Solarite Power Talon &amp; Twin-Linked Adrathic Destructor" hidden="false" collective="false" import="true" type="model">
               <constraints>
@@ -993,6 +1012,11 @@
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="105"/>
               </costs>
+              <categoryLinks>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="0563-3cce-4af3-bc5b" name="Infantry" primary="false"/>
+                <categoryLink targetId="59a4-7b61-600a-c457" id="6602-c3bf-45e0-b497" name="Skirmish" primary="false"/>
+                <categoryLink targetId="9231-183c-b97b-63f9" id="9b7c-798b-444b-bc5b" name="Heavy" primary="false"/>
+              </categoryLinks>
             </selectionEntry>
             <selectionEntry id="3b03-cf93-c721-4c45" name="Aquilon w/ Solarite Power Gauntlet &amp; Lastrum Storm Bolter" hidden="false" collective="false" import="true" type="model">
               <constraints>
@@ -1018,6 +1042,11 @@
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="90"/>
               </costs>
+              <categoryLinks>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="37ff-49bb-483d-b0b4" name="Infantry" primary="false"/>
+                <categoryLink targetId="59a4-7b61-600a-c457" id="9683-593f-4cdb-a0f7" name="Skirmish" primary="false"/>
+                <categoryLink targetId="9231-183c-b97b-63f9" id="4af5-c5e5-47f4-bec4" name="Heavy" primary="false"/>
+              </categoryLinks>
             </selectionEntry>
             <selectionEntry id="b50a-3dc9-3a90-c15c" name="Aquilon w/ Solarite Power Gauntlet &amp; Solarite Power Talon" hidden="false" collective="false" import="true" type="model">
               <constraints>
@@ -1043,6 +1072,11 @@
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="90"/>
               </costs>
+              <categoryLinks>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="d2df-32e1-4084-b94d" name="Infantry" primary="false"/>
+                <categoryLink targetId="59a4-7b61-600a-c457" id="3b30-6fbc-4091-9a84" name="Skirmish" primary="false"/>
+                <categoryLink targetId="9231-183c-b97b-63f9" id="3af8-be5b-4e1e-9d08" name="Heavy" primary="false"/>
+              </categoryLinks>
             </selectionEntry>
             <selectionEntry id="e10f-e6da-6a20-ae01" name="Aquilon w/ Solarite Power Talon &amp; Infernus Firepike" hidden="false" collective="false" import="true" type="model">
               <constraints>
@@ -1068,6 +1102,11 @@
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="105"/>
               </costs>
+              <categoryLinks>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="b998-3e8b-401b-b1c8" name="Infantry" primary="false"/>
+                <categoryLink targetId="59a4-7b61-600a-c457" id="50b3-d135-4068-8f1e" name="Skirmish" primary="false"/>
+                <categoryLink targetId="9231-183c-b97b-63f9" id="735f-c51f-4e77-80fb" name="Heavy" primary="false"/>
+              </categoryLinks>
             </selectionEntry>
             <selectionEntry id="02d3-2f77-69a4-b0a5" name="Aquilon w/ Solarite 2X Power Talons" hidden="false" collective="false" import="true" type="model">
               <constraints>
@@ -1101,6 +1140,11 @@
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="90"/>
               </costs>
+              <categoryLinks>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="7915-2833-41ff-8788" name="Infantry" primary="false"/>
+                <categoryLink targetId="59a4-7b61-600a-c457" id="1dfe-1969-4f68-85b2" name="Skirmish" primary="false"/>
+                <categoryLink targetId="9231-183c-b97b-63f9" id="89d1-c1a9-47f9-96a2" name="Heavy" primary="false"/>
+              </categoryLinks>
             </selectionEntry>
             <selectionEntry id="68d9-52e0-0e62-e879" name="Aquilon w/ Solarite Power Talon &amp; Lastrum Storm Bolter" hidden="false" collective="false" import="true" type="model">
               <constraints>
@@ -1126,6 +1170,11 @@
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="90"/>
               </costs>
+              <categoryLinks>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="a9ef-6b90-4daa-9b24" name="Infantry" primary="false"/>
+                <categoryLink targetId="59a4-7b61-600a-c457" id="bdec-23b6-414a-a92c" name="Skirmish" primary="false"/>
+                <categoryLink targetId="9231-183c-b97b-63f9" id="643b-f5cc-49e5-943f" name="Heavy" primary="false"/>
+              </categoryLinks>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
@@ -1187,6 +1236,11 @@
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="45"/>
               </costs>
+              <categoryLinks>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="e660-5ba3-449b-9ccb" name="Infantry" primary="false"/>
+                <categoryLink targetId="59a4-7b61-600a-c457" id="cc43-8b08-466c-882f" name="Skirmish" primary="false"/>
+                <categoryLink targetId="6399-5c65-7833-1025" id="0594-48ea-42e3-8f54" name="Line" primary="false"/>
+              </categoryLinks>
             </selectionEntry>
             <selectionEntry id="7546-51fe-0073-06fd" name="Custodian Guard w/ Pyrihite Spear" hidden="false" collective="false" import="true" type="model">
               <constraints>
@@ -1206,6 +1260,11 @@
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="60"/>
               </costs>
+              <categoryLinks>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="2241-cc7c-4a37-b6ba" name="Infantry" primary="false"/>
+                <categoryLink targetId="59a4-7b61-600a-c457" id="81ea-873e-4713-9174" name="Skirmish" primary="false"/>
+                <categoryLink targetId="6399-5c65-7833-1025" id="284c-b0cf-41e3-b944" name="Line" primary="false"/>
+              </categoryLinks>
             </selectionEntry>
             <selectionEntry id="be52-52ce-b2cf-bf20" name="Custodian Guard w/ Adrasite Spear" hidden="false" collective="false" import="true" type="model">
               <constraints>
@@ -1239,6 +1298,11 @@
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="55"/>
               </costs>
+              <categoryLinks>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="6ebc-04f0-4e7f-972b" name="Infantry" primary="false"/>
+                <categoryLink targetId="59a4-7b61-600a-c457" id="21b9-7a14-4716-b76e" name="Skirmish" primary="false"/>
+                <categoryLink targetId="6399-5c65-7833-1025" id="26b2-3b14-4b5a-93f8" name="Line" primary="false"/>
+              </categoryLinks>
             </selectionEntry>
             <selectionEntry id="0a74-0ea1-da5f-e3b7" name="Custodian Guard w/ Guardian Axe" hidden="false" collective="false" import="true" type="model">
               <constraints>
@@ -1258,6 +1322,11 @@
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="45"/>
               </costs>
+              <categoryLinks>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="fa94-6cd3-475f-b602" name="Infantry" primary="false"/>
+                <categoryLink targetId="59a4-7b61-600a-c457" id="60ac-062c-4e45-8ecf" name="Skirmish" primary="false"/>
+                <categoryLink targetId="6399-5c65-7833-1025" id="51c1-5156-4832-9209" name="Line" primary="false"/>
+              </categoryLinks>
             </selectionEntry>
           </selectionEntries>
           <selectionEntryGroups>
@@ -1276,6 +1345,11 @@
                   <costs>
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="65"/>
                   </costs>
+                  <categoryLinks>
+                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="c536-00ec-4746-b115" name="Infantry" primary="false"/>
+                    <categoryLink targetId="59a4-7b61-600a-c457" id="4937-3cd2-4b62-90e8" name="Skirmish" primary="false"/>
+                    <categoryLink targetId="6399-5c65-7833-1025" id="4f9e-0628-4b21-9bb7" name="Line" primary="false"/>
+                  </categoryLinks>
                 </selectionEntry>
                 <selectionEntry id="8dc5-b5d6-e154-a8eb" name="Custodian Guard w/ Master-Crafted Power Lance &amp; Vexilla" hidden="false" collective="false" import="true" type="model">
                   <constraints>
@@ -1287,6 +1361,11 @@
                   <costs>
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="60"/>
                   </costs>
+                  <categoryLinks>
+                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="6b19-48bf-4987-941d" name="Infantry" primary="false"/>
+                    <categoryLink targetId="59a4-7b61-600a-c457" id="af4c-53c7-4453-8d5d" name="Skirmish" primary="false"/>
+                    <categoryLink targetId="6399-5c65-7833-1025" id="063c-bd1e-42c5-ae76" name="Line" primary="false"/>
+                  </categoryLinks>
                 </selectionEntry>
                 <selectionEntry id="8de9-3bdc-c580-b9aa" name="Custodian Guard w/ Master-Crafted Power Maul &amp; Vexilla" hidden="false" collective="false" import="true" type="model">
                   <constraints>
@@ -1298,6 +1377,11 @@
                   <costs>
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="60"/>
                   </costs>
+                  <categoryLinks>
+                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="4fb3-3830-4fd1-8334" name="Infantry" primary="false"/>
+                    <categoryLink targetId="59a4-7b61-600a-c457" id="e7eb-ad61-403b-83d6" name="Skirmish" primary="false"/>
+                    <categoryLink targetId="6399-5c65-7833-1025" id="380f-a690-491b-91a5" name="Line" primary="false"/>
+                  </categoryLinks>
                 </selectionEntry>
                 <selectionEntry id="67fb-8d60-68ee-2fae" name="Custodian Guard w/ Master-Crafted Power Axe &amp; Vexilla" hidden="false" collective="false" import="true" type="model">
                   <constraints>
@@ -1309,6 +1393,11 @@
                   <costs>
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="60"/>
                   </costs>
+                  <categoryLinks>
+                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="c788-f6ed-4b5d-9fe9" name="Infantry" primary="false"/>
+                    <categoryLink targetId="59a4-7b61-600a-c457" id="1be0-a4a9-41d8-a144" name="Skirmish" primary="false"/>
+                    <categoryLink targetId="6399-5c65-7833-1025" id="97d1-7508-4349-8a74" name="Line" primary="false"/>
+                  </categoryLinks>
                 </selectionEntry>
                 <selectionEntry id="8497-6360-cc95-acf2" name="Custodian Guard w/ Master-Crafted Power Sword &amp; Vexilla" hidden="false" collective="false" import="true" type="model">
                   <constraints>
@@ -1399,6 +1488,11 @@
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="55"/>
               </costs>
+              <categoryLinks>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="4937-4abe-42c3-9b43" name="Infantry" primary="false"/>
+                <categoryLink targetId="59a4-7b61-600a-c457" id="7862-ef98-422d-b2a1" name="Skirmish" primary="false"/>
+                <categoryLink targetId="6399-5c65-7833-1025" id="3e83-08d3-46d0-8aad" name="Line" primary="false"/>
+              </categoryLinks>
             </selectionEntry>
             <selectionEntry id="fb12-f008-703b-3f30" name="Sentinel Guard w/ Solarite Power Gauntlet &amp; Shield" hidden="false" collective="false" import="true" type="model">
               <infoLinks>
@@ -1421,6 +1515,11 @@
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="75"/>
               </costs>
+              <categoryLinks>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="74d0-d192-4038-b9a5" name="Infantry" primary="false"/>
+                <categoryLink targetId="59a4-7b61-600a-c457" id="e77a-e42a-4984-b3d5" name="Skirmish" primary="false"/>
+                <categoryLink targetId="6399-5c65-7833-1025" id="2b10-84be-4be8-9df4" name="Line" primary="false"/>
+              </categoryLinks>
             </selectionEntry>
             <selectionEntry id="2906-1c80-a8ed-6672" name="Sentinel Guard w/ Sentinel Warblade &amp; Shield" hidden="false" collective="false" import="true" type="model">
               <profiles>
@@ -1457,6 +1556,11 @@
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="45"/>
               </costs>
+              <categoryLinks>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="4aa6-3cd4-4213-b3b5" name="Infantry" primary="false"/>
+                <categoryLink targetId="59a4-7b61-600a-c457" id="1e1b-c299-46ee-8441" name="Skirmish" primary="false"/>
+                <categoryLink targetId="6399-5c65-7833-1025" id="92ad-d1c4-47e2-966b" name="Line" primary="false"/>
+              </categoryLinks>
             </selectionEntry>
           </selectionEntries>
           <selectionEntryGroups>
@@ -1489,6 +1593,11 @@
                   <costs>
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="65"/>
                   </costs>
+                  <categoryLinks>
+                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="5b42-1678-4051-ba8b" name="Infantry" primary="false"/>
+                    <categoryLink targetId="59a4-7b61-600a-c457" id="9693-fe77-4a7a-a24f" name="Skirmish" primary="false"/>
+                    <categoryLink targetId="6399-5c65-7833-1025" id="67c4-b35f-4315-8f86" name="Line" primary="false"/>
+                  </categoryLinks>
                 </selectionEntry>
                 <selectionEntry id="3665-6d98-26e6-ef50" name="Sentinel Guard w/ Solarite Power Gauntlet &amp; Vexilla" hidden="false" collective="false" import="true" type="model">
                   <constraints>
@@ -1514,6 +1623,11 @@
                   <costs>
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="85"/>
                   </costs>
+                  <categoryLinks>
+                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="a5c0-775d-413f-a48c" name="Infantry" primary="false"/>
+                    <categoryLink targetId="59a4-7b61-600a-c457" id="3212-e18f-45a7-8524" name="Skirmish" primary="false"/>
+                    <categoryLink targetId="6399-5c65-7833-1025" id="4cde-612a-4737-aea4" name="Line" primary="false"/>
+                  </categoryLinks>
                 </selectionEntry>
                 <selectionEntry id="bf33-5019-fe30-a70a" name="Sentinel Guard w/ Sentinel Warblade &amp; Vexilla" hidden="false" collective="false" import="true" type="model">
                   <constraints>
@@ -1539,6 +1653,11 @@
                   <costs>
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="55"/>
                   </costs>
+                  <categoryLinks>
+                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="f62e-b918-41c2-a4c8" name="Infantry" primary="false"/>
+                    <categoryLink targetId="59a4-7b61-600a-c457" id="6de7-6eaa-45ee-8555" name="Skirmish" primary="false"/>
+                    <categoryLink targetId="6399-5c65-7833-1025" id="ce3c-fe94-42e0-85d8" name="Line" primary="false"/>
+                  </categoryLinks>
                 </selectionEntry>
               </selectionEntries>
             </selectionEntryGroup>
@@ -1675,6 +1794,11 @@
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="85"/>
               </costs>
+              <categoryLinks>
+                <categoryLink targetId="6d79-a3e4-381f-7b0f" id="d7ef-d039-4f6a-817e" name="Cavalry" primary="false"/>
+                <categoryLink targetId="59a4-7b61-600a-c457" id="4387-e6d6-4ebc-9521" name="Skirmish" primary="false"/>
+                <categoryLink targetId="4303-1348-cce4-9501" id="df36-422e-47d4-a220" name="Antigrav" primary="false"/>
+              </categoryLinks>
             </selectionEntry>
             <selectionEntry id="bc7b-9471-b7b9-dbd9" name="Agamatus with Adrathic Devastator" hidden="false" collective="false" import="true" type="model">
               <constraints>
@@ -1708,6 +1832,11 @@
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="100"/>
               </costs>
+              <categoryLinks>
+                <categoryLink targetId="6d79-a3e4-381f-7b0f" id="d296-4bff-4b3e-8122" name="Cavalry" primary="false"/>
+                <categoryLink targetId="59a4-7b61-600a-c457" id="1c18-6ff4-4530-a4f5" name="Skirmish" primary="false"/>
+                <categoryLink targetId="4303-1348-cce4-9501" id="1f94-0641-494f-b5b9" name="Antigrav" primary="false"/>
+              </categoryLinks>
             </selectionEntry>
             <selectionEntry id="c410-e50f-8751-bda1" name="Agamatus with Twin-linked Corvae Las-Pulser" hidden="false" collective="false" import="true" type="model">
               <constraints>
@@ -1727,6 +1856,11 @@
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="120"/>
               </costs>
+              <categoryLinks>
+                <categoryLink targetId="6d79-a3e4-381f-7b0f" id="5f9a-fd30-4383-a618" name="Cavalry" primary="false"/>
+                <categoryLink targetId="59a4-7b61-600a-c457" id="4f19-5cfd-4e2c-8d79" name="Skirmish" primary="false"/>
+                <categoryLink targetId="4303-1348-cce4-9501" id="6174-1f99-441f-8b19" name="Antigrav" primary="false"/>
+              </categoryLinks>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
@@ -1792,6 +1926,8 @@
               <categoryLinks>
                 <categoryLink id="01f1-f064-5384-5dfb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
                 <categoryLink id="cb6c-c2b2-8add-13da" name="Legio Custodes" hidden="false" targetId="ccca-a9de-0cd9-f8be" primary="false"/>
+                <categoryLink targetId="e2b6-b770-784c-9e95" id="3a06-5a51-4d5a-bb88" name="Vehicle" primary="false"/>
+                <categoryLink targetId="0ea2-efb5-b7af-226e" id="73d4-ef2e-4a7f-8174" name="Fast" primary="false"/>
               </categoryLinks>
               <entryLinks>
                 <entryLink id="2f39-a580-9869-d17a" name="Twin-Linked Arachnus Blaze Cannon" hidden="false" collective="false" import="true" targetId="1f5b-6e05-e40b-7305" type="selectionEntry">
@@ -1804,6 +1940,8 @@
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="60"/>
               </costs>
+              <comment>!BSC Errors from 20240328-1346
+Could not find type or subtype &apos;Skimmer&apos;</comment>
             </selectionEntry>
             <selectionEntry id="3394-a13d-f029-e555" name="Pallas with Twin-Linked Adrathic Devastator" publicationId="15a4-fc68-502d-48a9" page="29" hidden="false" collective="false" import="true" type="model">
               <profiles>
@@ -1824,6 +1962,8 @@
               <categoryLinks>
                 <categoryLink id="77f0-b604-ed69-9dec" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
                 <categoryLink id="8f99-1140-18b2-45d4" name="Legio Custodes" hidden="false" targetId="ccca-a9de-0cd9-f8be" primary="false"/>
+                <categoryLink targetId="e2b6-b770-784c-9e95" id="5f6b-405e-4f27-9aa7" name="Vehicle" primary="false"/>
+                <categoryLink targetId="0ea2-efb5-b7af-226e" id="4f54-94a5-453c-ba79" name="Fast" primary="false"/>
               </categoryLinks>
               <entryLinks>
                 <entryLink id="8a74-5ed5-7929-40a8" name="Twin-linked Adrathic Devastator" hidden="false" collective="false" import="true" targetId="4e5a-43f5-605d-0f4f" type="selectionEntry">
@@ -1836,6 +1976,8 @@
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="80"/>
               </costs>
+              <comment>!BSC Errors from 20240328-1346
+Could not find type or subtype &apos;Skimmer&apos;</comment>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
@@ -2078,6 +2220,10 @@
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="50"/>
               </costs>
+              <categoryLinks>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="ba9c-7001-461e-a6c4" name="Infantry" primary="false"/>
+                <categoryLink targetId="59a4-7b61-600a-c457" id="573e-d2eb-43ab-b20a" name="Skirmish" primary="false"/>
+              </categoryLinks>
             </selectionEntry>
             <selectionEntry id="c1a4-cce9-495b-1a0c" name="Sentinal Guard w/ Magisterium Vexilla and Adrathic Destructor" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
@@ -3342,6 +3488,11 @@ the Front Armour during the same Phase.�</characteristic>
       <costs>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="200"/>
       </costs>
+      <categoryLinks>
+        <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="d98d-b8eb-44ff-8da1" name="Infantry" primary="false"/>
+        <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="f11c-181e-4062-a315" name="Character" primary="false"/>
+        <categoryLink targetId="59a4-7b61-600a-c457" id="b212-6891-4c2a-af63" name="Skirmish" primary="false"/>
+      </categoryLinks>
     </selectionEntry>
     <selectionEntry id="abad-0b02-cb27-28b3" name="Contemptor-Achillus Dreadnought" hidden="false" collective="false" import="true" type="model">
       <profiles>
@@ -3571,6 +3722,9 @@ the Front Armour during the same Phase.�</characteristic>
       <costs>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="235"/>
       </costs>
+      <categoryLinks>
+        <categoryLink targetId="4280-4963-02b5-e31d" id="2226-9c28-4c15-81e7" name="Dreadnought" primary="false"/>
+      </categoryLinks>
     </selectionEntry>
     <selectionEntry id="7cf8-3f52-2876-60e9" name="Venatari Jump Harness" publicationId="15a4-fc68-502d-48a9" page="159" hidden="false" collective="false" import="true" type="upgrade">
       <profiles>
@@ -3730,6 +3884,10 @@ During a Reaction made in any Phase, a player may not choose to activate a model
       <costs>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="225"/>
       </costs>
+      <categoryLinks>
+        <categoryLink targetId="e2b6-b770-784c-9e95" id="ac91-afc2-4416-bf1f" name="Vehicle" primary="false"/>
+        <categoryLink targetId="4303-1348-cce4-9501" id="4e11-29e7-4774-a2ab" name="Antigrav" primary="false"/>
+      </categoryLinks>
     </selectionEntry>
     <selectionEntry id="6526-bdfb-4ebe-6e0a" name="Orion Assault Dropship" hidden="false" collective="false" import="true" type="model">
       <profiles>
@@ -3783,6 +3941,14 @@ During a Reaction made in any Phase, a player may not choose to activate a model
       <costs>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="600"/>
       </costs>
+      <categoryLinks>
+        <categoryLink targetId="e2b6-b770-784c-9e95" id="b8f4-59d9-4dc6-85b0" name="Vehicle" primary="false"/>
+        <categoryLink targetId="4e84-2d57-4986-2b23" id="dc1b-369d-4476-8b34" name="Flyer" primary="false"/>
+        <categoryLink targetId="3a7a-8bb7-b0d3-e2e7" id="cdee-8d6e-4d99-81b6" name="Hover" primary="false"/>
+        <categoryLink targetId="7f9b-c5ed-7edb-02dc" id="a526-c481-4d11-9f79" name="Lumbering" primary="false"/>
+      </categoryLinks>
+      <comment>!BSC Errors from 20240328-1346
+Could not find type or subtype &apos;Transpor&apos;</comment>
     </selectionEntry>
     <selectionEntry id="aa0c-15a3-9d4b-ac47" name="Ares Gunship" hidden="false" collective="false" import="true" type="model">
       <profiles>
@@ -3854,6 +4020,12 @@ During a Reaction made in any Phase, a player may not choose to activate a model
       <costs>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="650"/>
       </costs>
+      <categoryLinks>
+        <categoryLink targetId="e2b6-b770-784c-9e95" id="432d-cbb5-47c4-8267" name="Vehicle" primary="false"/>
+        <categoryLink targetId="4e84-2d57-4986-2b23" id="24f0-d6f5-4140-a5d1" name="Flyer" primary="false"/>
+        <categoryLink targetId="3a7a-8bb7-b0d3-e2e7" id="55ac-eadd-47bf-b853" name="Hover" primary="false"/>
+        <categoryLink targetId="7f9b-c5ed-7edb-02dc" id="a7ad-2abb-426d-8981" name="Lumbering" primary="false"/>
+      </categoryLinks>
     </selectionEntry>
     <selectionEntry id="2357-23af-0317-1a79" name="Adrastus Bolt Caliver" hidden="false" collective="false" import="true" type="upgrade">
       <profiles>

--- a/2022 - LI - Custodes.cat
+++ b/2022 - LI - Custodes.cat
@@ -1928,6 +1928,7 @@
                 <categoryLink id="cb6c-c2b2-8add-13da" name="Legio Custodes" hidden="false" targetId="ccca-a9de-0cd9-f8be" primary="false"/>
                 <categoryLink targetId="e2b6-b770-784c-9e95" id="3a06-5a51-4d5a-bb88" name="Vehicle" primary="false"/>
                 <categoryLink targetId="0ea2-efb5-b7af-226e" id="73d4-ef2e-4a7f-8174" name="Fast" primary="false"/>
+                <categoryLink targetId="6a28-17c5-8117-d99c" id="1e0c-9088-493b-a54f" name="Skimmer" primary="false"/>
               </categoryLinks>
               <entryLinks>
                 <entryLink id="2f39-a580-9869-d17a" name="Twin-Linked Arachnus Blaze Cannon" hidden="false" collective="false" import="true" targetId="1f5b-6e05-e40b-7305" type="selectionEntry">
@@ -1940,8 +1941,6 @@
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="60"/>
               </costs>
-              <comment>!BSC Errors from 20240328-1346
-Could not find type or subtype &apos;Skimmer&apos;</comment>
             </selectionEntry>
             <selectionEntry id="3394-a13d-f029-e555" name="Pallas with Twin-Linked Adrathic Devastator" publicationId="15a4-fc68-502d-48a9" page="29" hidden="false" collective="false" import="true" type="model">
               <profiles>
@@ -1964,6 +1963,7 @@ Could not find type or subtype &apos;Skimmer&apos;</comment>
                 <categoryLink id="8f99-1140-18b2-45d4" name="Legio Custodes" hidden="false" targetId="ccca-a9de-0cd9-f8be" primary="false"/>
                 <categoryLink targetId="e2b6-b770-784c-9e95" id="5f6b-405e-4f27-9aa7" name="Vehicle" primary="false"/>
                 <categoryLink targetId="0ea2-efb5-b7af-226e" id="4f54-94a5-453c-ba79" name="Fast" primary="false"/>
+                <categoryLink targetId="6a28-17c5-8117-d99c" id="f24d-aeed-4d71-83c6" name="Skimmer" primary="false"/>
               </categoryLinks>
               <entryLinks>
                 <entryLink id="8a74-5ed5-7929-40a8" name="Twin-linked Adrathic Devastator" hidden="false" collective="false" import="true" targetId="4e5a-43f5-605d-0f4f" type="selectionEntry">
@@ -1976,8 +1976,6 @@ Could not find type or subtype &apos;Skimmer&apos;</comment>
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="80"/>
               </costs>
-              <comment>!BSC Errors from 20240328-1346
-Could not find type or subtype &apos;Skimmer&apos;</comment>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>

--- a/2022 - LI - Custodes.cat
+++ b/2022 - LI - Custodes.cat
@@ -917,8 +917,8 @@
       <categoryLinks>
         <categoryLink id="12ab-2abe-e379-ae07" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="5797-77fd-47c1-3b72" name="Legio Custodes" hidden="false" targetId="ccca-a9de-0cd9-f8be" primary="false"/>
-        <categoryLink id="5977-631d-7dc9-bf7e" name="Skirmish Sub-type:" hidden="false" targetId="59a4-7b61-600a-c457" primary="false"/>
-        <categoryLink id="408b-7ea1-2f7e-fa1b" name="Heavy Sub-type:" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+        <categoryLink id="5977-631d-7dc9-bf7e" name="Skirmish Sub-type" hidden="false" targetId="59a4-7b61-600a-c457" primary="false"/>
+        <categoryLink id="408b-7ea1-2f7e-fa1b" name="Heavy Sub-type" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
         <categoryLink id="c43b-ac00-e293-42ed" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
@@ -1722,7 +1722,7 @@
         <categoryLink id="09ec-fc5e-3f34-aeb8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="b673-5b47-1b69-42ed" name="Legio Custodes" hidden="false" targetId="ccca-a9de-0cd9-f8be" primary="false"/>
         <categoryLink id="4776-46fc-0598-b8ab" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
-        <categoryLink id="96fe-fdac-52e7-ff96" name="Transport Sub-type:" hidden="false" targetId="7b0a-a743-a8da-3a39" primary="false"/>
+        <categoryLink id="96fe-fdac-52e7-ff96" name="Transport Sub-type" hidden="false" targetId="7b0a-a743-a8da-3a39" primary="false"/>
       </categoryLinks>
       <entryLinks>
         <entryLink id="5827-b8f8-6167-7700" name="Twin Lastrum Bolt Cannon" hidden="false" collective="false" import="true" targetId="5eb8-dd6c-05ee-17d5" type="selectionEntry">
@@ -1766,7 +1766,7 @@
       <categoryLinks>
         <categoryLink id="3f92-c5f9-653d-5ecc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="99f3-cd79-499a-6777" name="Legio Custodes" hidden="false" targetId="ccca-a9de-0cd9-f8be" primary="false"/>
-        <categoryLink id="6925-bf7b-5d67-58bb" name="Skirmish Sub-type:" hidden="false" targetId="59a4-7b61-600a-c457" primary="false"/>
+        <categoryLink id="6925-bf7b-5d67-58bb" name="Skirmish Sub-type" hidden="false" targetId="59a4-7b61-600a-c457" primary="false"/>
         <categoryLink id="8b0f-14af-9440-fba0" name="Antigrav Sub-type" hidden="false" targetId="4303-1348-cce4-9501" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
@@ -3517,7 +3517,7 @@ the Front Armour during the same Phase.�</characteristic>
         <infoLink id="2e0e-bab8-5973-011b" name="Loyalist" hidden="false" targetId="d1de-a45d-2b9b-c878" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="5e24-b212-8d6e-f99e" name="Dreadnought Unit-type:" hidden="false" targetId="4280-4963-02b5-e31d" primary="false"/>
+        <categoryLink id="5e24-b212-8d6e-f99e" name="Dreadnought Unit Type" hidden="false" targetId="4280-4963-02b5-e31d" primary="false"/>
         <categoryLink id="aced-8f0e-a2d4-d5ec" name="Legio Custodes" hidden="false" targetId="ccca-a9de-0cd9-f8be" primary="false"/>
         <categoryLink id="30f5-2d58-9563-d534" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>

--- a/2022 - LI - Sisters Of Silence.cat
+++ b/2022 - LI - Sisters Of Silence.cat
@@ -2533,7 +2533,7 @@ In addition, the Leadership Characteristic of a model with the Anathema Unit Sub
               <profiles>
                 <profile id="3095-90f5-f1f8-6da8" name="Questora" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName="Unit">
                   <characteristics>
-                    <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infanty (Light, Line, Anathema)</characteristic>
+                    <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Light, Line, Anathema)</characteristic>
                     <characteristic name="Move" typeId="893e-2d76-8f04-44e5">6</characteristic>
                     <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">5</characteristic>
                     <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
@@ -2608,9 +2608,8 @@ In addition, the Leadership Characteristic of a model with the Anathema Unit Sub
                 <categoryLink targetId="bff2-ae16-74a8-8712" id="7d84-14b4-40f2-a68d" name="Light" primary="false"/>
                 <categoryLink targetId="6399-5c65-7833-1025" id="3876-002a-40db-971c" name="Line" primary="false"/>
                 <categoryLink targetId="7e5d-d73e-8ff4-7345" id="8f05-a864-4625-a004" name="Anathema" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="b746-2c0a-4785-b50b" name="Infantry" primary="false"/>
               </categoryLinks>
-              <comment>!BSC Errors from 20240328-1346
-Could not find type or subtype &apos;Infanty&apos;</comment>
             </selectionEntry>
             <selectionEntry id="ab3d-ff19-d1d7-5aee" name="1) Questora w/ Pistols" hidden="false" collective="false" import="true" type="model">
               <modifiers>
@@ -2745,9 +2744,8 @@ Could not find type or subtype &apos;Infanty&apos;</comment>
                 <categoryLink targetId="bff2-ae16-74a8-8712" id="bca2-b5c6-42cf-a184" name="Light" primary="false"/>
                 <categoryLink targetId="6399-5c65-7833-1025" id="6177-cff5-4b22-be1a" name="Line" primary="false"/>
                 <categoryLink targetId="7e5d-d73e-8ff4-7345" id="c3be-47b5-429b-aad3" name="Anathema" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="e11c-ba12-49fd-a3a5" name="Infantry" primary="false"/>
               </categoryLinks>
-              <comment>!BSC Errors from 20240328-1346
-Could not find type or subtype &apos;Infanty&apos;</comment>
             </selectionEntry>
             <selectionEntry id="ee7c-6dad-729c-2139" name="2) Questora w/ Options" hidden="false" collective="false" import="true" type="model">
               <modifiers>
@@ -2903,9 +2901,8 @@ Could not find type or subtype &apos;Infanty&apos;</comment>
                 <categoryLink targetId="bff2-ae16-74a8-8712" id="61ab-e8fc-47ba-997e" name="Light" primary="false"/>
                 <categoryLink targetId="6399-5c65-7833-1025" id="ad9d-a246-4da2-908c" name="Line" primary="false"/>
                 <categoryLink targetId="7e5d-d73e-8ff4-7345" id="078d-7dd5-4d5c-a762" name="Anathema" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="a677-9888-4853-b198" name="Infantry" primary="false"/>
               </categoryLinks>
-              <comment>!BSC Errors from 20240328-1346
-Could not find type or subtype &apos;Infanty&apos;</comment>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>

--- a/2022 - LI - Sisters Of Silence.cat
+++ b/2022 - LI - Sisters Of Silence.cat
@@ -486,6 +486,13 @@ In addition, the Leadership Characteristic of a model with the Anathema Unit Sub
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="150"/>
           </costs>
+          <categoryLinks>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="fc63-b6be-433a-b68d" name="Infantry" primary="false"/>
+            <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="9790-c679-4843-acc9" name="Character" primary="false"/>
+            <categoryLink targetId="bff2-ae16-74a8-8712" id="5116-99bc-4f37-b532" name="Light" primary="false"/>
+            <categoryLink targetId="7e5d-d73e-8ff4-7345" id="71cd-f6b4-46a6-b9b7" name="Anathema" primary="false"/>
+            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="4457-7585-45d7-a648" name="Unique" primary="false"/>
+          </categoryLinks>
         </selectionEntry>
       </selectionEntries>
       <costs>
@@ -1028,6 +1035,12 @@ In addition, the Leadership Characteristic of a model with the Anathema Unit Sub
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="85"/>
           </costs>
+          <categoryLinks>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="bd31-9e55-41aa-b06c" name="Infantry" primary="false"/>
+            <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="ea86-1f3b-4828-886c" name="Character" primary="false"/>
+            <categoryLink targetId="bff2-ae16-74a8-8712" id="6431-7236-4bd3-9ec6" name="Light" primary="false"/>
+            <categoryLink targetId="7e5d-d73e-8ff4-7345" id="ed2f-7fd0-4d99-9c7b" name="Anathema" primary="false"/>
+          </categoryLinks>
         </selectionEntry>
       </selectionEntries>
       <costs>
@@ -1716,6 +1729,12 @@ In addition, the Leadership Characteristic of a model with the Anathema Unit Sub
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="55"/>
           </costs>
+          <categoryLinks>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="2918-5214-47f7-aa66" name="Infantry" primary="false"/>
+            <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="ba95-5e4c-42c7-ab62" name="Character" primary="false"/>
+            <categoryLink targetId="bff2-ae16-74a8-8712" id="dea5-d0a2-448b-b666" name="Light" primary="false"/>
+            <categoryLink targetId="7e5d-d73e-8ff4-7345" id="46c9-157a-4a48-a439" name="Anathema" primary="false"/>
+          </categoryLinks>
         </selectionEntry>
       </selectionEntries>
       <costs>
@@ -2311,6 +2330,13 @@ In addition, the Leadership Characteristic of a model with the Anathema Unit Sub
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="65"/>
           </costs>
+          <categoryLinks>
+            <categoryLink targetId="6d79-a3e4-381f-7b0f" id="458f-7e79-48af-b3e5" name="Cavalry" primary="false"/>
+            <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="2dc5-097b-479a-a335" name="Character" primary="false"/>
+            <categoryLink targetId="bff2-ae16-74a8-8712" id="b416-fea6-4f26-b398" name="Light" primary="false"/>
+            <categoryLink targetId="59a4-7b61-600a-c457" id="2e60-51f0-4ba3-b06f" name="Skirmish" primary="false"/>
+            <categoryLink targetId="7e5d-d73e-8ff4-7345" id="a3fe-a911-4218-b75d" name="Anathema" primary="false"/>
+          </categoryLinks>
         </selectionEntry>
       </selectionEntries>
       <costs>
@@ -2578,6 +2604,13 @@ In addition, the Leadership Characteristic of a model with the Anathema Unit Sub
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20"/>
               </costs>
+              <categoryLinks>
+                <categoryLink targetId="bff2-ae16-74a8-8712" id="7d84-14b4-40f2-a68d" name="Light" primary="false"/>
+                <categoryLink targetId="6399-5c65-7833-1025" id="3876-002a-40db-971c" name="Line" primary="false"/>
+                <categoryLink targetId="7e5d-d73e-8ff4-7345" id="8f05-a864-4625-a004" name="Anathema" primary="false"/>
+              </categoryLinks>
+              <comment>!BSC Errors from 20240328-1346
+Could not find type or subtype &apos;Infanty&apos;</comment>
             </selectionEntry>
             <selectionEntry id="ab3d-ff19-d1d7-5aee" name="1) Questora w/ Pistols" hidden="false" collective="false" import="true" type="model">
               <modifiers>
@@ -2708,6 +2741,13 @@ In addition, the Leadership Characteristic of a model with the Anathema Unit Sub
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20"/>
               </costs>
+              <categoryLinks>
+                <categoryLink targetId="bff2-ae16-74a8-8712" id="bca2-b5c6-42cf-a184" name="Light" primary="false"/>
+                <categoryLink targetId="6399-5c65-7833-1025" id="6177-cff5-4b22-be1a" name="Line" primary="false"/>
+                <categoryLink targetId="7e5d-d73e-8ff4-7345" id="c3be-47b5-429b-aad3" name="Anathema" primary="false"/>
+              </categoryLinks>
+              <comment>!BSC Errors from 20240328-1346
+Could not find type or subtype &apos;Infanty&apos;</comment>
             </selectionEntry>
             <selectionEntry id="ee7c-6dad-729c-2139" name="2) Questora w/ Options" hidden="false" collective="false" import="true" type="model">
               <modifiers>
@@ -2859,6 +2899,13 @@ In addition, the Leadership Characteristic of a model with the Anathema Unit Sub
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20"/>
               </costs>
+              <categoryLinks>
+                <categoryLink targetId="bff2-ae16-74a8-8712" id="61ab-e8fc-47ba-997e" name="Light" primary="false"/>
+                <categoryLink targetId="6399-5c65-7833-1025" id="ad9d-a246-4da2-908c" name="Line" primary="false"/>
+                <categoryLink targetId="7e5d-d73e-8ff4-7345" id="078d-7dd5-4d5c-a762" name="Anathema" primary="false"/>
+              </categoryLinks>
+              <comment>!BSC Errors from 20240328-1346
+Could not find type or subtype &apos;Infanty&apos;</comment>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
@@ -3065,6 +3112,12 @@ In addition, the Leadership Characteristic of a model with the Anathema Unit Sub
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="35"/>
           </costs>
+          <categoryLinks>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="9c68-cb62-4eb0-a73c" name="Infantry" primary="false"/>
+            <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="e51c-b1a6-4c33-9265" name="Character" primary="false"/>
+            <categoryLink targetId="bff2-ae16-74a8-8712" id="e658-b997-45c1-9086" name="Light" primary="false"/>
+            <categoryLink targetId="7e5d-d73e-8ff4-7345" id="578f-f743-4f13-8bb7" name="Anathema" primary="false"/>
+          </categoryLinks>
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
@@ -3181,6 +3234,8 @@ In addition, the Leadership Characteristic of a model with the Anathema Unit Sub
           </profiles>
           <categoryLinks>
             <categoryLink id="21ab-5752-4355-d9c0" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
+            <categoryLink targetId="bff2-ae16-74a8-8712" id="78a8-008e-4999-8cbc" name="Light" primary="false"/>
+            <categoryLink targetId="7e5d-d73e-8ff4-7345" id="09ff-d8ea-4d4f-b629" name="Anathema" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="b6d2-80ee-bf54-5b08" name="The Oblivion Knight Mistress may take any of the following:" hidden="false" collective="false" import="true">
@@ -3247,6 +3302,8 @@ In addition, the Leadership Characteristic of a model with the Anathema Unit Sub
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
           </costs>
+          <comment>!BSC Errors from 20240328-1346
+Could not find type or subtype &apos;Infanty&apos;</comment>
         </selectionEntry>
         <selectionEntry id="d862-dd78-104b-dc02" name="Oblivion Knight" hidden="false" collective="false" import="true" type="model">
           <modifierGroups>
@@ -3356,6 +3413,12 @@ In addition, the Leadership Characteristic of a model with the Anathema Unit Sub
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15"/>
           </costs>
+          <categoryLinks>
+            <categoryLink targetId="bff2-ae16-74a8-8712" id="3846-d1d6-4a33-8ab5" name="Light" primary="false"/>
+            <categoryLink targetId="7e5d-d73e-8ff4-7345" id="be0c-2621-41f1-9cc2" name="Anathema" primary="false"/>
+          </categoryLinks>
+          <comment>!BSC Errors from 20240328-1346
+Could not find type or subtype &apos;Infanty&apos;</comment>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
@@ -3445,6 +3508,8 @@ In addition, the Leadership Characteristic of a model with the Anathema Unit Sub
           </profiles>
           <categoryLinks>
             <categoryLink id="7d04-46e8-bd6a-a671" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
+            <categoryLink targetId="bff2-ae16-74a8-8712" id="5cd0-8b2b-40bc-8045" name="Light" primary="false"/>
+            <categoryLink targetId="7e5d-d73e-8ff4-7345" id="4630-8d85-43c0-a8c3" name="Anathema" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="465c-58a6-57df-a7ee" name="May take any of the following:" hidden="false" collective="false" import="true">
@@ -3583,6 +3648,8 @@ In addition, the Leadership Characteristic of a model with the Anathema Unit Sub
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
           </costs>
+          <comment>!BSC Errors from 20240328-1346
+Could not find type or subtype &apos;Infanty&apos;</comment>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
@@ -3642,6 +3709,12 @@ In addition, the Leadership Characteristic of a model with the Anathema Unit Sub
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10"/>
               </costs>
+              <categoryLinks>
+                <categoryLink targetId="bff2-ae16-74a8-8712" id="1a0b-cda2-422b-a4ad" name="Light" primary="false"/>
+                <categoryLink targetId="7e5d-d73e-8ff4-7345" id="20d5-118b-494f-9305" name="Anathema" primary="false"/>
+              </categoryLinks>
+              <comment>!BSC Errors from 20240328-1346
+Could not find type or subtype &apos;Infanty&apos;</comment>
             </selectionEntry>
             <selectionEntry id="1535-2e39-86f7-d64e" name="Eradicator w/ options" hidden="false" collective="false" import="true" type="model">
               <constraints>
@@ -3732,6 +3805,12 @@ In addition, the Leadership Characteristic of a model with the Anathema Unit Sub
               <infoLinks>
                 <infoLink id="c4f7-365a-e592-0f7e" name="Eradicator" targetId="1a1e-a7fd-7c32-3f56" type="profile"/>
               </infoLinks>
+              <categoryLinks>
+                <categoryLink targetId="bff2-ae16-74a8-8712" id="96df-1558-4545-b990" name="Light" primary="false"/>
+                <categoryLink targetId="7e5d-d73e-8ff4-7345" id="a2c9-e9d5-4a76-8ed4" name="Anathema" primary="false"/>
+              </categoryLinks>
+              <comment>!BSC Errors from 20240328-1346
+Could not find type or subtype &apos;Infanty&apos;</comment>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
@@ -3800,6 +3879,9 @@ In addition, the Leadership Characteristic of a model with the Anathema Unit Sub
           </profiles>
           <categoryLinks>
             <categoryLink id="57e4-d22a-0a57-b90c" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
+            <categoryLink targetId="bff2-ae16-74a8-8712" id="0939-8e62-4d0e-a482" name="Light" primary="false"/>
+            <categoryLink targetId="6399-5c65-7833-1025" id="b5c5-d909-401a-8de1" name="Line" primary="false"/>
+            <categoryLink targetId="7e5d-d73e-8ff4-7345" id="76a9-7b91-4c8a-9284" name="Anathema" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="a1ca-8743-3942-af58" name="May take any of the following:" hidden="false" collective="false" import="true">
@@ -3880,6 +3962,8 @@ In addition, the Leadership Characteristic of a model with the Anathema Unit Sub
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
           </costs>
+          <comment>!BSC Errors from 20240328-1346
+Could not find type or subtype &apos;Infanty&apos;</comment>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
@@ -3983,6 +4067,13 @@ In addition, the Leadership Characteristic of a model with the Anathema Unit Sub
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10"/>
               </costs>
+              <categoryLinks>
+                <categoryLink targetId="bff2-ae16-74a8-8712" id="015a-1702-40ea-b4dd" name="Light" primary="false"/>
+                <categoryLink targetId="6399-5c65-7833-1025" id="f89d-241b-4266-b94b" name="Line" primary="false"/>
+                <categoryLink targetId="7e5d-d73e-8ff4-7345" id="3be1-2220-46d6-9ee9" name="Anathema" primary="false"/>
+              </categoryLinks>
+              <comment>!BSC Errors from 20240328-1346
+Could not find type or subtype &apos;Infanty&apos;</comment>
             </selectionEntry>
             <selectionEntry id="6969-562f-576e-3775" name="Prosecutor w/ Options" hidden="false" collective="false" import="true" type="model">
               <constraints>
@@ -4055,6 +4146,13 @@ In addition, the Leadership Characteristic of a model with the Anathema Unit Sub
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10"/>
               </costs>
+              <categoryLinks>
+                <categoryLink targetId="bff2-ae16-74a8-8712" id="b9ee-98cd-4c4c-aa02" name="Light" primary="false"/>
+                <categoryLink targetId="6399-5c65-7833-1025" id="66a2-a6a1-40a5-9b5e" name="Line" primary="false"/>
+                <categoryLink targetId="7e5d-d73e-8ff4-7345" id="5d11-22e0-4609-a0e0" name="Anathema" primary="false"/>
+              </categoryLinks>
+              <comment>!BSC Errors from 20240328-1346
+Could not find type or subtype &apos;Infanty&apos;</comment>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
@@ -4123,6 +4221,9 @@ In addition, the Leadership Characteristic of a model with the Anathema Unit Sub
           </profiles>
           <categoryLinks>
             <categoryLink id="1644-2516-5c07-f6ae" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
+            <categoryLink targetId="bff2-ae16-74a8-8712" id="fef7-3655-4f05-91a4" name="Light" primary="false"/>
+            <categoryLink targetId="6399-5c65-7833-1025" id="a47f-dd19-4a53-a9a2" name="Line" primary="false"/>
+            <categoryLink targetId="7e5d-d73e-8ff4-7345" id="9f28-4cfa-4804-bba1" name="Anathema" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="c7ef-5a25-b4d3-119d" name="The Vigilator Mistress may exchange her bolt pistol for:" hidden="false" collective="false" import="true" defaultSelectionEntryId="c0df-0a3d-1f1e-2b22">
@@ -4186,6 +4287,8 @@ In addition, the Leadership Characteristic of a model with the Anathema Unit Sub
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
           </costs>
+          <comment>!BSC Errors from 20240328-1346
+Could not find type or subtype &apos;Infanty&apos;</comment>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
@@ -4251,6 +4354,13 @@ In addition, the Leadership Characteristic of a model with the Anathema Unit Sub
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="12"/>
               </costs>
+              <categoryLinks>
+                <categoryLink targetId="bff2-ae16-74a8-8712" id="7629-4925-4e1c-9c47" name="Light" primary="false"/>
+                <categoryLink targetId="6399-5c65-7833-1025" id="0ef9-fd3b-4c23-b3fb" name="Line" primary="false"/>
+                <categoryLink targetId="7e5d-d73e-8ff4-7345" id="f8a3-ad39-469c-8882" name="Anathema" primary="false"/>
+              </categoryLinks>
+              <comment>!BSC Errors from 20240328-1346
+Could not find type or subtype &apos;Infanty&apos;</comment>
             </selectionEntry>
             <selectionEntry id="b3e6-36fa-0ba0-3367" name="Vigilator w/ Hand Flamer" hidden="false" collective="false" import="true" type="model">
               <constraints>
@@ -4294,6 +4404,13 @@ In addition, the Leadership Characteristic of a model with the Anathema Unit Sub
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="17"/>
               </costs>
+              <categoryLinks>
+                <categoryLink targetId="bff2-ae16-74a8-8712" id="c2ef-aca9-4e99-b942" name="Light" primary="false"/>
+                <categoryLink targetId="6399-5c65-7833-1025" id="bf4c-4d26-4061-8db5" name="Line" primary="false"/>
+                <categoryLink targetId="7e5d-d73e-8ff4-7345" id="aa4c-b1e6-41bc-9551" name="Anathema" primary="false"/>
+              </categoryLinks>
+              <comment>!BSC Errors from 20240328-1346
+Could not find type or subtype &apos;Infanty&apos;</comment>
             </selectionEntry>
             <selectionEntry id="0003-0eb7-35d4-291b" name="Vigilator w/ Needle Pistol" hidden="false" collective="false" import="true" type="model">
               <constraints>
@@ -4337,6 +4454,13 @@ In addition, the Leadership Characteristic of a model with the Anathema Unit Sub
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="17"/>
               </costs>
+              <categoryLinks>
+                <categoryLink targetId="bff2-ae16-74a8-8712" id="48f8-459b-4814-a82a" name="Light" primary="false"/>
+                <categoryLink targetId="6399-5c65-7833-1025" id="5de3-d025-4063-be90" name="Line" primary="false"/>
+                <categoryLink targetId="7e5d-d73e-8ff4-7345" id="4874-90b5-4876-a67b" name="Anathema" primary="false"/>
+              </categoryLinks>
+              <comment>!BSC Errors from 20240328-1346
+Could not find type or subtype &apos;Infanty&apos;</comment>
             </selectionEntry>
             <selectionEntry id="f963-6c4f-1844-36cb" name="Vigilator w/ Hand Flamer &amp; Compression Tanks" hidden="false" collective="false" import="true" type="model">
               <constraints>
@@ -4386,6 +4510,13 @@ In addition, the Leadership Characteristic of a model with the Anathema Unit Sub
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="22"/>
               </costs>
+              <categoryLinks>
+                <categoryLink targetId="bff2-ae16-74a8-8712" id="ae93-72af-4ed4-8ecf" name="Light" primary="false"/>
+                <categoryLink targetId="6399-5c65-7833-1025" id="c3d9-b241-4f1f-a5fc" name="Line" primary="false"/>
+                <categoryLink targetId="7e5d-d73e-8ff4-7345" id="1e15-5f32-4ae8-9a22" name="Anathema" primary="false"/>
+              </categoryLinks>
+              <comment>!BSC Errors from 20240328-1346
+Could not find type or subtype &apos;Infanty&apos;</comment>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
@@ -4535,6 +4666,13 @@ In addition, the Leadership Characteristic of a model with the Anathema Unit Sub
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10"/>
           </costs>
+          <categoryLinks>
+            <categoryLink targetId="bff2-ae16-74a8-8712" id="1651-66bb-45fe-bf45" name="Light" primary="false"/>
+            <categoryLink targetId="59a4-7b61-600a-c457" id="9f3c-0771-4ff0-ad45" name="Skirmish" primary="false"/>
+            <categoryLink targetId="7e5d-d73e-8ff4-7345" id="dfb3-22a6-421b-a956" name="Anathema" primary="false"/>
+          </categoryLinks>
+          <comment>!BSC Errors from 20240328-1346
+Could not find type or subtype &apos;Infanty&apos;</comment>
         </selectionEntry>
         <selectionEntry id="db82-614f-481c-733a" name="Pursuer Mistress" hidden="false" collective="false" import="true" type="model">
           <constraints>
@@ -4574,6 +4712,9 @@ In addition, the Leadership Characteristic of a model with the Anathema Unit Sub
           </infoLinks>
           <categoryLinks>
             <categoryLink id="23a2-da24-63d8-e3ea" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
+            <categoryLink targetId="bff2-ae16-74a8-8712" id="a007-be09-44a8-920e" name="Light" primary="false"/>
+            <categoryLink targetId="59a4-7b61-600a-c457" id="d4e1-a3fc-42b3-a4f3" name="Skirmish" primary="false"/>
+            <categoryLink targetId="7e5d-d73e-8ff4-7345" id="61ad-1f88-4d6d-908e" name="Anathema" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="3c06-4d60-bad4-72b8" name="1) May exchange Bolt Pistols for:" hidden="false" collective="false" import="true" defaultSelectionEntryId="0429-cae8-931d-6d5d">
@@ -4683,6 +4824,8 @@ In addition, the Leadership Characteristic of a model with the Anathema Unit Sub
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
           </costs>
+          <comment>!BSC Errors from 20240328-1346
+Could not find type or subtype &apos;Infanty&apos;</comment>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
@@ -5052,6 +5195,8 @@ In addition, the Leadership Characteristic of a model with the Anathema Unit Sub
           </infoLinks>
           <categoryLinks>
             <categoryLink id="6240-80b8-87db-7755" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
+            <categoryLink targetId="bff2-ae16-74a8-8712" id="f23f-c715-434a-9da5" name="Light" primary="false"/>
+            <categoryLink targetId="7e5d-d73e-8ff4-7345" id="84a4-5c39-4b37-ab95" name="Anathema" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="a32b-5932-a006-09fa" name="1) May take any of the following:" hidden="false" collective="false" import="true">
@@ -5156,6 +5301,8 @@ In addition, the Leadership Characteristic of a model with the Anathema Unit Sub
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
           </costs>
+          <comment>!BSC Errors from 20240328-1346
+Could not find type or subtype &apos;Infanty&apos;</comment>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
@@ -5244,6 +5391,12 @@ In addition, the Leadership Characteristic of a model with the Anathema Unit Sub
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="12"/>
               </costs>
+              <categoryLinks>
+                <categoryLink targetId="bff2-ae16-74a8-8712" id="22ef-a5cb-42eb-b6cb" name="Light" primary="false"/>
+                <categoryLink targetId="7e5d-d73e-8ff4-7345" id="45d8-9131-4505-95e9" name="Anathema" primary="false"/>
+              </categoryLinks>
+              <comment>!BSC Errors from 20240328-1346
+Could not find type or subtype &apos;Infanty&apos;</comment>
             </selectionEntry>
             <selectionEntry id="da7c-d3f3-f39b-8ba3" name="Firebrand w/ Options" hidden="false" collective="false" import="true" type="model">
               <constraints>
@@ -5326,6 +5479,12 @@ In addition, the Leadership Characteristic of a model with the Anathema Unit Sub
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="12"/>
               </costs>
+              <categoryLinks>
+                <categoryLink targetId="bff2-ae16-74a8-8712" id="0b07-2bb9-4900-966c" name="Light" primary="false"/>
+                <categoryLink targetId="7e5d-d73e-8ff4-7345" id="7a40-1c75-41f6-862e" name="Anathema" primary="false"/>
+              </categoryLinks>
+              <comment>!BSC Errors from 20240328-1346
+Could not find type or subtype &apos;Infanty&apos;</comment>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
@@ -5447,6 +5606,13 @@ In addition, the Leadership Characteristic of a model with the Anathema Unit Sub
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25"/>
           </costs>
+          <categoryLinks>
+            <categoryLink targetId="6d79-a3e4-381f-7b0f" id="a2fc-4d18-42f8-bf16" name="Cavalry" primary="false"/>
+            <categoryLink targetId="4303-1348-cce4-9501" id="5655-0888-414f-baa0" name="Antigrav" primary="false"/>
+            <categoryLink targetId="59a4-7b61-600a-c457" id="d1c4-36d2-4bde-8e84" name="Skirmish" primary="false"/>
+            <categoryLink targetId="bff2-ae16-74a8-8712" id="4b00-3947-4ad3-b8d8" name="Light" primary="false"/>
+            <categoryLink targetId="7e5d-d73e-8ff4-7345" id="5359-7c2a-4992-bf5f" name="Anathema" primary="false"/>
+          </categoryLinks>
         </selectionEntry>
         <selectionEntry id="39a2-688f-ecfc-33e3" name="Subjugator Mistress" hidden="false" collective="false" import="true" type="model">
           <constraints>
@@ -5489,6 +5655,11 @@ In addition, the Leadership Characteristic of a model with the Anathema Unit Sub
           </infoLinks>
           <categoryLinks>
             <categoryLink id="51b2-ac8e-bb94-23ad" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
+            <categoryLink targetId="6d79-a3e4-381f-7b0f" id="eb23-b886-413d-8fab" name="Cavalry" primary="false"/>
+            <categoryLink targetId="4303-1348-cce4-9501" id="8743-ff53-4f08-9ff5" name="Antigrav" primary="false"/>
+            <categoryLink targetId="59a4-7b61-600a-c457" id="7957-94a7-4ead-92a8" name="Skirmish" primary="false"/>
+            <categoryLink targetId="bff2-ae16-74a8-8712" id="1f63-9bb8-4b63-be7a" name="Light" primary="false"/>
+            <categoryLink targetId="7e5d-d73e-8ff4-7345" id="eaf2-ce6f-4bfb-ab3c" name="Anathema" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="7dc8-c1a2-c1a5-8650" name="1) May exchange her Bolt Pistol for:" hidden="false" collective="false" import="true" defaultSelectionEntryId="cb54-6f43-91d1-541f">
@@ -5676,6 +5847,8 @@ In addition, the Leadership Characteristic of a model with the Anathema Unit Sub
           </infoLinks>
           <categoryLinks>
             <categoryLink id="b4bb-969f-3acf-a826" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
+            <categoryLink targetId="bff2-ae16-74a8-8712" id="145d-cceb-44a7-ad57" name="Light" primary="false"/>
+            <categoryLink targetId="7e5d-d73e-8ff4-7345" id="7ec6-0d38-4700-9fed" name="Anathema" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="78a8-3907-7b7a-683b" name="3) May take any of the following:" hidden="false" collective="false" import="true">
@@ -5762,6 +5935,8 @@ In addition, the Leadership Characteristic of a model with the Anathema Unit Sub
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
           </costs>
+          <comment>!BSC Errors from 20240328-1346
+Could not find type or subtype &apos;Infanty&apos;</comment>
         </selectionEntry>
         <selectionEntry id="9309-bc23-d5b6-e197" name="Sanctioner" hidden="false" collective="false" import="true" type="model">
           <modifierGroups>
@@ -5845,6 +6020,12 @@ In addition, the Leadership Characteristic of a model with the Anathema Unit Sub
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15"/>
           </costs>
+          <categoryLinks>
+            <categoryLink targetId="bff2-ae16-74a8-8712" id="3cab-446a-4d7f-868e" name="Light" primary="false"/>
+            <categoryLink targetId="7e5d-d73e-8ff4-7345" id="89fe-45ab-4966-bd6a" name="Anathema" primary="false"/>
+          </categoryLinks>
+          <comment>!BSC Errors from 20240328-1346
+Could not find type or subtype &apos;Infanty&apos;</comment>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
@@ -5961,6 +6142,8 @@ In addition, the Leadership Characteristic of a model with the Anathema Unit Sub
           </infoLinks>
           <categoryLinks>
             <categoryLink id="99e9-1644-5b36-e317" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
+            <categoryLink targetId="bff2-ae16-74a8-8712" id="76af-f93c-403e-b5bf" name="Light" primary="false"/>
+            <categoryLink targetId="7e5d-d73e-8ff4-7345" id="a5d2-c852-4ed3-8562" name="Anathema" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="b8db-504b-f14e-cf4f" name="1) May take any of the following:" hidden="false" collective="false" import="true">
@@ -6060,6 +6243,8 @@ In addition, the Leadership Characteristic of a model with the Anathema Unit Sub
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
           </costs>
+          <comment>!BSC Errors from 20240328-1346
+Could not find type or subtype &apos;Infanty&apos;</comment>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
@@ -6181,6 +6366,12 @@ In addition, the Leadership Characteristic of a model with the Anathema Unit Sub
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15"/>
               </costs>
+              <categoryLinks>
+                <categoryLink targetId="bff2-ae16-74a8-8712" id="262a-74a7-4e1a-aaa5" name="Light" primary="false"/>
+                <categoryLink targetId="7e5d-d73e-8ff4-7345" id="4fd8-eb48-45a3-a1a6" name="Anathema" primary="false"/>
+              </categoryLinks>
+              <comment>!BSC Errors from 20240328-1346
+Could not find type or subtype &apos;Infanty&apos;</comment>
             </selectionEntry>
             <selectionEntry id="27c3-138b-b421-f670" name="Expurgator w/ Options" hidden="false" collective="false" import="true" type="model">
               <constraints>
@@ -6254,6 +6445,12 @@ In addition, the Leadership Characteristic of a model with the Anathema Unit Sub
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15"/>
               </costs>
+              <categoryLinks>
+                <categoryLink targetId="bff2-ae16-74a8-8712" id="ddf3-4181-4dc9-9365" name="Light" primary="false"/>
+                <categoryLink targetId="7e5d-d73e-8ff4-7345" id="cb48-eec4-49da-8c82" name="Anathema" primary="false"/>
+              </categoryLinks>
+              <comment>!BSC Errors from 20240328-1346
+Could not find type or subtype &apos;Infanty&apos;</comment>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
@@ -7328,6 +7525,12 @@ In addition, the Leadership Characteristic of a model with the Anathema Unit Sub
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="55"/>
           </costs>
+          <categoryLinks>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="c5ee-8575-4a55-92b0" name="Infantry" primary="false"/>
+            <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="0533-fe07-43d1-9a81" name="Character" primary="false"/>
+            <categoryLink targetId="bff2-ae16-74a8-8712" id="023e-2d8b-4dea-96ef" name="Light" primary="false"/>
+            <categoryLink targetId="7e5d-d73e-8ff4-7345" id="12d4-74a6-4719-bcdd" name="Anathema" primary="false"/>
+          </categoryLinks>
         </selectionEntry>
       </selectionEntries>
       <costs>
@@ -7443,6 +7646,12 @@ In addition, the Leadership Characteristic of a model with the Anathema Unit Sub
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25"/>
               </costs>
+              <categoryLinks>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="722f-a854-4483-8d4f" name="Infantry" primary="false"/>
+                <categoryLink targetId="bff2-ae16-74a8-8712" id="eaa5-9848-462f-9f9c" name="Light" primary="false"/>
+                <categoryLink targetId="6399-5c65-7833-1025" id="b191-5e2a-48c5-abdf" name="Line" primary="false"/>
+                <categoryLink targetId="7e5d-d73e-8ff4-7345" id="1aec-d49e-49d2-aa1a" name="Anathema" primary="false"/>
+              </categoryLinks>
             </selectionEntry>
             <selectionEntry id="feee-7064-0491-2bba" name="Raptora w/ Hand Flamer &amp; Execution Blade" hidden="false" collective="false" import="true" type="model">
               <constraints>
@@ -7501,6 +7710,12 @@ In addition, the Leadership Characteristic of a model with the Anathema Unit Sub
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25"/>
               </costs>
+              <categoryLinks>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="3da5-3639-46e4-b043" name="Infantry" primary="false"/>
+                <categoryLink targetId="bff2-ae16-74a8-8712" id="4052-2618-468f-9307" name="Light" primary="false"/>
+                <categoryLink targetId="6399-5c65-7833-1025" id="b59c-e5f4-42e4-9123" name="Line" primary="false"/>
+                <categoryLink targetId="7e5d-d73e-8ff4-7345" id="a371-7b59-4f08-a418" name="Anathema" primary="false"/>
+              </categoryLinks>
             </selectionEntry>
             <selectionEntry id="b391-8afe-9d4f-c87a" name="Raptora w/ Needle Pistol &amp; Execution Blade" hidden="false" collective="false" import="true" type="model">
               <constraints>
@@ -7559,6 +7774,12 @@ In addition, the Leadership Characteristic of a model with the Anathema Unit Sub
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25"/>
               </costs>
+              <categoryLinks>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="9461-2459-4641-bbde" name="Infantry" primary="false"/>
+                <categoryLink targetId="bff2-ae16-74a8-8712" id="93e6-9e55-4da7-97d6" name="Light" primary="false"/>
+                <categoryLink targetId="6399-5c65-7833-1025" id="7804-ee65-437a-9715" name="Line" primary="false"/>
+                <categoryLink targetId="7e5d-d73e-8ff4-7345" id="7dd9-b381-4011-af51" name="Anathema" primary="false"/>
+              </categoryLinks>
             </selectionEntry>
             <selectionEntry id="15a2-7606-593d-23ee" name="Raptora w/ Options" hidden="false" collective="false" import="true" type="model">
               <infoLinks>
@@ -7686,6 +7907,12 @@ In addition, the Leadership Characteristic of a model with the Anathema Unit Sub
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25"/>
               </costs>
+              <categoryLinks>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="02a2-daa9-4b73-a553" name="Infantry" primary="false"/>
+                <categoryLink targetId="bff2-ae16-74a8-8712" id="72d8-3085-426f-a21b" name="Light" primary="false"/>
+                <categoryLink targetId="6399-5c65-7833-1025" id="54e4-2df9-41ac-8cfc" name="Line" primary="false"/>
+                <categoryLink targetId="7e5d-d73e-8ff4-7345" id="d80b-9751-4aff-9a5f" name="Anathema" primary="false"/>
+              </categoryLinks>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>

--- a/2022 - LI - Sisters Of Silence.cat
+++ b/2022 - LI - Sisters Of Silence.cat
@@ -291,7 +291,7 @@ In addition, the Leadership Characteristic of a model with the Anathema Unit Sub
         <categoryLink id="5ad9-6ca7-f429-8abc" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
         <categoryLink id="9f01-5e74-7b16-9aa5" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
         <categoryLink id="2896-3a6a-a393-937f" name="Light Sub-type" hidden="false" targetId="bff2-ae16-74a8-8712" primary="false"/>
-        <categoryLink id="7427-31c7-286b-2b07" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="7427-31c7-286b-2b07" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="d3b1-7626-4c83-0d6a" name="Silent Sisterhood (Chamber of Obivion)" hidden="false" targetId="a7e3-4559-7267-8bf6" primary="false"/>
         <categoryLink id="e9d1-0d5f-e474-800a" name="Obivion HQ" hidden="false" targetId="b760-8313-847f-1afa" primary="false"/>
       </categoryLinks>
@@ -487,11 +487,11 @@ In addition, the Leadership Characteristic of a model with the Anathema Unit Sub
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="150"/>
           </costs>
           <categoryLinks>
-            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="fc63-b6be-433a-b68d" name="Infantry" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="fc63-b6be-433a-b68d" name="Infantry Unit Type" primary="false"/>
             <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="9790-c679-4843-acc9" name="Character" primary="false"/>
-            <categoryLink targetId="bff2-ae16-74a8-8712" id="5116-99bc-4f37-b532" name="Light" primary="false"/>
-            <categoryLink targetId="7e5d-d73e-8ff4-7345" id="71cd-f6b4-46a6-b9b7" name="Anathema" primary="false"/>
-            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="4457-7585-45d7-a648" name="Unique" primary="false"/>
+            <categoryLink targetId="bff2-ae16-74a8-8712" id="5116-99bc-4f37-b532" name="Light Sub-type" primary="false"/>
+            <categoryLink targetId="7e5d-d73e-8ff4-7345" id="71cd-f6b4-46a6-b9b7" name="Anathema Sub-type" primary="false"/>
+            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="4457-7585-45d7-a648" name="Unique Sub-type" primary="false"/>
           </categoryLinks>
         </selectionEntry>
       </selectionEntries>
@@ -511,7 +511,7 @@ In addition, the Leadership Characteristic of a model with the Anathema Unit Sub
         <categoryLink id="c19a-9d92-b941-8bfb" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
         <categoryLink id="4261-d9e6-6761-57c0" name="Light Sub-type" hidden="false" targetId="bff2-ae16-74a8-8712" primary="false"/>
         <categoryLink id="d32c-fd83-381e-9d0e" name="Anathema Sub-type" hidden="false" targetId="7e5d-d73e-8ff4-7345" primary="false"/>
-        <categoryLink id="1617-b424-fdfc-c3a1" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="1617-b424-fdfc-c3a1" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="eab7-89d5-4457-152c" name="Silent Sisterhood (Chamber of Obivion)" hidden="false" targetId="a7e3-4559-7267-8bf6" primary="false"/>
         <categoryLink id="bdb4-4118-7f7a-05d9" name="Obivion HQ" hidden="false" targetId="b760-8313-847f-1afa" primary="false"/>
       </categoryLinks>
@@ -1036,10 +1036,10 @@ In addition, the Leadership Characteristic of a model with the Anathema Unit Sub
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="85"/>
           </costs>
           <categoryLinks>
-            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="bd31-9e55-41aa-b06c" name="Infantry" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="bd31-9e55-41aa-b06c" name="Infantry Unit Type" primary="false"/>
             <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="ea86-1f3b-4828-886c" name="Character" primary="false"/>
-            <categoryLink targetId="bff2-ae16-74a8-8712" id="6431-7236-4bd3-9ec6" name="Light" primary="false"/>
-            <categoryLink targetId="7e5d-d73e-8ff4-7345" id="ed2f-7fd0-4d99-9c7b" name="Anathema" primary="false"/>
+            <categoryLink targetId="bff2-ae16-74a8-8712" id="6431-7236-4bd3-9ec6" name="Light Sub-type" primary="false"/>
+            <categoryLink targetId="7e5d-d73e-8ff4-7345" id="ed2f-7fd0-4d99-9c7b" name="Anathema Sub-type" primary="false"/>
           </categoryLinks>
         </selectionEntry>
       </selectionEntries>
@@ -1052,7 +1052,7 @@ In addition, the Leadership Characteristic of a model with the Anathema Unit Sub
         <infoLink id="1d1a-906b-5276-ee9b" name="Silent Sisterhood (X)" hidden="false" targetId="1d8d-3038-9267-6f1b" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="599e-9f9e-659f-36b3" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="599e-9f9e-659f-36b3" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="cece-9f62-cd60-5420" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
         <categoryLink id="d3f6-0f11-c7e5-eef7" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
         <categoryLink id="c30d-388d-58fa-37df" name="Light Sub-type" hidden="false" targetId="bff2-ae16-74a8-8712" primary="false"/>
@@ -1730,10 +1730,10 @@ In addition, the Leadership Characteristic of a model with the Anathema Unit Sub
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="55"/>
           </costs>
           <categoryLinks>
-            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="2918-5214-47f7-aa66" name="Infantry" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="2918-5214-47f7-aa66" name="Infantry Unit Type" primary="false"/>
             <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="ba95-5e4c-42c7-ab62" name="Character" primary="false"/>
-            <categoryLink targetId="bff2-ae16-74a8-8712" id="dea5-d0a2-448b-b666" name="Light" primary="false"/>
-            <categoryLink targetId="7e5d-d73e-8ff4-7345" id="46c9-157a-4a48-a439" name="Anathema" primary="false"/>
+            <categoryLink targetId="bff2-ae16-74a8-8712" id="dea5-d0a2-448b-b666" name="Light Sub-type" primary="false"/>
+            <categoryLink targetId="7e5d-d73e-8ff4-7345" id="46c9-157a-4a48-a439" name="Anathema Sub-type" primary="false"/>
           </categoryLinks>
         </selectionEntry>
       </selectionEntries>
@@ -2331,11 +2331,11 @@ In addition, the Leadership Characteristic of a model with the Anathema Unit Sub
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="65"/>
           </costs>
           <categoryLinks>
-            <categoryLink targetId="6d79-a3e4-381f-7b0f" id="458f-7e79-48af-b3e5" name="Cavalry" primary="false"/>
+            <categoryLink targetId="6d79-a3e4-381f-7b0f" id="458f-7e79-48af-b3e5" name="Cavalry Unit Type" primary="false"/>
             <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="2dc5-097b-479a-a335" name="Character" primary="false"/>
-            <categoryLink targetId="bff2-ae16-74a8-8712" id="b416-fea6-4f26-b398" name="Light" primary="false"/>
-            <categoryLink targetId="59a4-7b61-600a-c457" id="2e60-51f0-4ba3-b06f" name="Skirmish" primary="false"/>
-            <categoryLink targetId="7e5d-d73e-8ff4-7345" id="a3fe-a911-4218-b75d" name="Anathema" primary="false"/>
+            <categoryLink targetId="bff2-ae16-74a8-8712" id="b416-fea6-4f26-b398" name="Light Sub-type" primary="false"/>
+            <categoryLink targetId="59a4-7b61-600a-c457" id="2e60-51f0-4ba3-b06f" name="Skirmish Sub-type" primary="false"/>
+            <categoryLink targetId="7e5d-d73e-8ff4-7345" id="a3fe-a911-4218-b75d" name="Anathema Sub-type" primary="false"/>
           </categoryLinks>
         </selectionEntry>
       </selectionEntries>
@@ -2348,7 +2348,7 @@ In addition, the Leadership Characteristic of a model with the Anathema Unit Sub
         <infoLink id="d245-968f-e5e8-a780" name="Silent Sisterhood (X)" hidden="false" targetId="1d8d-3038-9267-6f1b" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="f0e2-9af7-25e4-a985" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="f0e2-9af7-25e4-a985" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="ffad-b6d0-11e6-70cf" name="Light Sub-type" hidden="false" targetId="bff2-ae16-74a8-8712" primary="false"/>
         <categoryLink id="40c2-d8d1-0517-51db" name="Line Sub-type" hidden="false" targetId="6399-5c65-7833-1025" primary="false"/>
         <categoryLink id="5526-deb2-d4aa-dff7" name="Anathema Sub-type" hidden="false" targetId="7e5d-d73e-8ff4-7345" primary="false"/>
@@ -2605,10 +2605,10 @@ In addition, the Leadership Characteristic of a model with the Anathema Unit Sub
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20"/>
               </costs>
               <categoryLinks>
-                <categoryLink targetId="bff2-ae16-74a8-8712" id="7d84-14b4-40f2-a68d" name="Light" primary="false"/>
-                <categoryLink targetId="6399-5c65-7833-1025" id="3876-002a-40db-971c" name="Line" primary="false"/>
-                <categoryLink targetId="7e5d-d73e-8ff4-7345" id="8f05-a864-4625-a004" name="Anathema" primary="false"/>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="b746-2c0a-4785-b50b" name="Infantry" primary="false"/>
+                <categoryLink targetId="bff2-ae16-74a8-8712" id="7d84-14b4-40f2-a68d" name="Light Sub-type" primary="false"/>
+                <categoryLink targetId="6399-5c65-7833-1025" id="3876-002a-40db-971c" name="Line Sub-type" primary="false"/>
+                <categoryLink targetId="7e5d-d73e-8ff4-7345" id="8f05-a864-4625-a004" name="Anathema Sub-type" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="b746-2c0a-4785-b50b" name="Infantry Unit Type" primary="false"/>
               </categoryLinks>
             </selectionEntry>
             <selectionEntry id="ab3d-ff19-d1d7-5aee" name="1) Questora w/ Pistols" hidden="false" collective="false" import="true" type="model">
@@ -2741,10 +2741,10 @@ In addition, the Leadership Characteristic of a model with the Anathema Unit Sub
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20"/>
               </costs>
               <categoryLinks>
-                <categoryLink targetId="bff2-ae16-74a8-8712" id="bca2-b5c6-42cf-a184" name="Light" primary="false"/>
-                <categoryLink targetId="6399-5c65-7833-1025" id="6177-cff5-4b22-be1a" name="Line" primary="false"/>
-                <categoryLink targetId="7e5d-d73e-8ff4-7345" id="c3be-47b5-429b-aad3" name="Anathema" primary="false"/>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="e11c-ba12-49fd-a3a5" name="Infantry" primary="false"/>
+                <categoryLink targetId="bff2-ae16-74a8-8712" id="bca2-b5c6-42cf-a184" name="Light Sub-type" primary="false"/>
+                <categoryLink targetId="6399-5c65-7833-1025" id="6177-cff5-4b22-be1a" name="Line Sub-type" primary="false"/>
+                <categoryLink targetId="7e5d-d73e-8ff4-7345" id="c3be-47b5-429b-aad3" name="Anathema Sub-type" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="e11c-ba12-49fd-a3a5" name="Infantry Unit Type" primary="false"/>
               </categoryLinks>
             </selectionEntry>
             <selectionEntry id="ee7c-6dad-729c-2139" name="2) Questora w/ Options" hidden="false" collective="false" import="true" type="model">
@@ -2898,10 +2898,10 @@ In addition, the Leadership Characteristic of a model with the Anathema Unit Sub
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20"/>
               </costs>
               <categoryLinks>
-                <categoryLink targetId="bff2-ae16-74a8-8712" id="61ab-e8fc-47ba-997e" name="Light" primary="false"/>
-                <categoryLink targetId="6399-5c65-7833-1025" id="ad9d-a246-4da2-908c" name="Line" primary="false"/>
-                <categoryLink targetId="7e5d-d73e-8ff4-7345" id="078d-7dd5-4d5c-a762" name="Anathema" primary="false"/>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="a677-9888-4853-b198" name="Infantry" primary="false"/>
+                <categoryLink targetId="bff2-ae16-74a8-8712" id="61ab-e8fc-47ba-997e" name="Light Sub-type" primary="false"/>
+                <categoryLink targetId="6399-5c65-7833-1025" id="ad9d-a246-4da2-908c" name="Line Sub-type" primary="false"/>
+                <categoryLink targetId="7e5d-d73e-8ff4-7345" id="078d-7dd5-4d5c-a762" name="Anathema Sub-type" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="a677-9888-4853-b198" name="Infantry Unit Type" primary="false"/>
               </categoryLinks>
             </selectionEntry>
           </selectionEntries>
@@ -2931,7 +2931,7 @@ In addition, the Leadership Characteristic of a model with the Anathema Unit Sub
         <infoLink id="9a7c-efcd-668f-3157" name="Silent Sisterhood (X)" hidden="false" targetId="1d8d-3038-9267-6f1b" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="2dbd-dcff-f67e-57d4" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="2dbd-dcff-f67e-57d4" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="bee8-f85e-9c9f-71cc" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
         <categoryLink id="9647-5e27-4d48-5fca" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
         <categoryLink id="e35f-892f-5cf1-8766" name="Light Sub-type" hidden="false" targetId="bff2-ae16-74a8-8712" primary="false"/>
@@ -3110,10 +3110,10 @@ In addition, the Leadership Characteristic of a model with the Anathema Unit Sub
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="35"/>
           </costs>
           <categoryLinks>
-            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="9c68-cb62-4eb0-a73c" name="Infantry" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="9c68-cb62-4eb0-a73c" name="Infantry Unit Type" primary="false"/>
             <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="e51c-b1a6-4c33-9265" name="Character" primary="false"/>
-            <categoryLink targetId="bff2-ae16-74a8-8712" id="e658-b997-45c1-9086" name="Light" primary="false"/>
-            <categoryLink targetId="7e5d-d73e-8ff4-7345" id="578f-f743-4f13-8bb7" name="Anathema" primary="false"/>
+            <categoryLink targetId="bff2-ae16-74a8-8712" id="e658-b997-45c1-9086" name="Light Sub-type" primary="false"/>
+            <categoryLink targetId="7e5d-d73e-8ff4-7345" id="578f-f743-4f13-8bb7" name="Anathema Sub-type" primary="false"/>
           </categoryLinks>
         </selectionEntry>
       </selectionEntries>
@@ -3150,7 +3150,7 @@ In addition, the Leadership Characteristic of a model with the Anathema Unit Sub
         <infoLink id="260a-5eba-3fe9-3c0f" name="Stubborn" hidden="false" targetId="7989-1f2c-a43d-82ae" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="4dd1-451d-eb5c-8276" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="4dd1-451d-eb5c-8276" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="a8b1-1974-7b8f-3940" name="Light Sub-type" hidden="false" targetId="bff2-ae16-74a8-8712" primary="false"/>
         <categoryLink id="cd46-4eab-7d03-c98a" name="Anathema Sub-type" hidden="false" targetId="7e5d-d73e-8ff4-7345" primary="false"/>
         <categoryLink id="bf15-9553-bb6a-212e" name="Silent Sisterhood (Chamber of Obivion)" hidden="false" targetId="a7e3-4559-7267-8bf6" primary="false"/>
@@ -3231,8 +3231,8 @@ In addition, the Leadership Characteristic of a model with the Anathema Unit Sub
           </profiles>
           <categoryLinks>
             <categoryLink id="21ab-5752-4355-d9c0" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
-            <categoryLink targetId="bff2-ae16-74a8-8712" id="78a8-008e-4999-8cbc" name="Light" primary="false"/>
-            <categoryLink targetId="7e5d-d73e-8ff4-7345" id="09ff-d8ea-4d4f-b629" name="Anathema" primary="false"/>
+            <categoryLink targetId="bff2-ae16-74a8-8712" id="78a8-008e-4999-8cbc" name="Light Sub-type" primary="false"/>
+            <categoryLink targetId="7e5d-d73e-8ff4-7345" id="09ff-d8ea-4d4f-b629" name="Anathema Sub-type" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="b6d2-80ee-bf54-5b08" name="The Oblivion Knight Mistress may take any of the following:" hidden="false" collective="false" import="true">
@@ -3299,8 +3299,6 @@ In addition, the Leadership Characteristic of a model with the Anathema Unit Sub
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
           </costs>
-          <comment>!BSC Errors from 20240328-1346
-Could not find type or subtype &apos;Infanty&apos;</comment>
         </selectionEntry>
         <selectionEntry id="d862-dd78-104b-dc02" name="Oblivion Knight" hidden="false" collective="false" import="true" type="model">
           <modifierGroups>
@@ -3411,11 +3409,9 @@ Could not find type or subtype &apos;Infanty&apos;</comment>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15"/>
           </costs>
           <categoryLinks>
-            <categoryLink targetId="bff2-ae16-74a8-8712" id="3846-d1d6-4a33-8ab5" name="Light" primary="false"/>
-            <categoryLink targetId="7e5d-d73e-8ff4-7345" id="be0c-2621-41f1-9cc2" name="Anathema" primary="false"/>
+            <categoryLink targetId="bff2-ae16-74a8-8712" id="3846-d1d6-4a33-8ab5" name="Light Sub-type" primary="false"/>
+            <categoryLink targetId="7e5d-d73e-8ff4-7345" id="be0c-2621-41f1-9cc2" name="Anathema Sub-type" primary="false"/>
           </categoryLinks>
-          <comment>!BSC Errors from 20240328-1346
-Could not find type or subtype &apos;Infanty&apos;</comment>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
@@ -3475,7 +3471,7 @@ Could not find type or subtype &apos;Infanty&apos;</comment>
         </infoLink>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="44f5-b8c0-a974-015e" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="44f5-b8c0-a974-015e" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="2b36-13ce-ad0c-62cc" name="Light Sub-type" hidden="false" targetId="bff2-ae16-74a8-8712" primary="false"/>
         <categoryLink id="53a0-afde-583a-8dff" name="Anathema Sub-type" hidden="false" targetId="7e5d-d73e-8ff4-7345" primary="false"/>
         <categoryLink id="1a5d-f7be-b0dc-e195" name="Silent Sisterhood (Chamber of Vigilance)" hidden="false" targetId="b6d7-6924-37fb-dd32" primary="false"/>
@@ -3505,8 +3501,8 @@ Could not find type or subtype &apos;Infanty&apos;</comment>
           </profiles>
           <categoryLinks>
             <categoryLink id="7d04-46e8-bd6a-a671" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
-            <categoryLink targetId="bff2-ae16-74a8-8712" id="5cd0-8b2b-40bc-8045" name="Light" primary="false"/>
-            <categoryLink targetId="7e5d-d73e-8ff4-7345" id="4630-8d85-43c0-a8c3" name="Anathema" primary="false"/>
+            <categoryLink targetId="bff2-ae16-74a8-8712" id="5cd0-8b2b-40bc-8045" name="Light Sub-type" primary="false"/>
+            <categoryLink targetId="7e5d-d73e-8ff4-7345" id="4630-8d85-43c0-a8c3" name="Anathema Sub-type" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="465c-58a6-57df-a7ee" name="May take any of the following:" hidden="false" collective="false" import="true">
@@ -3645,8 +3641,6 @@ Could not find type or subtype &apos;Infanty&apos;</comment>
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
           </costs>
-          <comment>!BSC Errors from 20240328-1346
-Could not find type or subtype &apos;Infanty&apos;</comment>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
@@ -3707,11 +3701,9 @@ Could not find type or subtype &apos;Infanty&apos;</comment>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10"/>
               </costs>
               <categoryLinks>
-                <categoryLink targetId="bff2-ae16-74a8-8712" id="1a0b-cda2-422b-a4ad" name="Light" primary="false"/>
-                <categoryLink targetId="7e5d-d73e-8ff4-7345" id="20d5-118b-494f-9305" name="Anathema" primary="false"/>
+                <categoryLink targetId="bff2-ae16-74a8-8712" id="1a0b-cda2-422b-a4ad" name="Light Sub-type" primary="false"/>
+                <categoryLink targetId="7e5d-d73e-8ff4-7345" id="20d5-118b-494f-9305" name="Anathema Sub-type" primary="false"/>
               </categoryLinks>
-              <comment>!BSC Errors from 20240328-1346
-Could not find type or subtype &apos;Infanty&apos;</comment>
             </selectionEntry>
             <selectionEntry id="1535-2e39-86f7-d64e" name="Eradicator w/ options" hidden="false" collective="false" import="true" type="model">
               <constraints>
@@ -3803,11 +3795,9 @@ Could not find type or subtype &apos;Infanty&apos;</comment>
                 <infoLink id="c4f7-365a-e592-0f7e" name="Eradicator" targetId="1a1e-a7fd-7c32-3f56" type="profile"/>
               </infoLinks>
               <categoryLinks>
-                <categoryLink targetId="bff2-ae16-74a8-8712" id="96df-1558-4545-b990" name="Light" primary="false"/>
-                <categoryLink targetId="7e5d-d73e-8ff4-7345" id="a2c9-e9d5-4a76-8ed4" name="Anathema" primary="false"/>
+                <categoryLink targetId="bff2-ae16-74a8-8712" id="96df-1558-4545-b990" name="Light Sub-type" primary="false"/>
+                <categoryLink targetId="7e5d-d73e-8ff4-7345" id="a2c9-e9d5-4a76-8ed4" name="Anathema Sub-type" primary="false"/>
               </categoryLinks>
-              <comment>!BSC Errors from 20240328-1346
-Could not find type or subtype &apos;Infanty&apos;</comment>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
@@ -3845,7 +3835,7 @@ Could not find type or subtype &apos;Infanty&apos;</comment>
         </infoLink>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="d06a-2352-d3b5-1a8e" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="d06a-2352-d3b5-1a8e" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="6886-2fd9-b955-9168" name="Light Sub-type" hidden="false" targetId="bff2-ae16-74a8-8712" primary="false"/>
         <categoryLink id="4518-335f-866a-0f7d" name="Line Sub-type" hidden="false" targetId="6399-5c65-7833-1025" primary="false"/>
         <categoryLink id="1a82-a3c6-c790-de15" name="Anathema Sub-type" hidden="false" targetId="7e5d-d73e-8ff4-7345" primary="false"/>
@@ -3876,9 +3866,9 @@ Could not find type or subtype &apos;Infanty&apos;</comment>
           </profiles>
           <categoryLinks>
             <categoryLink id="57e4-d22a-0a57-b90c" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
-            <categoryLink targetId="bff2-ae16-74a8-8712" id="0939-8e62-4d0e-a482" name="Light" primary="false"/>
-            <categoryLink targetId="6399-5c65-7833-1025" id="b5c5-d909-401a-8de1" name="Line" primary="false"/>
-            <categoryLink targetId="7e5d-d73e-8ff4-7345" id="76a9-7b91-4c8a-9284" name="Anathema" primary="false"/>
+            <categoryLink targetId="bff2-ae16-74a8-8712" id="0939-8e62-4d0e-a482" name="Light Sub-type" primary="false"/>
+            <categoryLink targetId="6399-5c65-7833-1025" id="b5c5-d909-401a-8de1" name="Line Sub-type" primary="false"/>
+            <categoryLink targetId="7e5d-d73e-8ff4-7345" id="76a9-7b91-4c8a-9284" name="Anathema Sub-type" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="a1ca-8743-3942-af58" name="May take any of the following:" hidden="false" collective="false" import="true">
@@ -3959,8 +3949,6 @@ Could not find type or subtype &apos;Infanty&apos;</comment>
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
           </costs>
-          <comment>!BSC Errors from 20240328-1346
-Could not find type or subtype &apos;Infanty&apos;</comment>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
@@ -4065,12 +4053,10 @@ Could not find type or subtype &apos;Infanty&apos;</comment>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10"/>
               </costs>
               <categoryLinks>
-                <categoryLink targetId="bff2-ae16-74a8-8712" id="015a-1702-40ea-b4dd" name="Light" primary="false"/>
-                <categoryLink targetId="6399-5c65-7833-1025" id="f89d-241b-4266-b94b" name="Line" primary="false"/>
-                <categoryLink targetId="7e5d-d73e-8ff4-7345" id="3be1-2220-46d6-9ee9" name="Anathema" primary="false"/>
+                <categoryLink targetId="bff2-ae16-74a8-8712" id="015a-1702-40ea-b4dd" name="Light Sub-type" primary="false"/>
+                <categoryLink targetId="6399-5c65-7833-1025" id="f89d-241b-4266-b94b" name="Line Sub-type" primary="false"/>
+                <categoryLink targetId="7e5d-d73e-8ff4-7345" id="3be1-2220-46d6-9ee9" name="Anathema Sub-type" primary="false"/>
               </categoryLinks>
-              <comment>!BSC Errors from 20240328-1346
-Could not find type or subtype &apos;Infanty&apos;</comment>
             </selectionEntry>
             <selectionEntry id="6969-562f-576e-3775" name="Prosecutor w/ Options" hidden="false" collective="false" import="true" type="model">
               <constraints>
@@ -4144,12 +4130,10 @@ Could not find type or subtype &apos;Infanty&apos;</comment>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10"/>
               </costs>
               <categoryLinks>
-                <categoryLink targetId="bff2-ae16-74a8-8712" id="b9ee-98cd-4c4c-aa02" name="Light" primary="false"/>
-                <categoryLink targetId="6399-5c65-7833-1025" id="66a2-a6a1-40a5-9b5e" name="Line" primary="false"/>
-                <categoryLink targetId="7e5d-d73e-8ff4-7345" id="5d11-22e0-4609-a0e0" name="Anathema" primary="false"/>
+                <categoryLink targetId="bff2-ae16-74a8-8712" id="b9ee-98cd-4c4c-aa02" name="Light Sub-type" primary="false"/>
+                <categoryLink targetId="6399-5c65-7833-1025" id="66a2-a6a1-40a5-9b5e" name="Line Sub-type" primary="false"/>
+                <categoryLink targetId="7e5d-d73e-8ff4-7345" id="5d11-22e0-4609-a0e0" name="Anathema Sub-type" primary="false"/>
               </categoryLinks>
-              <comment>!BSC Errors from 20240328-1346
-Could not find type or subtype &apos;Infanty&apos;</comment>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
@@ -4187,7 +4171,7 @@ Could not find type or subtype &apos;Infanty&apos;</comment>
         <infoLink id="3327-0f0a-665d-f4d5" name="Stubborn" hidden="false" targetId="7989-1f2c-a43d-82ae" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="8c22-4db8-43b2-f419" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="8c22-4db8-43b2-f419" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="c81b-2a93-d091-3f92" name="Light Sub-type" hidden="false" targetId="bff2-ae16-74a8-8712" primary="false"/>
         <categoryLink id="a8ad-9b44-f397-f115" name="Line Sub-type" hidden="false" targetId="6399-5c65-7833-1025" primary="false"/>
         <categoryLink id="d300-24f4-6452-4ad4" name="Anathema Sub-type" hidden="false" targetId="7e5d-d73e-8ff4-7345" primary="false"/>
@@ -4218,9 +4202,9 @@ Could not find type or subtype &apos;Infanty&apos;</comment>
           </profiles>
           <categoryLinks>
             <categoryLink id="1644-2516-5c07-f6ae" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
-            <categoryLink targetId="bff2-ae16-74a8-8712" id="fef7-3655-4f05-91a4" name="Light" primary="false"/>
-            <categoryLink targetId="6399-5c65-7833-1025" id="a47f-dd19-4a53-a9a2" name="Line" primary="false"/>
-            <categoryLink targetId="7e5d-d73e-8ff4-7345" id="9f28-4cfa-4804-bba1" name="Anathema" primary="false"/>
+            <categoryLink targetId="bff2-ae16-74a8-8712" id="fef7-3655-4f05-91a4" name="Light Sub-type" primary="false"/>
+            <categoryLink targetId="6399-5c65-7833-1025" id="a47f-dd19-4a53-a9a2" name="Line Sub-type" primary="false"/>
+            <categoryLink targetId="7e5d-d73e-8ff4-7345" id="9f28-4cfa-4804-bba1" name="Anathema Sub-type" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="c7ef-5a25-b4d3-119d" name="The Vigilator Mistress may exchange her bolt pistol for:" hidden="false" collective="false" import="true" defaultSelectionEntryId="c0df-0a3d-1f1e-2b22">
@@ -4284,8 +4268,6 @@ Could not find type or subtype &apos;Infanty&apos;</comment>
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
           </costs>
-          <comment>!BSC Errors from 20240328-1346
-Could not find type or subtype &apos;Infanty&apos;</comment>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
@@ -4352,12 +4334,10 @@ Could not find type or subtype &apos;Infanty&apos;</comment>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="12"/>
               </costs>
               <categoryLinks>
-                <categoryLink targetId="bff2-ae16-74a8-8712" id="7629-4925-4e1c-9c47" name="Light" primary="false"/>
-                <categoryLink targetId="6399-5c65-7833-1025" id="0ef9-fd3b-4c23-b3fb" name="Line" primary="false"/>
-                <categoryLink targetId="7e5d-d73e-8ff4-7345" id="f8a3-ad39-469c-8882" name="Anathema" primary="false"/>
+                <categoryLink targetId="bff2-ae16-74a8-8712" id="7629-4925-4e1c-9c47" name="Light Sub-type" primary="false"/>
+                <categoryLink targetId="6399-5c65-7833-1025" id="0ef9-fd3b-4c23-b3fb" name="Line Sub-type" primary="false"/>
+                <categoryLink targetId="7e5d-d73e-8ff4-7345" id="f8a3-ad39-469c-8882" name="Anathema Sub-type" primary="false"/>
               </categoryLinks>
-              <comment>!BSC Errors from 20240328-1346
-Could not find type or subtype &apos;Infanty&apos;</comment>
             </selectionEntry>
             <selectionEntry id="b3e6-36fa-0ba0-3367" name="Vigilator w/ Hand Flamer" hidden="false" collective="false" import="true" type="model">
               <constraints>
@@ -4402,12 +4382,10 @@ Could not find type or subtype &apos;Infanty&apos;</comment>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="17"/>
               </costs>
               <categoryLinks>
-                <categoryLink targetId="bff2-ae16-74a8-8712" id="c2ef-aca9-4e99-b942" name="Light" primary="false"/>
-                <categoryLink targetId="6399-5c65-7833-1025" id="bf4c-4d26-4061-8db5" name="Line" primary="false"/>
-                <categoryLink targetId="7e5d-d73e-8ff4-7345" id="aa4c-b1e6-41bc-9551" name="Anathema" primary="false"/>
+                <categoryLink targetId="bff2-ae16-74a8-8712" id="c2ef-aca9-4e99-b942" name="Light Sub-type" primary="false"/>
+                <categoryLink targetId="6399-5c65-7833-1025" id="bf4c-4d26-4061-8db5" name="Line Sub-type" primary="false"/>
+                <categoryLink targetId="7e5d-d73e-8ff4-7345" id="aa4c-b1e6-41bc-9551" name="Anathema Sub-type" primary="false"/>
               </categoryLinks>
-              <comment>!BSC Errors from 20240328-1346
-Could not find type or subtype &apos;Infanty&apos;</comment>
             </selectionEntry>
             <selectionEntry id="0003-0eb7-35d4-291b" name="Vigilator w/ Needle Pistol" hidden="false" collective="false" import="true" type="model">
               <constraints>
@@ -4452,12 +4430,10 @@ Could not find type or subtype &apos;Infanty&apos;</comment>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="17"/>
               </costs>
               <categoryLinks>
-                <categoryLink targetId="bff2-ae16-74a8-8712" id="48f8-459b-4814-a82a" name="Light" primary="false"/>
-                <categoryLink targetId="6399-5c65-7833-1025" id="5de3-d025-4063-be90" name="Line" primary="false"/>
-                <categoryLink targetId="7e5d-d73e-8ff4-7345" id="4874-90b5-4876-a67b" name="Anathema" primary="false"/>
+                <categoryLink targetId="bff2-ae16-74a8-8712" id="48f8-459b-4814-a82a" name="Light Sub-type" primary="false"/>
+                <categoryLink targetId="6399-5c65-7833-1025" id="5de3-d025-4063-be90" name="Line Sub-type" primary="false"/>
+                <categoryLink targetId="7e5d-d73e-8ff4-7345" id="4874-90b5-4876-a67b" name="Anathema Sub-type" primary="false"/>
               </categoryLinks>
-              <comment>!BSC Errors from 20240328-1346
-Could not find type or subtype &apos;Infanty&apos;</comment>
             </selectionEntry>
             <selectionEntry id="f963-6c4f-1844-36cb" name="Vigilator w/ Hand Flamer &amp; Compression Tanks" hidden="false" collective="false" import="true" type="model">
               <constraints>
@@ -4508,12 +4484,10 @@ Could not find type or subtype &apos;Infanty&apos;</comment>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="22"/>
               </costs>
               <categoryLinks>
-                <categoryLink targetId="bff2-ae16-74a8-8712" id="ae93-72af-4ed4-8ecf" name="Light" primary="false"/>
-                <categoryLink targetId="6399-5c65-7833-1025" id="c3d9-b241-4f1f-a5fc" name="Line" primary="false"/>
-                <categoryLink targetId="7e5d-d73e-8ff4-7345" id="1e15-5f32-4ae8-9a22" name="Anathema" primary="false"/>
+                <categoryLink targetId="bff2-ae16-74a8-8712" id="ae93-72af-4ed4-8ecf" name="Light Sub-type" primary="false"/>
+                <categoryLink targetId="6399-5c65-7833-1025" id="c3d9-b241-4f1f-a5fc" name="Line Sub-type" primary="false"/>
+                <categoryLink targetId="7e5d-d73e-8ff4-7345" id="1e15-5f32-4ae8-9a22" name="Anathema Sub-type" primary="false"/>
               </categoryLinks>
-              <comment>!BSC Errors from 20240328-1346
-Could not find type or subtype &apos;Infanty&apos;</comment>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
@@ -4544,7 +4518,7 @@ Could not find type or subtype &apos;Infanty&apos;</comment>
         <infoLink id="558c-ce66-9a1c-0692" name="Silent Sisterhood (X)" hidden="false" targetId="1d8d-3038-9267-6f1b" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="57ef-494e-3aa2-9833" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="57ef-494e-3aa2-9833" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="3e09-e5a2-cb66-5771" name="Light Sub-type" hidden="false" targetId="bff2-ae16-74a8-8712" primary="false"/>
         <categoryLink id="ec95-6148-86cc-881a" name="Skirmish Sub-type" hidden="false" targetId="59a4-7b61-600a-c457" primary="false"/>
         <categoryLink id="577d-16f2-efd7-c704" name="Anathema Sub-type" hidden="false" targetId="7e5d-d73e-8ff4-7345" primary="false"/>
@@ -4664,12 +4638,10 @@ Could not find type or subtype &apos;Infanty&apos;</comment>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10"/>
           </costs>
           <categoryLinks>
-            <categoryLink targetId="bff2-ae16-74a8-8712" id="1651-66bb-45fe-bf45" name="Light" primary="false"/>
-            <categoryLink targetId="59a4-7b61-600a-c457" id="9f3c-0771-4ff0-ad45" name="Skirmish" primary="false"/>
-            <categoryLink targetId="7e5d-d73e-8ff4-7345" id="dfb3-22a6-421b-a956" name="Anathema" primary="false"/>
+            <categoryLink targetId="bff2-ae16-74a8-8712" id="1651-66bb-45fe-bf45" name="Light Sub-type" primary="false"/>
+            <categoryLink targetId="59a4-7b61-600a-c457" id="9f3c-0771-4ff0-ad45" name="Skirmish Sub-type" primary="false"/>
+            <categoryLink targetId="7e5d-d73e-8ff4-7345" id="dfb3-22a6-421b-a956" name="Anathema Sub-type" primary="false"/>
           </categoryLinks>
-          <comment>!BSC Errors from 20240328-1346
-Could not find type or subtype &apos;Infanty&apos;</comment>
         </selectionEntry>
         <selectionEntry id="db82-614f-481c-733a" name="Pursuer Mistress" hidden="false" collective="false" import="true" type="model">
           <constraints>
@@ -4709,9 +4681,9 @@ Could not find type or subtype &apos;Infanty&apos;</comment>
           </infoLinks>
           <categoryLinks>
             <categoryLink id="23a2-da24-63d8-e3ea" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
-            <categoryLink targetId="bff2-ae16-74a8-8712" id="a007-be09-44a8-920e" name="Light" primary="false"/>
-            <categoryLink targetId="59a4-7b61-600a-c457" id="d4e1-a3fc-42b3-a4f3" name="Skirmish" primary="false"/>
-            <categoryLink targetId="7e5d-d73e-8ff4-7345" id="61ad-1f88-4d6d-908e" name="Anathema" primary="false"/>
+            <categoryLink targetId="bff2-ae16-74a8-8712" id="a007-be09-44a8-920e" name="Light Sub-type" primary="false"/>
+            <categoryLink targetId="59a4-7b61-600a-c457" id="d4e1-a3fc-42b3-a4f3" name="Skirmish Sub-type" primary="false"/>
+            <categoryLink targetId="7e5d-d73e-8ff4-7345" id="61ad-1f88-4d6d-908e" name="Anathema Sub-type" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="3c06-4d60-bad4-72b8" name="1) May exchange Bolt Pistols for:" hidden="false" collective="false" import="true" defaultSelectionEntryId="0429-cae8-931d-6d5d">
@@ -4821,8 +4793,6 @@ Could not find type or subtype &apos;Infanty&apos;</comment>
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
           </costs>
-          <comment>!BSC Errors from 20240328-1346
-Could not find type or subtype &apos;Infanty&apos;</comment>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
@@ -5148,7 +5118,7 @@ Could not find type or subtype &apos;Infanty&apos;</comment>
         <infoLink id="7aee-09ad-4a4f-44e0" name="Silent Sisterhood (X)" hidden="false" targetId="1d8d-3038-9267-6f1b" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="9db2-bfb0-c5e6-d7ef" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="9db2-bfb0-c5e6-d7ef" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="31d8-9d04-7d76-9deb" name="Light Sub-type" hidden="false" targetId="bff2-ae16-74a8-8712" primary="false"/>
         <categoryLink id="b77f-9ef1-89f1-0a62" name="Anathema Sub-type" hidden="false" targetId="7e5d-d73e-8ff4-7345" primary="false"/>
         <categoryLink id="e0cf-9714-f0f4-5e3f" name="Silent Sisterhood (Chamber of Judgement)" hidden="false" targetId="b71a-371d-4401-9dc0" primary="false"/>
@@ -5192,8 +5162,8 @@ Could not find type or subtype &apos;Infanty&apos;</comment>
           </infoLinks>
           <categoryLinks>
             <categoryLink id="6240-80b8-87db-7755" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
-            <categoryLink targetId="bff2-ae16-74a8-8712" id="f23f-c715-434a-9da5" name="Light" primary="false"/>
-            <categoryLink targetId="7e5d-d73e-8ff4-7345" id="84a4-5c39-4b37-ab95" name="Anathema" primary="false"/>
+            <categoryLink targetId="bff2-ae16-74a8-8712" id="f23f-c715-434a-9da5" name="Light Sub-type" primary="false"/>
+            <categoryLink targetId="7e5d-d73e-8ff4-7345" id="84a4-5c39-4b37-ab95" name="Anathema Sub-type" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="a32b-5932-a006-09fa" name="1) May take any of the following:" hidden="false" collective="false" import="true">
@@ -5298,8 +5268,6 @@ Could not find type or subtype &apos;Infanty&apos;</comment>
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
           </costs>
-          <comment>!BSC Errors from 20240328-1346
-Could not find type or subtype &apos;Infanty&apos;</comment>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
@@ -5389,11 +5357,9 @@ Could not find type or subtype &apos;Infanty&apos;</comment>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="12"/>
               </costs>
               <categoryLinks>
-                <categoryLink targetId="bff2-ae16-74a8-8712" id="22ef-a5cb-42eb-b6cb" name="Light" primary="false"/>
-                <categoryLink targetId="7e5d-d73e-8ff4-7345" id="45d8-9131-4505-95e9" name="Anathema" primary="false"/>
+                <categoryLink targetId="bff2-ae16-74a8-8712" id="22ef-a5cb-42eb-b6cb" name="Light Sub-type" primary="false"/>
+                <categoryLink targetId="7e5d-d73e-8ff4-7345" id="45d8-9131-4505-95e9" name="Anathema Sub-type" primary="false"/>
               </categoryLinks>
-              <comment>!BSC Errors from 20240328-1346
-Could not find type or subtype &apos;Infanty&apos;</comment>
             </selectionEntry>
             <selectionEntry id="da7c-d3f3-f39b-8ba3" name="Firebrand w/ Options" hidden="false" collective="false" import="true" type="model">
               <constraints>
@@ -5477,11 +5443,9 @@ Could not find type or subtype &apos;Infanty&apos;</comment>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="12"/>
               </costs>
               <categoryLinks>
-                <categoryLink targetId="bff2-ae16-74a8-8712" id="0b07-2bb9-4900-966c" name="Light" primary="false"/>
-                <categoryLink targetId="7e5d-d73e-8ff4-7345" id="7a40-1c75-41f6-862e" name="Anathema" primary="false"/>
+                <categoryLink targetId="bff2-ae16-74a8-8712" id="0b07-2bb9-4900-966c" name="Light Sub-type" primary="false"/>
+                <categoryLink targetId="7e5d-d73e-8ff4-7345" id="7a40-1c75-41f6-862e" name="Anathema Sub-type" primary="false"/>
               </categoryLinks>
-              <comment>!BSC Errors from 20240328-1346
-Could not find type or subtype &apos;Infanty&apos;</comment>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
@@ -5604,11 +5568,11 @@ Could not find type or subtype &apos;Infanty&apos;</comment>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25"/>
           </costs>
           <categoryLinks>
-            <categoryLink targetId="6d79-a3e4-381f-7b0f" id="a2fc-4d18-42f8-bf16" name="Cavalry" primary="false"/>
-            <categoryLink targetId="4303-1348-cce4-9501" id="5655-0888-414f-baa0" name="Antigrav" primary="false"/>
-            <categoryLink targetId="59a4-7b61-600a-c457" id="d1c4-36d2-4bde-8e84" name="Skirmish" primary="false"/>
-            <categoryLink targetId="bff2-ae16-74a8-8712" id="4b00-3947-4ad3-b8d8" name="Light" primary="false"/>
-            <categoryLink targetId="7e5d-d73e-8ff4-7345" id="5359-7c2a-4992-bf5f" name="Anathema" primary="false"/>
+            <categoryLink targetId="6d79-a3e4-381f-7b0f" id="a2fc-4d18-42f8-bf16" name="Cavalry Unit Type" primary="false"/>
+            <categoryLink targetId="4303-1348-cce4-9501" id="5655-0888-414f-baa0" name="Antigrav Sub-type" primary="false"/>
+            <categoryLink targetId="59a4-7b61-600a-c457" id="d1c4-36d2-4bde-8e84" name="Skirmish Sub-type" primary="false"/>
+            <categoryLink targetId="bff2-ae16-74a8-8712" id="4b00-3947-4ad3-b8d8" name="Light Sub-type" primary="false"/>
+            <categoryLink targetId="7e5d-d73e-8ff4-7345" id="5359-7c2a-4992-bf5f" name="Anathema Sub-type" primary="false"/>
           </categoryLinks>
         </selectionEntry>
         <selectionEntry id="39a2-688f-ecfc-33e3" name="Subjugator Mistress" hidden="false" collective="false" import="true" type="model">
@@ -5652,11 +5616,11 @@ Could not find type or subtype &apos;Infanty&apos;</comment>
           </infoLinks>
           <categoryLinks>
             <categoryLink id="51b2-ac8e-bb94-23ad" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
-            <categoryLink targetId="6d79-a3e4-381f-7b0f" id="eb23-b886-413d-8fab" name="Cavalry" primary="false"/>
-            <categoryLink targetId="4303-1348-cce4-9501" id="8743-ff53-4f08-9ff5" name="Antigrav" primary="false"/>
-            <categoryLink targetId="59a4-7b61-600a-c457" id="7957-94a7-4ead-92a8" name="Skirmish" primary="false"/>
-            <categoryLink targetId="bff2-ae16-74a8-8712" id="1f63-9bb8-4b63-be7a" name="Light" primary="false"/>
-            <categoryLink targetId="7e5d-d73e-8ff4-7345" id="eaf2-ce6f-4bfb-ab3c" name="Anathema" primary="false"/>
+            <categoryLink targetId="6d79-a3e4-381f-7b0f" id="eb23-b886-413d-8fab" name="Cavalry Unit Type" primary="false"/>
+            <categoryLink targetId="4303-1348-cce4-9501" id="8743-ff53-4f08-9ff5" name="Antigrav Sub-type" primary="false"/>
+            <categoryLink targetId="59a4-7b61-600a-c457" id="7957-94a7-4ead-92a8" name="Skirmish Sub-type" primary="false"/>
+            <categoryLink targetId="bff2-ae16-74a8-8712" id="1f63-9bb8-4b63-be7a" name="Light Sub-type" primary="false"/>
+            <categoryLink targetId="7e5d-d73e-8ff4-7345" id="eaf2-ce6f-4bfb-ab3c" name="Anathema Sub-type" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="7dc8-c1a2-c1a5-8650" name="1) May exchange her Bolt Pistol for:" hidden="false" collective="false" import="true" defaultSelectionEntryId="cb54-6f43-91d1-541f">
@@ -5799,7 +5763,7 @@ Could not find type or subtype &apos;Infanty&apos;</comment>
         <infoLink id="9293-1687-0991-7342" name="Silent Sisterhood (X)" hidden="false" targetId="1d8d-3038-9267-6f1b" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="bc1f-91e3-e70f-a124" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="bc1f-91e3-e70f-a124" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="ea0d-b7b5-6a3f-b11d" name="Light Sub-type" hidden="false" targetId="bff2-ae16-74a8-8712" primary="false"/>
         <categoryLink id="5a5e-a5d0-530a-2ca3" name="Anathema Sub-type" hidden="false" targetId="7e5d-d73e-8ff4-7345" primary="false"/>
         <categoryLink id="84b5-7a8e-290b-2a8a" name="Silent Sisterhood (Chamber of Vigilance)" hidden="false" targetId="b6d7-6924-37fb-dd32" primary="false"/>
@@ -5844,8 +5808,8 @@ Could not find type or subtype &apos;Infanty&apos;</comment>
           </infoLinks>
           <categoryLinks>
             <categoryLink id="b4bb-969f-3acf-a826" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
-            <categoryLink targetId="bff2-ae16-74a8-8712" id="145d-cceb-44a7-ad57" name="Light" primary="false"/>
-            <categoryLink targetId="7e5d-d73e-8ff4-7345" id="7ec6-0d38-4700-9fed" name="Anathema" primary="false"/>
+            <categoryLink targetId="bff2-ae16-74a8-8712" id="145d-cceb-44a7-ad57" name="Light Sub-type" primary="false"/>
+            <categoryLink targetId="7e5d-d73e-8ff4-7345" id="7ec6-0d38-4700-9fed" name="Anathema Sub-type" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="78a8-3907-7b7a-683b" name="3) May take any of the following:" hidden="false" collective="false" import="true">
@@ -5932,8 +5896,6 @@ Could not find type or subtype &apos;Infanty&apos;</comment>
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
           </costs>
-          <comment>!BSC Errors from 20240328-1346
-Could not find type or subtype &apos;Infanty&apos;</comment>
         </selectionEntry>
         <selectionEntry id="9309-bc23-d5b6-e197" name="Sanctioner" hidden="false" collective="false" import="true" type="model">
           <modifierGroups>
@@ -6018,11 +5980,9 @@ Could not find type or subtype &apos;Infanty&apos;</comment>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15"/>
           </costs>
           <categoryLinks>
-            <categoryLink targetId="bff2-ae16-74a8-8712" id="3cab-446a-4d7f-868e" name="Light" primary="false"/>
-            <categoryLink targetId="7e5d-d73e-8ff4-7345" id="89fe-45ab-4966-bd6a" name="Anathema" primary="false"/>
+            <categoryLink targetId="bff2-ae16-74a8-8712" id="3cab-446a-4d7f-868e" name="Light Sub-type" primary="false"/>
+            <categoryLink targetId="7e5d-d73e-8ff4-7345" id="89fe-45ab-4966-bd6a" name="Anathema Sub-type" primary="false"/>
           </categoryLinks>
-          <comment>!BSC Errors from 20240328-1346
-Could not find type or subtype &apos;Infanty&apos;</comment>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
@@ -6095,7 +6055,7 @@ Could not find type or subtype &apos;Infanty&apos;</comment>
         <infoLink id="8a88-073d-ea2e-8958" name="Silent Sisterhood (X)" hidden="false" targetId="1d8d-3038-9267-6f1b" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="1a2d-44ca-d649-1acd" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="1a2d-44ca-d649-1acd" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="98de-79c1-6f1f-0770" name="Light Sub-type" hidden="false" targetId="bff2-ae16-74a8-8712" primary="false"/>
         <categoryLink id="6851-3518-9357-740a" name="Anathema Sub-type" hidden="false" targetId="7e5d-d73e-8ff4-7345" primary="false"/>
         <categoryLink id="e1c9-bccb-4d65-2bf6" name="Silent Sisterhood (Chamber of Judgement)" hidden="false" targetId="b71a-371d-4401-9dc0" primary="false"/>
@@ -6139,8 +6099,8 @@ Could not find type or subtype &apos;Infanty&apos;</comment>
           </infoLinks>
           <categoryLinks>
             <categoryLink id="99e9-1644-5b36-e317" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
-            <categoryLink targetId="bff2-ae16-74a8-8712" id="76af-f93c-403e-b5bf" name="Light" primary="false"/>
-            <categoryLink targetId="7e5d-d73e-8ff4-7345" id="a5d2-c852-4ed3-8562" name="Anathema" primary="false"/>
+            <categoryLink targetId="bff2-ae16-74a8-8712" id="76af-f93c-403e-b5bf" name="Light Sub-type" primary="false"/>
+            <categoryLink targetId="7e5d-d73e-8ff4-7345" id="a5d2-c852-4ed3-8562" name="Anathema Sub-type" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="b8db-504b-f14e-cf4f" name="1) May take any of the following:" hidden="false" collective="false" import="true">
@@ -6240,8 +6200,6 @@ Could not find type or subtype &apos;Infanty&apos;</comment>
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
           </costs>
-          <comment>!BSC Errors from 20240328-1346
-Could not find type or subtype &apos;Infanty&apos;</comment>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
@@ -6364,11 +6322,9 @@ Could not find type or subtype &apos;Infanty&apos;</comment>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15"/>
               </costs>
               <categoryLinks>
-                <categoryLink targetId="bff2-ae16-74a8-8712" id="262a-74a7-4e1a-aaa5" name="Light" primary="false"/>
-                <categoryLink targetId="7e5d-d73e-8ff4-7345" id="4fd8-eb48-45a3-a1a6" name="Anathema" primary="false"/>
+                <categoryLink targetId="bff2-ae16-74a8-8712" id="262a-74a7-4e1a-aaa5" name="Light Sub-type" primary="false"/>
+                <categoryLink targetId="7e5d-d73e-8ff4-7345" id="4fd8-eb48-45a3-a1a6" name="Anathema Sub-type" primary="false"/>
               </categoryLinks>
-              <comment>!BSC Errors from 20240328-1346
-Could not find type or subtype &apos;Infanty&apos;</comment>
             </selectionEntry>
             <selectionEntry id="27c3-138b-b421-f670" name="Expurgator w/ Options" hidden="false" collective="false" import="true" type="model">
               <constraints>
@@ -6443,11 +6399,9 @@ Could not find type or subtype &apos;Infanty&apos;</comment>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15"/>
               </costs>
               <categoryLinks>
-                <categoryLink targetId="bff2-ae16-74a8-8712" id="ddf3-4181-4dc9-9365" name="Light" primary="false"/>
-                <categoryLink targetId="7e5d-d73e-8ff4-7345" id="cb48-eec4-49da-8c82" name="Anathema" primary="false"/>
+                <categoryLink targetId="bff2-ae16-74a8-8712" id="ddf3-4181-4dc9-9365" name="Light Sub-type" primary="false"/>
+                <categoryLink targetId="7e5d-d73e-8ff4-7345" id="cb48-eec4-49da-8c82" name="Anathema Sub-type" primary="false"/>
               </categoryLinks>
-              <comment>!BSC Errors from 20240328-1346
-Could not find type or subtype &apos;Infanty&apos;</comment>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
@@ -7033,7 +6987,7 @@ Could not find type or subtype &apos;Infanty&apos;</comment>
         <infoLink id="73e7-a19d-cd0a-ac08" name="Silent Sisterhood (X)" hidden="false" targetId="1d8d-3038-9267-6f1b" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="48ce-0e11-c465-9cb0" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="48ce-0e11-c465-9cb0" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="8994-cd0a-2d20-817b" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
         <categoryLink id="f4b0-fe45-b143-b438" name="Light Sub-type" hidden="false" targetId="bff2-ae16-74a8-8712" primary="false"/>
         <categoryLink id="d52b-fe94-4b9c-c324" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
@@ -7523,10 +7477,10 @@ Could not find type or subtype &apos;Infanty&apos;</comment>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="55"/>
           </costs>
           <categoryLinks>
-            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="c5ee-8575-4a55-92b0" name="Infantry" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="c5ee-8575-4a55-92b0" name="Infantry Unit Type" primary="false"/>
             <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="0533-fe07-43d1-9a81" name="Character" primary="false"/>
-            <categoryLink targetId="bff2-ae16-74a8-8712" id="023e-2d8b-4dea-96ef" name="Light" primary="false"/>
-            <categoryLink targetId="7e5d-d73e-8ff4-7345" id="12d4-74a6-4719-bcdd" name="Anathema" primary="false"/>
+            <categoryLink targetId="bff2-ae16-74a8-8712" id="023e-2d8b-4dea-96ef" name="Light Sub-type" primary="false"/>
+            <categoryLink targetId="7e5d-d73e-8ff4-7345" id="12d4-74a6-4719-bcdd" name="Anathema Sub-type" primary="false"/>
           </categoryLinks>
         </selectionEntry>
       </selectionEntries>
@@ -7563,7 +7517,7 @@ Could not find type or subtype &apos;Infanty&apos;</comment>
         <infoLink id="1525-f9a9-9169-5cdd" name="Loyalist" hidden="false" targetId="d1de-a45d-2b9b-c878" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="0f9a-4249-f52d-2bac" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="0f9a-4249-f52d-2bac" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="9bb6-7048-8c86-71d1" name="Light Sub-type" hidden="false" targetId="bff2-ae16-74a8-8712" primary="false"/>
         <categoryLink id="3948-60a9-31e6-00c0" name="Line Sub-type" hidden="false" targetId="6399-5c65-7833-1025" primary="false"/>
         <categoryLink id="9427-3df2-5bd8-4d6a" name="Anathema Sub-type" hidden="false" targetId="7e5d-d73e-8ff4-7345" primary="false"/>
@@ -7644,10 +7598,10 @@ Could not find type or subtype &apos;Infanty&apos;</comment>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25"/>
               </costs>
               <categoryLinks>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="722f-a854-4483-8d4f" name="Infantry" primary="false"/>
-                <categoryLink targetId="bff2-ae16-74a8-8712" id="eaa5-9848-462f-9f9c" name="Light" primary="false"/>
-                <categoryLink targetId="6399-5c65-7833-1025" id="b191-5e2a-48c5-abdf" name="Line" primary="false"/>
-                <categoryLink targetId="7e5d-d73e-8ff4-7345" id="1aec-d49e-49d2-aa1a" name="Anathema" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="722f-a854-4483-8d4f" name="Infantry Unit Type" primary="false"/>
+                <categoryLink targetId="bff2-ae16-74a8-8712" id="eaa5-9848-462f-9f9c" name="Light Sub-type" primary="false"/>
+                <categoryLink targetId="6399-5c65-7833-1025" id="b191-5e2a-48c5-abdf" name="Line Sub-type" primary="false"/>
+                <categoryLink targetId="7e5d-d73e-8ff4-7345" id="1aec-d49e-49d2-aa1a" name="Anathema Sub-type" primary="false"/>
               </categoryLinks>
             </selectionEntry>
             <selectionEntry id="feee-7064-0491-2bba" name="Raptora w/ Hand Flamer &amp; Execution Blade" hidden="false" collective="false" import="true" type="model">
@@ -7708,10 +7662,10 @@ Could not find type or subtype &apos;Infanty&apos;</comment>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25"/>
               </costs>
               <categoryLinks>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="3da5-3639-46e4-b043" name="Infantry" primary="false"/>
-                <categoryLink targetId="bff2-ae16-74a8-8712" id="4052-2618-468f-9307" name="Light" primary="false"/>
-                <categoryLink targetId="6399-5c65-7833-1025" id="b59c-e5f4-42e4-9123" name="Line" primary="false"/>
-                <categoryLink targetId="7e5d-d73e-8ff4-7345" id="a371-7b59-4f08-a418" name="Anathema" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="3da5-3639-46e4-b043" name="Infantry Unit Type" primary="false"/>
+                <categoryLink targetId="bff2-ae16-74a8-8712" id="4052-2618-468f-9307" name="Light Sub-type" primary="false"/>
+                <categoryLink targetId="6399-5c65-7833-1025" id="b59c-e5f4-42e4-9123" name="Line Sub-type" primary="false"/>
+                <categoryLink targetId="7e5d-d73e-8ff4-7345" id="a371-7b59-4f08-a418" name="Anathema Sub-type" primary="false"/>
               </categoryLinks>
             </selectionEntry>
             <selectionEntry id="b391-8afe-9d4f-c87a" name="Raptora w/ Needle Pistol &amp; Execution Blade" hidden="false" collective="false" import="true" type="model">
@@ -7772,10 +7726,10 @@ Could not find type or subtype &apos;Infanty&apos;</comment>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25"/>
               </costs>
               <categoryLinks>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="9461-2459-4641-bbde" name="Infantry" primary="false"/>
-                <categoryLink targetId="bff2-ae16-74a8-8712" id="93e6-9e55-4da7-97d6" name="Light" primary="false"/>
-                <categoryLink targetId="6399-5c65-7833-1025" id="7804-ee65-437a-9715" name="Line" primary="false"/>
-                <categoryLink targetId="7e5d-d73e-8ff4-7345" id="7dd9-b381-4011-af51" name="Anathema" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="9461-2459-4641-bbde" name="Infantry Unit Type" primary="false"/>
+                <categoryLink targetId="bff2-ae16-74a8-8712" id="93e6-9e55-4da7-97d6" name="Light Sub-type" primary="false"/>
+                <categoryLink targetId="6399-5c65-7833-1025" id="7804-ee65-437a-9715" name="Line Sub-type" primary="false"/>
+                <categoryLink targetId="7e5d-d73e-8ff4-7345" id="7dd9-b381-4011-af51" name="Anathema Sub-type" primary="false"/>
               </categoryLinks>
             </selectionEntry>
             <selectionEntry id="15a2-7606-593d-23ee" name="Raptora w/ Options" hidden="false" collective="false" import="true" type="model">
@@ -7905,10 +7859,10 @@ Could not find type or subtype &apos;Infanty&apos;</comment>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25"/>
               </costs>
               <categoryLinks>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="02a2-daa9-4b73-a553" name="Infantry" primary="false"/>
-                <categoryLink targetId="bff2-ae16-74a8-8712" id="72d8-3085-426f-a21b" name="Light" primary="false"/>
-                <categoryLink targetId="6399-5c65-7833-1025" id="54e4-2df9-41ac-8cfc" name="Line" primary="false"/>
-                <categoryLink targetId="7e5d-d73e-8ff4-7345" id="d80b-9751-4aff-9a5f" name="Anathema" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="02a2-daa9-4b73-a553" name="Infantry Unit Type" primary="false"/>
+                <categoryLink targetId="bff2-ae16-74a8-8712" id="72d8-3085-426f-a21b" name="Light Sub-type" primary="false"/>
+                <categoryLink targetId="6399-5c65-7833-1025" id="54e4-2df9-41ac-8cfc" name="Line Sub-type" primary="false"/>
+                <categoryLink targetId="7e5d-d73e-8ff4-7345" id="d80b-9751-4aff-9a5f" name="Anathema Sub-type" primary="false"/>
               </categoryLinks>
             </selectionEntry>
           </selectionEntries>

--- a/2022 - LI - Sisters Of Silence.cat
+++ b/2022 - LI - Sisters Of Silence.cat
@@ -290,7 +290,7 @@ In addition, the Leadership Characteristic of a model with the Anathema Unit Sub
         <categoryLink id="6b15-c8be-e78d-6b37" name="Anathema Sub-type" hidden="false" targetId="7e5d-d73e-8ff4-7345" primary="false"/>
         <categoryLink id="5ad9-6ca7-f429-8abc" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
         <categoryLink id="9f01-5e74-7b16-9aa5" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
-        <categoryLink id="2896-3a6a-a393-937f" name="Light Sub-type:" hidden="false" targetId="bff2-ae16-74a8-8712" primary="false"/>
+        <categoryLink id="2896-3a6a-a393-937f" name="Light Sub-type" hidden="false" targetId="bff2-ae16-74a8-8712" primary="false"/>
         <categoryLink id="7427-31c7-286b-2b07" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="d3b1-7626-4c83-0d6a" name="Silent Sisterhood (Chamber of Obivion)" hidden="false" targetId="a7e3-4559-7267-8bf6" primary="false"/>
         <categoryLink id="e9d1-0d5f-e474-800a" name="Obivion HQ" hidden="false" targetId="b760-8313-847f-1afa" primary="false"/>
@@ -509,7 +509,7 @@ In addition, the Leadership Characteristic of a model with the Anathema Unit Sub
       <categoryLinks>
         <categoryLink id="9114-4a2e-5f6d-513c" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
         <categoryLink id="c19a-9d92-b941-8bfb" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
-        <categoryLink id="4261-d9e6-6761-57c0" name="Light Sub-type:" hidden="false" targetId="bff2-ae16-74a8-8712" primary="false"/>
+        <categoryLink id="4261-d9e6-6761-57c0" name="Light Sub-type" hidden="false" targetId="bff2-ae16-74a8-8712" primary="false"/>
         <categoryLink id="d32c-fd83-381e-9d0e" name="Anathema Sub-type" hidden="false" targetId="7e5d-d73e-8ff4-7345" primary="false"/>
         <categoryLink id="1617-b424-fdfc-c3a1" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="eab7-89d5-4457-152c" name="Silent Sisterhood (Chamber of Obivion)" hidden="false" targetId="a7e3-4559-7267-8bf6" primary="false"/>
@@ -1055,7 +1055,7 @@ In addition, the Leadership Characteristic of a model with the Anathema Unit Sub
         <categoryLink id="599e-9f9e-659f-36b3" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="cece-9f62-cd60-5420" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
         <categoryLink id="d3f6-0f11-c7e5-eef7" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
-        <categoryLink id="c30d-388d-58fa-37df" name="Light Sub-type:" hidden="false" targetId="bff2-ae16-74a8-8712" primary="false"/>
+        <categoryLink id="c30d-388d-58fa-37df" name="Light Sub-type" hidden="false" targetId="bff2-ae16-74a8-8712" primary="false"/>
         <categoryLink id="0460-c73c-b374-b426" name="Anathema Sub-type" hidden="false" targetId="7e5d-d73e-8ff4-7345" primary="false"/>
         <categoryLink id="3f58-3284-3fb8-9697" name="Silent Sisterhood (Chamber of Judgement)" hidden="false" targetId="b71a-371d-4401-9dc0" primary="false"/>
         <categoryLink id="77b9-8a80-9cab-9009" name="Judgement HQ" hidden="false" targetId="a9b6-f66f-e8ee-553e" primary="false"/>
@@ -1746,11 +1746,11 @@ In addition, the Leadership Characteristic of a model with the Anathema Unit Sub
         <infoLink id="17cc-cdff-f607-79d6" name="Silent Sisterhood (X)" hidden="false" targetId="1d8d-3038-9267-6f1b" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="41d2-f0d2-14d0-fe27" name="Cavalry Unit-type:" hidden="false" targetId="6d79-a3e4-381f-7b0f" primary="false"/>
+        <categoryLink id="41d2-f0d2-14d0-fe27" name="Cavalry Unit Type" hidden="false" targetId="6d79-a3e4-381f-7b0f" primary="false"/>
         <categoryLink id="d3d4-0f12-5244-f4e7" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
         <categoryLink id="b1a3-b5d8-3818-dd07" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
-        <categoryLink id="bfe0-fc96-b80f-f1f2" name="Light Sub-type:" hidden="false" targetId="bff2-ae16-74a8-8712" primary="false"/>
-        <categoryLink id="e3a4-034d-cc1f-6ca7" name="Skirmish Sub-type:" hidden="false" targetId="59a4-7b61-600a-c457" primary="false"/>
+        <categoryLink id="bfe0-fc96-b80f-f1f2" name="Light Sub-type" hidden="false" targetId="bff2-ae16-74a8-8712" primary="false"/>
+        <categoryLink id="e3a4-034d-cc1f-6ca7" name="Skirmish Sub-type" hidden="false" targetId="59a4-7b61-600a-c457" primary="false"/>
         <categoryLink id="f298-67b4-a90f-95ad" name="Anathema Sub-type" hidden="false" targetId="7e5d-d73e-8ff4-7345" primary="false"/>
         <categoryLink id="a6a3-d469-031a-9773" name="Silent Sisterhood (Chamber of Judgement)" hidden="false" targetId="b71a-371d-4401-9dc0" primary="false"/>
         <categoryLink id="f9fd-e06e-70df-4045" name="Judgement HQ" hidden="false" targetId="a9b6-f66f-e8ee-553e" primary="false"/>
@@ -2349,8 +2349,8 @@ In addition, the Leadership Characteristic of a model with the Anathema Unit Sub
       </infoLinks>
       <categoryLinks>
         <categoryLink id="f0e2-9af7-25e4-a985" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="ffad-b6d0-11e6-70cf" name="Light Sub-type:" hidden="false" targetId="bff2-ae16-74a8-8712" primary="false"/>
-        <categoryLink id="40c2-d8d1-0517-51db" name="Line Sub-type:" hidden="false" targetId="6399-5c65-7833-1025" primary="false"/>
+        <categoryLink id="ffad-b6d0-11e6-70cf" name="Light Sub-type" hidden="false" targetId="bff2-ae16-74a8-8712" primary="false"/>
+        <categoryLink id="40c2-d8d1-0517-51db" name="Line Sub-type" hidden="false" targetId="6399-5c65-7833-1025" primary="false"/>
         <categoryLink id="5526-deb2-d4aa-dff7" name="Anathema Sub-type" hidden="false" targetId="7e5d-d73e-8ff4-7345" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
@@ -2937,7 +2937,7 @@ Could not find type or subtype &apos;Infanty&apos;</comment>
         <categoryLink id="2dbd-dcff-f67e-57d4" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="bee8-f85e-9c9f-71cc" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
         <categoryLink id="9647-5e27-4d48-5fca" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
-        <categoryLink id="e35f-892f-5cf1-8766" name="Light Sub-type:" hidden="false" targetId="bff2-ae16-74a8-8712" primary="false"/>
+        <categoryLink id="e35f-892f-5cf1-8766" name="Light Sub-type" hidden="false" targetId="bff2-ae16-74a8-8712" primary="false"/>
         <categoryLink id="9141-5125-97c3-d1cb" name="Anathema Sub-type" hidden="false" targetId="7e5d-d73e-8ff4-7345" primary="false"/>
         <categoryLink id="55eb-6a52-6728-5484" name="Silent Sisterhood (Chamber of Vigilance)" hidden="false" targetId="b6d7-6924-37fb-dd32" primary="false"/>
       </categoryLinks>
@@ -3154,7 +3154,7 @@ Could not find type or subtype &apos;Infanty&apos;</comment>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="4dd1-451d-eb5c-8276" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="a8b1-1974-7b8f-3940" name="Light Sub-type:" hidden="false" targetId="bff2-ae16-74a8-8712" primary="false"/>
+        <categoryLink id="a8b1-1974-7b8f-3940" name="Light Sub-type" hidden="false" targetId="bff2-ae16-74a8-8712" primary="false"/>
         <categoryLink id="cd46-4eab-7d03-c98a" name="Anathema Sub-type" hidden="false" targetId="7e5d-d73e-8ff4-7345" primary="false"/>
         <categoryLink id="bf15-9553-bb6a-212e" name="Silent Sisterhood (Chamber of Obivion)" hidden="false" targetId="a7e3-4559-7267-8bf6" primary="false"/>
       </categoryLinks>
@@ -3479,7 +3479,7 @@ Could not find type or subtype &apos;Infanty&apos;</comment>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="44f5-b8c0-a974-015e" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="2b36-13ce-ad0c-62cc" name="Light Sub-type:" hidden="false" targetId="bff2-ae16-74a8-8712" primary="false"/>
+        <categoryLink id="2b36-13ce-ad0c-62cc" name="Light Sub-type" hidden="false" targetId="bff2-ae16-74a8-8712" primary="false"/>
         <categoryLink id="53a0-afde-583a-8dff" name="Anathema Sub-type" hidden="false" targetId="7e5d-d73e-8ff4-7345" primary="false"/>
         <categoryLink id="1a5d-f7be-b0dc-e195" name="Silent Sisterhood (Chamber of Vigilance)" hidden="false" targetId="b6d7-6924-37fb-dd32" primary="false"/>
       </categoryLinks>
@@ -3849,8 +3849,8 @@ Could not find type or subtype &apos;Infanty&apos;</comment>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="d06a-2352-d3b5-1a8e" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="6886-2fd9-b955-9168" name="Light Sub-type:" hidden="false" targetId="bff2-ae16-74a8-8712" primary="false"/>
-        <categoryLink id="4518-335f-866a-0f7d" name="Line Sub-type:" hidden="false" targetId="6399-5c65-7833-1025" primary="false"/>
+        <categoryLink id="6886-2fd9-b955-9168" name="Light Sub-type" hidden="false" targetId="bff2-ae16-74a8-8712" primary="false"/>
+        <categoryLink id="4518-335f-866a-0f7d" name="Line Sub-type" hidden="false" targetId="6399-5c65-7833-1025" primary="false"/>
         <categoryLink id="1a82-a3c6-c790-de15" name="Anathema Sub-type" hidden="false" targetId="7e5d-d73e-8ff4-7345" primary="false"/>
         <categoryLink id="4758-e616-4aa5-f193" name="Silent Sisterhood (Chamber of Vigilance)" hidden="false" targetId="b6d7-6924-37fb-dd32" primary="false"/>
       </categoryLinks>
@@ -4191,8 +4191,8 @@ Could not find type or subtype &apos;Infanty&apos;</comment>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="8c22-4db8-43b2-f419" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="c81b-2a93-d091-3f92" name="Light Sub-type:" hidden="false" targetId="bff2-ae16-74a8-8712" primary="false"/>
-        <categoryLink id="a8ad-9b44-f397-f115" name="Line Sub-type:" hidden="false" targetId="6399-5c65-7833-1025" primary="false"/>
+        <categoryLink id="c81b-2a93-d091-3f92" name="Light Sub-type" hidden="false" targetId="bff2-ae16-74a8-8712" primary="false"/>
+        <categoryLink id="a8ad-9b44-f397-f115" name="Line Sub-type" hidden="false" targetId="6399-5c65-7833-1025" primary="false"/>
         <categoryLink id="d300-24f4-6452-4ad4" name="Anathema Sub-type" hidden="false" targetId="7e5d-d73e-8ff4-7345" primary="false"/>
         <categoryLink id="2e13-4669-f5a8-771a" name="Silent Sisterhood (Chamber of Obivion)" hidden="false" targetId="a7e3-4559-7267-8bf6" primary="false"/>
       </categoryLinks>
@@ -4548,8 +4548,8 @@ Could not find type or subtype &apos;Infanty&apos;</comment>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="57ef-494e-3aa2-9833" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="3e09-e5a2-cb66-5771" name="Light Sub-type:" hidden="false" targetId="bff2-ae16-74a8-8712" primary="false"/>
-        <categoryLink id="ec95-6148-86cc-881a" name="Skirmish Sub-type:" hidden="false" targetId="59a4-7b61-600a-c457" primary="false"/>
+        <categoryLink id="3e09-e5a2-cb66-5771" name="Light Sub-type" hidden="false" targetId="bff2-ae16-74a8-8712" primary="false"/>
+        <categoryLink id="ec95-6148-86cc-881a" name="Skirmish Sub-type" hidden="false" targetId="59a4-7b61-600a-c457" primary="false"/>
         <categoryLink id="577d-16f2-efd7-c704" name="Anathema Sub-type" hidden="false" targetId="7e5d-d73e-8ff4-7345" primary="false"/>
         <categoryLink id="8e8b-8ba5-8e2a-de48" name="Silent Sisterhood (Chamber of Obivion)" hidden="false" targetId="a7e3-4559-7267-8bf6" primary="false"/>
       </categoryLinks>
@@ -5152,7 +5152,7 @@ Could not find type or subtype &apos;Infanty&apos;</comment>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="9db2-bfb0-c5e6-d7ef" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="31d8-9d04-7d76-9deb" name="Light Sub-type:" hidden="false" targetId="bff2-ae16-74a8-8712" primary="false"/>
+        <categoryLink id="31d8-9d04-7d76-9deb" name="Light Sub-type" hidden="false" targetId="bff2-ae16-74a8-8712" primary="false"/>
         <categoryLink id="b77f-9ef1-89f1-0a62" name="Anathema Sub-type" hidden="false" targetId="7e5d-d73e-8ff4-7345" primary="false"/>
         <categoryLink id="e0cf-9714-f0f4-5e3f" name="Silent Sisterhood (Chamber of Judgement)" hidden="false" targetId="b71a-371d-4401-9dc0" primary="false"/>
       </categoryLinks>
@@ -5529,8 +5529,8 @@ Could not find type or subtype &apos;Infanty&apos;</comment>
         <infoLink id="6b02-b6a8-2663-228f" name="Silent Sisterhood (X)" hidden="false" targetId="1d8d-3038-9267-6f1b" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="cba8-faf1-bd05-d46a" name="Cavalry Unit-type:" hidden="false" targetId="6d79-a3e4-381f-7b0f" primary="false"/>
-        <categoryLink id="d29d-2c7e-9074-1379" name="Skirmish Sub-type:" hidden="false" targetId="59a4-7b61-600a-c457" primary="false"/>
+        <categoryLink id="cba8-faf1-bd05-d46a" name="Cavalry Unit Type" hidden="false" targetId="6d79-a3e4-381f-7b0f" primary="false"/>
+        <categoryLink id="d29d-2c7e-9074-1379" name="Skirmish Sub-type" hidden="false" targetId="59a4-7b61-600a-c457" primary="false"/>
         <categoryLink id="b917-710e-795f-1ea1" name="Silent Sisterhood (Chamber of Judgement)" hidden="false" targetId="b71a-371d-4401-9dc0" primary="false"/>
         <categoryLink id="87bb-2a59-f19c-aac1" name="Antigrav Sub-type" hidden="false" targetId="4303-1348-cce4-9501" primary="false"/>
         <categoryLink targetId="7e5d-d73e-8ff4-7345" id="d3f8-7758-da7d-b4ce" primary="false" name="Anathema Sub-type"/>
@@ -5803,7 +5803,7 @@ Could not find type or subtype &apos;Infanty&apos;</comment>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="bc1f-91e3-e70f-a124" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="ea0d-b7b5-6a3f-b11d" name="Light Sub-type:" hidden="false" targetId="bff2-ae16-74a8-8712" primary="false"/>
+        <categoryLink id="ea0d-b7b5-6a3f-b11d" name="Light Sub-type" hidden="false" targetId="bff2-ae16-74a8-8712" primary="false"/>
         <categoryLink id="5a5e-a5d0-530a-2ca3" name="Anathema Sub-type" hidden="false" targetId="7e5d-d73e-8ff4-7345" primary="false"/>
         <categoryLink id="84b5-7a8e-290b-2a8a" name="Silent Sisterhood (Chamber of Vigilance)" hidden="false" targetId="b6d7-6924-37fb-dd32" primary="false"/>
       </categoryLinks>
@@ -6099,7 +6099,7 @@ Could not find type or subtype &apos;Infanty&apos;</comment>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="1a2d-44ca-d649-1acd" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="98de-79c1-6f1f-0770" name="Light Sub-type:" hidden="false" targetId="bff2-ae16-74a8-8712" primary="false"/>
+        <categoryLink id="98de-79c1-6f1f-0770" name="Light Sub-type" hidden="false" targetId="bff2-ae16-74a8-8712" primary="false"/>
         <categoryLink id="6851-3518-9357-740a" name="Anathema Sub-type" hidden="false" targetId="7e5d-d73e-8ff4-7345" primary="false"/>
         <categoryLink id="e1c9-bccb-4d65-2bf6" name="Silent Sisterhood (Chamber of Judgement)" hidden="false" targetId="b71a-371d-4401-9dc0" primary="false"/>
       </categoryLinks>
@@ -6919,8 +6919,8 @@ Could not find type or subtype &apos;Infanty&apos;</comment>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="4048-cdbc-7bad-778e" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
-        <categoryLink id="d29e-cf5d-77db-4913" name="Fast Sub-type:" hidden="false" targetId="0ea2-efb5-b7af-226e" primary="false"/>
-        <categoryLink id="529d-3432-2c61-6c5a" name="Transport Sub-type:" hidden="false" targetId="7b0a-a743-a8da-3a39" primary="false"/>
+        <categoryLink id="d29e-cf5d-77db-4913" name="Fast Sub-type" hidden="false" targetId="0ea2-efb5-b7af-226e" primary="false"/>
+        <categoryLink id="529d-3432-2c61-6c5a" name="Transport Sub-type" hidden="false" targetId="7b0a-a743-a8da-3a39" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="e5ea-5a84-b7d2-eadd" name="1) Hull (Front) Mounted Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="1962-701d-5052-32ab">
@@ -7038,7 +7038,7 @@ Could not find type or subtype &apos;Infanty&apos;</comment>
       <categoryLinks>
         <categoryLink id="48ce-0e11-c465-9cb0" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="8994-cd0a-2d20-817b" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
-        <categoryLink id="f4b0-fe45-b143-b438" name="Light Sub-type:" hidden="false" targetId="bff2-ae16-74a8-8712" primary="false"/>
+        <categoryLink id="f4b0-fe45-b143-b438" name="Light Sub-type" hidden="false" targetId="bff2-ae16-74a8-8712" primary="false"/>
         <categoryLink id="d52b-fe94-4b9c-c324" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
         <categoryLink id="e41b-0ca6-ae79-fc71" name="Anathema Sub-type" hidden="false" targetId="7e5d-d73e-8ff4-7345" primary="false"/>
         <categoryLink id="b087-f275-3695-b08b" name="Obivion HQ" hidden="false" targetId="b760-8313-847f-1afa" primary="false"/>
@@ -7567,8 +7567,8 @@ Could not find type or subtype &apos;Infanty&apos;</comment>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="0f9a-4249-f52d-2bac" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="9bb6-7048-8c86-71d1" name="Light Sub-type:" hidden="false" targetId="bff2-ae16-74a8-8712" primary="false"/>
-        <categoryLink id="3948-60a9-31e6-00c0" name="Line Sub-type:" hidden="false" targetId="6399-5c65-7833-1025" primary="false"/>
+        <categoryLink id="9bb6-7048-8c86-71d1" name="Light Sub-type" hidden="false" targetId="bff2-ae16-74a8-8712" primary="false"/>
+        <categoryLink id="3948-60a9-31e6-00c0" name="Line Sub-type" hidden="false" targetId="6399-5c65-7833-1025" primary="false"/>
         <categoryLink id="9427-3df2-5bd8-4d6a" name="Anathema Sub-type" hidden="false" targetId="7e5d-d73e-8ff4-7345" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>

--- a/2022 - LI - Solar Auxilia.cat
+++ b/2022 - LI - Solar Auxilia.cat
@@ -803,7 +803,7 @@
         <constraint field="selections" scope="force" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="154d-0b2b-1215-38bb" type="max"/>
       </constraints>
       <categoryLinks>
-        <categoryLink id="e7bd-8dd9-39fd-4e7d" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="e7bd-8dd9-39fd-4e7d" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="3890-ed31-5e7e-4b77" name="Heavy Sub-type" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
         <categoryLink id="fb94-9780-7cb6-f0d9" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
         <categoryLink name="SA or IM Unit" hidden="false" id="e61e-4d32-7f6f-c86a" targetId="4aca-2849-7f41-0200" primary="false"/>
@@ -1185,8 +1185,8 @@
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="85"/>
           </costs>
           <categoryLinks>
-            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="f2a3-dfb3-4cc5-8000" name="Infantry" primary="false"/>
-            <categoryLink targetId="9231-183c-b97b-63f9" id="4a38-8694-4340-b714" name="Heavy" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="f2a3-dfb3-4cc5-8000" name="Infantry Unit Type" primary="false"/>
+            <categoryLink targetId="9231-183c-b97b-63f9" id="4a38-8694-4340-b714" name="Heavy Sub-type" primary="false"/>
             <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="cadf-ce18-4f5a-8b07" name="Character" primary="false"/>
           </categoryLinks>
         </selectionEntry>
@@ -1257,7 +1257,7 @@
     </selectionEntry>
     <selectionEntry id="e9d4-7207-71e0-0762" name="Tactical Command Tercio" hidden="false" collective="false" import="true" type="unit">
       <categoryLinks>
-        <categoryLink id="ab79-0133-fa4a-cd86" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="ab79-0133-fa4a-cd86" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="2b04-daec-c616-d6bc" name="Close-order Sub-type" hidden="false" targetId="0af0-ea84-09d7-2b1f" primary="false"/>
         <categoryLink name="SA or IM Unit" hidden="false" id="c4b1-9d02-6d2b-116f" targetId="4aca-2849-7f41-0200" primary="false"/>
       </categoryLinks>
@@ -1473,8 +1473,8 @@
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="12"/>
               </costs>
               <categoryLinks>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="1f7f-9894-48d0-a8a9" name="Infantry" primary="false"/>
-                <categoryLink targetId="0af0-ea84-09d7-2b1f" id="82d8-8f4c-4f28-8088" name="Close-order" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="1f7f-9894-48d0-a8a9" name="Infantry Unit Type" primary="false"/>
+                <categoryLink targetId="0af0-ea84-09d7-2b1f" id="82d8-8f4c-4f28-8088" name="Close-order Sub-type" primary="false"/>
               </categoryLinks>
             </selectionEntry>
             <selectionEntry id="672b-ea90-3efc-dee2" name="Auxilia Captain" hidden="false" collective="false" import="true" type="model">
@@ -2035,8 +2035,8 @@
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10"/>
                   </costs>
                   <categoryLinks>
-                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="675c-e497-4f65-be3d" name="Infantry" primary="false"/>
-                    <categoryLink targetId="0af0-ea84-09d7-2b1f" id="4242-fc7f-43eb-bbe1" name="Close-order" primary="false"/>
+                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="675c-e497-4f65-be3d" name="Infantry Unit Type" primary="false"/>
+                    <categoryLink targetId="0af0-ea84-09d7-2b1f" id="4242-fc7f-43eb-bbe1" name="Close-order Sub-type" primary="false"/>
                     <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="c41f-e660-4fb0-a546" name="Character" primary="false"/>
                   </categoryLinks>
                 </selectionEntry>
@@ -2270,8 +2270,8 @@
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="12"/>
               </costs>
               <categoryLinks>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="4d3f-f5fe-4022-ad68" name="Infantry" primary="false"/>
-                <categoryLink targetId="0af0-ea84-09d7-2b1f" id="ca2e-b7ba-4dab-9642" name="Close-order" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="4d3f-f5fe-4022-ad68" name="Infantry Unit Type" primary="false"/>
+                <categoryLink targetId="0af0-ea84-09d7-2b1f" id="ca2e-b7ba-4dab-9642" name="Close-order Sub-type" primary="false"/>
               </categoryLinks>
             </selectionEntry>
           </selectionEntries>
@@ -2394,7 +2394,7 @@
         <constraint field="selections" scope="parent" value="-1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ca24-f640-593d-b537" type="max"/>
       </constraints>
       <categoryLinks>
-        <categoryLink id="4ee4-cb02-24f5-137f" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="4ee4-cb02-24f5-137f" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="43e3-5243-c97d-3eda" name="Close-order Sub-type" hidden="false" targetId="0af0-ea84-09d7-2b1f" primary="false"/>
         <categoryLink name="SA or IM Unit" hidden="false" id="b65c-3d61-86-e4eb" targetId="4aca-2849-7f41-0200" primary="false"/>
       </categoryLinks>
@@ -2482,8 +2482,8 @@
               </profiles>
               <categoryLinks>
                 <categoryLink id="1278-bf88-ac56-9920" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="c68b-e63c-4de7-a247" name="Infantry" primary="false"/>
-                <categoryLink targetId="9231-183c-b97b-63f9" id="95bf-a49f-432a-b6c4" name="Heavy" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="c68b-e63c-4de7-a247" name="Infantry Unit Type" primary="false"/>
+                <categoryLink targetId="9231-183c-b97b-63f9" id="95bf-a49f-432a-b6c4" name="Heavy Sub-type" primary="false"/>
               </categoryLinks>
               <selectionEntryGroups>
                 <selectionEntryGroup id="1cb1-052d-9cfe-0fc5" name="Armour" hidden="false" collective="false" import="true" defaultSelectionEntryId="09b8-e985-c536-4684">
@@ -2726,8 +2726,8 @@
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="13"/>
                   </costs>
                   <categoryLinks>
-                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="da5d-531c-4a24-b7e6" name="Infantry" primary="false"/>
-                    <categoryLink targetId="9231-183c-b97b-63f9" id="9e8e-cfdf-4797-85b8" name="Heavy" primary="false"/>
+                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="da5d-531c-4a24-b7e6" name="Infantry Unit Type" primary="false"/>
+                    <categoryLink targetId="9231-183c-b97b-63f9" id="9e8e-cfdf-4797-85b8" name="Heavy Sub-type" primary="false"/>
                   </categoryLinks>
                 </selectionEntry>
                 <selectionEntry id="6e26-de36-1442-bf11" name="Veletarii w/ Power Lance" hidden="false" collective="false" import="true" type="model">
@@ -2755,8 +2755,8 @@
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="13"/>
                   </costs>
                   <categoryLinks>
-                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="7540-5336-4847-b983" name="Infantry" primary="false"/>
-                    <categoryLink targetId="9231-183c-b97b-63f9" id="68b3-64f4-4caa-ba98" name="Heavy" primary="false"/>
+                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="7540-5336-4847-b983" name="Infantry Unit Type" primary="false"/>
+                    <categoryLink targetId="9231-183c-b97b-63f9" id="68b3-64f4-4caa-ba98" name="Heavy Sub-type" primary="false"/>
                   </categoryLinks>
                 </selectionEntry>
                 <selectionEntry id="2ccc-2dc8-9580-f134" name="Veletarii w/ Power Maul" hidden="false" collective="false" import="true" type="model">
@@ -2784,8 +2784,8 @@
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="13"/>
                   </costs>
                   <categoryLinks>
-                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="a09f-5726-4cb7-80fd" name="Infantry" primary="false"/>
-                    <categoryLink targetId="9231-183c-b97b-63f9" id="a5f9-e2a7-4afc-9773" name="Heavy" primary="false"/>
+                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="a09f-5726-4cb7-80fd" name="Infantry Unit Type" primary="false"/>
+                    <categoryLink targetId="9231-183c-b97b-63f9" id="a5f9-e2a7-4afc-9773" name="Heavy Sub-type" primary="false"/>
                   </categoryLinks>
                 </selectionEntry>
                 <selectionEntry id="c39a-711f-3566-712d" name="Veletarii w/ Volkite Charger" hidden="false" collective="false" import="true" type="model">
@@ -2813,8 +2813,8 @@
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="8"/>
                   </costs>
                   <categoryLinks>
-                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="22fb-ac5b-423d-9dcb" name="Infantry" primary="false"/>
-                    <categoryLink targetId="9231-183c-b97b-63f9" id="8e3d-b560-4e82-9a41" name="Heavy" primary="false"/>
+                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="22fb-ac5b-423d-9dcb" name="Infantry Unit Type" primary="false"/>
+                    <categoryLink targetId="9231-183c-b97b-63f9" id="8e3d-b560-4e82-9a41" name="Heavy Sub-type" primary="false"/>
                   </categoryLinks>
                 </selectionEntry>
                 <selectionEntry id="0797-e0e8-65b9-9a4a" name="Veletarii w/ Power Axe" hidden="false" collective="false" import="true" type="model">
@@ -2873,8 +2873,8 @@
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="13"/>
                   </costs>
                   <categoryLinks>
-                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="41ec-9595-4956-87b5" name="Infantry" primary="false"/>
-                    <categoryLink targetId="9231-183c-b97b-63f9" id="bfd9-9a27-46f5-aa92" name="Heavy" primary="false"/>
+                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="41ec-9595-4956-87b5" name="Infantry Unit Type" primary="false"/>
+                    <categoryLink targetId="9231-183c-b97b-63f9" id="bfd9-9a27-46f5-aa92" name="Heavy Sub-type" primary="false"/>
                   </categoryLinks>
                 </selectionEntry>
                 <selectionEntry id="3d9e-0a04-4a3b-de52" name="Veletarii w/ Autorifle" hidden="true" collective="false" import="true" type="model">
@@ -2909,8 +2909,8 @@
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="8"/>
                   </costs>
                   <categoryLinks>
-                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="678c-1f1f-4ffe-bc29" name="Infantry" primary="false"/>
-                    <categoryLink targetId="9231-183c-b97b-63f9" id="42c2-a51c-4b49-a73f" name="Heavy" primary="false"/>
+                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="678c-1f1f-4ffe-bc29" name="Infantry Unit Type" primary="false"/>
+                    <categoryLink targetId="9231-183c-b97b-63f9" id="42c2-a51c-4b49-a73f" name="Heavy Sub-type" primary="false"/>
                   </categoryLinks>
                 </selectionEntry>
                 <selectionEntry id="9323-ccf8-496d-ec8f" name="Veletarii w/ Lascarbine" hidden="true" collective="false" import="true" type="model">
@@ -2945,8 +2945,8 @@
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="8"/>
                   </costs>
                   <categoryLinks>
-                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="123c-6d08-491f-8922" name="Infantry" primary="false"/>
-                    <categoryLink targetId="9231-183c-b97b-63f9" id="185b-0ae6-4b5d-9e60" name="Heavy" primary="false"/>
+                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="123c-6d08-491f-8922" name="Infantry Unit Type" primary="false"/>
+                    <categoryLink targetId="9231-183c-b97b-63f9" id="185b-0ae6-4b5d-9e60" name="Heavy Sub-type" primary="false"/>
                   </categoryLinks>
                 </selectionEntry>
                 <selectionEntry id="957e-31e3-8b91-a469" name="Veletarii w/ Lasgun" hidden="true" collective="false" import="true" type="model">
@@ -2981,8 +2981,8 @@
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="8"/>
                   </costs>
                   <categoryLinks>
-                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="52c2-d432-4ffa-8fca" name="Infantry" primary="false"/>
-                    <categoryLink targetId="9231-183c-b97b-63f9" id="fe39-c692-4547-bbce" name="Heavy" primary="false"/>
+                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="52c2-d432-4ffa-8fca" name="Infantry Unit Type" primary="false"/>
+                    <categoryLink targetId="9231-183c-b97b-63f9" id="fe39-c692-4547-bbce" name="Heavy Sub-type" primary="false"/>
                   </categoryLinks>
                 </selectionEntry>
                 <selectionEntry id="5b3a-4395-95a9-9851" name="Veletarii w/ Shotgun" hidden="true" collective="false" import="true" type="model">
@@ -3017,8 +3017,8 @@
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="8"/>
                   </costs>
                   <categoryLinks>
-                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="d42f-a701-478d-9506" name="Infantry" primary="false"/>
-                    <categoryLink targetId="9231-183c-b97b-63f9" id="f200-f456-4ece-a5d4" name="Heavy" primary="false"/>
+                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="d42f-a701-478d-9506" name="Infantry Unit Type" primary="false"/>
+                    <categoryLink targetId="9231-183c-b97b-63f9" id="f200-f456-4ece-a5d4" name="Heavy Sub-type" primary="false"/>
                   </categoryLinks>
                 </selectionEntry>
                 <selectionEntry id="fa18-90d2-821e-4291" name="Veletarii w/ Stubcarbine" hidden="true" collective="false" import="true" type="model">
@@ -3053,8 +3053,8 @@
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="8"/>
                   </costs>
                   <categoryLinks>
-                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="a55c-660d-42fc-aac5" name="Infantry" primary="false"/>
-                    <categoryLink targetId="9231-183c-b97b-63f9" id="8a20-14c5-4324-b20d" name="Heavy" primary="false"/>
+                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="a55c-660d-42fc-aac5" name="Infantry Unit Type" primary="false"/>
+                    <categoryLink targetId="9231-183c-b97b-63f9" id="8a20-14c5-4324-b20d" name="Heavy Sub-type" primary="false"/>
                   </categoryLinks>
                 </selectionEntry>
               </selectionEntries>
@@ -3164,8 +3164,8 @@
               </profiles>
               <categoryLinks>
                 <categoryLink id="6ba0-d806-4ca8-1add" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="aa8d-3d92-43b7-92f0" name="Infantry" primary="false"/>
-                <categoryLink targetId="9231-183c-b97b-63f9" id="06b4-6138-47bc-8318" name="Heavy" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="aa8d-3d92-43b7-92f0" name="Infantry Unit Type" primary="false"/>
+                <categoryLink targetId="9231-183c-b97b-63f9" id="06b4-6138-47bc-8318" name="Heavy Sub-type" primary="false"/>
               </categoryLinks>
               <selectionEntryGroups>
                 <selectionEntryGroup id="7420-8069-6ac7-b72b" name="Armour" hidden="false" collective="false" import="true" defaultSelectionEntryId="1d16-82e9-d8f6-943e">
@@ -3415,8 +3415,8 @@
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="13"/>
                   </costs>
                   <categoryLinks>
-                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="07f8-8827-4d4d-a2b6" name="Infantry" primary="false"/>
-                    <categoryLink targetId="9231-183c-b97b-63f9" id="3c04-a03b-4798-a9f1" name="Heavy" primary="false"/>
+                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="07f8-8827-4d4d-a2b6" name="Infantry Unit Type" primary="false"/>
+                    <categoryLink targetId="9231-183c-b97b-63f9" id="3c04-a03b-4798-a9f1" name="Heavy Sub-type" primary="false"/>
                   </categoryLinks>
                 </selectionEntry>
                 <selectionEntry id="9194-cb55-09ee-7817" name="Veletarii w/ Volkite Charger" hidden="false" collective="false" import="true" type="model">
@@ -3444,8 +3444,8 @@
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="8"/>
                   </costs>
                   <categoryLinks>
-                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="d7c8-7590-4f0d-9f98" name="Infantry" primary="false"/>
-                    <categoryLink targetId="9231-183c-b97b-63f9" id="8b6f-f985-403b-a672" name="Heavy" primary="false"/>
+                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="d7c8-7590-4f0d-9f98" name="Infantry Unit Type" primary="false"/>
+                    <categoryLink targetId="9231-183c-b97b-63f9" id="8b6f-f985-403b-a672" name="Heavy Sub-type" primary="false"/>
                   </categoryLinks>
                 </selectionEntry>
                 <selectionEntry id="c110-0436-5b73-08f7" name="Veletarii w/ Autorifle" hidden="true" collective="false" import="true" type="model">
@@ -3480,8 +3480,8 @@
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="8"/>
                   </costs>
                   <categoryLinks>
-                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="468f-3b13-4401-b378" name="Infantry" primary="false"/>
-                    <categoryLink targetId="9231-183c-b97b-63f9" id="004b-b83d-4a38-98f5" name="Heavy" primary="false"/>
+                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="468f-3b13-4401-b378" name="Infantry Unit Type" primary="false"/>
+                    <categoryLink targetId="9231-183c-b97b-63f9" id="004b-b83d-4a38-98f5" name="Heavy Sub-type" primary="false"/>
                   </categoryLinks>
                 </selectionEntry>
                 <selectionEntry id="0d2b-3943-df76-12a2" name="Veletarii w/ Lascarbine" hidden="true" collective="false" import="true" type="model">
@@ -3516,8 +3516,8 @@
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="8"/>
                   </costs>
                   <categoryLinks>
-                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="1ab6-3841-492b-bbdd" name="Infantry" primary="false"/>
-                    <categoryLink targetId="9231-183c-b97b-63f9" id="6343-81d6-4fbf-a868" name="Heavy" primary="false"/>
+                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="1ab6-3841-492b-bbdd" name="Infantry Unit Type" primary="false"/>
+                    <categoryLink targetId="9231-183c-b97b-63f9" id="6343-81d6-4fbf-a868" name="Heavy Sub-type" primary="false"/>
                   </categoryLinks>
                 </selectionEntry>
                 <selectionEntry id="6e53-e90b-d8a4-5158" name="Veletarii w/ Lasrifle" hidden="true" collective="false" import="true" type="model">
@@ -3552,8 +3552,8 @@
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="8"/>
                   </costs>
                   <categoryLinks>
-                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="c5fd-b27a-4353-8829" name="Infantry" primary="false"/>
-                    <categoryLink targetId="9231-183c-b97b-63f9" id="ed9c-67f7-47f5-b458" name="Heavy" primary="false"/>
+                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="c5fd-b27a-4353-8829" name="Infantry Unit Type" primary="false"/>
+                    <categoryLink targetId="9231-183c-b97b-63f9" id="ed9c-67f7-47f5-b458" name="Heavy Sub-type" primary="false"/>
                   </categoryLinks>
                 </selectionEntry>
                 <selectionEntry id="b70f-a612-df9c-7d7f" name="Veletarii w/ Shotgun" hidden="true" collective="false" import="true" type="model">
@@ -3588,8 +3588,8 @@
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="8"/>
                   </costs>
                   <categoryLinks>
-                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="1b45-74cb-4613-91a0" name="Infantry" primary="false"/>
-                    <categoryLink targetId="9231-183c-b97b-63f9" id="50ca-be6e-420a-b6d0" name="Heavy" primary="false"/>
+                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="1b45-74cb-4613-91a0" name="Infantry Unit Type" primary="false"/>
+                    <categoryLink targetId="9231-183c-b97b-63f9" id="50ca-be6e-420a-b6d0" name="Heavy Sub-type" primary="false"/>
                   </categoryLinks>
                 </selectionEntry>
                 <selectionEntry id="df5d-e57c-15b3-cfa8" name="Veletarii w/ Stubcarbine" hidden="true" collective="false" import="true" type="model">
@@ -3624,8 +3624,8 @@
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="8"/>
                   </costs>
                   <categoryLinks>
-                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="ef1f-eca1-4550-b3aa" name="Infantry" primary="false"/>
-                    <categoryLink targetId="9231-183c-b97b-63f9" id="f3fe-c8f7-4d3e-8a39" name="Heavy" primary="false"/>
+                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="ef1f-eca1-4550-b3aa" name="Infantry Unit Type" primary="false"/>
+                    <categoryLink targetId="9231-183c-b97b-63f9" id="f3fe-c8f7-4d3e-8a39" name="Heavy Sub-type" primary="false"/>
                   </categoryLinks>
                 </selectionEntry>
               </selectionEntries>
@@ -3778,8 +3778,8 @@
               </profiles>
               <categoryLinks>
                 <categoryLink id="1616-4d93-a1d7-8b9b" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="8fa1-01d6-460d-85e3" name="Infantry" primary="false"/>
-                <categoryLink targetId="9231-183c-b97b-63f9" id="00f5-66cf-4ee6-ad5e" name="Heavy" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="8fa1-01d6-460d-85e3" name="Infantry Unit Type" primary="false"/>
+                <categoryLink targetId="9231-183c-b97b-63f9" id="00f5-66cf-4ee6-ad5e" name="Heavy Sub-type" primary="false"/>
               </categoryLinks>
               <selectionEntryGroups>
                 <selectionEntryGroup id="cb16-77f4-dd20-bb13" name="Armour" hidden="false" collective="false" import="true" defaultSelectionEntryId="76fe-62a6-e1f1-1fe4">
@@ -3979,8 +3979,8 @@
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="8"/>
                   </costs>
                   <categoryLinks>
-                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="6f23-5f3d-4711-95f0" name="Infantry" primary="false"/>
-                    <categoryLink targetId="9231-183c-b97b-63f9" id="1dc5-a978-4d98-9614" name="Heavy" primary="false"/>
+                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="6f23-5f3d-4711-95f0" name="Infantry Unit Type" primary="false"/>
+                    <categoryLink targetId="9231-183c-b97b-63f9" id="1dc5-a978-4d98-9614" name="Heavy Sub-type" primary="false"/>
                   </categoryLinks>
                 </selectionEntry>
                 <selectionEntry id="e5b2-9536-03f8-39e2" name="Veletarii w/ Rotor Cannon" hidden="false" collective="false" import="true" type="model">
@@ -4008,8 +4008,8 @@
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="8"/>
                   </costs>
                   <categoryLinks>
-                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="bfc0-d686-421b-a079" name="Infantry" primary="false"/>
-                    <categoryLink targetId="9231-183c-b97b-63f9" id="48de-c21c-48be-b669" name="Heavy" primary="false"/>
+                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="bfc0-d686-421b-a079" name="Infantry Unit Type" primary="false"/>
+                    <categoryLink targetId="9231-183c-b97b-63f9" id="48de-c21c-48be-b669" name="Heavy Sub-type" primary="false"/>
                   </categoryLinks>
                 </selectionEntry>
               </selectionEntries>
@@ -4101,7 +4101,7 @@
         </infoLink>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="ea45-885f-a928-08b4" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="ea45-885f-a928-08b4" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink name="SA or IM Unit" hidden="false" id="6af-ba9c-854b-74a5" targetId="4aca-2849-7f41-0200" primary="false"/>
       </categoryLinks>
       <selectionEntries>
@@ -4152,8 +4152,8 @@
           </infoLinks>
           <categoryLinks>
             <categoryLink id="0b71-539b-8899-6356" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
-            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="f81f-88d9-40f5-b3a2" name="Infantry" primary="false"/>
-            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="5c97-b256-44f6-a399" name="Unique" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="f81f-88d9-40f5-b3a2" name="Infantry Unit Type" primary="false"/>
+            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="5c97-b256-44f6-a399" name="Unique Sub-type" primary="false"/>
           </categoryLinks>
           <selectionEntries>
             <selectionEntry id="e08f-f2c7-19eb-9d01" name="Auto-gurney" hidden="false" collective="false" import="true" type="upgrade">
@@ -4234,7 +4234,7 @@ If the unit that includes Aevos Jovan also includes one or more Medicae Orderlie
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5"/>
           </costs>
           <categoryLinks>
-            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="2048-a95c-4e6f-9012" name="Infantry" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="2048-a95c-4e6f-9012" name="Infantry Unit Type" primary="false"/>
           </categoryLinks>
         </selectionEntry>
       </selectionEntries>
@@ -4432,7 +4432,7 @@ Once assigned to a unit, the Auxilia Medicae is considered part of that unit and
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15"/>
           </costs>
           <categoryLinks>
-            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="fa07-ebc9-4911-9715" name="Infantry" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="fa07-ebc9-4911-9715" name="Infantry Unit Type" primary="false"/>
             <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="1563-37df-4e65-ac61" name="Character" primary="false"/>
           </categoryLinks>
         </selectionEntry>
@@ -4556,8 +4556,8 @@ Once assigned to a unit, the Auxilia Medicae is considered part of that unit and
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="40"/>
           </costs>
           <categoryLinks>
-            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="fe3b-9db6-4b84-9eb6" name="Infantry" primary="false"/>
-            <categoryLink targetId="7d95-f9d1-440a-67bd" id="0fe6-d1a6-488a-bf4f" name="Monstrous" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="fe3b-9db6-4b84-9eb6" name="Infantry Unit Type" primary="false"/>
+            <categoryLink targetId="7d95-f9d1-440a-67bd" id="0fe6-d1a6-488a-bf4f" name="Monstrous Sub-type" primary="false"/>
           </categoryLinks>
         </selectionEntry>
       </selectionEntries>
@@ -4846,7 +4846,7 @@ Once assigned to a unit, the Auxilia Medicae is considered part of that unit and
         </rule>
       </rules>
       <categoryLinks>
-        <categoryLink id="7d8a-a782-82d7-4852" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="7d8a-a782-82d7-4852" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="6513-cab0-be87-36fd" name="Close-order Sub-type" hidden="false" targetId="0af0-ea84-09d7-2b1f" primary="false"/>
       </categoryLinks>
       <selectionEntries>
@@ -4933,9 +4933,9 @@ Once assigned to a unit, the Auxilia Medicae is considered part of that unit and
               </profiles>
               <categoryLinks>
                 <categoryLink id="099b-266a-e368-1e64" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="34da-3008-4752-b617" name="Infantry" primary="false"/>
-                <categoryLink targetId="6399-5c65-7833-1025" id="e2cb-92eb-47ce-87ec" name="Line" primary="false"/>
-                <categoryLink targetId="0af0-ea84-09d7-2b1f" id="9f08-82b0-426a-a9a9" name="Close-order" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="34da-3008-4752-b617" name="Infantry Unit Type" primary="false"/>
+                <categoryLink targetId="6399-5c65-7833-1025" id="e2cb-92eb-47ce-87ec" name="Line Sub-type" primary="false"/>
+                <categoryLink targetId="0af0-ea84-09d7-2b1f" id="9f08-82b0-426a-a9a9" name="Close-order Sub-type" primary="false"/>
               </categoryLinks>
               <selectionEntryGroups>
                 <selectionEntryGroup id="d7f7-a7a6-c792-ada8" name="Weapons" hidden="false" collective="false" import="true" defaultSelectionEntryId="32ae-3f3b-8b44-9b87">
@@ -5230,9 +5230,9 @@ Once assigned to a unit, the Auxilia Medicae is considered part of that unit and
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="8"/>
                   </costs>
                   <categoryLinks>
-                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="846b-a82e-4b8d-94d6" name="Infantry" primary="false"/>
-                    <categoryLink targetId="6399-5c65-7833-1025" id="f5e5-9023-46db-ae72" name="Line" primary="false"/>
-                    <categoryLink targetId="0af0-ea84-09d7-2b1f" id="0df9-c7bd-4a3c-81d1" name="Close-order" primary="false"/>
+                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="846b-a82e-4b8d-94d6" name="Infantry Unit Type" primary="false"/>
+                    <categoryLink targetId="6399-5c65-7833-1025" id="f5e5-9023-46db-ae72" name="Line Sub-type" primary="false"/>
+                    <categoryLink targetId="0af0-ea84-09d7-2b1f" id="0df9-c7bd-4a3c-81d1" name="Close-order Sub-type" primary="false"/>
                   </categoryLinks>
                 </selectionEntry>
                 <selectionEntry id="88a5-af55-4a9b-63bf" name="Auxilia Veteran w/ Lasrifle and Bayonet" hidden="false" collective="false" import="true" type="model">
@@ -5260,9 +5260,9 @@ Once assigned to a unit, the Auxilia Medicae is considered part of that unit and
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="9"/>
                   </costs>
                   <categoryLinks>
-                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="db2d-d153-4567-a527" name="Infantry" primary="false"/>
-                    <categoryLink targetId="6399-5c65-7833-1025" id="fb3f-9225-445d-a4ed" name="Line" primary="false"/>
-                    <categoryLink targetId="0af0-ea84-09d7-2b1f" id="85e9-e5c7-439d-ad66" name="Close-order" primary="false"/>
+                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="db2d-d153-4567-a527" name="Infantry Unit Type" primary="false"/>
+                    <categoryLink targetId="6399-5c65-7833-1025" id="fb3f-9225-445d-a4ed" name="Line Sub-type" primary="false"/>
+                    <categoryLink targetId="0af0-ea84-09d7-2b1f" id="85e9-e5c7-439d-ad66" name="Close-order Sub-type" primary="false"/>
                   </categoryLinks>
                 </selectionEntry>
                 <selectionEntry id="f53f-6476-b0c8-4289" name="Auxilia Veteran w/ Autorifle" hidden="true" collective="false" import="true" type="model">
@@ -5291,9 +5291,9 @@ Once assigned to a unit, the Auxilia Medicae is considered part of that unit and
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="8"/>
                   </costs>
                   <categoryLinks>
-                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="4d30-2332-4684-8a69" name="Infantry" primary="false"/>
-                    <categoryLink targetId="6399-5c65-7833-1025" id="3ce2-cd48-4268-9bc3" name="Line" primary="false"/>
-                    <categoryLink targetId="0af0-ea84-09d7-2b1f" id="bfcb-476b-4b03-9cd5" name="Close-order" primary="false"/>
+                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="4d30-2332-4684-8a69" name="Infantry Unit Type" primary="false"/>
+                    <categoryLink targetId="6399-5c65-7833-1025" id="3ce2-cd48-4268-9bc3" name="Line Sub-type" primary="false"/>
+                    <categoryLink targetId="0af0-ea84-09d7-2b1f" id="bfcb-476b-4b03-9cd5" name="Close-order Sub-type" primary="false"/>
                   </categoryLinks>
                 </selectionEntry>
                 <selectionEntry id="5363-7ae2-cdf2-cbbe" name="Auxilia Veteran w/ Lascarbine" hidden="true" collective="false" import="true" type="model">
@@ -5322,9 +5322,9 @@ Once assigned to a unit, the Auxilia Medicae is considered part of that unit and
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="8"/>
                   </costs>
                   <categoryLinks>
-                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="bae6-0272-4b1a-9f0d" name="Infantry" primary="false"/>
-                    <categoryLink targetId="6399-5c65-7833-1025" id="28c0-7e94-464d-bf37" name="Line" primary="false"/>
-                    <categoryLink targetId="0af0-ea84-09d7-2b1f" id="8f7d-8d0e-4846-968d" name="Close-order" primary="false"/>
+                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="bae6-0272-4b1a-9f0d" name="Infantry Unit Type" primary="false"/>
+                    <categoryLink targetId="6399-5c65-7833-1025" id="28c0-7e94-464d-bf37" name="Line Sub-type" primary="false"/>
+                    <categoryLink targetId="0af0-ea84-09d7-2b1f" id="8f7d-8d0e-4846-968d" name="Close-order Sub-type" primary="false"/>
                   </categoryLinks>
                 </selectionEntry>
                 <selectionEntry id="0515-f66c-1d64-0b6c" name="Auxilia Veteran w/ Lasgun" hidden="true" collective="false" import="true" type="model">
@@ -5353,9 +5353,9 @@ Once assigned to a unit, the Auxilia Medicae is considered part of that unit and
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="8"/>
                   </costs>
                   <categoryLinks>
-                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="c113-d488-46c6-a7a9" name="Infantry" primary="false"/>
-                    <categoryLink targetId="6399-5c65-7833-1025" id="2359-2f47-40ba-b9f4" name="Line" primary="false"/>
-                    <categoryLink targetId="0af0-ea84-09d7-2b1f" id="3358-8fa2-450f-9e77" name="Close-order" primary="false"/>
+                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="c113-d488-46c6-a7a9" name="Infantry Unit Type" primary="false"/>
+                    <categoryLink targetId="6399-5c65-7833-1025" id="2359-2f47-40ba-b9f4" name="Line Sub-type" primary="false"/>
+                    <categoryLink targetId="0af0-ea84-09d7-2b1f" id="3358-8fa2-450f-9e77" name="Close-order Sub-type" primary="false"/>
                   </categoryLinks>
                 </selectionEntry>
                 <selectionEntry id="4c67-77b7-5785-4a87" name="Auxilia Veteran w/ Shotgun" hidden="true" collective="false" import="true" type="model">
@@ -5384,9 +5384,9 @@ Once assigned to a unit, the Auxilia Medicae is considered part of that unit and
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="8"/>
                   </costs>
                   <categoryLinks>
-                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="4b89-4817-431d-8c0a" name="Infantry" primary="false"/>
-                    <categoryLink targetId="6399-5c65-7833-1025" id="f11c-e9c6-408f-bef2" name="Line" primary="false"/>
-                    <categoryLink targetId="0af0-ea84-09d7-2b1f" id="d9c0-1922-4be8-a99b" name="Close-order" primary="false"/>
+                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="4b89-4817-431d-8c0a" name="Infantry Unit Type" primary="false"/>
+                    <categoryLink targetId="6399-5c65-7833-1025" id="f11c-e9c6-408f-bef2" name="Line Sub-type" primary="false"/>
+                    <categoryLink targetId="0af0-ea84-09d7-2b1f" id="d9c0-1922-4be8-a99b" name="Close-order Sub-type" primary="false"/>
                   </categoryLinks>
                 </selectionEntry>
                 <selectionEntry id="3128-3d49-4df3-dfc2" name="Auxilia Veteran w/ Stubcarbine" hidden="true" collective="false" import="true" type="model">
@@ -5415,9 +5415,9 @@ Once assigned to a unit, the Auxilia Medicae is considered part of that unit and
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="8"/>
                   </costs>
                   <categoryLinks>
-                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="19a3-2c49-42b2-b40f" name="Infantry" primary="false"/>
-                    <categoryLink targetId="6399-5c65-7833-1025" id="92f1-894c-45ad-8f2d" name="Line" primary="false"/>
-                    <categoryLink targetId="0af0-ea84-09d7-2b1f" id="f7a0-eb91-4278-89ea" name="Close-order" primary="false"/>
+                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="19a3-2c49-42b2-b40f" name="Infantry Unit Type" primary="false"/>
+                    <categoryLink targetId="6399-5c65-7833-1025" id="92f1-894c-45ad-8f2d" name="Line Sub-type" primary="false"/>
+                    <categoryLink targetId="0af0-ea84-09d7-2b1f" id="f7a0-eb91-4278-89ea" name="Close-order Sub-type" primary="false"/>
                   </categoryLinks>
                 </selectionEntry>
               </selectionEntries>
@@ -5542,9 +5542,9 @@ Once assigned to a unit, the Auxilia Medicae is considered part of that unit and
               </profiles>
               <categoryLinks>
                 <categoryLink id="e8df-cf83-9688-d89f" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="d959-a0f3-4c11-8191" name="Infantry" primary="false"/>
-                <categoryLink targetId="6399-5c65-7833-1025" id="3993-3a35-408c-9256" name="Line" primary="false"/>
-                <categoryLink targetId="0af0-ea84-09d7-2b1f" id="b75c-e8fe-4897-861c" name="Close-order" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="d959-a0f3-4c11-8191" name="Infantry Unit Type" primary="false"/>
+                <categoryLink targetId="6399-5c65-7833-1025" id="3993-3a35-408c-9256" name="Line Sub-type" primary="false"/>
+                <categoryLink targetId="0af0-ea84-09d7-2b1f" id="b75c-e8fe-4897-861c" name="Close-order Sub-type" primary="false"/>
               </categoryLinks>
               <selectionEntryGroups>
                 <selectionEntryGroup id="8db8-4d63-3ff8-0124" name="Weapons" hidden="false" collective="false" import="true" defaultSelectionEntryId="6d17-07d2-d48a-0c7f">
@@ -5803,9 +5803,9 @@ Once assigned to a unit, the Auxilia Medicae is considered part of that unit and
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5"/>
                   </costs>
                   <categoryLinks>
-                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="784a-fa1c-4629-b69e" name="Infantry" primary="false"/>
-                    <categoryLink targetId="6399-5c65-7833-1025" id="521c-b0e8-4c10-9234" name="Line" primary="false"/>
-                    <categoryLink targetId="0af0-ea84-09d7-2b1f" id="cc5a-3417-41b9-97d6" name="Close-order" primary="false"/>
+                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="784a-fa1c-4629-b69e" name="Infantry Unit Type" primary="false"/>
+                    <categoryLink targetId="6399-5c65-7833-1025" id="521c-b0e8-4c10-9234" name="Line Sub-type" primary="false"/>
+                    <categoryLink targetId="0af0-ea84-09d7-2b1f" id="cc5a-3417-41b9-97d6" name="Close-order Sub-type" primary="false"/>
                   </categoryLinks>
                 </selectionEntry>
                 <selectionEntry id="d75c-1339-aa85-0b76" name="Auxilia w/ Lasrifle and Bayonet" hidden="false" collective="false" import="true" type="model">
@@ -5833,9 +5833,9 @@ Once assigned to a unit, the Auxilia Medicae is considered part of that unit and
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="6"/>
                   </costs>
                   <categoryLinks>
-                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="e6cb-9bb7-46d2-b533" name="Infantry" primary="false"/>
-                    <categoryLink targetId="6399-5c65-7833-1025" id="f8fc-b8ab-4c5f-a55c" name="Line" primary="false"/>
-                    <categoryLink targetId="0af0-ea84-09d7-2b1f" id="3f54-3682-4db8-9d53" name="Close-order" primary="false"/>
+                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="e6cb-9bb7-46d2-b533" name="Infantry Unit Type" primary="false"/>
+                    <categoryLink targetId="6399-5c65-7833-1025" id="f8fc-b8ab-4c5f-a55c" name="Line Sub-type" primary="false"/>
+                    <categoryLink targetId="0af0-ea84-09d7-2b1f" id="3f54-3682-4db8-9d53" name="Close-order Sub-type" primary="false"/>
                   </categoryLinks>
                 </selectionEntry>
                 <selectionEntry id="b44b-d4d9-ba86-416c" name="Auxilia w/ Autorifle" hidden="true" collective="false" import="true" type="model">
@@ -5864,9 +5864,9 @@ Once assigned to a unit, the Auxilia Medicae is considered part of that unit and
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5"/>
                   </costs>
                   <categoryLinks>
-                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="03e4-fcc9-4ce1-b8ce" name="Infantry" primary="false"/>
-                    <categoryLink targetId="6399-5c65-7833-1025" id="6c52-333d-45c8-a9b6" name="Line" primary="false"/>
-                    <categoryLink targetId="0af0-ea84-09d7-2b1f" id="43a7-132b-4b9a-8ec6" name="Close-order" primary="false"/>
+                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="03e4-fcc9-4ce1-b8ce" name="Infantry Unit Type" primary="false"/>
+                    <categoryLink targetId="6399-5c65-7833-1025" id="6c52-333d-45c8-a9b6" name="Line Sub-type" primary="false"/>
+                    <categoryLink targetId="0af0-ea84-09d7-2b1f" id="43a7-132b-4b9a-8ec6" name="Close-order Sub-type" primary="false"/>
                   </categoryLinks>
                 </selectionEntry>
                 <selectionEntry id="ae80-cf1e-3816-3b1d" name="Auxilia w/ Lascarbine" hidden="true" collective="false" import="true" type="model">
@@ -5895,9 +5895,9 @@ Once assigned to a unit, the Auxilia Medicae is considered part of that unit and
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5"/>
                   </costs>
                   <categoryLinks>
-                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="6bf8-0593-468a-b599" name="Infantry" primary="false"/>
-                    <categoryLink targetId="6399-5c65-7833-1025" id="59b4-a4dd-4be0-89d5" name="Line" primary="false"/>
-                    <categoryLink targetId="0af0-ea84-09d7-2b1f" id="7e1e-7fbf-4868-8efb" name="Close-order" primary="false"/>
+                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="6bf8-0593-468a-b599" name="Infantry Unit Type" primary="false"/>
+                    <categoryLink targetId="6399-5c65-7833-1025" id="59b4-a4dd-4be0-89d5" name="Line Sub-type" primary="false"/>
+                    <categoryLink targetId="0af0-ea84-09d7-2b1f" id="7e1e-7fbf-4868-8efb" name="Close-order Sub-type" primary="false"/>
                   </categoryLinks>
                 </selectionEntry>
                 <selectionEntry id="ebcb-7ca4-cae8-145f" name="Auxilia w/ Lasgun" hidden="true" collective="false" import="true" type="model">
@@ -5926,9 +5926,9 @@ Once assigned to a unit, the Auxilia Medicae is considered part of that unit and
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5"/>
                   </costs>
                   <categoryLinks>
-                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="3f7f-5fd9-4319-861c" name="Infantry" primary="false"/>
-                    <categoryLink targetId="6399-5c65-7833-1025" id="2db3-55fd-4ba0-98c0" name="Line" primary="false"/>
-                    <categoryLink targetId="0af0-ea84-09d7-2b1f" id="f335-62bd-4b16-93db" name="Close-order" primary="false"/>
+                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="3f7f-5fd9-4319-861c" name="Infantry Unit Type" primary="false"/>
+                    <categoryLink targetId="6399-5c65-7833-1025" id="2db3-55fd-4ba0-98c0" name="Line Sub-type" primary="false"/>
+                    <categoryLink targetId="0af0-ea84-09d7-2b1f" id="f335-62bd-4b16-93db" name="Close-order Sub-type" primary="false"/>
                   </categoryLinks>
                 </selectionEntry>
                 <selectionEntry id="2974-bd81-4134-3d04" name="Auxilia w/ Shotgun" hidden="true" collective="false" import="true" type="model">
@@ -5957,9 +5957,9 @@ Once assigned to a unit, the Auxilia Medicae is considered part of that unit and
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5"/>
                   </costs>
                   <categoryLinks>
-                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="b933-b80e-4953-b4ae" name="Infantry" primary="false"/>
-                    <categoryLink targetId="6399-5c65-7833-1025" id="b1b4-4b28-418e-9877" name="Line" primary="false"/>
-                    <categoryLink targetId="0af0-ea84-09d7-2b1f" id="c90d-6756-4aea-9686" name="Close-order" primary="false"/>
+                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="b933-b80e-4953-b4ae" name="Infantry Unit Type" primary="false"/>
+                    <categoryLink targetId="6399-5c65-7833-1025" id="b1b4-4b28-418e-9877" name="Line Sub-type" primary="false"/>
+                    <categoryLink targetId="0af0-ea84-09d7-2b1f" id="c90d-6756-4aea-9686" name="Close-order Sub-type" primary="false"/>
                   </categoryLinks>
                 </selectionEntry>
                 <selectionEntry id="fcdf-545e-a859-4590" name="Auxilia w/ Stubcarbine" hidden="true" collective="false" import="true" type="model">
@@ -5988,9 +5988,9 @@ Once assigned to a unit, the Auxilia Medicae is considered part of that unit and
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5"/>
                   </costs>
                   <categoryLinks>
-                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="fee4-cdaf-45b5-b71a" name="Infantry" primary="false"/>
-                    <categoryLink targetId="6399-5c65-7833-1025" id="a6f9-e408-4705-b3af" name="Line" primary="false"/>
-                    <categoryLink targetId="0af0-ea84-09d7-2b1f" id="60fc-d5f7-48d9-936c" name="Close-order" primary="false"/>
+                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="fee4-cdaf-45b5-b71a" name="Infantry Unit Type" primary="false"/>
+                    <categoryLink targetId="6399-5c65-7833-1025" id="a6f9-e408-4705-b3af" name="Line Sub-type" primary="false"/>
+                    <categoryLink targetId="0af0-ea84-09d7-2b1f" id="60fc-d5f7-48d9-936c" name="Close-order Sub-type" primary="false"/>
                   </categoryLinks>
                 </selectionEntry>
                 <selectionEntry id="15a4-62c6-5d72-fe17" name="Auxilia w/ Heavy Stubber" hidden="true" collective="false" import="true" type="model">
@@ -6019,9 +6019,9 @@ Once assigned to a unit, the Auxilia Medicae is considered part of that unit and
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10"/>
                   </costs>
                   <categoryLinks>
-                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="9630-80e3-4660-ae0f" name="Infantry" primary="false"/>
-                    <categoryLink targetId="6399-5c65-7833-1025" id="c683-37ce-444a-b29e" name="Line" primary="false"/>
-                    <categoryLink targetId="0af0-ea84-09d7-2b1f" id="e224-d6bd-4aee-ba51" name="Close-order" primary="false"/>
+                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="9630-80e3-4660-ae0f" name="Infantry Unit Type" primary="false"/>
+                    <categoryLink targetId="6399-5c65-7833-1025" id="c683-37ce-444a-b29e" name="Line Sub-type" primary="false"/>
+                    <categoryLink targetId="0af0-ea84-09d7-2b1f" id="e224-d6bd-4aee-ba51" name="Close-order Sub-type" primary="false"/>
                   </categoryLinks>
                 </selectionEntry>
               </selectionEntries>
@@ -6678,7 +6678,7 @@ Once assigned to a unit, the Auxilia Medicae is considered part of that unit and
                         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="185"/>
                       </costs>
                       <categoryLinks>
-                        <categoryLink targetId="e2b6-b770-784c-9e95" id="5c0b-faa9-4959-ae28" name="Vehicle" primary="false"/>
+                        <categoryLink targetId="e2b6-b770-784c-9e95" id="5c0b-faa9-4959-ae28" name="Vehicle:" primary="false"/>
                       </categoryLinks>
                     </selectionEntry>
                   </selectionEntries>
@@ -6894,7 +6894,7 @@ Once assigned to a unit, the Auxilia Medicae is considered part of that unit and
                         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="135"/>
                       </costs>
                       <categoryLinks>
-                        <categoryLink targetId="e2b6-b770-784c-9e95" id="6b03-4b72-4276-babc" name="Vehicle" primary="false"/>
+                        <categoryLink targetId="e2b6-b770-784c-9e95" id="6b03-4b72-4276-babc" name="Vehicle:" primary="false"/>
                       </categoryLinks>
                     </selectionEntry>
                   </selectionEntries>
@@ -6967,7 +6967,7 @@ Once assigned to a unit, the Auxilia Medicae is considered part of that unit and
             </infoLink>
           </infoLinks>
           <categoryLinks>
-            <categoryLink id="aba2-1ca5-8019-fdff" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+            <categoryLink id="aba2-1ca5-8019-fdff" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
             <categoryLink id="f08a-755e-031d-0c47" name="Close-order Sub-type" hidden="false" targetId="0af0-ea84-09d7-2b1f" primary="false"/>
             <categoryLink name="SA or IM Unit" hidden="false" id="da87-72e-6fd9-7310" targetId="4aca-2849-7f41-0200" primary="false"/>
           </categoryLinks>
@@ -7008,8 +7008,8 @@ Once assigned to a unit, the Auxilia Medicae is considered part of that unit and
               </profiles>
               <categoryLinks>
                 <categoryLink id="9877-bb07-821b-d994" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="e89d-53d4-4a25-8a30" name="Infantry" primary="false"/>
-                <categoryLink targetId="0af0-ea84-09d7-2b1f" id="2b71-cb23-4eb9-b1c5" name="Close-order" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="e89d-53d4-4a25-8a30" name="Infantry Unit Type" primary="false"/>
+                <categoryLink targetId="0af0-ea84-09d7-2b1f" id="2b71-cb23-4eb9-b1c5" name="Close-order Sub-type" primary="false"/>
               </categoryLinks>
               <selectionEntryGroups>
                 <selectionEntryGroup id="eda3-b51a-5701-eb27" name="The Auxilia Troop Master may select any of the following:" hidden="false" collective="false" import="true">
@@ -7254,8 +7254,8 @@ Once assigned to a unit, the Auxilia Medicae is considered part of that unit and
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="8"/>
                   </costs>
                   <categoryLinks>
-                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="920a-1a14-4b79-8668" name="Infantry" primary="false"/>
-                    <categoryLink targetId="0af0-ea84-09d7-2b1f" id="309d-4954-4600-93f9" name="Close-order" primary="false"/>
+                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="920a-1a14-4b79-8668" name="Infantry Unit Type" primary="false"/>
+                    <categoryLink targetId="0af0-ea84-09d7-2b1f" id="309d-4954-4600-93f9" name="Close-order Sub-type" primary="false"/>
                   </categoryLinks>
                 </selectionEntry>
                 <selectionEntry id="ab64-add2-57e2-ce11" name="Auxilia Veteran w/ Lasrifle and Bayonet" hidden="false" collective="false" import="true" type="model">
@@ -7283,9 +7283,9 @@ Once assigned to a unit, the Auxilia Medicae is considered part of that unit and
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="9"/>
                   </costs>
                   <categoryLinks>
-                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="11af-39b6-4d18-b4f4" name="Infantry" primary="false"/>
-                    <categoryLink targetId="6399-5c65-7833-1025" id="032f-5a17-48b2-a045" name="Line" primary="false"/>
-                    <categoryLink targetId="0af0-ea84-09d7-2b1f" id="fc50-2a81-43e7-9e79" name="Close-order" primary="false"/>
+                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="11af-39b6-4d18-b4f4" name="Infantry Unit Type" primary="false"/>
+                    <categoryLink targetId="6399-5c65-7833-1025" id="032f-5a17-48b2-a045" name="Line Sub-type" primary="false"/>
+                    <categoryLink targetId="0af0-ea84-09d7-2b1f" id="fc50-2a81-43e7-9e79" name="Close-order Sub-type" primary="false"/>
                   </categoryLinks>
                 </selectionEntry>
                 <selectionEntry id="1306-1e1d-992a-6fc6" name="Auxilia Veteran w/ Autorifle" hidden="true" collective="false" import="true" type="model">
@@ -7342,9 +7342,9 @@ Once assigned to a unit, the Auxilia Medicae is considered part of that unit and
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="8"/>
                   </costs>
                   <categoryLinks>
-                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="ac44-57cf-4259-8a92" name="Infantry" primary="false"/>
-                    <categoryLink targetId="6399-5c65-7833-1025" id="d836-955e-4ab4-b9d4" name="Line" primary="false"/>
-                    <categoryLink targetId="0af0-ea84-09d7-2b1f" id="d449-fcc8-4778-b1ff" name="Close-order" primary="false"/>
+                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="ac44-57cf-4259-8a92" name="Infantry Unit Type" primary="false"/>
+                    <categoryLink targetId="6399-5c65-7833-1025" id="d836-955e-4ab4-b9d4" name="Line Sub-type" primary="false"/>
+                    <categoryLink targetId="0af0-ea84-09d7-2b1f" id="d449-fcc8-4778-b1ff" name="Close-order Sub-type" primary="false"/>
                   </categoryLinks>
                 </selectionEntry>
                 <selectionEntry id="01c0-60c7-ee5f-4a48" name="Auxilia Veteran w/ Lasgun" hidden="true" collective="false" import="true" type="model">
@@ -7378,9 +7378,9 @@ Once assigned to a unit, the Auxilia Medicae is considered part of that unit and
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="8"/>
                   </costs>
                   <categoryLinks>
-                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="39cb-d82f-4445-95b4" name="Infantry" primary="false"/>
-                    <categoryLink targetId="6399-5c65-7833-1025" id="c063-4618-4f3c-9e12" name="Line" primary="false"/>
-                    <categoryLink targetId="0af0-ea84-09d7-2b1f" id="e819-dfa4-484c-b7c9" name="Close-order" primary="false"/>
+                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="39cb-d82f-4445-95b4" name="Infantry Unit Type" primary="false"/>
+                    <categoryLink targetId="6399-5c65-7833-1025" id="c063-4618-4f3c-9e12" name="Line Sub-type" primary="false"/>
+                    <categoryLink targetId="0af0-ea84-09d7-2b1f" id="e819-dfa4-484c-b7c9" name="Close-order Sub-type" primary="false"/>
                   </categoryLinks>
                 </selectionEntry>
                 <selectionEntry id="511c-8e43-1c88-9b3c" name="Auxilia Veteran w/ Shotgun" hidden="true" collective="false" import="true" type="model">
@@ -7414,9 +7414,9 @@ Once assigned to a unit, the Auxilia Medicae is considered part of that unit and
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="8"/>
                   </costs>
                   <categoryLinks>
-                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="5662-91c1-47e6-b4d2" name="Infantry" primary="false"/>
-                    <categoryLink targetId="6399-5c65-7833-1025" id="3d8a-837e-4b0b-b5bf" name="Line" primary="false"/>
-                    <categoryLink targetId="0af0-ea84-09d7-2b1f" id="b581-bcf8-4c00-a89d" name="Close-order" primary="false"/>
+                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="5662-91c1-47e6-b4d2" name="Infantry Unit Type" primary="false"/>
+                    <categoryLink targetId="6399-5c65-7833-1025" id="3d8a-837e-4b0b-b5bf" name="Line Sub-type" primary="false"/>
+                    <categoryLink targetId="0af0-ea84-09d7-2b1f" id="b581-bcf8-4c00-a89d" name="Close-order Sub-type" primary="false"/>
                   </categoryLinks>
                 </selectionEntry>
                 <selectionEntry id="0cbe-0cb9-3c39-e9f2" name="Auxilia Veteran w/ Stubcarbine" hidden="true" collective="false" import="true" type="model">
@@ -7445,9 +7445,9 @@ Once assigned to a unit, the Auxilia Medicae is considered part of that unit and
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="8"/>
                   </costs>
                   <categoryLinks>
-                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="dcb9-bb38-4e26-ac18" name="Infantry" primary="false"/>
-                    <categoryLink targetId="6399-5c65-7833-1025" id="4efd-8849-4228-8fa3" name="Line" primary="false"/>
-                    <categoryLink targetId="0af0-ea84-09d7-2b1f" id="90aa-b427-4bcb-80aa" name="Close-order" primary="false"/>
+                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="dcb9-bb38-4e26-ac18" name="Infantry Unit Type" primary="false"/>
+                    <categoryLink targetId="6399-5c65-7833-1025" id="4efd-8849-4228-8fa3" name="Line Sub-type" primary="false"/>
+                    <categoryLink targetId="0af0-ea84-09d7-2b1f" id="90aa-b427-4bcb-80aa" name="Close-order Sub-type" primary="false"/>
                   </categoryLinks>
                 </selectionEntry>
               </selectionEntries>
@@ -7586,7 +7586,7 @@ Once assigned to a unit, the Auxilia Medicae is considered part of that unit and
                 </infoLink>
               </infoLinks>
               <categoryLinks>
-                <categoryLink id="f126-fcd8-a3da-7052" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+                <categoryLink id="f126-fcd8-a3da-7052" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
                 <categoryLink id="ea27-b5c3-6bb1-fb72" name="Automated Artillery Sub-type" hidden="false" targetId="0faa-1bab-2901-4330" primary="false"/>
                 <categoryLink name="SA or IM Unit" hidden="false" id="215c-9e75-e21f-5cfe" targetId="4aca-2849-7f41-0200" primary="false"/>
               </categoryLinks>
@@ -7628,9 +7628,9 @@ Once assigned to a unit, the Auxilia Medicae is considered part of that unit and
                         <infoLink id="8232-66ae-1bb7-357b" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule"/>
                       </infoLinks>
                       <categoryLinks>
-                        <categoryLink id="7cc6-7c1b-0126-7396" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+                        <categoryLink id="7cc6-7c1b-0126-7396" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
                         <categoryLink id="e5e1-0a3a-df3f-7aff" name="Heavy Sub-type" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
-                        <categoryLink targetId="6f99-c178-6f9d-fb63" id="25e0-6cd2-458d-86a2" name="Artillery" primary="false"/>
+                        <categoryLink targetId="6f99-c178-6f9d-fb63" id="25e0-6cd2-458d-86a2" name="Artillery Sub-type" primary="false"/>
                       </categoryLinks>
                       <selectionEntries>
                         <selectionEntry id="8965-b004-fc05-1160" name="Auxilia Gunners" hidden="false" collective="true" import="true" type="model">
@@ -7674,8 +7674,8 @@ Once assigned to a unit, the Auxilia Medicae is considered part of that unit and
                             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
                           </costs>
                           <categoryLinks>
-                            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="a67a-9deb-4883-8b6e" name="Infantry" primary="false"/>
-                            <categoryLink targetId="9231-183c-b97b-63f9" id="a05d-64e7-4096-bf7d" name="Heavy" primary="false"/>
+                            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="a67a-9deb-4883-8b6e" name="Infantry Unit Type" primary="false"/>
+                            <categoryLink targetId="9231-183c-b97b-63f9" id="a05d-64e7-4096-bf7d" name="Heavy Sub-type" primary="false"/>
                           </categoryLinks>
                         </selectionEntry>
                       </selectionEntries>
@@ -7799,7 +7799,7 @@ Once assigned to a unit, the Auxilia Medicae is considered part of that unit and
                 </infoLink>
               </infoLinks>
               <categoryLinks>
-                <categoryLink id="0f06-68df-a24d-f08d" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+                <categoryLink id="0f06-68df-a24d-f08d" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
                 <categoryLink id="adbc-da3c-9c32-c931" name="Automated Artillery Sub-type" hidden="false" targetId="0faa-1bab-2901-4330" primary="false"/>
                 <categoryLink name="SA or IM Unit" hidden="false" id="d22a-8c15-6eab-5aad" targetId="4aca-2849-7f41-0200" primary="false"/>
               </categoryLinks>
@@ -7843,8 +7843,8 @@ Once assigned to a unit, the Auxilia Medicae is considered part of that unit and
                         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20"/>
                       </costs>
                       <categoryLinks>
-                        <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="293c-fe04-4710-a496" name="Infantry" primary="false"/>
-                        <categoryLink targetId="0faa-1bab-2901-4330" id="c34c-6926-4fd9-ade6" name="Automated Artillery" primary="false"/>
+                        <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="293c-fe04-4710-a496" name="Infantry Unit Type" primary="false"/>
+                        <categoryLink targetId="0faa-1bab-2901-4330" id="c34c-6926-4fd9-ade6" name="Automated Artillery Sub-type" primary="false"/>
                       </categoryLinks>
                     </selectionEntry>
                   </selectionEntries>
@@ -8122,8 +8122,8 @@ Once assigned to a unit, the Auxilia Medicae is considered part of that unit and
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="225"/>
           </costs>
           <categoryLinks>
-            <categoryLink targetId="e2b6-b770-784c-9e95" id="5d45-6227-4a45-bfb0" name="Vehicle" primary="false"/>
-            <categoryLink targetId="9b0d-738c-10e4-4ec1" id="b9bc-dd90-4b4a-a35d" name="Reinforced" primary="false"/>
+            <categoryLink targetId="e2b6-b770-784c-9e95" id="5d45-6227-4a45-bfb0" name="Vehicle:" primary="false"/>
+            <categoryLink targetId="9b0d-738c-10e4-4ec1" id="b9bc-dd90-4b4a-a35d" name="Reinforced Sub-type" primary="false"/>
           </categoryLinks>
         </selectionEntry>
       </selectionEntries>
@@ -8206,8 +8206,8 @@ Once assigned to a unit, the Auxilia Medicae is considered part of that unit and
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="200"/>
           </costs>
           <categoryLinks>
-            <categoryLink targetId="e2b6-b770-784c-9e95" id="99bf-44fc-44ea-9ac7" name="Vehicle" primary="false"/>
-            <categoryLink targetId="d5df-57ac-8f3c-097b" id="00f2-b771-4360-99ad" name="Bombard" primary="false"/>
+            <categoryLink targetId="e2b6-b770-784c-9e95" id="99bf-44fc-44ea-9ac7" name="Vehicle:" primary="false"/>
+            <categoryLink targetId="d5df-57ac-8f3c-097b" id="00f2-b771-4360-99ad" name="Bombard Sub-type" primary="false"/>
           </categoryLinks>
         </selectionEntry>
       </selectionEntries>
@@ -8362,8 +8362,8 @@ Once assigned to a unit, the Auxilia Medicae is considered part of that unit and
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
           </costs>
           <categoryLinks>
-            <categoryLink targetId="e2b6-b770-784c-9e95" id="aecb-cd92-4e6f-8f2c" name="Vehicle" primary="false"/>
-            <categoryLink targetId="9b0d-738c-10e4-4ec1" id="cce9-8949-4d9e-b9c4" name="Reinforced" primary="false"/>
+            <categoryLink targetId="e2b6-b770-784c-9e95" id="aecb-cd92-4e6f-8f2c" name="Vehicle:" primary="false"/>
+            <categoryLink targetId="9b0d-738c-10e4-4ec1" id="cce9-8949-4d9e-b9c4" name="Reinforced Sub-type" primary="false"/>
           </categoryLinks>
         </selectionEntry>
       </selectionEntries>
@@ -8373,7 +8373,7 @@ Once assigned to a unit, the Auxilia Medicae is considered part of that unit and
     </selectionEntry>
     <selectionEntry id="2f8d-70ea-fbb2-53e2" name="Cyclops Demolition Section" hidden="false" collective="false" import="true" type="unit">
       <categoryLinks>
-        <categoryLink id="c7a1-846f-70f4-f7dc" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="c7a1-846f-70f4-f7dc" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="f39e-e2f9-5ada-4445" name="Heavy Sub-type" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
         <categoryLink name="SA or IM Unit" hidden="false" id="24a3-4565-5c7a-8d54" targetId="4aca-2849-7f41-0200" primary="false"/>
       </categoryLinks>
@@ -8439,8 +8439,8 @@ Once assigned to a unit, the Auxilia Medicae is considered part of that unit and
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
               </costs>
               <categoryLinks>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="083b-2768-4902-917a" name="Infantry" primary="false"/>
-                <categoryLink targetId="9231-183c-b97b-63f9" id="dae3-ce0f-4254-9541" name="Heavy" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="083b-2768-4902-917a" name="Infantry Unit Type" primary="false"/>
+                <categoryLink targetId="9231-183c-b97b-63f9" id="dae3-ce0f-4254-9541" name="Heavy Sub-type" primary="false"/>
               </categoryLinks>
             </selectionEntry>
             <selectionEntry id="48fc-f925-ae4a-180b" name="Cyclops" hidden="false" collective="true" import="true" type="model">
@@ -8485,9 +8485,9 @@ Once assigned to a unit, the Auxilia Medicae is considered part of that unit and
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
               </costs>
               <categoryLinks>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="d815-cd87-49e8-9b18" name="Infantry" primary="false"/>
-                <categoryLink targetId="0faa-1bab-2901-4330" id="bfc1-7ef0-4711-9cdd" name="Automated Artillery" primary="false"/>
-                <categoryLink targetId="9231-183c-b97b-63f9" id="bf9a-03a7-4cd6-b4ae" name="Heavy" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="d815-cd87-49e8-9b18" name="Infantry Unit Type" primary="false"/>
+                <categoryLink targetId="0faa-1bab-2901-4330" id="bfc1-7ef0-4711-9cdd" name="Automated Artillery Sub-type" primary="false"/>
+                <categoryLink targetId="9231-183c-b97b-63f9" id="bf9a-03a7-4cd6-b4ae" name="Heavy Sub-type" primary="false"/>
               </categoryLinks>
             </selectionEntry>
           </selectionEntries>
@@ -8755,8 +8755,8 @@ Once assigned to a unit, the Auxilia Medicae is considered part of that unit and
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
           </costs>
           <categoryLinks>
-            <categoryLink targetId="e2b6-b770-784c-9e95" id="45df-cce8-4b9c-9750" name="Vehicle" primary="false"/>
-            <categoryLink targetId="9b0d-738c-10e4-4ec1" id="2d35-75bd-4015-b826" name="Reinforced" primary="false"/>
+            <categoryLink targetId="e2b6-b770-784c-9e95" id="45df-cce8-4b9c-9750" name="Vehicle:" primary="false"/>
+            <categoryLink targetId="9b0d-738c-10e4-4ec1" id="2d35-75bd-4015-b826" name="Reinforced Sub-type" primary="false"/>
           </categoryLinks>
         </selectionEntry>
       </selectionEntries>
@@ -9306,7 +9306,7 @@ Once assigned to a unit, the Auxilia Medicae is considered part of that unit and
           </profiles>
           <categoryLinks>
             <categoryLink id="9e0c-ea43-0714-f9d6" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
-            <categoryLink targetId="7b0a-a743-a8da-3a39" id="833d-9681-473e-a0b9" name="Transport" primary="false"/>
+            <categoryLink targetId="7b0a-a743-a8da-3a39" id="833d-9681-473e-a0b9" name="Transport Sub-type" primary="false"/>
           </categoryLinks>
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
@@ -9914,8 +9914,8 @@ If a Weapon Destroyed result is repaired, that weapon may not be used to attack 
           </profiles>
           <categoryLinks>
             <categoryLink id="ef6b-5a75-45f9-9bf3" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
-            <categoryLink targetId="c4a5-4def-dc2c-7ce2" id="1aa7-7ef8-4483-b1a3" name="Slow" primary="false"/>
-            <categoryLink targetId="9b0d-738c-10e4-4ec1" id="6794-0a0e-4e46-930f" name="Reinforced" primary="false"/>
+            <categoryLink targetId="c4a5-4def-dc2c-7ce2" id="1aa7-7ef8-4483-b1a3" name="Slow Sub-type" primary="false"/>
+            <categoryLink targetId="9b0d-738c-10e4-4ec1" id="6794-0a0e-4e46-930f" name="Reinforced Sub-type" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="3838-1b61-9897-ce35" name="May take:" hidden="false" collective="false" import="true">
@@ -10000,7 +10000,7 @@ If a Weapon Destroyed result is repaired, that weapon may not be used to attack 
           </profiles>
           <categoryLinks>
             <categoryLink id="47e4-9cd8-d66e-2c84" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
-            <categoryLink targetId="7381-1130-ca6e-1806" id="123c-7159-411c-8956" name="Super-heavy" primary="false"/>
+            <categoryLink targetId="7381-1130-ca6e-1806" id="123c-7159-411c-8956" name="Super-heavy Sub-type" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="1293-cf52-b3db-1611" name="2) Pintle mounted Weapon:" hidden="false" collective="false" import="true">
@@ -11057,9 +11057,9 @@ If a Weapon Destroyed result is repaired, that weapon may not be used to attack 
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="300"/>
           </costs>
           <categoryLinks>
-            <categoryLink targetId="e2b6-b770-784c-9e95" id="1973-389d-42e7-9332" name="Vehicle" primary="false"/>
-            <categoryLink targetId="7381-1130-ca6e-1806" id="3a1c-3747-4b37-9839" name="Super-heavy" primary="false"/>
-            <categoryLink targetId="7b0a-a743-a8da-3a39" id="d8ed-cff9-47b3-bda9" name="Transport" primary="false"/>
+            <categoryLink targetId="e2b6-b770-784c-9e95" id="1973-389d-42e7-9332" name="Vehicle:" primary="false"/>
+            <categoryLink targetId="7381-1130-ca6e-1806" id="3a1c-3747-4b37-9839" name="Super-heavy Sub-type" primary="false"/>
+            <categoryLink targetId="7b0a-a743-a8da-3a39" id="d8ed-cff9-47b3-bda9" name="Transport Sub-type" primary="false"/>
           </categoryLinks>
         </selectionEntry>
       </selectionEntries>
@@ -11152,8 +11152,8 @@ If a Weapon Destroyed result is repaired, that weapon may not be used to attack 
                         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
                       </costs>
                       <categoryLinks>
-                        <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="b96b-e7e4-402f-89bb" name="Infantry" primary="false"/>
-                        <categoryLink targetId="9231-183c-b97b-63f9" id="0bea-8fb2-4fd0-90cc" name="Heavy" primary="false"/>
+                        <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="b96b-e7e4-402f-89bb" name="Infantry Unit Type" primary="false"/>
+                        <categoryLink targetId="9231-183c-b97b-63f9" id="0bea-8fb2-4fd0-90cc" name="Heavy Sub-type" primary="false"/>
                       </categoryLinks>
                     </selectionEntry>
                     <selectionEntry id="958d-a7de-99a8-033f" name="Earthshaker" hidden="false" collective="true" import="true" type="upgrade">
@@ -11177,9 +11177,9 @@ If a Weapon Destroyed result is repaired, that weapon may not be used to attack 
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="100"/>
                   </costs>
                   <categoryLinks>
-                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="c127-5742-4d6f-92d4" name="Infantry" primary="false"/>
+                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="c127-5742-4d6f-92d4" name="Infantry Unit Type" primary="false"/>
                     <categoryLink targetId="19f3-8727-02db-3ce5" id="1546-0c9e-43c9-b5bb" name="Static Artillery" primary="false"/>
-                    <categoryLink targetId="9231-183c-b97b-63f9" id="6ef3-17e3-489d-ad53" name="Heavy" primary="false"/>
+                    <categoryLink targetId="9231-183c-b97b-63f9" id="6ef3-17e3-489d-ad53" name="Heavy Sub-type" primary="false"/>
                   </categoryLinks>
                 </selectionEntry>
               </selectionEntries>
@@ -11226,8 +11226,8 @@ If a Weapon Destroyed result is repaired, that weapon may not be used to attack 
                         <infoLink id="666b-98d4-aeab-f6d5" name="Auxilia Gunners" targetId="cdec-8d38-f1bd-12df" type="profile"/>
                       </infoLinks>
                       <categoryLinks>
-                        <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="4559-a5cd-4154-8103" name="Infantry" primary="false"/>
-                        <categoryLink targetId="9231-183c-b97b-63f9" id="a981-5680-4595-b297" name="Heavy" primary="false"/>
+                        <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="4559-a5cd-4154-8103" name="Infantry Unit Type" primary="false"/>
+                        <categoryLink targetId="9231-183c-b97b-63f9" id="a981-5680-4595-b297" name="Heavy Sub-type" primary="false"/>
                       </categoryLinks>
                     </selectionEntry>
                     <selectionEntry id="5608-a41b-086f-59d6" name="Medusa" hidden="false" collective="true" import="true" type="upgrade">
@@ -11255,9 +11255,9 @@ If a Weapon Destroyed result is repaired, that weapon may not be used to attack 
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="100"/>
                   </costs>
                   <categoryLinks>
-                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="fb7d-b2aa-4699-914c" name="Infantry" primary="false"/>
+                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="fb7d-b2aa-4699-914c" name="Infantry Unit Type" primary="false"/>
                     <categoryLink targetId="19f3-8727-02db-3ce5" id="05ff-7970-47ff-a991" name="Static Artillery" primary="false"/>
-                    <categoryLink targetId="9231-183c-b97b-63f9" id="13c8-42b0-48a4-90a2" name="Heavy" primary="false"/>
+                    <categoryLink targetId="9231-183c-b97b-63f9" id="13c8-42b0-48a4-90a2" name="Heavy Sub-type" primary="false"/>
                   </categoryLinks>
                 </selectionEntry>
               </selectionEntries>
@@ -11275,7 +11275,7 @@ If a Weapon Destroyed result is repaired, that weapon may not be used to attack 
     <selectionEntry name="Solar Auxilia Aethon Heavy Sentinel Squadron" type="unit" id="a67f-63df-43c3-8e3c" page="1" publicationId="2d3f-82d2-9db5-ca6d">
       <categoryLinks>
         <categoryLink targetId="36c3-e85e-97cc-c503" name="Unit:" primary="false" id="7766-8c5f-4470-b3af"/>
-        <categoryLink targetId="7031-469a-1aeb-eab0" primary="true" id="ff6c-9b27-43f5-87c6" name="Heavy Support"/>
+        <categoryLink targetId="7031-469a-1aeb-eab0" primary="true" id="ff6c-9b27-43f5-87c6" name="Heavy Support:"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry type="model" name="Aethon Heavy Sentinel" id="fc1e-8738-4e75-bf6e" page="1" publicationId="2d3f-82d2-9db5-ca6d">
@@ -11311,7 +11311,7 @@ If a Weapon Destroyed result is repaired, that weapon may not be used to attack 
                     <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="e14e-cf71-4616-b0f4"/>
                   </constraints>
                 </entryLink>
-                <entryLink name="Volkite culverin" hidden="false" type="selectionEntry" targetId="170d-44e0-455c-8207" id="290b-6678-4687-bf31">
+                <entryLink name="Volkite Culverin" hidden="false" type="selectionEntry" targetId="170d-44e0-455c-8207" id="290b-6678-4687-bf31">
                   <costs>
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10"/>
                   </costs>
@@ -11423,9 +11423,9 @@ If a Weapon Destroyed result is repaired, that weapon may not be used to attack 
             </selectionEntryGroup>
           </selectionEntryGroups>
           <categoryLinks>
-            <categoryLink targetId="6d79-a3e4-381f-7b0f" primary="false" id="d127-c87a-4697-be59" name="Cavalry"/>
-            <categoryLink targetId="9231-183c-b97b-63f9" primary="false" id="e5c1-4757-445d-8ee0" name="Heavy"/>
-            <categoryLink targetId="e929-a5c3-451c-6f19" primary="false" id="2e11-596e-43ca-8e5b" name="Mechanised"/>
+            <categoryLink targetId="6d79-a3e4-381f-7b0f" primary="false" id="d127-c87a-4697-be59" name="Cavalry Unit Type"/>
+            <categoryLink targetId="9231-183c-b97b-63f9" primary="false" id="e5c1-4757-445d-8ee0" name="Heavy Sub-type"/>
+            <categoryLink targetId="e929-a5c3-451c-6f19" primary="false" id="2e11-596e-43ca-8e5b" name="Mechanised Unit Sub-type"/>
           </categoryLinks>
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="65"/>

--- a/2022 - LI - Solar Auxilia.cat
+++ b/2022 - LI - Solar Auxilia.cat
@@ -6992,7 +6992,7 @@ Once assigned to a unit, the Auxilia Medicae is considered part of that unit and
                     </modifier>
                   </modifiers>
                   <characteristics>
-                    <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Close Order, Character)</characteristic>
+                    <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Close-order, Character)</characteristic>
                     <characteristic name="Move" typeId="893e-2d76-8f04-44e5">6</characteristic>
                     <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
                     <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
@@ -7009,6 +7009,7 @@ Once assigned to a unit, the Auxilia Medicae is considered part of that unit and
               <categoryLinks>
                 <categoryLink id="9877-bb07-821b-d994" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
                 <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="e89d-53d4-4a25-8a30" name="Infantry" primary="false"/>
+                <categoryLink targetId="0af0-ea84-09d7-2b1f" id="2b71-cb23-4eb9-b1c5" name="Close-order" primary="false"/>
               </categoryLinks>
               <selectionEntryGroups>
                 <selectionEntryGroup id="eda3-b51a-5701-eb27" name="The Auxilia Troop Master may select any of the following:" hidden="false" collective="false" import="true">
@@ -7199,8 +7200,6 @@ Once assigned to a unit, the Auxilia Medicae is considered part of that unit and
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="33"/>
               </costs>
-              <comment>!BSC Errors from 20240328-1346
-Could not find type or subtype &apos;Close Order&apos;</comment>
             </selectionEntry>
           </selectionEntries>
           <selectionEntryGroups>

--- a/2022 - LI - Solar Auxilia.cat
+++ b/2022 - LI - Solar Auxilia.cat
@@ -1184,6 +1184,11 @@
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="85"/>
           </costs>
+          <categoryLinks>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="f2a3-dfb3-4cc5-8000" name="Infantry" primary="false"/>
+            <categoryLink targetId="9231-183c-b97b-63f9" id="4a38-8694-4340-b714" name="Heavy" primary="false"/>
+            <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="cadf-ce18-4f5a-8b07" name="Character" primary="false"/>
+          </categoryLinks>
         </selectionEntry>
       </selectionEntries>
       <costs>
@@ -1467,6 +1472,10 @@
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="12"/>
               </costs>
+              <categoryLinks>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="1f7f-9894-48d0-a8a9" name="Infantry" primary="false"/>
+                <categoryLink targetId="0af0-ea84-09d7-2b1f" id="82d8-8f4c-4f28-8088" name="Close-order" primary="false"/>
+              </categoryLinks>
             </selectionEntry>
             <selectionEntry id="672b-ea90-3efc-dee2" name="Auxilia Captain" hidden="false" collective="false" import="true" type="model">
               <constraints>
@@ -2025,6 +2034,11 @@
                   <costs>
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10"/>
                   </costs>
+                  <categoryLinks>
+                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="675c-e497-4f65-be3d" name="Infantry" primary="false"/>
+                    <categoryLink targetId="0af0-ea84-09d7-2b1f" id="4242-fc7f-43eb-bbe1" name="Close-order" primary="false"/>
+                    <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="c41f-e660-4fb0-a546" name="Character" primary="false"/>
+                  </categoryLinks>
                 </selectionEntry>
               </selectionEntries>
               <selectionEntryGroups>
@@ -2255,6 +2269,10 @@
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="12"/>
               </costs>
+              <categoryLinks>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="4d3f-f5fe-4022-ad68" name="Infantry" primary="false"/>
+                <categoryLink targetId="0af0-ea84-09d7-2b1f" id="ca2e-b7ba-4dab-9642" name="Close-order" primary="false"/>
+              </categoryLinks>
             </selectionEntry>
           </selectionEntries>
           <selectionEntryGroups>
@@ -2464,6 +2482,8 @@
               </profiles>
               <categoryLinks>
                 <categoryLink id="1278-bf88-ac56-9920" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="c68b-e63c-4de7-a247" name="Infantry" primary="false"/>
+                <categoryLink targetId="9231-183c-b97b-63f9" id="95bf-a49f-432a-b6c4" name="Heavy" primary="false"/>
               </categoryLinks>
               <selectionEntryGroups>
                 <selectionEntryGroup id="1cb1-052d-9cfe-0fc5" name="Armour" hidden="false" collective="false" import="true" defaultSelectionEntryId="09b8-e985-c536-4684">
@@ -2705,6 +2725,10 @@
                   <costs>
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="13"/>
                   </costs>
+                  <categoryLinks>
+                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="da5d-531c-4a24-b7e6" name="Infantry" primary="false"/>
+                    <categoryLink targetId="9231-183c-b97b-63f9" id="9e8e-cfdf-4797-85b8" name="Heavy" primary="false"/>
+                  </categoryLinks>
                 </selectionEntry>
                 <selectionEntry id="6e26-de36-1442-bf11" name="Veletarii w/ Power Lance" hidden="false" collective="false" import="true" type="model">
                   <constraints>
@@ -2730,6 +2754,10 @@
                   <costs>
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="13"/>
                   </costs>
+                  <categoryLinks>
+                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="7540-5336-4847-b983" name="Infantry" primary="false"/>
+                    <categoryLink targetId="9231-183c-b97b-63f9" id="68b3-64f4-4caa-ba98" name="Heavy" primary="false"/>
+                  </categoryLinks>
                 </selectionEntry>
                 <selectionEntry id="2ccc-2dc8-9580-f134" name="Veletarii w/ Power Maul" hidden="false" collective="false" import="true" type="model">
                   <constraints>
@@ -2755,6 +2783,10 @@
                   <costs>
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="13"/>
                   </costs>
+                  <categoryLinks>
+                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="a09f-5726-4cb7-80fd" name="Infantry" primary="false"/>
+                    <categoryLink targetId="9231-183c-b97b-63f9" id="a5f9-e2a7-4afc-9773" name="Heavy" primary="false"/>
+                  </categoryLinks>
                 </selectionEntry>
                 <selectionEntry id="c39a-711f-3566-712d" name="Veletarii w/ Volkite Charger" hidden="false" collective="false" import="true" type="model">
                   <constraints>
@@ -2780,6 +2812,10 @@
                   <costs>
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="8"/>
                   </costs>
+                  <categoryLinks>
+                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="22fb-ac5b-423d-9dcb" name="Infantry" primary="false"/>
+                    <categoryLink targetId="9231-183c-b97b-63f9" id="8e3d-b560-4e82-9a41" name="Heavy" primary="false"/>
+                  </categoryLinks>
                 </selectionEntry>
                 <selectionEntry id="0797-e0e8-65b9-9a4a" name="Veletarii w/ Power Axe" hidden="false" collective="false" import="true" type="model">
                   <constraints>
@@ -2836,6 +2872,10 @@
                   <costs>
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="13"/>
                   </costs>
+                  <categoryLinks>
+                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="41ec-9595-4956-87b5" name="Infantry" primary="false"/>
+                    <categoryLink targetId="9231-183c-b97b-63f9" id="bfd9-9a27-46f5-aa92" name="Heavy" primary="false"/>
+                  </categoryLinks>
                 </selectionEntry>
                 <selectionEntry id="3d9e-0a04-4a3b-de52" name="Veletarii w/ Autorifle" hidden="true" collective="false" import="true" type="model">
                   <modifiers>
@@ -2868,6 +2908,10 @@
                   <costs>
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="8"/>
                   </costs>
+                  <categoryLinks>
+                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="678c-1f1f-4ffe-bc29" name="Infantry" primary="false"/>
+                    <categoryLink targetId="9231-183c-b97b-63f9" id="42c2-a51c-4b49-a73f" name="Heavy" primary="false"/>
+                  </categoryLinks>
                 </selectionEntry>
                 <selectionEntry id="9323-ccf8-496d-ec8f" name="Veletarii w/ Lascarbine" hidden="true" collective="false" import="true" type="model">
                   <modifiers>
@@ -2900,6 +2944,10 @@
                   <costs>
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="8"/>
                   </costs>
+                  <categoryLinks>
+                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="123c-6d08-491f-8922" name="Infantry" primary="false"/>
+                    <categoryLink targetId="9231-183c-b97b-63f9" id="185b-0ae6-4b5d-9e60" name="Heavy" primary="false"/>
+                  </categoryLinks>
                 </selectionEntry>
                 <selectionEntry id="957e-31e3-8b91-a469" name="Veletarii w/ Lasgun" hidden="true" collective="false" import="true" type="model">
                   <modifiers>
@@ -2932,6 +2980,10 @@
                   <costs>
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="8"/>
                   </costs>
+                  <categoryLinks>
+                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="52c2-d432-4ffa-8fca" name="Infantry" primary="false"/>
+                    <categoryLink targetId="9231-183c-b97b-63f9" id="fe39-c692-4547-bbce" name="Heavy" primary="false"/>
+                  </categoryLinks>
                 </selectionEntry>
                 <selectionEntry id="5b3a-4395-95a9-9851" name="Veletarii w/ Shotgun" hidden="true" collective="false" import="true" type="model">
                   <modifiers>
@@ -2964,6 +3016,10 @@
                   <costs>
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="8"/>
                   </costs>
+                  <categoryLinks>
+                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="d42f-a701-478d-9506" name="Infantry" primary="false"/>
+                    <categoryLink targetId="9231-183c-b97b-63f9" id="f200-f456-4ece-a5d4" name="Heavy" primary="false"/>
+                  </categoryLinks>
                 </selectionEntry>
                 <selectionEntry id="fa18-90d2-821e-4291" name="Veletarii w/ Stubcarbine" hidden="true" collective="false" import="true" type="model">
                   <modifiers>
@@ -2996,6 +3052,10 @@
                   <costs>
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="8"/>
                   </costs>
+                  <categoryLinks>
+                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="a55c-660d-42fc-aac5" name="Infantry" primary="false"/>
+                    <categoryLink targetId="9231-183c-b97b-63f9" id="8a20-14c5-4324-b20d" name="Heavy" primary="false"/>
+                  </categoryLinks>
                 </selectionEntry>
               </selectionEntries>
             </selectionEntryGroup>
@@ -3104,6 +3164,8 @@
               </profiles>
               <categoryLinks>
                 <categoryLink id="6ba0-d806-4ca8-1add" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="aa8d-3d92-43b7-92f0" name="Infantry" primary="false"/>
+                <categoryLink targetId="9231-183c-b97b-63f9" id="06b4-6138-47bc-8318" name="Heavy" primary="false"/>
               </categoryLinks>
               <selectionEntryGroups>
                 <selectionEntryGroup id="7420-8069-6ac7-b72b" name="Armour" hidden="false" collective="false" import="true" defaultSelectionEntryId="1d16-82e9-d8f6-943e">
@@ -3352,6 +3414,10 @@
                   <costs>
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="13"/>
                   </costs>
+                  <categoryLinks>
+                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="07f8-8827-4d4d-a2b6" name="Infantry" primary="false"/>
+                    <categoryLink targetId="9231-183c-b97b-63f9" id="3c04-a03b-4798-a9f1" name="Heavy" primary="false"/>
+                  </categoryLinks>
                 </selectionEntry>
                 <selectionEntry id="9194-cb55-09ee-7817" name="Veletarii w/ Volkite Charger" hidden="false" collective="false" import="true" type="model">
                   <constraints>
@@ -3377,6 +3443,10 @@
                   <costs>
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="8"/>
                   </costs>
+                  <categoryLinks>
+                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="d7c8-7590-4f0d-9f98" name="Infantry" primary="false"/>
+                    <categoryLink targetId="9231-183c-b97b-63f9" id="8b6f-f985-403b-a672" name="Heavy" primary="false"/>
+                  </categoryLinks>
                 </selectionEntry>
                 <selectionEntry id="c110-0436-5b73-08f7" name="Veletarii w/ Autorifle" hidden="true" collective="false" import="true" type="model">
                   <modifiers>
@@ -3409,6 +3479,10 @@
                   <costs>
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="8"/>
                   </costs>
+                  <categoryLinks>
+                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="468f-3b13-4401-b378" name="Infantry" primary="false"/>
+                    <categoryLink targetId="9231-183c-b97b-63f9" id="004b-b83d-4a38-98f5" name="Heavy" primary="false"/>
+                  </categoryLinks>
                 </selectionEntry>
                 <selectionEntry id="0d2b-3943-df76-12a2" name="Veletarii w/ Lascarbine" hidden="true" collective="false" import="true" type="model">
                   <modifiers>
@@ -3441,6 +3515,10 @@
                   <costs>
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="8"/>
                   </costs>
+                  <categoryLinks>
+                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="1ab6-3841-492b-bbdd" name="Infantry" primary="false"/>
+                    <categoryLink targetId="9231-183c-b97b-63f9" id="6343-81d6-4fbf-a868" name="Heavy" primary="false"/>
+                  </categoryLinks>
                 </selectionEntry>
                 <selectionEntry id="6e53-e90b-d8a4-5158" name="Veletarii w/ Lasrifle" hidden="true" collective="false" import="true" type="model">
                   <modifiers>
@@ -3473,6 +3551,10 @@
                   <costs>
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="8"/>
                   </costs>
+                  <categoryLinks>
+                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="c5fd-b27a-4353-8829" name="Infantry" primary="false"/>
+                    <categoryLink targetId="9231-183c-b97b-63f9" id="ed9c-67f7-47f5-b458" name="Heavy" primary="false"/>
+                  </categoryLinks>
                 </selectionEntry>
                 <selectionEntry id="b70f-a612-df9c-7d7f" name="Veletarii w/ Shotgun" hidden="true" collective="false" import="true" type="model">
                   <modifiers>
@@ -3505,6 +3587,10 @@
                   <costs>
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="8"/>
                   </costs>
+                  <categoryLinks>
+                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="1b45-74cb-4613-91a0" name="Infantry" primary="false"/>
+                    <categoryLink targetId="9231-183c-b97b-63f9" id="50ca-be6e-420a-b6d0" name="Heavy" primary="false"/>
+                  </categoryLinks>
                 </selectionEntry>
                 <selectionEntry id="df5d-e57c-15b3-cfa8" name="Veletarii w/ Stubcarbine" hidden="true" collective="false" import="true" type="model">
                   <modifiers>
@@ -3537,6 +3623,10 @@
                   <costs>
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="8"/>
                   </costs>
+                  <categoryLinks>
+                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="ef1f-eca1-4550-b3aa" name="Infantry" primary="false"/>
+                    <categoryLink targetId="9231-183c-b97b-63f9" id="f3fe-c8f7-4d3e-8a39" name="Heavy" primary="false"/>
+                  </categoryLinks>
                 </selectionEntry>
               </selectionEntries>
             </selectionEntryGroup>
@@ -3688,6 +3778,8 @@
               </profiles>
               <categoryLinks>
                 <categoryLink id="1616-4d93-a1d7-8b9b" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="8fa1-01d6-460d-85e3" name="Infantry" primary="false"/>
+                <categoryLink targetId="9231-183c-b97b-63f9" id="00f5-66cf-4ee6-ad5e" name="Heavy" primary="false"/>
               </categoryLinks>
               <selectionEntryGroups>
                 <selectionEntryGroup id="cb16-77f4-dd20-bb13" name="Armour" hidden="false" collective="false" import="true" defaultSelectionEntryId="76fe-62a6-e1f1-1fe4">
@@ -3886,6 +3978,10 @@
                   <costs>
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="8"/>
                   </costs>
+                  <categoryLinks>
+                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="6f23-5f3d-4711-95f0" name="Infantry" primary="false"/>
+                    <categoryLink targetId="9231-183c-b97b-63f9" id="1dc5-a978-4d98-9614" name="Heavy" primary="false"/>
+                  </categoryLinks>
                 </selectionEntry>
                 <selectionEntry id="e5b2-9536-03f8-39e2" name="Veletarii w/ Rotor Cannon" hidden="false" collective="false" import="true" type="model">
                   <constraints>
@@ -3911,6 +4007,10 @@
                   <costs>
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="8"/>
                   </costs>
+                  <categoryLinks>
+                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="bfc0-d686-421b-a079" name="Infantry" primary="false"/>
+                    <categoryLink targetId="9231-183c-b97b-63f9" id="48de-c21c-48be-b669" name="Heavy" primary="false"/>
+                  </categoryLinks>
                 </selectionEntry>
               </selectionEntries>
             </selectionEntryGroup>
@@ -4052,6 +4152,8 @@
           </infoLinks>
           <categoryLinks>
             <categoryLink id="0b71-539b-8899-6356" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="f81f-88d9-40f5-b3a2" name="Infantry" primary="false"/>
+            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="5c97-b256-44f6-a399" name="Unique" primary="false"/>
           </categoryLinks>
           <selectionEntries>
             <selectionEntry id="e08f-f2c7-19eb-9d01" name="Auto-gurney" hidden="false" collective="false" import="true" type="upgrade">
@@ -4131,6 +4233,9 @@ If the unit that includes Aevos Jovan also includes one or more Medicae Orderlie
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5"/>
           </costs>
+          <categoryLinks>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="2048-a95c-4e6f-9012" name="Infantry" primary="false"/>
+          </categoryLinks>
         </selectionEntry>
       </selectionEntries>
       <costs>
@@ -4326,6 +4431,10 @@ Once assigned to a unit, the Auxilia Medicae is considered part of that unit and
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15"/>
           </costs>
+          <categoryLinks>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="fa07-ebc9-4911-9715" name="Infantry" primary="false"/>
+            <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="1563-37df-4e65-ac61" name="Character" primary="false"/>
+          </categoryLinks>
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
@@ -4446,6 +4555,10 @@ Once assigned to a unit, the Auxilia Medicae is considered part of that unit and
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="40"/>
           </costs>
+          <categoryLinks>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="fe3b-9db6-4b84-9eb6" name="Infantry" primary="false"/>
+            <categoryLink targetId="7d95-f9d1-440a-67bd" id="0fe6-d1a6-488a-bf4f" name="Monstrous" primary="false"/>
+          </categoryLinks>
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
@@ -4820,6 +4933,9 @@ Once assigned to a unit, the Auxilia Medicae is considered part of that unit and
               </profiles>
               <categoryLinks>
                 <categoryLink id="099b-266a-e368-1e64" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="34da-3008-4752-b617" name="Infantry" primary="false"/>
+                <categoryLink targetId="6399-5c65-7833-1025" id="e2cb-92eb-47ce-87ec" name="Line" primary="false"/>
+                <categoryLink targetId="0af0-ea84-09d7-2b1f" id="9f08-82b0-426a-a9a9" name="Close-order" primary="false"/>
               </categoryLinks>
               <selectionEntryGroups>
                 <selectionEntryGroup id="d7f7-a7a6-c792-ada8" name="Weapons" hidden="false" collective="false" import="true" defaultSelectionEntryId="32ae-3f3b-8b44-9b87">
@@ -5113,6 +5229,11 @@ Once assigned to a unit, the Auxilia Medicae is considered part of that unit and
                   <costs>
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="8"/>
                   </costs>
+                  <categoryLinks>
+                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="846b-a82e-4b8d-94d6" name="Infantry" primary="false"/>
+                    <categoryLink targetId="6399-5c65-7833-1025" id="f5e5-9023-46db-ae72" name="Line" primary="false"/>
+                    <categoryLink targetId="0af0-ea84-09d7-2b1f" id="0df9-c7bd-4a3c-81d1" name="Close-order" primary="false"/>
+                  </categoryLinks>
                 </selectionEntry>
                 <selectionEntry id="88a5-af55-4a9b-63bf" name="Auxilia Veteran w/ Lasrifle and Bayonet" hidden="false" collective="false" import="true" type="model">
                   <constraints>
@@ -5138,6 +5259,11 @@ Once assigned to a unit, the Auxilia Medicae is considered part of that unit and
                   <costs>
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="9"/>
                   </costs>
+                  <categoryLinks>
+                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="db2d-d153-4567-a527" name="Infantry" primary="false"/>
+                    <categoryLink targetId="6399-5c65-7833-1025" id="fb3f-9225-445d-a4ed" name="Line" primary="false"/>
+                    <categoryLink targetId="0af0-ea84-09d7-2b1f" id="85e9-e5c7-439d-ad66" name="Close-order" primary="false"/>
+                  </categoryLinks>
                 </selectionEntry>
                 <selectionEntry id="f53f-6476-b0c8-4289" name="Auxilia Veteran w/ Autorifle" hidden="true" collective="false" import="true" type="model">
                   <modifiers>
@@ -5164,6 +5290,11 @@ Once assigned to a unit, the Auxilia Medicae is considered part of that unit and
                   <costs>
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="8"/>
                   </costs>
+                  <categoryLinks>
+                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="4d30-2332-4684-8a69" name="Infantry" primary="false"/>
+                    <categoryLink targetId="6399-5c65-7833-1025" id="3ce2-cd48-4268-9bc3" name="Line" primary="false"/>
+                    <categoryLink targetId="0af0-ea84-09d7-2b1f" id="bfcb-476b-4b03-9cd5" name="Close-order" primary="false"/>
+                  </categoryLinks>
                 </selectionEntry>
                 <selectionEntry id="5363-7ae2-cdf2-cbbe" name="Auxilia Veteran w/ Lascarbine" hidden="true" collective="false" import="true" type="model">
                   <modifiers>
@@ -5190,6 +5321,11 @@ Once assigned to a unit, the Auxilia Medicae is considered part of that unit and
                   <costs>
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="8"/>
                   </costs>
+                  <categoryLinks>
+                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="bae6-0272-4b1a-9f0d" name="Infantry" primary="false"/>
+                    <categoryLink targetId="6399-5c65-7833-1025" id="28c0-7e94-464d-bf37" name="Line" primary="false"/>
+                    <categoryLink targetId="0af0-ea84-09d7-2b1f" id="8f7d-8d0e-4846-968d" name="Close-order" primary="false"/>
+                  </categoryLinks>
                 </selectionEntry>
                 <selectionEntry id="0515-f66c-1d64-0b6c" name="Auxilia Veteran w/ Lasgun" hidden="true" collective="false" import="true" type="model">
                   <modifiers>
@@ -5216,6 +5352,11 @@ Once assigned to a unit, the Auxilia Medicae is considered part of that unit and
                   <costs>
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="8"/>
                   </costs>
+                  <categoryLinks>
+                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="c113-d488-46c6-a7a9" name="Infantry" primary="false"/>
+                    <categoryLink targetId="6399-5c65-7833-1025" id="2359-2f47-40ba-b9f4" name="Line" primary="false"/>
+                    <categoryLink targetId="0af0-ea84-09d7-2b1f" id="3358-8fa2-450f-9e77" name="Close-order" primary="false"/>
+                  </categoryLinks>
                 </selectionEntry>
                 <selectionEntry id="4c67-77b7-5785-4a87" name="Auxilia Veteran w/ Shotgun" hidden="true" collective="false" import="true" type="model">
                   <modifiers>
@@ -5242,6 +5383,11 @@ Once assigned to a unit, the Auxilia Medicae is considered part of that unit and
                   <costs>
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="8"/>
                   </costs>
+                  <categoryLinks>
+                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="4b89-4817-431d-8c0a" name="Infantry" primary="false"/>
+                    <categoryLink targetId="6399-5c65-7833-1025" id="f11c-e9c6-408f-bef2" name="Line" primary="false"/>
+                    <categoryLink targetId="0af0-ea84-09d7-2b1f" id="d9c0-1922-4be8-a99b" name="Close-order" primary="false"/>
+                  </categoryLinks>
                 </selectionEntry>
                 <selectionEntry id="3128-3d49-4df3-dfc2" name="Auxilia Veteran w/ Stubcarbine" hidden="true" collective="false" import="true" type="model">
                   <modifiers>
@@ -5268,6 +5414,11 @@ Once assigned to a unit, the Auxilia Medicae is considered part of that unit and
                   <costs>
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="8"/>
                   </costs>
+                  <categoryLinks>
+                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="19a3-2c49-42b2-b40f" name="Infantry" primary="false"/>
+                    <categoryLink targetId="6399-5c65-7833-1025" id="92f1-894c-45ad-8f2d" name="Line" primary="false"/>
+                    <categoryLink targetId="0af0-ea84-09d7-2b1f" id="f7a0-eb91-4278-89ea" name="Close-order" primary="false"/>
+                  </categoryLinks>
                 </selectionEntry>
               </selectionEntries>
             </selectionEntryGroup>
@@ -5391,6 +5542,9 @@ Once assigned to a unit, the Auxilia Medicae is considered part of that unit and
               </profiles>
               <categoryLinks>
                 <categoryLink id="e8df-cf83-9688-d89f" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="d959-a0f3-4c11-8191" name="Infantry" primary="false"/>
+                <categoryLink targetId="6399-5c65-7833-1025" id="3993-3a35-408c-9256" name="Line" primary="false"/>
+                <categoryLink targetId="0af0-ea84-09d7-2b1f" id="b75c-e8fe-4897-861c" name="Close-order" primary="false"/>
               </categoryLinks>
               <selectionEntryGroups>
                 <selectionEntryGroup id="8db8-4d63-3ff8-0124" name="Weapons" hidden="false" collective="false" import="true" defaultSelectionEntryId="6d17-07d2-d48a-0c7f">
@@ -5648,6 +5802,11 @@ Once assigned to a unit, the Auxilia Medicae is considered part of that unit and
                   <costs>
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5"/>
                   </costs>
+                  <categoryLinks>
+                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="784a-fa1c-4629-b69e" name="Infantry" primary="false"/>
+                    <categoryLink targetId="6399-5c65-7833-1025" id="521c-b0e8-4c10-9234" name="Line" primary="false"/>
+                    <categoryLink targetId="0af0-ea84-09d7-2b1f" id="cc5a-3417-41b9-97d6" name="Close-order" primary="false"/>
+                  </categoryLinks>
                 </selectionEntry>
                 <selectionEntry id="d75c-1339-aa85-0b76" name="Auxilia w/ Lasrifle and Bayonet" hidden="false" collective="false" import="true" type="model">
                   <constraints>
@@ -5673,6 +5832,11 @@ Once assigned to a unit, the Auxilia Medicae is considered part of that unit and
                   <costs>
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="6"/>
                   </costs>
+                  <categoryLinks>
+                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="e6cb-9bb7-46d2-b533" name="Infantry" primary="false"/>
+                    <categoryLink targetId="6399-5c65-7833-1025" id="f8fc-b8ab-4c5f-a55c" name="Line" primary="false"/>
+                    <categoryLink targetId="0af0-ea84-09d7-2b1f" id="3f54-3682-4db8-9d53" name="Close-order" primary="false"/>
+                  </categoryLinks>
                 </selectionEntry>
                 <selectionEntry id="b44b-d4d9-ba86-416c" name="Auxilia w/ Autorifle" hidden="true" collective="false" import="true" type="model">
                   <modifiers>
@@ -5699,6 +5863,11 @@ Once assigned to a unit, the Auxilia Medicae is considered part of that unit and
                   <costs>
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5"/>
                   </costs>
+                  <categoryLinks>
+                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="03e4-fcc9-4ce1-b8ce" name="Infantry" primary="false"/>
+                    <categoryLink targetId="6399-5c65-7833-1025" id="6c52-333d-45c8-a9b6" name="Line" primary="false"/>
+                    <categoryLink targetId="0af0-ea84-09d7-2b1f" id="43a7-132b-4b9a-8ec6" name="Close-order" primary="false"/>
+                  </categoryLinks>
                 </selectionEntry>
                 <selectionEntry id="ae80-cf1e-3816-3b1d" name="Auxilia w/ Lascarbine" hidden="true" collective="false" import="true" type="model">
                   <modifiers>
@@ -5725,6 +5894,11 @@ Once assigned to a unit, the Auxilia Medicae is considered part of that unit and
                   <costs>
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5"/>
                   </costs>
+                  <categoryLinks>
+                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="6bf8-0593-468a-b599" name="Infantry" primary="false"/>
+                    <categoryLink targetId="6399-5c65-7833-1025" id="59b4-a4dd-4be0-89d5" name="Line" primary="false"/>
+                    <categoryLink targetId="0af0-ea84-09d7-2b1f" id="7e1e-7fbf-4868-8efb" name="Close-order" primary="false"/>
+                  </categoryLinks>
                 </selectionEntry>
                 <selectionEntry id="ebcb-7ca4-cae8-145f" name="Auxilia w/ Lasgun" hidden="true" collective="false" import="true" type="model">
                   <modifiers>
@@ -5751,6 +5925,11 @@ Once assigned to a unit, the Auxilia Medicae is considered part of that unit and
                   <costs>
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5"/>
                   </costs>
+                  <categoryLinks>
+                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="3f7f-5fd9-4319-861c" name="Infantry" primary="false"/>
+                    <categoryLink targetId="6399-5c65-7833-1025" id="2db3-55fd-4ba0-98c0" name="Line" primary="false"/>
+                    <categoryLink targetId="0af0-ea84-09d7-2b1f" id="f335-62bd-4b16-93db" name="Close-order" primary="false"/>
+                  </categoryLinks>
                 </selectionEntry>
                 <selectionEntry id="2974-bd81-4134-3d04" name="Auxilia w/ Shotgun" hidden="true" collective="false" import="true" type="model">
                   <modifiers>
@@ -5777,6 +5956,11 @@ Once assigned to a unit, the Auxilia Medicae is considered part of that unit and
                   <costs>
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5"/>
                   </costs>
+                  <categoryLinks>
+                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="b933-b80e-4953-b4ae" name="Infantry" primary="false"/>
+                    <categoryLink targetId="6399-5c65-7833-1025" id="b1b4-4b28-418e-9877" name="Line" primary="false"/>
+                    <categoryLink targetId="0af0-ea84-09d7-2b1f" id="c90d-6756-4aea-9686" name="Close-order" primary="false"/>
+                  </categoryLinks>
                 </selectionEntry>
                 <selectionEntry id="fcdf-545e-a859-4590" name="Auxilia w/ Stubcarbine" hidden="true" collective="false" import="true" type="model">
                   <modifiers>
@@ -5803,6 +5987,11 @@ Once assigned to a unit, the Auxilia Medicae is considered part of that unit and
                   <costs>
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5"/>
                   </costs>
+                  <categoryLinks>
+                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="fee4-cdaf-45b5-b71a" name="Infantry" primary="false"/>
+                    <categoryLink targetId="6399-5c65-7833-1025" id="a6f9-e408-4705-b3af" name="Line" primary="false"/>
+                    <categoryLink targetId="0af0-ea84-09d7-2b1f" id="60fc-d5f7-48d9-936c" name="Close-order" primary="false"/>
+                  </categoryLinks>
                 </selectionEntry>
                 <selectionEntry id="15a4-62c6-5d72-fe17" name="Auxilia w/ Heavy Stubber" hidden="true" collective="false" import="true" type="model">
                   <modifiers>
@@ -5829,6 +6018,11 @@ Once assigned to a unit, the Auxilia Medicae is considered part of that unit and
                   <costs>
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10"/>
                   </costs>
+                  <categoryLinks>
+                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="9630-80e3-4660-ae0f" name="Infantry" primary="false"/>
+                    <categoryLink targetId="6399-5c65-7833-1025" id="c683-37ce-444a-b29e" name="Line" primary="false"/>
+                    <categoryLink targetId="0af0-ea84-09d7-2b1f" id="e224-d6bd-4aee-ba51" name="Close-order" primary="false"/>
+                  </categoryLinks>
                 </selectionEntry>
               </selectionEntries>
             </selectionEntryGroup>
@@ -6483,6 +6677,9 @@ Once assigned to a unit, the Auxilia Medicae is considered part of that unit and
                       <costs>
                         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="185"/>
                       </costs>
+                      <categoryLinks>
+                        <categoryLink targetId="e2b6-b770-784c-9e95" id="5c0b-faa9-4959-ae28" name="Vehicle" primary="false"/>
+                      </categoryLinks>
                     </selectionEntry>
                   </selectionEntries>
                 </selectionEntryGroup>
@@ -6696,6 +6893,9 @@ Once assigned to a unit, the Auxilia Medicae is considered part of that unit and
                       <costs>
                         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="135"/>
                       </costs>
+                      <categoryLinks>
+                        <categoryLink targetId="e2b6-b770-784c-9e95" id="6b03-4b72-4276-babc" name="Vehicle" primary="false"/>
+                      </categoryLinks>
                     </selectionEntry>
                   </selectionEntries>
                 </selectionEntryGroup>
@@ -6808,6 +7008,7 @@ Once assigned to a unit, the Auxilia Medicae is considered part of that unit and
               </profiles>
               <categoryLinks>
                 <categoryLink id="9877-bb07-821b-d994" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="e89d-53d4-4a25-8a30" name="Infantry" primary="false"/>
               </categoryLinks>
               <selectionEntryGroups>
                 <selectionEntryGroup id="eda3-b51a-5701-eb27" name="The Auxilia Troop Master may select any of the following:" hidden="false" collective="false" import="true">
@@ -6998,6 +7199,8 @@ Once assigned to a unit, the Auxilia Medicae is considered part of that unit and
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="33"/>
               </costs>
+              <comment>!BSC Errors from 20240328-1346
+Could not find type or subtype &apos;Close Order&apos;</comment>
             </selectionEntry>
           </selectionEntries>
           <selectionEntryGroups>
@@ -7051,6 +7254,10 @@ Once assigned to a unit, the Auxilia Medicae is considered part of that unit and
                   <costs>
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="8"/>
                   </costs>
+                  <categoryLinks>
+                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="920a-1a14-4b79-8668" name="Infantry" primary="false"/>
+                    <categoryLink targetId="0af0-ea84-09d7-2b1f" id="309d-4954-4600-93f9" name="Close-order" primary="false"/>
+                  </categoryLinks>
                 </selectionEntry>
                 <selectionEntry id="ab64-add2-57e2-ce11" name="Auxilia Veteran w/ Lasrifle and Bayonet" hidden="false" collective="false" import="true" type="model">
                   <constraints>
@@ -7076,6 +7283,11 @@ Once assigned to a unit, the Auxilia Medicae is considered part of that unit and
                   <costs>
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="9"/>
                   </costs>
+                  <categoryLinks>
+                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="11af-39b6-4d18-b4f4" name="Infantry" primary="false"/>
+                    <categoryLink targetId="6399-5c65-7833-1025" id="032f-5a17-48b2-a045" name="Line" primary="false"/>
+                    <categoryLink targetId="0af0-ea84-09d7-2b1f" id="fc50-2a81-43e7-9e79" name="Close-order" primary="false"/>
+                  </categoryLinks>
                 </selectionEntry>
                 <selectionEntry id="1306-1e1d-992a-6fc6" name="Auxilia Veteran w/ Autorifle" hidden="true" collective="false" import="true" type="model">
                   <modifiers>
@@ -7130,6 +7342,11 @@ Once assigned to a unit, the Auxilia Medicae is considered part of that unit and
                   <costs>
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="8"/>
                   </costs>
+                  <categoryLinks>
+                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="ac44-57cf-4259-8a92" name="Infantry" primary="false"/>
+                    <categoryLink targetId="6399-5c65-7833-1025" id="d836-955e-4ab4-b9d4" name="Line" primary="false"/>
+                    <categoryLink targetId="0af0-ea84-09d7-2b1f" id="d449-fcc8-4778-b1ff" name="Close-order" primary="false"/>
+                  </categoryLinks>
                 </selectionEntry>
                 <selectionEntry id="01c0-60c7-ee5f-4a48" name="Auxilia Veteran w/ Lasgun" hidden="true" collective="false" import="true" type="model">
                   <modifiers>
@@ -7161,6 +7378,11 @@ Once assigned to a unit, the Auxilia Medicae is considered part of that unit and
                   <costs>
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="8"/>
                   </costs>
+                  <categoryLinks>
+                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="39cb-d82f-4445-95b4" name="Infantry" primary="false"/>
+                    <categoryLink targetId="6399-5c65-7833-1025" id="c063-4618-4f3c-9e12" name="Line" primary="false"/>
+                    <categoryLink targetId="0af0-ea84-09d7-2b1f" id="e819-dfa4-484c-b7c9" name="Close-order" primary="false"/>
+                  </categoryLinks>
                 </selectionEntry>
                 <selectionEntry id="511c-8e43-1c88-9b3c" name="Auxilia Veteran w/ Shotgun" hidden="true" collective="false" import="true" type="model">
                   <modifiers>
@@ -7192,6 +7414,11 @@ Once assigned to a unit, the Auxilia Medicae is considered part of that unit and
                   <costs>
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="8"/>
                   </costs>
+                  <categoryLinks>
+                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="5662-91c1-47e6-b4d2" name="Infantry" primary="false"/>
+                    <categoryLink targetId="6399-5c65-7833-1025" id="3d8a-837e-4b0b-b5bf" name="Line" primary="false"/>
+                    <categoryLink targetId="0af0-ea84-09d7-2b1f" id="b581-bcf8-4c00-a89d" name="Close-order" primary="false"/>
+                  </categoryLinks>
                 </selectionEntry>
                 <selectionEntry id="0cbe-0cb9-3c39-e9f2" name="Auxilia Veteran w/ Stubcarbine" hidden="true" collective="false" import="true" type="model">
                   <modifiers>
@@ -7218,6 +7445,11 @@ Once assigned to a unit, the Auxilia Medicae is considered part of that unit and
                   <costs>
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="8"/>
                   </costs>
+                  <categoryLinks>
+                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="dcb9-bb38-4e26-ac18" name="Infantry" primary="false"/>
+                    <categoryLink targetId="6399-5c65-7833-1025" id="4efd-8849-4228-8fa3" name="Line" primary="false"/>
+                    <categoryLink targetId="0af0-ea84-09d7-2b1f" id="90aa-b427-4bcb-80aa" name="Close-order" primary="false"/>
+                  </categoryLinks>
                 </selectionEntry>
               </selectionEntries>
             </selectionEntryGroup>
@@ -7399,6 +7631,7 @@ Once assigned to a unit, the Auxilia Medicae is considered part of that unit and
                       <categoryLinks>
                         <categoryLink id="7cc6-7c1b-0126-7396" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
                         <categoryLink id="e5e1-0a3a-df3f-7aff" name="Heavy Sub-type:" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+                        <categoryLink targetId="6f99-c178-6f9d-fb63" id="25e0-6cd2-458d-86a2" name="Artillery" primary="false"/>
                       </categoryLinks>
                       <selectionEntries>
                         <selectionEntry id="8965-b004-fc05-1160" name="Auxilia Gunners" hidden="false" collective="true" import="true" type="model">
@@ -7441,6 +7674,10 @@ Once assigned to a unit, the Auxilia Medicae is considered part of that unit and
                           <costs>
                             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
                           </costs>
+                          <categoryLinks>
+                            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="a67a-9deb-4883-8b6e" name="Infantry" primary="false"/>
+                            <categoryLink targetId="9231-183c-b97b-63f9" id="a05d-64e7-4096-bf7d" name="Heavy" primary="false"/>
+                          </categoryLinks>
                         </selectionEntry>
                       </selectionEntries>
                       <costs>
@@ -7606,6 +7843,10 @@ Once assigned to a unit, the Auxilia Medicae is considered part of that unit and
                       <costs>
                         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20"/>
                       </costs>
+                      <categoryLinks>
+                        <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="293c-fe04-4710-a496" name="Infantry" primary="false"/>
+                        <categoryLink targetId="0faa-1bab-2901-4330" id="c34c-6926-4fd9-ade6" name="Automated Artillery" primary="false"/>
+                      </categoryLinks>
                     </selectionEntry>
                   </selectionEntries>
                 </selectionEntryGroup>
@@ -7881,6 +8122,10 @@ Once assigned to a unit, the Auxilia Medicae is considered part of that unit and
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="225"/>
           </costs>
+          <categoryLinks>
+            <categoryLink targetId="e2b6-b770-784c-9e95" id="5d45-6227-4a45-bfb0" name="Vehicle" primary="false"/>
+            <categoryLink targetId="9b0d-738c-10e4-4ec1" id="b9bc-dd90-4b4a-a35d" name="Reinforced" primary="false"/>
+          </categoryLinks>
         </selectionEntry>
       </selectionEntries>
       <costs>
@@ -7961,6 +8206,10 @@ Once assigned to a unit, the Auxilia Medicae is considered part of that unit and
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="200"/>
           </costs>
+          <categoryLinks>
+            <categoryLink targetId="e2b6-b770-784c-9e95" id="99bf-44fc-44ea-9ac7" name="Vehicle" primary="false"/>
+            <categoryLink targetId="d5df-57ac-8f3c-097b" id="00f2-b771-4360-99ad" name="Bombard" primary="false"/>
+          </categoryLinks>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
@@ -8113,6 +8362,10 @@ Once assigned to a unit, the Auxilia Medicae is considered part of that unit and
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
           </costs>
+          <categoryLinks>
+            <categoryLink targetId="e2b6-b770-784c-9e95" id="aecb-cd92-4e6f-8f2c" name="Vehicle" primary="false"/>
+            <categoryLink targetId="9b0d-738c-10e4-4ec1" id="cce9-8949-4d9e-b9c4" name="Reinforced" primary="false"/>
+          </categoryLinks>
         </selectionEntry>
       </selectionEntries>
       <costs>
@@ -8186,6 +8439,10 @@ Once assigned to a unit, the Auxilia Medicae is considered part of that unit and
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
               </costs>
+              <categoryLinks>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="083b-2768-4902-917a" name="Infantry" primary="false"/>
+                <categoryLink targetId="9231-183c-b97b-63f9" id="dae3-ce0f-4254-9541" name="Heavy" primary="false"/>
+              </categoryLinks>
             </selectionEntry>
             <selectionEntry id="48fc-f925-ae4a-180b" name="Cyclops" hidden="false" collective="true" import="true" type="model">
               <constraints>
@@ -8228,6 +8485,11 @@ Once assigned to a unit, the Auxilia Medicae is considered part of that unit and
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
               </costs>
+              <categoryLinks>
+                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="d815-cd87-49e8-9b18" name="Infantry" primary="false"/>
+                <categoryLink targetId="0faa-1bab-2901-4330" id="bfc1-7ef0-4711-9cdd" name="Automated Artillery" primary="false"/>
+                <categoryLink targetId="9231-183c-b97b-63f9" id="bf9a-03a7-4cd6-b4ae" name="Heavy" primary="false"/>
+              </categoryLinks>
             </selectionEntry>
           </selectionEntries>
           <costs>
@@ -8493,6 +8755,10 @@ Once assigned to a unit, the Auxilia Medicae is considered part of that unit and
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
           </costs>
+          <categoryLinks>
+            <categoryLink targetId="e2b6-b770-784c-9e95" id="45df-cce8-4b9c-9750" name="Vehicle" primary="false"/>
+            <categoryLink targetId="9b0d-738c-10e4-4ec1" id="2d35-75bd-4015-b826" name="Reinforced" primary="false"/>
+          </categoryLinks>
         </selectionEntry>
       </selectionEntries>
       <costs>
@@ -9041,6 +9307,7 @@ Once assigned to a unit, the Auxilia Medicae is considered part of that unit and
           </profiles>
           <categoryLinks>
             <categoryLink id="9e0c-ea43-0714-f9d6" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+            <categoryLink targetId="7b0a-a743-a8da-3a39" id="833d-9681-473e-a0b9" name="Transport" primary="false"/>
           </categoryLinks>
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
@@ -9648,6 +9915,8 @@ If a Weapon Destroyed result is repaired, that weapon may not be used to attack 
           </profiles>
           <categoryLinks>
             <categoryLink id="ef6b-5a75-45f9-9bf3" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+            <categoryLink targetId="c4a5-4def-dc2c-7ce2" id="1aa7-7ef8-4483-b1a3" name="Slow" primary="false"/>
+            <categoryLink targetId="9b0d-738c-10e4-4ec1" id="6794-0a0e-4e46-930f" name="Reinforced" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="3838-1b61-9897-ce35" name="May take:" hidden="false" collective="false" import="true">
@@ -9732,6 +10001,7 @@ If a Weapon Destroyed result is repaired, that weapon may not be used to attack 
           </profiles>
           <categoryLinks>
             <categoryLink id="47e4-9cd8-d66e-2c84" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+            <categoryLink targetId="7381-1130-ca6e-1806" id="123c-7159-411c-8956" name="Super-heavy" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="1293-cf52-b3db-1611" name="2) Pintle mounted Weapon:" hidden="false" collective="false" import="true">
@@ -10787,6 +11057,11 @@ If a Weapon Destroyed result is repaired, that weapon may not be used to attack 
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="300"/>
           </costs>
+          <categoryLinks>
+            <categoryLink targetId="e2b6-b770-784c-9e95" id="1973-389d-42e7-9332" name="Vehicle" primary="false"/>
+            <categoryLink targetId="7381-1130-ca6e-1806" id="3a1c-3747-4b37-9839" name="Super-heavy" primary="false"/>
+            <categoryLink targetId="7b0a-a743-a8da-3a39" id="d8ed-cff9-47b3-bda9" name="Transport" primary="false"/>
+          </categoryLinks>
         </selectionEntry>
       </selectionEntries>
       <costs>
@@ -10877,6 +11152,10 @@ If a Weapon Destroyed result is repaired, that weapon may not be used to attack 
                       <costs>
                         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
                       </costs>
+                      <categoryLinks>
+                        <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="b96b-e7e4-402f-89bb" name="Infantry" primary="false"/>
+                        <categoryLink targetId="9231-183c-b97b-63f9" id="0bea-8fb2-4fd0-90cc" name="Heavy" primary="false"/>
+                      </categoryLinks>
                     </selectionEntry>
                     <selectionEntry id="958d-a7de-99a8-033f" name="Earthshaker" hidden="false" collective="true" import="true" type="upgrade">
                       <constraints>
@@ -10898,6 +11177,11 @@ If a Weapon Destroyed result is repaired, that weapon may not be used to attack 
                   <costs>
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="100"/>
                   </costs>
+                  <categoryLinks>
+                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="c127-5742-4d6f-92d4" name="Infantry" primary="false"/>
+                    <categoryLink targetId="19f3-8727-02db-3ce5" id="1546-0c9e-43c9-b5bb" name="Static Artillery" primary="false"/>
+                    <categoryLink targetId="9231-183c-b97b-63f9" id="6ef3-17e3-489d-ad53" name="Heavy" primary="false"/>
+                  </categoryLinks>
                 </selectionEntry>
               </selectionEntries>
               <costs>
@@ -10942,6 +11226,10 @@ If a Weapon Destroyed result is repaired, that weapon may not be used to attack 
                       <infoLinks>
                         <infoLink id="666b-98d4-aeab-f6d5" name="Auxilia Gunners" targetId="cdec-8d38-f1bd-12df" type="profile"/>
                       </infoLinks>
+                      <categoryLinks>
+                        <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="4559-a5cd-4154-8103" name="Infantry" primary="false"/>
+                        <categoryLink targetId="9231-183c-b97b-63f9" id="a981-5680-4595-b297" name="Heavy" primary="false"/>
+                      </categoryLinks>
                     </selectionEntry>
                     <selectionEntry id="5608-a41b-086f-59d6" name="Medusa" hidden="false" collective="true" import="true" type="upgrade">
                       <constraints>
@@ -10967,6 +11255,11 @@ If a Weapon Destroyed result is repaired, that weapon may not be used to attack 
                   <costs>
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="100"/>
                   </costs>
+                  <categoryLinks>
+                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="fb7d-b2aa-4699-914c" name="Infantry" primary="false"/>
+                    <categoryLink targetId="19f3-8727-02db-3ce5" id="05ff-7970-47ff-a991" name="Static Artillery" primary="false"/>
+                    <categoryLink targetId="9231-183c-b97b-63f9" id="13c8-42b0-48a4-90a2" name="Heavy" primary="false"/>
+                  </categoryLinks>
                 </selectionEntry>
               </selectionEntries>
               <costs>

--- a/2022 - LI - Solar Auxilia.cat
+++ b/2022 - LI - Solar Auxilia.cat
@@ -804,7 +804,7 @@
       </constraints>
       <categoryLinks>
         <categoryLink id="e7bd-8dd9-39fd-4e7d" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="3890-ed31-5e7e-4b77" name="Heavy Sub-type:" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+        <categoryLink id="3890-ed31-5e7e-4b77" name="Heavy Sub-type" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
         <categoryLink id="fb94-9780-7cb6-f0d9" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
         <categoryLink name="SA or IM Unit" hidden="false" id="e61e-4d32-7f6f-c86a" targetId="4aca-2849-7f41-0200" primary="false"/>
       </categoryLinks>
@@ -4685,7 +4685,7 @@ Once assigned to a unit, the Auxilia Medicae is considered part of that unit and
       </profiles>
       <categoryLinks>
         <categoryLink id="31c2-f607-8c09-ec8b" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
-        <categoryLink id="f219-feb4-2842-67ad" name="Reinforced Sub-type:" hidden="false" targetId="9b0d-738c-10e4-4ec1" primary="false"/>
+        <categoryLink id="f219-feb4-2842-67ad" name="Reinforced Sub-type" hidden="false" targetId="9b0d-738c-10e4-4ec1" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="ae92-926f-4cc9-a78b" name="May exchange its Hull (Front) Mounted Gravis lascannon for:" hidden="false" collective="false" import="true" defaultSelectionEntryId="a2de-e36e-920f-ed49">
@@ -6569,7 +6569,7 @@ Once assigned to a unit, the Auxilia Medicae is considered part of that unit and
               </constraints>
               <categoryLinks>
                 <categoryLink id="e8b2-5f14-594d-096c" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
-                <categoryLink id="1a71-c891-d71e-b039" name="Reinforced Sub-type:" hidden="false" targetId="9b0d-738c-10e4-4ec1" primary="false"/>
+                <categoryLink id="1a71-c891-d71e-b039" name="Reinforced Sub-type" hidden="false" targetId="9b0d-738c-10e4-4ec1" primary="false"/>
                 <categoryLink name="SA or IM Unit" hidden="false" id="d70a-51d5-e10e-8b01" targetId="4aca-2849-7f41-0200" primary="false"/>
               </categoryLinks>
               <selectionEntryGroups>
@@ -7588,7 +7588,7 @@ Could not find type or subtype &apos;Close Order&apos;</comment>
               </infoLinks>
               <categoryLinks>
                 <categoryLink id="f126-fcd8-a3da-7052" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-                <categoryLink id="ea27-b5c3-6bb1-fb72" name="Automated Artillery Sub-Type" hidden="false" targetId="0faa-1bab-2901-4330" primary="false"/>
+                <categoryLink id="ea27-b5c3-6bb1-fb72" name="Automated Artillery Sub-type" hidden="false" targetId="0faa-1bab-2901-4330" primary="false"/>
                 <categoryLink name="SA or IM Unit" hidden="false" id="215c-9e75-e21f-5cfe" targetId="4aca-2849-7f41-0200" primary="false"/>
               </categoryLinks>
               <selectionEntryGroups>
@@ -7630,7 +7630,7 @@ Could not find type or subtype &apos;Close Order&apos;</comment>
                       </infoLinks>
                       <categoryLinks>
                         <categoryLink id="7cc6-7c1b-0126-7396" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-                        <categoryLink id="e5e1-0a3a-df3f-7aff" name="Heavy Sub-type:" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+                        <categoryLink id="e5e1-0a3a-df3f-7aff" name="Heavy Sub-type" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
                         <categoryLink targetId="6f99-c178-6f9d-fb63" id="25e0-6cd2-458d-86a2" name="Artillery" primary="false"/>
                       </categoryLinks>
                       <selectionEntries>
@@ -7801,7 +7801,7 @@ Could not find type or subtype &apos;Close Order&apos;</comment>
               </infoLinks>
               <categoryLinks>
                 <categoryLink id="0f06-68df-a24d-f08d" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-                <categoryLink id="adbc-da3c-9c32-c931" name="Automated Artillery Sub-Type" hidden="false" targetId="0faa-1bab-2901-4330" primary="false"/>
+                <categoryLink id="adbc-da3c-9c32-c931" name="Automated Artillery Sub-type" hidden="false" targetId="0faa-1bab-2901-4330" primary="false"/>
                 <categoryLink name="SA or IM Unit" hidden="false" id="d22a-8c15-6eab-5aad" targetId="4aca-2849-7f41-0200" primary="false"/>
               </categoryLinks>
               <selectionEntryGroups>
@@ -7940,7 +7940,7 @@ Could not find type or subtype &apos;Close Order&apos;</comment>
     <selectionEntry id="7040-cbf9-ae05-d34f" name="Malcador Heavy Tank Squadron" hidden="false" collective="false" import="true" type="unit">
       <categoryLinks>
         <categoryLink id="599e-e4ee-408f-8006" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
-        <categoryLink id="46f0-6ee0-d708-646e" name="Reinforced Sub-type:" hidden="false" targetId="9b0d-738c-10e4-4ec1" primary="false"/>
+        <categoryLink id="46f0-6ee0-d708-646e" name="Reinforced Sub-type" hidden="false" targetId="9b0d-738c-10e4-4ec1" primary="false"/>
         <categoryLink name="SA or IM Unit" hidden="false" id="a0d9-5a0a-c774-22c4" targetId="4aca-2849-7f41-0200" primary="false"/>
       </categoryLinks>
       <selectionEntries>
@@ -8135,7 +8135,7 @@ Could not find type or subtype &apos;Close Order&apos;</comment>
     <selectionEntry id="c020-7685-ddf4-a10a" name="Armoured Battery" hidden="false" collective="false" import="true" type="unit">
       <categoryLinks>
         <categoryLink id="70e5-c4bd-67d1-48b6" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
-        <categoryLink id="90dd-77e1-f4c9-494a" name="Bombard Sub-type:" hidden="false" targetId="d5df-57ac-8f3c-097b" primary="false"/>
+        <categoryLink id="90dd-77e1-f4c9-494a" name="Bombard Sub-type" hidden="false" targetId="d5df-57ac-8f3c-097b" primary="false"/>
         <categoryLink primary="false" targetId="4aca-2849-7f41-0200" name="SA or IM Unit" id="516f-e476-46d4-b515"/>
       </categoryLinks>
       <selectionEntries>
@@ -8234,7 +8234,7 @@ Could not find type or subtype &apos;Close Order&apos;</comment>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="877d-1506-c333-394d" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
-        <categoryLink id="379b-9b35-3537-5b57" name="Reinforced Sub-type:" hidden="false" targetId="9b0d-738c-10e4-4ec1" primary="false"/>
+        <categoryLink id="379b-9b35-3537-5b57" name="Reinforced Sub-type" hidden="false" targetId="9b0d-738c-10e4-4ec1" primary="false"/>
         <categoryLink name="SA or IM Unit" hidden="false" id="a361-f57a-50f8-e582" targetId="4aca-2849-7f41-0200" primary="false"/>
       </categoryLinks>
       <selectionEntries>
@@ -8375,7 +8375,7 @@ Could not find type or subtype &apos;Close Order&apos;</comment>
     <selectionEntry id="2f8d-70ea-fbb2-53e2" name="Cyclops Demolition Section" hidden="false" collective="false" import="true" type="unit">
       <categoryLinks>
         <categoryLink id="c7a1-846f-70f4-f7dc" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="f39e-e2f9-5ada-4445" name="Heavy Sub-type:" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+        <categoryLink id="f39e-e2f9-5ada-4445" name="Heavy Sub-type" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
         <categoryLink name="SA or IM Unit" hidden="false" id="24a3-4565-5c7a-8d54" targetId="4aca-2849-7f41-0200" primary="false"/>
       </categoryLinks>
       <selectionEntries>
@@ -8576,7 +8576,7 @@ Could not find type or subtype &apos;Close Order&apos;</comment>
     <selectionEntry id="b0a8-0f45-9999-b893" name="Malcador Infernus Squadron" hidden="false" collective="false" import="true" type="unit">
       <categoryLinks>
         <categoryLink id="2be0-c1f0-c1aa-8dee" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
-        <categoryLink id="e099-bd75-a34a-7a25" name="Reinforced Sub-type:" hidden="false" targetId="9b0d-738c-10e4-4ec1" primary="false"/>
+        <categoryLink id="e099-bd75-a34a-7a25" name="Reinforced Sub-type" hidden="false" targetId="9b0d-738c-10e4-4ec1" primary="false"/>
         <categoryLink id="e500-6757-140f-aa62" name="LoW &amp; Primarchs (25% Limit)" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false"/>
         <categoryLink name="SA or IM Unit" hidden="false" id="3071-4407-8b63-f5bb" targetId="4aca-2849-7f41-0200" primary="false"/>
       </categoryLinks>
@@ -8784,7 +8784,7 @@ Could not find type or subtype &apos;Close Order&apos;</comment>
       <categoryLinks>
         <categoryLink id="8103-298f-c2e8-b5b3" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
         <categoryLink id="9141-41d3-5ce3-3abc" name="LoW &amp; Primarchs (25% Limit)" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false"/>
-        <categoryLink id="4e8f-271c-2fd5-7f27" name="Super-heavy Sub-type:" hidden="false" targetId="7381-1130-ca6e-1806" primary="false"/>
+        <categoryLink id="4e8f-271c-2fd5-7f27" name="Super-heavy Sub-type" hidden="false" targetId="7381-1130-ca6e-1806" primary="false"/>
         <categoryLink id="151f-d2f4-bd4f-ee41" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
       </categoryLinks>
       <selectionEntries>
@@ -9270,7 +9270,7 @@ Could not find type or subtype &apos;Close Order&apos;</comment>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="f5e3-7554-5a00-ec73" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
-        <categoryLink id="39b0-c99a-a789-d3d0" name="Transport Sub-type:" hidden="false" targetId="7b0a-a743-a8da-3a39" primary="false"/>
+        <categoryLink id="39b0-c99a-a789-d3d0" name="Transport Sub-type" hidden="false" targetId="7b0a-a743-a8da-3a39" primary="false"/>
         <categoryLink primary="false" targetId="4aca-2849-7f41-0200" name="SA or IM Unit" id="58ae-ad29-4402-95b9"/>
       </categoryLinks>
       <selectionEntries>
@@ -9555,8 +9555,8 @@ If a Weapon Destroyed result is repaired, that weapon may not be used to attack 
                   </infoLinks>
                   <categoryLinks>
                     <categoryLink id="4144-f3f8-f494-3176" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
-                    <categoryLink id="4d49-6dbc-f300-a436" name="Reinforced Sub-type:" hidden="false" targetId="9b0d-738c-10e4-4ec1" primary="false"/>
-                    <categoryLink id="c181-f890-47ac-0eb6" name="Slow Sub-type:" hidden="false" targetId="c4a5-4def-dc2c-7ce2" primary="false"/>
+                    <categoryLink id="4d49-6dbc-f300-a436" name="Reinforced Sub-type" hidden="false" targetId="9b0d-738c-10e4-4ec1" primary="false"/>
+                    <categoryLink id="c181-f890-47ac-0eb6" name="Slow Sub-type" hidden="false" targetId="c4a5-4def-dc2c-7ce2" primary="false"/>
                   </categoryLinks>
                   <selectionEntryGroups>
                     <selectionEntryGroup id="1dba-8542-2187-2bc0" name="May take:" hidden="false" collective="false" import="true">
@@ -9655,8 +9655,8 @@ If a Weapon Destroyed result is repaired, that weapon may not be used to attack 
                   </infoLinks>
                   <categoryLinks>
                     <categoryLink id="b522-f221-0c27-8d1d" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
-                    <categoryLink id="29a7-ec16-c691-3110" name="Reinforced Sub-type:" hidden="false" targetId="9b0d-738c-10e4-4ec1" primary="false"/>
-                    <categoryLink id="a7db-4019-4daa-53ac" name="Slow Sub-type:" hidden="false" targetId="c4a5-4def-dc2c-7ce2" primary="false"/>
+                    <categoryLink id="29a7-ec16-c691-3110" name="Reinforced Sub-type" hidden="false" targetId="9b0d-738c-10e4-4ec1" primary="false"/>
+                    <categoryLink id="a7db-4019-4daa-53ac" name="Slow Sub-type" hidden="false" targetId="c4a5-4def-dc2c-7ce2" primary="false"/>
                   </categoryLinks>
                   <selectionEntryGroups>
                     <selectionEntryGroup id="f368-4516-3e29-eb76" name="May take:" hidden="false" collective="false" import="true">
@@ -9793,8 +9793,8 @@ If a Weapon Destroyed result is repaired, that weapon may not be used to attack 
                   </infoLinks>
                   <categoryLinks>
                     <categoryLink id="d8e3-76eb-a832-de91" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
-                    <categoryLink id="8c1f-3293-8b65-19c8" name="Reinforced Sub-type:" hidden="false" targetId="9b0d-738c-10e4-4ec1" primary="false"/>
-                    <categoryLink id="c87e-3820-c613-7e6f" name="Slow Sub-type:" hidden="false" targetId="c4a5-4def-dc2c-7ce2" primary="false"/>
+                    <categoryLink id="8c1f-3293-8b65-19c8" name="Reinforced Sub-type" hidden="false" targetId="9b0d-738c-10e4-4ec1" primary="false"/>
+                    <categoryLink id="c87e-3820-c613-7e6f" name="Slow Sub-type" hidden="false" targetId="c4a5-4def-dc2c-7ce2" primary="false"/>
                   </categoryLinks>
                   <selectionEntryGroups>
                     <selectionEntryGroup id="1545-5bda-4a1b-892f" name="May take:" hidden="false" collective="false" import="true">
@@ -9889,8 +9889,8 @@ If a Weapon Destroyed result is repaired, that weapon may not be used to attack 
     <selectionEntry id="838e-101d-5501-3261" name="Minotaur Battery" hidden="false" collective="false" import="true" type="unit">
       <categoryLinks>
         <categoryLink id="0d9a-7bc3-a965-032a" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
-        <categoryLink id="ac7f-9374-c266-cd0a" name="Reinforced Sub-type:" hidden="false" targetId="9b0d-738c-10e4-4ec1" primary="false"/>
-        <categoryLink id="a3e7-0f6c-dd72-bb1e" name="Slow Sub-type:" hidden="false" targetId="c4a5-4def-dc2c-7ce2" primary="false"/>
+        <categoryLink id="ac7f-9374-c266-cd0a" name="Reinforced Sub-type" hidden="false" targetId="9b0d-738c-10e4-4ec1" primary="false"/>
+        <categoryLink id="a3e7-0f6c-dd72-bb1e" name="Slow Sub-type" hidden="false" targetId="c4a5-4def-dc2c-7ce2" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="98d0-88df-32dd-7e35" name="Minotaur" hidden="false" collective="false" import="true" type="model">
@@ -9975,7 +9975,7 @@ If a Weapon Destroyed result is repaired, that weapon may not be used to attack 
     <selectionEntry id="e59c-1b65-8de1-4490" name="Macharius Heavy Tank Squadron" hidden="false" collective="false" import="true" type="unit">
       <categoryLinks>
         <categoryLink id="3cf6-cfb2-9cec-19aa" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
-        <categoryLink id="0894-5a2a-e649-9e11" name="Super-heavy Sub-type:" hidden="false" targetId="7381-1130-ca6e-1806" primary="false"/>
+        <categoryLink id="0894-5a2a-e649-9e11" name="Super-heavy Sub-type" hidden="false" targetId="7381-1130-ca6e-1806" primary="false"/>
         <categoryLink id="ef5d-7e4a-3f44-2c74" name="LoW &amp; Primarchs (25% Limit)" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false"/>
       </categoryLinks>
       <selectionEntries>
@@ -10149,7 +10149,7 @@ If a Weapon Destroyed result is repaired, that weapon may not be used to attack 
       <categoryLinks>
         <categoryLink id="de09-1df4-8669-471a" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="ad54-ca78-7edc-a179" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
-        <categoryLink id="69ce-1545-0115-6b4c" name="Super-heavy Sub-type:" hidden="false" targetId="7381-1130-ca6e-1806" primary="false"/>
+        <categoryLink id="69ce-1545-0115-6b4c" name="Super-heavy Sub-type" hidden="false" targetId="7381-1130-ca6e-1806" primary="false"/>
         <categoryLink id="d531-f3df-e669-2625" name="LoW &amp; Primarchs (25% Limit)" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
@@ -10258,7 +10258,7 @@ If a Weapon Destroyed result is repaired, that weapon may not be used to attack 
       <categoryLinks>
         <categoryLink id="19d7-d7c4-347e-ab03" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="f144-30f4-a71a-1ae2" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
-        <categoryLink id="6efd-84a8-f464-cf15" name="Super-heavy Sub-type:" hidden="false" targetId="7381-1130-ca6e-1806" primary="false"/>
+        <categoryLink id="6efd-84a8-f464-cf15" name="Super-heavy Sub-type" hidden="false" targetId="7381-1130-ca6e-1806" primary="false"/>
         <categoryLink id="f0e7-a326-6e7e-379a" name="LoW &amp; Primarchs (25% Limit)" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
@@ -10394,7 +10394,7 @@ If a Weapon Destroyed result is repaired, that weapon may not be used to attack 
       <categoryLinks>
         <categoryLink id="f58f-1579-7361-c081" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="e4ad-1c54-0ec3-d2e9" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
-        <categoryLink id="037c-b14a-bd4d-4165" name="Super-heavy Sub-type:" hidden="false" targetId="7381-1130-ca6e-1806" primary="false"/>
+        <categoryLink id="037c-b14a-bd4d-4165" name="Super-heavy Sub-type" hidden="false" targetId="7381-1130-ca6e-1806" primary="false"/>
         <categoryLink id="ab12-4d4c-d43a-85ae" name="LoW &amp; Primarchs (25% Limit)" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
@@ -10512,8 +10512,8 @@ If a Weapon Destroyed result is repaired, that weapon may not be used to attack 
       <categoryLinks>
         <categoryLink id="c889-d1a9-8e16-1443" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="aed3-b3e9-451c-a98a" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
-        <categoryLink id="ec0b-0bbd-f8e9-c06a" name="Super-heavy Sub-type:" hidden="false" targetId="7381-1130-ca6e-1806" primary="false"/>
-        <categoryLink id="26c6-dd68-7098-6b24" name="Transport Sub-type:" hidden="false" targetId="7b0a-a743-a8da-3a39" primary="false"/>
+        <categoryLink id="ec0b-0bbd-f8e9-c06a" name="Super-heavy Sub-type" hidden="false" targetId="7381-1130-ca6e-1806" primary="false"/>
+        <categoryLink id="26c6-dd68-7098-6b24" name="Transport Sub-type" hidden="false" targetId="7b0a-a743-a8da-3a39" primary="false"/>
         <categoryLink id="a37a-866c-74a7-ff6e" name="LoW &amp; Primarchs (25% Limit)" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
@@ -10622,7 +10622,7 @@ If a Weapon Destroyed result is repaired, that weapon may not be used to attack 
       <categoryLinks>
         <categoryLink id="68fc-594f-9744-6ddc" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="4084-88dc-f96d-60c9" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
-        <categoryLink id="2f9c-4226-7b42-7315" name="Super-heavy Sub-type:" hidden="false" targetId="7381-1130-ca6e-1806" primary="false"/>
+        <categoryLink id="2f9c-4226-7b42-7315" name="Super-heavy Sub-type" hidden="false" targetId="7381-1130-ca6e-1806" primary="false"/>
         <categoryLink id="73f8-ec6c-d95f-2590" name="LoW &amp; Primarchs (25% Limit)" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
@@ -10739,7 +10739,7 @@ If a Weapon Destroyed result is repaired, that weapon may not be used to attack 
       <categoryLinks>
         <categoryLink id="bc40-3790-05be-92af" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="8b0f-4a5b-5b79-4889" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
-        <categoryLink id="64f9-5968-2846-c2dd" name="Super-heavy Sub-type:" hidden="false" targetId="7381-1130-ca6e-1806" primary="false"/>
+        <categoryLink id="64f9-5968-2846-c2dd" name="Super-heavy Sub-type" hidden="false" targetId="7381-1130-ca6e-1806" primary="false"/>
         <categoryLink id="430e-9dcd-57a4-c158" name="LoW &amp; Primarchs (25% Limit)" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
@@ -10868,7 +10868,7 @@ If a Weapon Destroyed result is repaired, that weapon may not be used to attack 
       <categoryLinks>
         <categoryLink id="b18b-0269-2997-701b" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
         <categoryLink id="292c-2ba6-1ffe-edf3" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
-        <categoryLink id="68b3-c9fb-8111-8174" name="Super-heavy Sub-type:" hidden="false" targetId="7381-1130-ca6e-1806" primary="false"/>
+        <categoryLink id="68b3-c9fb-8111-8174" name="Super-heavy Sub-type" hidden="false" targetId="7381-1130-ca6e-1806" primary="false"/>
         <categoryLink id="ee2c-9ed9-6d30-f2f7" name="LoW &amp; Primarchs (25% Limit)" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false"/>
       </categoryLinks>
       <selectionEntries>
@@ -10967,8 +10967,8 @@ If a Weapon Destroyed result is repaired, that weapon may not be used to attack 
     </selectionEntry>
     <selectionEntry id="8cec-2913-77a0-c4e4" name="Crassus Armoured Assault Transport" hidden="false" collective="false" import="true" type="unit">
       <categoryLinks>
-        <categoryLink id="6e85-cf68-151f-a77a" name="Transport Sub-type:" hidden="false" targetId="7b0a-a743-a8da-3a39" primary="false"/>
-        <categoryLink id="97e6-b9cf-c1f9-798c" name="Super-heavy Sub-type:" hidden="false" targetId="7381-1130-ca6e-1806" primary="false"/>
+        <categoryLink id="6e85-cf68-151f-a77a" name="Transport Sub-type" hidden="false" targetId="7b0a-a743-a8da-3a39" primary="false"/>
+        <categoryLink id="97e6-b9cf-c1f9-798c" name="Super-heavy Sub-type" hidden="false" targetId="7381-1130-ca6e-1806" primary="false"/>
         <categoryLink id="bd8e-77b3-327b-2d75" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink id="5d63-23f1-06ba-ecf7" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
         <categoryLink id="3963-6e6a-dbb0-a0f5" name="LoW &amp; Primarchs (25% Limit)" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false"/>
@@ -11070,7 +11070,7 @@ If a Weapon Destroyed result is repaired, that weapon may not be used to attack 
     </selectionEntry>
     <selectionEntry id="2f28-4a7d-bc90-589b" name="Artillery Battery" hidden="false" collective="false" import="true" type="unit">
       <categoryLinks>
-        <categoryLink id="9464-ef7e-aae6-f5bf" name="Heavy Sub-type:" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+        <categoryLink id="9464-ef7e-aae6-f5bf" name="Heavy Sub-type" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
         <categoryLink id="6245-19c4-15bc-896e" name="Static Artillery" hidden="false" targetId="19f3-8727-02db-3ce5" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>

--- a/2022 - Mech Library.cat
+++ b/2022 - Mech Library.cat
@@ -1259,7 +1259,7 @@ Invulnerable Saves granted by a mag-inverter shield do not stack with other Invu
           </infoLinks>
           <categoryLinks>
             <categoryLink id="75c6-f54e-a02e-e590" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
-            <categoryLink id="e91e-b235-f4d0-bc52" name="Fast Sub-type:" hidden="false" targetId="0ea2-efb5-b7af-226e" primary="false"/>
+            <categoryLink id="e91e-b235-f4d0-bc52" name="Fast Sub-type" hidden="false" targetId="0ea2-efb5-b7af-226e" primary="false"/>
             <categoryLink targetId="4280-2d8-16c6-d60b" id="0fb5-56c3-4439-be41" name="Titan" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
@@ -1790,8 +1790,8 @@ Invulnerable Saves granted by a mag-inverter shield do not stack with other Invu
     </selectionEntry>
     <selectionEntry id="bd5d-61fa-d2f6-45a2" name="Armiger Helverin Talon" publicationId="bde1-6db1-163b-3b76" page="77" hidden="false" collective="false" import="true" type="unit">
       <categoryLinks>
-        <categoryLink id="38cf-c6b2-0439-f97e" name="Line Sub-type:" hidden="false" targetId="6399-5c65-7833-1025" primary="false"/>
-        <categoryLink id="becc-46dc-f49b-4272" name="Skirmish Sub-type:" hidden="false" targetId="59a4-7b61-600a-c457" primary="false"/>
+        <categoryLink id="38cf-c6b2-0439-f97e" name="Line Sub-type" hidden="false" targetId="6399-5c65-7833-1025" primary="false"/>
+        <categoryLink id="becc-46dc-f49b-4272" name="Skirmish Sub-type" hidden="false" targetId="59a4-7b61-600a-c457" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="488a-c9e1-0b4f-5349" name="Armiger Helverin" publicationId="bde1-6db1-163b-3b76" page="77" hidden="false" collective="false" import="true" type="upgrade">
@@ -1913,8 +1913,8 @@ Invulnerable Saves granted by a mag-inverter shield do not stack with other Invu
     </selectionEntry>
     <selectionEntry id="df92-71d6-bf1a-d62e" name="Armiger Warglaive Talon" publicationId="bde1-6db1-163b-3b76" page="76" hidden="false" collective="false" import="true" type="unit">
       <categoryLinks>
-        <categoryLink id="039c-067d-bcb0-4af7" name="Line Sub-type:" hidden="false" targetId="6399-5c65-7833-1025" primary="false"/>
-        <categoryLink id="d253-48d8-cdf3-0cdb" name="Skirmish Sub-type:" hidden="false" targetId="59a4-7b61-600a-c457" primary="false"/>
+        <categoryLink id="039c-067d-bcb0-4af7" name="Line Sub-type" hidden="false" targetId="6399-5c65-7833-1025" primary="false"/>
+        <categoryLink id="d253-48d8-cdf3-0cdb" name="Skirmish Sub-type" hidden="false" targetId="59a4-7b61-600a-c457" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="0670-d7df-534f-4c84" name="Armiger Warglaive" publicationId="bde1-6db1-163b-3b76" page="76" hidden="false" collective="false" import="true" type="upgrade">
@@ -4298,8 +4298,8 @@ Invulnerable Saves granted by a mag-inverter shield do not stack with other Invu
     </selectionEntry>
     <selectionEntry id="537f-846d-90e3-2526" name="Castellax Battle-Automata Maniple" publicationId="bde1-6db1-163b-3b76" page="37" hidden="false" collective="false" import="true" type="unit">
       <categoryLinks>
-        <categoryLink id="5cd5-6009-fe69-4b41" name="Automata Unit-type:" hidden="false" targetId="d8ab-8e21-e193-63ba" primary="false"/>
-        <categoryLink id="df13-6b0d-fd20-dd68" name="Cybernetica Sub-type:" hidden="false" targetId="2440-b64e-cb24-87f0" primary="false"/>
+        <categoryLink id="5cd5-6009-fe69-4b41" name="Automata Unit Type" hidden="false" targetId="d8ab-8e21-e193-63ba" primary="false"/>
+        <categoryLink id="df13-6b0d-fd20-dd68" name="Cybernetica Sub-type" hidden="false" targetId="2440-b64e-cb24-87f0" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="ab78-91e2-bb5c-9da3" name="Castellax" publicationId="bde1-6db1-163b-3b76" page="37" hidden="false" collective="false" import="true" type="model">
@@ -4643,8 +4643,8 @@ Invulnerable Saves granted by a mag-inverter shield do not stack with other Invu
     </selectionEntry>
     <selectionEntry id="1a1b-fa35-a6a2-ca78" name="Domitar Battle-Automata Maniple" publicationId="bde1-6db1-163b-3b76" page="31" hidden="false" collective="false" import="true" type="unit">
       <categoryLinks>
-        <categoryLink id="80b1-ecda-9fbc-d9bd" name="Automata Unit-type:" hidden="false" targetId="d8ab-8e21-e193-63ba" primary="false"/>
-        <categoryLink id="abca-590e-bde7-fa3a" name="Cybernetica Sub-type:" hidden="false" targetId="2440-b64e-cb24-87f0" primary="false"/>
+        <categoryLink id="80b1-ecda-9fbc-d9bd" name="Automata Unit Type" hidden="false" targetId="d8ab-8e21-e193-63ba" primary="false"/>
+        <categoryLink id="abca-590e-bde7-fa3a" name="Cybernetica Sub-type" hidden="false" targetId="2440-b64e-cb24-87f0" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="200f-3379-95a3-c3a4" name="Domitar" hidden="false" collective="false" import="true" type="model">
@@ -4976,9 +4976,9 @@ Invulnerable Saves granted by a mag-inverter shield do not stack with other Invu
         <constraint field="selections" scope="force" value="-1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ed02-9ebb-5829-d554" type="max"/>
       </constraints>
       <categoryLinks>
-        <categoryLink id="d13c-fa11-113a-6b4b" name="Automata Unit-type:" hidden="false" targetId="d8ab-8e21-e193-63ba" primary="false"/>
-        <categoryLink id="ae51-75de-b9f6-61c2" name="Cybernetica Sub-type:" hidden="false" targetId="2440-b64e-cb24-87f0" primary="false"/>
-        <categoryLink id="0f64-8711-75d2-ad9b" name="Heavy Sub-type:" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+        <categoryLink id="d13c-fa11-113a-6b4b" name="Automata Unit Type" hidden="false" targetId="d8ab-8e21-e193-63ba" primary="false"/>
+        <categoryLink id="ae51-75de-b9f6-61c2" name="Cybernetica Sub-type" hidden="false" targetId="2440-b64e-cb24-87f0" primary="false"/>
+        <categoryLink id="0f64-8711-75d2-ad9b" name="Heavy Sub-type" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="c48e-f9ea-9d9d-46aa" name="Thanatar" publicationId="bde1-6db1-163b-3b76" page="46" hidden="false" collective="false" import="true" type="model">
@@ -5254,9 +5254,9 @@ Invulnerable Saves granted by a mag-inverter shield do not stack with other Invu
     </selectionEntry>
     <selectionEntry id="f144-1079-11ff-019d" name="Vorax Battle-automata Maniple" publicationId="bde1-6db1-163b-3b76" page="42" hidden="false" collective="false" import="true" type="unit">
       <categoryLinks>
-        <categoryLink id="1779-4c37-6c7f-b6ea" name="Automata Unit-type:" hidden="false" targetId="d8ab-8e21-e193-63ba" primary="false"/>
-        <categoryLink id="da80-a4b4-47a6-5c31" name="Cybernetica Sub-type:" hidden="false" targetId="2440-b64e-cb24-87f0" primary="false"/>
-        <categoryLink id="e468-fb52-fd0d-7af6" name="Light Sub-type:" hidden="false" targetId="bff2-ae16-74a8-8712" primary="false"/>
+        <categoryLink id="1779-4c37-6c7f-b6ea" name="Automata Unit Type" hidden="false" targetId="d8ab-8e21-e193-63ba" primary="false"/>
+        <categoryLink id="da80-a4b4-47a6-5c31" name="Cybernetica Sub-type" hidden="false" targetId="2440-b64e-cb24-87f0" primary="false"/>
+        <categoryLink id="e468-fb52-fd0d-7af6" name="Light Sub-type" hidden="false" targetId="bff2-ae16-74a8-8712" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="6711-d580-b463-bc7e" name="Vorax" publicationId="bde1-6db1-163b-3b76" page="42" hidden="false" collective="false" import="true" type="model">
@@ -6315,7 +6315,7 @@ A unit composed entirely of models with Utan jump boosters may not Run. During R
     <selectionEntry id="25c8-3e0f-e22d-a7eb" name="Thallax Cohort" publicationId="bde1-6db1-163b-3b76" page="35" hidden="false" collective="false" import="true" type="unit">
       <categoryLinks>
         <categoryLink id="1658-ac7c-537e-4524" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="4fae-7dfa-1556-c875" name="Line Sub-type:" hidden="false" targetId="6399-5c65-7833-1025" primary="false"/>
+        <categoryLink id="4fae-7dfa-1556-c875" name="Line Sub-type" hidden="false" targetId="6399-5c65-7833-1025" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="acc0-4cf8-5c18-a8d1" name="Thallax" publicationId="bde1-6db1-163b-3b76" page="35" hidden="false" collective="false" import="true" type="model">
@@ -6877,7 +6877,7 @@ A unit composed entirely of models with Utan jump boosters may not Run. During R
     <selectionEntry type="unit" import="true" name="Blood Slaughterer" hidden="false" id="2d70-676d-68aa-1973" publicationId="6bcf-2297-2bcd-51be" page="13">
       <categoryLinks>
         <categoryLink targetId="a443-dbf4-cb6c-4da1" id="af0-7a45-f939-713b" primary="false" name="Corrupted Engine Sub-type"/>
-        <categoryLink targetId="4280-4963-02b5-e31d" id="7fdd-1633-d072-3977" primary="false" name="Dreadnought Unit-type:"/>
+        <categoryLink targetId="4280-4963-02b5-e31d" id="7fdd-1633-d072-3977" primary="false" name="Dreadnought Unit Type"/>
         <categoryLink targetId="20ef-cd01-a8da-376e" id="26a0-1087-70ac-206c" primary="true" name="Fast Attack:"/>
         <categoryLink targetId="3c75-d5f8-1ad4-24e5" id="16e6-99f9-975e-c247" primary="false" name="Compulsory Fast Attack:"/>
         <categoryLink targetId="f074-f60a-9aa6-c52a" id="1f3b-bc68-b474-2154" primary="false" name="Heedless Slaughter"/>
@@ -7017,9 +7017,9 @@ A unit composed entirely of models with Utan jump boosters may not Run. During R
     <selectionEntry type="unit" import="true" name="Decimator" hidden="false" id="b1a5-42a-a6ee-2223" publicationId="6bcf-2297-2bcd-51be" page="14">
       <categoryLinks>
         <categoryLink targetId="a443-dbf4-cb6c-4da1" id="9ff1-2e56-f502-d653" primary="false" name="Corrupted Engine Sub-type"/>
-        <categoryLink targetId="4280-4963-02b5-e31d" id="527f-7bcf-e17a-4a0b" primary="false" name="Dreadnought Unit-type:"/>
+        <categoryLink targetId="4280-4963-02b5-e31d" id="527f-7bcf-e17a-4a0b" primary="false" name="Dreadnought Unit Type"/>
         <categoryLink targetId="7031-469a-1aeb-eab0" id="5e43-52a1-b262-7d22" primary="true" name="Heavy Support:"/>
-        <categoryLink targetId="9231-183c-b97b-63f9" id="4b4c-beca-7b8e-2a07" primary="false" name="Heavy Sub-type:"/>
+        <categoryLink targetId="9231-183c-b97b-63f9" id="4b4c-beca-7b8e-2a07" primary="false" name="Heavy Sub-type"/>
         <categoryLink targetId="030f-3801-4f54-e7f8" id="d660-2b02-63a4-3154" primary="false" name="Compulsory Heavy Support:"/>
         <categoryLink targetId="bcf6-8350-9099-1e91" id="558f-4a2c-c0c3-df0" primary="false" name="Malevolent Artifice"/>
       </categoryLinks>

--- a/2022 - Mech Library.cat
+++ b/2022 - Mech Library.cat
@@ -652,7 +652,7 @@ Cruel Taskmaster – If any friendly unit with at least one model within 12&quot
         </infoLink>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="535d-121f-5839-a712" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="535d-121f-5839-a712" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="ab7c-4dce-52a0-3b2a" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
         <categoryLink id="ca1a-d504-80f8-2b44" name="Cybertheurgist" hidden="false" targetId="57a1-ae47-ff1b-36e4" primary="false"/>
       </categoryLinks>
@@ -905,7 +905,7 @@ Invulnerable Saves granted by a mag-inverter shield do not stack with other Invu
           </infoLinks>
           <categoryLinks>
             <categoryLink id="8f20-9c8d-f873-27e3" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
-            <categoryLink targetId="4280-2d8-16c6-d60b" id="8e9f-b564-418e-bbce" name="Titan" primary="false"/>
+            <categoryLink targetId="4280-2d8-16c6-d60b" id="8e9f-b564-418e-bbce" name="Titan Sub-type" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="4bd0-7503-e4af-d39d" name="Left Arm Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="a056-17b7-f14b-85e8">
@@ -1043,7 +1043,7 @@ Invulnerable Saves granted by a mag-inverter shield do not stack with other Invu
           </infoLinks>
           <categoryLinks>
             <categoryLink id="f66b-4dee-d200-9691" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
-            <categoryLink targetId="4280-2d8-16c6-d60b" id="4c4b-ba4e-453c-a0b1" name="Titan" primary="false"/>
+            <categoryLink targetId="4280-2d8-16c6-d60b" id="4c4b-ba4e-453c-a0b1" name="Titan Sub-type" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="9fdb-9757-b9d8-f13f" name="Left Arm Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="12a0-894b-9d31-af12">
@@ -1260,7 +1260,7 @@ Invulnerable Saves granted by a mag-inverter shield do not stack with other Invu
           <categoryLinks>
             <categoryLink id="75c6-f54e-a02e-e590" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
             <categoryLink id="e91e-b235-f4d0-bc52" name="Fast Sub-type" hidden="false" targetId="0ea2-efb5-b7af-226e" primary="false"/>
-            <categoryLink targetId="4280-2d8-16c6-d60b" id="0fb5-56c3-4439-be41" name="Titan" primary="false"/>
+            <categoryLink targetId="4280-2d8-16c6-d60b" id="0fb5-56c3-4439-be41" name="Titan Sub-type" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="9421-2b5c-e5f4-6029" name="Left Arm Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="d7e1-874e-679e-bb26">
@@ -1387,7 +1387,7 @@ Invulnerable Saves granted by a mag-inverter shield do not stack with other Invu
           </infoLinks>
           <categoryLinks>
             <categoryLink id="baca-62ce-c351-565d" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
-            <categoryLink targetId="4280-2d8-16c6-d60b" id="0ffc-72e3-47db-829a" name="Titan" primary="false"/>
+            <categoryLink targetId="4280-2d8-16c6-d60b" id="0ffc-72e3-47db-829a" name="Titan Sub-type" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="4eb8-020c-c441-cfe5" name="Left Arm Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="baf6-5b24-9ff5-36fc">
@@ -4535,8 +4535,8 @@ Invulnerable Saves granted by a mag-inverter shield do not stack with other Invu
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="85"/>
           </costs>
           <categoryLinks>
-            <categoryLink targetId="d8ab-8e21-e193-63ba" id="be9c-9e1a-4b2b-ad73" name="Automata" primary="false"/>
-            <categoryLink targetId="2440-b64e-cb24-87f0" id="f457-42c5-48b1-b774" name="Cybernetica" primary="false"/>
+            <categoryLink targetId="d8ab-8e21-e193-63ba" id="be9c-9e1a-4b2b-ad73" name="Automata Unit Type" primary="false"/>
+            <categoryLink targetId="2440-b64e-cb24-87f0" id="f457-42c5-48b1-b774" name="Cybernetica Sub-type" primary="false"/>
           </categoryLinks>
         </selectionEntry>
       </selectionEntries>
@@ -4774,8 +4774,8 @@ Invulnerable Saves granted by a mag-inverter shield do not stack with other Invu
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="130"/>
           </costs>
           <categoryLinks>
-            <categoryLink targetId="d8ab-8e21-e193-63ba" id="dc0d-2e59-4dd2-937b" name="Automata" primary="false"/>
-            <categoryLink targetId="2440-b64e-cb24-87f0" id="6a4b-c42d-4a4f-8139" name="Cybernetica" primary="false"/>
+            <categoryLink targetId="d8ab-8e21-e193-63ba" id="dc0d-2e59-4dd2-937b" name="Automata Unit Type" primary="false"/>
+            <categoryLink targetId="2440-b64e-cb24-87f0" id="6a4b-c42d-4a4f-8139" name="Cybernetica Sub-type" primary="false"/>
           </categoryLinks>
         </selectionEntry>
       </selectionEntries>
@@ -5351,9 +5351,9 @@ Invulnerable Saves granted by a mag-inverter shield do not stack with other Invu
             </entryLink>
           </entryLinks>
           <categoryLinks>
-            <categoryLink targetId="d8ab-8e21-e193-63ba" id="8c90-6098-48f0-a483" name="Automata" primary="false"/>
-            <categoryLink targetId="2440-b64e-cb24-87f0" id="3c99-a64c-4798-88d4" name="Cybernetica" primary="false"/>
-            <categoryLink targetId="bff2-ae16-74a8-8712" id="644d-802c-40b4-b32e" name="Light" primary="false"/>
+            <categoryLink targetId="d8ab-8e21-e193-63ba" id="8c90-6098-48f0-a483" name="Automata Unit Type" primary="false"/>
+            <categoryLink targetId="2440-b64e-cb24-87f0" id="3c99-a64c-4798-88d4" name="Cybernetica Sub-type" primary="false"/>
+            <categoryLink targetId="bff2-ae16-74a8-8712" id="644d-802c-40b4-b32e" name="Light Sub-type" primary="false"/>
           </categoryLinks>
         </selectionEntry>
         <selectionEntry id="cff3-2ddf-4024-f463" name="Two Power Blade Arrays with In-Built Rotar Cannons" hidden="false" collective="false" import="true" type="upgrade">
@@ -6314,7 +6314,7 @@ A unit composed entirely of models with Utan jump boosters may not Run. During R
     </selectionEntry>
     <selectionEntry id="25c8-3e0f-e22d-a7eb" name="Thallax Cohort" publicationId="bde1-6db1-163b-3b76" page="35" hidden="false" collective="false" import="true" type="unit">
       <categoryLinks>
-        <categoryLink id="1658-ac7c-537e-4524" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="1658-ac7c-537e-4524" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="4fae-7dfa-1556-c875" name="Line Sub-type" hidden="false" targetId="6399-5c65-7833-1025" primary="false"/>
       </categoryLinks>
       <selectionEntries>
@@ -6375,8 +6375,8 @@ A unit composed entirely of models with Utan jump boosters may not Run. During R
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="37"/>
           </costs>
           <categoryLinks>
-            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="629a-187b-4fc4-9b9e" name="Infantry" primary="false"/>
-            <categoryLink targetId="6399-5c65-7833-1025" id="96ce-05df-4a30-8730" name="Line" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="629a-187b-4fc4-9b9e" name="Infantry Unit Type" primary="false"/>
+            <categoryLink targetId="6399-5c65-7833-1025" id="96ce-05df-4a30-8730" name="Line Sub-type" primary="false"/>
           </categoryLinks>
         </selectionEntry>
       </selectionEntries>
@@ -7001,8 +7001,8 @@ A unit composed entirely of models with Utan jump boosters may not Run. During R
             </entryLink>
           </entryLinks>
           <categoryLinks>
-            <categoryLink targetId="4280-4963-02b5-e31d" id="5ae3-42e9-4737-8d29" name="Dreadnought" primary="false"/>
-            <categoryLink targetId="a443-dbf4-cb6c-4da1" id="0e34-859c-4416-814b" name="Corrupted Engine" primary="false"/>
+            <categoryLink targetId="4280-4963-02b5-e31d" id="5ae3-42e9-4737-8d29" name="Dreadnought Unit Type" primary="false"/>
+            <categoryLink targetId="a443-dbf4-cb6c-4da1" id="0e34-859c-4416-814b" name="Corrupted Engine Sub-type" primary="false"/>
           </categoryLinks>
         </selectionEntry>
       </selectionEntries>

--- a/2022 - Mech Library.cat
+++ b/2022 - Mech Library.cat
@@ -905,6 +905,7 @@ Invulnerable Saves granted by a mag-inverter shield do not stack with other Invu
           </infoLinks>
           <categoryLinks>
             <categoryLink id="8f20-9c8d-f873-27e3" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+            <categoryLink targetId="4280-2d8-16c6-d60b" id="8e9f-b564-418e-bbce" name="Titan" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="4bd0-7503-e4af-d39d" name="Left Arm Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="a056-17b7-f14b-85e8">
@@ -1042,6 +1043,7 @@ Invulnerable Saves granted by a mag-inverter shield do not stack with other Invu
           </infoLinks>
           <categoryLinks>
             <categoryLink id="f66b-4dee-d200-9691" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+            <categoryLink targetId="4280-2d8-16c6-d60b" id="4c4b-ba4e-453c-a0b1" name="Titan" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="9fdb-9757-b9d8-f13f" name="Left Arm Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="12a0-894b-9d31-af12">
@@ -1258,6 +1260,7 @@ Invulnerable Saves granted by a mag-inverter shield do not stack with other Invu
           <categoryLinks>
             <categoryLink id="75c6-f54e-a02e-e590" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
             <categoryLink id="e91e-b235-f4d0-bc52" name="Fast Sub-type:" hidden="false" targetId="0ea2-efb5-b7af-226e" primary="false"/>
+            <categoryLink targetId="4280-2d8-16c6-d60b" id="0fb5-56c3-4439-be41" name="Titan" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="9421-2b5c-e5f4-6029" name="Left Arm Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="d7e1-874e-679e-bb26">
@@ -1384,6 +1387,7 @@ Invulnerable Saves granted by a mag-inverter shield do not stack with other Invu
           </infoLinks>
           <categoryLinks>
             <categoryLink id="baca-62ce-c351-565d" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+            <categoryLink targetId="4280-2d8-16c6-d60b" id="0ffc-72e3-47db-829a" name="Titan" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="4eb8-020c-c441-cfe5" name="Left Arm Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="baf6-5b24-9ff5-36fc">
@@ -4530,6 +4534,10 @@ Invulnerable Saves granted by a mag-inverter shield do not stack with other Invu
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="85"/>
           </costs>
+          <categoryLinks>
+            <categoryLink targetId="d8ab-8e21-e193-63ba" id="be9c-9e1a-4b2b-ad73" name="Automata" primary="false"/>
+            <categoryLink targetId="2440-b64e-cb24-87f0" id="f457-42c5-48b1-b774" name="Cybernetica" primary="false"/>
+          </categoryLinks>
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
@@ -4765,6 +4773,10 @@ Invulnerable Saves granted by a mag-inverter shield do not stack with other Invu
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="130"/>
           </costs>
+          <categoryLinks>
+            <categoryLink targetId="d8ab-8e21-e193-63ba" id="dc0d-2e59-4dd2-937b" name="Automata" primary="false"/>
+            <categoryLink targetId="2440-b64e-cb24-87f0" id="6a4b-c42d-4a4f-8139" name="Cybernetica" primary="false"/>
+          </categoryLinks>
         </selectionEntry>
       </selectionEntries>
       <costs>
@@ -5338,6 +5350,11 @@ Invulnerable Saves granted by a mag-inverter shield do not stack with other Invu
               </constraints>
             </entryLink>
           </entryLinks>
+          <categoryLinks>
+            <categoryLink targetId="d8ab-8e21-e193-63ba" id="8c90-6098-48f0-a483" name="Automata" primary="false"/>
+            <categoryLink targetId="2440-b64e-cb24-87f0" id="3c99-a64c-4798-88d4" name="Cybernetica" primary="false"/>
+            <categoryLink targetId="bff2-ae16-74a8-8712" id="644d-802c-40b4-b32e" name="Light" primary="false"/>
+          </categoryLinks>
         </selectionEntry>
         <selectionEntry id="cff3-2ddf-4024-f463" name="Two Power Blade Arrays with In-Built Rotar Cannons" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
@@ -6357,6 +6374,10 @@ A unit composed entirely of models with Utan jump boosters may not Run. During R
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="37"/>
           </costs>
+          <categoryLinks>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="629a-187b-4fc4-9b9e" name="Infantry" primary="false"/>
+            <categoryLink targetId="6399-5c65-7833-1025" id="96ce-05df-4a30-8730" name="Line" primary="false"/>
+          </categoryLinks>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
@@ -6979,6 +7000,10 @@ A unit composed entirely of models with Utan jump boosters may not Run. During R
               </constraints>
             </entryLink>
           </entryLinks>
+          <categoryLinks>
+            <categoryLink targetId="4280-4963-02b5-e31d" id="5ae3-42e9-4737-8d29" name="Dreadnought" primary="false"/>
+            <categoryLink targetId="a443-dbf4-cb6c-4da1" id="0e34-859c-4416-814b" name="Corrupted Engine" primary="false"/>
+          </categoryLinks>
         </selectionEntry>
       </selectionEntries>
       <modifiers>

--- a/2022 - Mechanicum.cat
+++ b/2022 - Mechanicum.cat
@@ -998,7 +998,7 @@
       </infoLinks>
       <categoryLinks>
         <categoryLink id="8bf8-9627-3e73-b8bc" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
-        <categoryLink id="6a96-9d2f-a329-7562" name="Monstrous Sub-type:" hidden="false" targetId="7d95-f9d1-440a-67bd" primary="false"/>
+        <categoryLink id="6a96-9d2f-a329-7562" name="Monstrous Sub-type" hidden="false" targetId="7d95-f9d1-440a-67bd" primary="false"/>
         <categoryLink id="ff95-2620-6ec4-9e60" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="4699-a334-97a9-2479" name="Feudal Hierarchy (On Abeyant)" hidden="false" targetId="4c2b-03e9-abb7-7209" primary="false"/>
       </categoryLinks>
@@ -1253,7 +1253,7 @@
       <categoryLinks>
         <categoryLink id="4312-d152-9e2a-c653" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
         <categoryLink id="176d-fff6-f157-330a" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="a16c-e7f6-08fc-a357" name="Heavy Sub-type:" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+        <categoryLink id="a16c-e7f6-08fc-a357" name="Heavy Sub-type" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="0cae-ba4f-f97c-5f0f" name="May take any of the following options:" hidden="false" collective="false" import="true">
@@ -1483,9 +1483,9 @@
       </infoLinks>
       <categoryLinks>
         <categoryLink id="7d92-0210-bdb9-cd3a" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
-        <categoryLink id="8595-f4c5-ba1d-69b5" name="Monstrous Sub-type:" hidden="false" targetId="7d95-f9d1-440a-67bd" primary="false"/>
+        <categoryLink id="8595-f4c5-ba1d-69b5" name="Monstrous Sub-type" hidden="false" targetId="7d95-f9d1-440a-67bd" primary="false"/>
         <categoryLink id="f75f-bd69-3fb1-c37d" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="ad3f-ad1c-6a50-2d8c" name="Heavy Sub-type:" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+        <categoryLink id="ad3f-ad1c-6a50-2d8c" name="Heavy Sub-type" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="14fc-6747-0f45-1075" name="May take one of the following options:" hidden="false" collective="false" import="true">
@@ -1829,7 +1829,7 @@
     </selectionEntry>
     <selectionEntry id="0eae-0c52-1087-a3b0" name="Tech-Priest Auxilia" publicationId="bde1-6db1-163b-3b76" page="28" hidden="false" collective="false" import="true" type="unit">
       <categoryLinks>
-        <categoryLink id="0f49-7308-c6f1-e967" name="Line Sub-type:" hidden="false" targetId="6399-5c65-7833-1025" primary="false"/>
+        <categoryLink id="0f49-7308-c6f1-e967" name="Line Sub-type" hidden="false" targetId="6399-5c65-7833-1025" primary="false"/>
         <categoryLink targetId="86dd-51d8-3669-68ca" id="2b8b-9a5c-efda-9e8b" primary="false" name="Tech-Priest Auxilia"/>
       </categoryLinks>
       <selectionEntries>
@@ -2207,7 +2207,7 @@
             </infoLink>
           </infoLinks>
           <categoryLinks>
-            <categoryLink id="0811-7d31-715c-ef42" name="Automata Unit-type:" hidden="false" targetId="d8ab-8e21-e193-63ba" primary="false"/>
+            <categoryLink id="0811-7d31-715c-ef42" name="Automata Unit Type" hidden="false" targetId="d8ab-8e21-e193-63ba" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="5d44-26bf-c747-c100" name="Any Servo-automata may take one of the following:" hidden="false" collective="false" import="true">
@@ -2636,7 +2636,7 @@ This unit may be upgraded freely as described in their profile, though they may 
     <selectionEntry id="1869-2d16-d825-04c3" name="Myrmidon Secutor Host" publicationId="bde1-6db1-163b-3b76" page="32" hidden="false" collective="false" import="true" type="unit">
       <categoryLinks>
         <categoryLink id="524b-df9c-a50f-7103" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="f7bb-798d-a14e-4915" name="Heavy Sub-type:" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+        <categoryLink id="f7bb-798d-a14e-4915" name="Heavy Sub-type" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="33d3-7ec5-ef32-38ca" name="Myrmidon Secutors" publicationId="bde1-6db1-163b-3b76" page="32" hidden="false" collective="false" import="true" type="model">
@@ -2844,8 +2844,8 @@ This unit may be upgraded freely as described in their profile, though they may 
     </selectionEntry>
     <selectionEntry id="bc2c-076a-209b-f121" name="Adsecularis Tech-thralls Covenant" publicationId="bde1-6db1-163b-3b76" page="34" hidden="false" collective="false" import="true" type="unit">
       <categoryLinks>
-        <categoryLink id="8ee7-e36b-9a79-6998" name="Heavy Sub-type:" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
-        <categoryLink id="2d6d-c8c5-9da8-958a" name="Line Sub-type:" hidden="false" targetId="6399-5c65-7833-1025" primary="false"/>
+        <categoryLink id="8ee7-e36b-9a79-6998" name="Heavy Sub-type" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+        <categoryLink id="2d6d-c8c5-9da8-958a" name="Line Sub-type" hidden="false" targetId="6399-5c65-7833-1025" primary="false"/>
         <categoryLink id="09f4-c088-2ec8-fac3" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
       </categoryLinks>
       <selectionEntries>
@@ -2944,9 +2944,9 @@ This unit may be upgraded freely as described in their profile, though they may 
     </selectionEntry>
     <selectionEntry id="57ab-2409-6707-b967" name="Scyllax Guardian-Automata Maniple" publicationId="bde1-6db1-163b-3b76" page="36" hidden="false" collective="false" import="true" type="unit">
       <categoryLinks>
-        <categoryLink id="07b9-a447-feb6-8bfe" name="Heavy Sub-type:" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
-        <categoryLink id="807c-edb4-9721-da11" name="Line Sub-type:" hidden="false" targetId="6399-5c65-7833-1025" primary="false"/>
-        <categoryLink id="e3b7-cbc5-ca8e-80e2" name="Automata Unit-type:" hidden="false" targetId="d8ab-8e21-e193-63ba" primary="false"/>
+        <categoryLink id="07b9-a447-feb6-8bfe" name="Heavy Sub-type" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+        <categoryLink id="807c-edb4-9721-da11" name="Line Sub-type" hidden="false" targetId="6399-5c65-7833-1025" primary="false"/>
+        <categoryLink id="e3b7-cbc5-ca8e-80e2" name="Automata Unit Type" hidden="false" targetId="d8ab-8e21-e193-63ba" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="b707-5b11-0c1c-e5a1" name="Scyllax" publicationId="bde1-6db1-163b-3b76" page="36" hidden="false" collective="false" import="true" type="model">
@@ -3206,8 +3206,8 @@ Could not find type or subtype &apos;Guardian&apos;</comment>
     </selectionEntry>
     <selectionEntry id="b178-7d35-136f-d305" name="Arlatax Battle-Automata Maniple" publicationId="bde1-6db1-163b-3b76" page="40" hidden="false" collective="false" import="true" type="unit">
       <categoryLinks>
-        <categoryLink id="891f-df7d-04cb-caf1" name="Automata Unit-type:" hidden="false" targetId="d8ab-8e21-e193-63ba" primary="false"/>
-        <categoryLink id="f9ac-c447-beb5-ba0f" name="Cybernetica Sub-type:" hidden="false" targetId="2440-b64e-cb24-87f0" primary="false"/>
+        <categoryLink id="891f-df7d-04cb-caf1" name="Automata Unit Type" hidden="false" targetId="d8ab-8e21-e193-63ba" primary="false"/>
+        <categoryLink id="f9ac-c447-beb5-ba0f" name="Cybernetica Sub-type" hidden="false" targetId="2440-b64e-cb24-87f0" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="e713-beb2-95dd-51cb" name="Arlatax" publicationId="bde1-6db1-163b-3b76" page="40" hidden="false" collective="false" import="true" type="model">
@@ -3516,8 +3516,8 @@ Could not find type or subtype &apos;Guardian&apos;</comment>
     </selectionEntry>
     <selectionEntry id="0e08-6b7e-8fff-1f02" name="Vultarax Stratos-Automata Squadron" publicationId="bde1-6db1-163b-3b76" page="43" hidden="false" collective="false" import="true" type="unit">
       <categoryLinks>
-        <categoryLink id="eb08-ad92-7257-4980" name="Automata Unit-type:" hidden="false" targetId="d8ab-8e21-e193-63ba" primary="false"/>
-        <categoryLink id="dbd6-f6ad-4b5a-db84" name="Cybernetica Sub-type:" hidden="false" targetId="2440-b64e-cb24-87f0" primary="false"/>
+        <categoryLink id="eb08-ad92-7257-4980" name="Automata Unit Type" hidden="false" targetId="d8ab-8e21-e193-63ba" primary="false"/>
+        <categoryLink id="dbd6-f6ad-4b5a-db84" name="Cybernetica Sub-type" hidden="false" targetId="2440-b64e-cb24-87f0" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="c731-8052-ca8a-0b37" name="Vultarax" publicationId="bde1-6db1-163b-3b76" page="43" hidden="false" collective="false" import="true" type="model">
@@ -3635,7 +3635,7 @@ Could not find type or subtype &apos;Guardian&apos;</comment>
     <selectionEntry id="356f-a88b-1d13-3700" name="Myrmidon Destructor Host" publicationId="bde1-6db1-163b-3b76" page="47" hidden="false" collective="false" import="true" type="unit">
       <categoryLinks>
         <categoryLink id="dd54-d5d1-0a67-2cc1" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="300d-bc70-c03a-6048" name="Heavy Sub-type:" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+        <categoryLink id="300d-bc70-c03a-6048" name="Heavy Sub-type" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="ef1e-ad56-2550-340f" name="Destructor Lord" publicationId="bde1-6db1-163b-3b76" page="47" hidden="false" collective="false" import="true" type="model">
@@ -3913,7 +3913,7 @@ Could not find type or subtype &apos;Guardian&apos;</comment>
     </selectionEntry>
     <selectionEntry id="ce87-68e2-0134-3c84" name="Krios Squadron" publicationId="bde1-6db1-163b-3b76" page="49" hidden="false" collective="false" import="true" type="unit">
       <categoryLinks>
-        <categoryLink id="c4aa-2ea1-7395-2961" name="Fast Sub-type:" hidden="false" targetId="0ea2-efb5-b7af-226e" primary="false"/>
+        <categoryLink id="c4aa-2ea1-7395-2961" name="Fast Sub-type" hidden="false" targetId="0ea2-efb5-b7af-226e" primary="false"/>
         <categoryLink id="a179-577f-cd12-e576" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
       </categoryLinks>
       <selectionEntries>
@@ -4291,9 +4291,9 @@ At the beginning of each of the controlling player’s Shooting phases for the r
       </infoLinks>
       <categoryLinks>
         <categoryLink id="35ea-4280-934d-b8e0" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
-        <categoryLink id="b65c-4e4f-9056-3390" name="Monstrous Sub-type:" hidden="false" targetId="7d95-f9d1-440a-67bd" primary="false"/>
+        <categoryLink id="b65c-4e4f-9056-3390" name="Monstrous Sub-type" hidden="false" targetId="7d95-f9d1-440a-67bd" primary="false"/>
         <categoryLink id="1048-d3fc-35af-c693" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="75ce-3f3b-dc4a-ecad" name="Heavy Sub-type:" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+        <categoryLink id="75ce-3f3b-dc4a-ecad" name="Heavy Sub-type" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
         <categoryLink id="d4ac-5be1-aa59-90ad" name="Feudal Hierarchy (On Abeyant)" hidden="false" targetId="4c2b-03e9-abb7-7209" primary="false"/>
       </categoryLinks>
       <selectionEntries>
@@ -4939,8 +4939,8 @@ removed as a casualty.�</characteristic>
     </selectionEntry>
     <selectionEntry id="4436-7062-9be3-b233" name="Adsecularis Tech-thralls Certus Covenant" publicationId="3886-76e5-438f-159f" page="3" hidden="false" collective="false" import="true" type="unit">
       <categoryLinks>
-        <categoryLink id="4189-3144-1000-df23" name="Heavy Sub-type:" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
-        <categoryLink id="f4be-0d9a-9547-9567" name="Line Sub-type:" hidden="false" targetId="6399-5c65-7833-1025" primary="false"/>
+        <categoryLink id="4189-3144-1000-df23" name="Heavy Sub-type" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+        <categoryLink id="f4be-0d9a-9547-9567" name="Line Sub-type" hidden="false" targetId="6399-5c65-7833-1025" primary="false"/>
         <categoryLink id="77ac-25a2-4098-2aaa" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
       </categoryLinks>
       <selectionEntries>
@@ -5150,7 +5150,7 @@ removed as a casualty.�</characteristic>
         </infoLink>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="ae3d-aa42-c8ba-a4f9" name="Artillery Sub-type:" hidden="false" targetId="6f99-c178-6f9d-fb63" primary="false"/>
+        <categoryLink id="ae3d-aa42-c8ba-a4f9" name="Artillery Sub-type" hidden="false" targetId="6f99-c178-6f9d-fb63" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="1bd9-d2d6-a322-2151" name="All Tarantula Sentry Guns in the unit may take:" hidden="false" collective="false" import="true">
@@ -5334,7 +5334,7 @@ removed as a casualty.�</characteristic>
         <infoLink id="4bae-d7d8-90fb-f037" name="Feudal Hierarchy" hidden="false" targetId="7d4f-c9a9-f9c0-b49a" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="12a1-ade9-ce31-301a" name="Monstrous Sub-type:" hidden="false" targetId="7d95-f9d1-440a-67bd" primary="false"/>
+        <categoryLink id="12a1-ade9-ce31-301a" name="Monstrous Sub-type" hidden="false" targetId="7d95-f9d1-440a-67bd" primary="false"/>
         <categoryLink id="27c1-95be-258a-994e" name="Cybertheurgist" hidden="false" targetId="57a1-ae47-ff1b-36e4" primary="false"/>
         <categoryLink id="c9b9-7842-05fe-d0d6" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
         <categoryLink id="ab6b-df7c-a7a9-0ddf" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
@@ -5461,7 +5461,7 @@ Additionally, each time Inar Satarael makes a successful Invulnable Save on a ro
         <infoLink id="ddc2-8fa9-da51-339c" name="Assault Vehicle" hidden="false" targetId="aa61-11f6-2bb5-7c0e" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="2ea0-1231-e5ff-56ea" name="Reinforced Sub-type:" hidden="false" targetId="9b0d-738c-10e4-4ec1" primary="false"/>
+        <categoryLink id="2ea0-1231-e5ff-56ea" name="Reinforced Sub-type" hidden="false" targetId="9b0d-738c-10e4-4ec1" primary="false"/>
         <categoryLink id="b478-a64a-ef2a-f8ab" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
         <categoryLink id="eae4-b808-6715-48a1" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink targetId="7b0a-a743-a8da-3a39" id="76d6-a2f2-49eb-a4f1" name="Transport" primary="false"/>
@@ -6667,7 +6667,7 @@ Additionally, each time Inar Satarael makes a successful Invulnable Save on a ro
           </infoLinks>
           <categoryLinks>
             <categoryLink id="cfb1-6cf0-eb24-09cb" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
-            <categoryLink id="acb8-1c6e-457c-6aea" name="Reinforced Sub-type:" hidden="false" targetId="9b0d-738c-10e4-4ec1" primary="false"/>
+            <categoryLink id="acb8-1c6e-457c-6aea" name="Reinforced Sub-type" hidden="false" targetId="9b0d-738c-10e4-4ec1" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="4aa9-3e5d-adc3-8322" name="May Take:" hidden="false" collective="false" import="true">

--- a/2022 - Mechanicum.cat
+++ b/2022 - Mechanicum.cat
@@ -698,7 +698,7 @@
       </infoLinks>
       <categoryLinks>
         <categoryLink id="fc8b-7c82-9965-120f" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
-        <categoryLink id="699b-4a76-ee6f-f722" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="699b-4a76-ee6f-f722" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="2eab-eaf4-105a-f2a0" name="Cybertheurgist" hidden="false" targetId="57a1-ae47-ff1b-36e4" primary="false"/>
         <categoryLink id="9c62-aa7d-142d-51f5" name="Feudal Hierarchy (On Foot)" hidden="false" targetId="ff97-e64e-506b-0587" primary="false"/>
       </categoryLinks>
@@ -999,7 +999,7 @@
       <categoryLinks>
         <categoryLink id="8bf8-9627-3e73-b8bc" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
         <categoryLink id="6a96-9d2f-a329-7562" name="Monstrous Sub-type" hidden="false" targetId="7d95-f9d1-440a-67bd" primary="false"/>
-        <categoryLink id="ff95-2620-6ec4-9e60" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="ff95-2620-6ec4-9e60" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="4699-a334-97a9-2479" name="Feudal Hierarchy (On Abeyant)" hidden="false" targetId="4c2b-03e9-abb7-7209" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
@@ -1252,7 +1252,7 @@
       </infoLinks>
       <categoryLinks>
         <categoryLink id="4312-d152-9e2a-c653" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
-        <categoryLink id="176d-fff6-f157-330a" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="176d-fff6-f157-330a" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="a16c-e7f6-08fc-a357" name="Heavy Sub-type" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
@@ -1484,7 +1484,7 @@
       <categoryLinks>
         <categoryLink id="7d92-0210-bdb9-cd3a" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
         <categoryLink id="8595-f4c5-ba1d-69b5" name="Monstrous Sub-type" hidden="false" targetId="7d95-f9d1-440a-67bd" primary="false"/>
-        <categoryLink id="f75f-bd69-3fb1-c37d" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="f75f-bd69-3fb1-c37d" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="ad3f-ad1c-6a50-2d8c" name="Heavy Sub-type" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
@@ -1892,7 +1892,7 @@
           </infoLinks>
           <categoryLinks>
             <categoryLink id="02be-cd76-9a50-d755" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
-            <categoryLink id="03b4-892e-1b2f-2071" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+            <categoryLink id="03b4-892e-1b2f-2071" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="7fed-0d9f-2849-b801" name="Tech-Priest or Magos Auxilia" hidden="false" collective="false" import="true" defaultSelectionEntryId="abdc-96ec-d4d8-7779">
@@ -2208,7 +2208,7 @@
           </infoLinks>
           <categoryLinks>
             <categoryLink id="0811-7d31-715c-ef42" name="Automata Unit Type" hidden="false" targetId="d8ab-8e21-e193-63ba" primary="false"/>
-            <categoryLink targetId="8745-b21e-8576-7c30" id="3f5a-4b6e-4abf-bb95" name="Guardian" primary="false"/>
+            <categoryLink targetId="8745-b21e-8576-7c30" id="3f5a-4b6e-4abf-bb95" name="Guardian Unit Sub-type" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="5d44-26bf-c747-c100" name="Any Servo-automata may take one of the following:" hidden="false" collective="false" import="true">
@@ -2589,7 +2589,7 @@
           </costs>
           <categoryLinks>
             <categoryLink targetId="4f07-3d45-4f28-a0c6" id="d69-8243-201c-fa43" primary="false" name="Independent Character"/>
-            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="6c89-6b5f-412f-9f20" name="Infantry" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="6c89-6b5f-412f-9f20" name="Infantry Unit Type" primary="false"/>
             <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="a638-c3fc-4915-80d7" name="Character" primary="false"/>
           </categoryLinks>
         </selectionEntry>
@@ -2634,7 +2634,7 @@ This unit may be upgraded freely as described in their profile, though they may 
     </selectionEntry>
     <selectionEntry id="1869-2d16-d825-04c3" name="Myrmidon Secutor Host" publicationId="bde1-6db1-163b-3b76" page="32" hidden="false" collective="false" import="true" type="unit">
       <categoryLinks>
-        <categoryLink id="524b-df9c-a50f-7103" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="524b-df9c-a50f-7103" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="f7bb-798d-a14e-4915" name="Heavy Sub-type" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
       </categoryLinks>
       <selectionEntries>
@@ -2683,8 +2683,8 @@ This unit may be upgraded freely as described in their profile, though they may 
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="45"/>
           </costs>
           <categoryLinks>
-            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="0694-0df6-42e9-bed9" name="Infantry" primary="false"/>
-            <categoryLink targetId="9231-183c-b97b-63f9" id="7f03-6079-4fe2-ab1c" name="Heavy" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="0694-0df6-42e9-bed9" name="Infantry Unit Type" primary="false"/>
+            <categoryLink targetId="9231-183c-b97b-63f9" id="7f03-6079-4fe2-ab1c" name="Heavy Sub-type" primary="false"/>
           </categoryLinks>
         </selectionEntry>
         <selectionEntry id="90fe-b909-c0a9-9053" name="Secutor Lord" publicationId="bde1-6db1-163b-3b76" hidden="false" collective="false" import="true" type="model">
@@ -2730,8 +2730,8 @@ This unit may be upgraded freely as described in their profile, though they may 
           </infoLinks>
           <categoryLinks>
             <categoryLink id="a497-9936-5e88-4943" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
-            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="43c4-5f60-46b6-aaaa" name="Infantry" primary="false"/>
-            <categoryLink targetId="9231-183c-b97b-63f9" id="d559-bc95-42d7-81bb" name="Heavy" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="43c4-5f60-46b6-aaaa" name="Infantry Unit Type" primary="false"/>
+            <categoryLink targetId="9231-183c-b97b-63f9" id="d559-bc95-42d7-81bb" name="Heavy Sub-type" primary="false"/>
           </categoryLinks>
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
@@ -2845,7 +2845,7 @@ This unit may be upgraded freely as described in their profile, though they may 
       <categoryLinks>
         <categoryLink id="8ee7-e36b-9a79-6998" name="Heavy Sub-type" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
         <categoryLink id="2d6d-c8c5-9da8-958a" name="Line Sub-type" hidden="false" targetId="6399-5c65-7833-1025" primary="false"/>
-        <categoryLink id="09f4-c088-2ec8-fac3" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="09f4-c088-2ec8-fac3" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="ce84-58bb-48ce-c2ea" name="Tech-thralls" publicationId="bde1-6db1-163b-3b76" page="34" hidden="false" collective="false" import="true" type="model">
@@ -2895,9 +2895,9 @@ This unit may be upgraded freely as described in their profile, though they may 
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="3"/>
           </costs>
           <categoryLinks>
-            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="39bc-0638-43f0-89a7" name="Infantry" primary="false"/>
-            <categoryLink targetId="9231-183c-b97b-63f9" id="da71-35a8-434b-8313" name="Heavy" primary="false"/>
-            <categoryLink targetId="6399-5c65-7833-1025" id="6b64-4a5d-4b7c-9065" name="Line" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="39bc-0638-43f0-89a7" name="Infantry Unit Type" primary="false"/>
+            <categoryLink targetId="9231-183c-b97b-63f9" id="da71-35a8-434b-8313" name="Heavy Sub-type" primary="false"/>
+            <categoryLink targetId="6399-5c65-7833-1025" id="6b64-4a5d-4b7c-9065" name="Line Sub-type" primary="false"/>
           </categoryLinks>
         </selectionEntry>
       </selectionEntries>
@@ -2981,10 +2981,10 @@ This unit may be upgraded freely as described in their profile, though they may 
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25"/>
           </costs>
           <categoryLinks>
-            <categoryLink targetId="d8ab-8e21-e193-63ba" id="3aab-8a87-4cab-8b51" name="Automata" primary="false"/>
-            <categoryLink targetId="9231-183c-b97b-63f9" id="29de-3763-462e-9365" name="Heavy" primary="false"/>
-            <categoryLink targetId="6399-5c65-7833-1025" id="ec59-b2aa-43d5-9746" name="Line" primary="false"/>
-            <categoryLink targetId="8745-b21e-8576-7c30" id="5c5c-1ed0-45e5-80d6" name="Guardian" primary="false"/>
+            <categoryLink targetId="d8ab-8e21-e193-63ba" id="3aab-8a87-4cab-8b51" name="Automata Unit Type" primary="false"/>
+            <categoryLink targetId="9231-183c-b97b-63f9" id="29de-3763-462e-9365" name="Heavy Sub-type" primary="false"/>
+            <categoryLink targetId="6399-5c65-7833-1025" id="ec59-b2aa-43d5-9746" name="Line Sub-type" primary="false"/>
+            <categoryLink targetId="8745-b21e-8576-7c30" id="5c5c-1ed0-45e5-80d6" name="Guardian Unit Sub-type" primary="false"/>
           </categoryLinks>
         </selectionEntry>
         <selectionEntry id="89ed-ac7c-70ea-754b" name="Scyllax Combat Array" publicationId="bde1-6db1-163b-3b76" page="120" hidden="false" collective="false" import="true" type="upgrade">
@@ -3365,8 +3365,8 @@ This unit may be upgraded freely as described in their profile, though they may 
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="135"/>
           </costs>
           <categoryLinks>
-            <categoryLink targetId="d8ab-8e21-e193-63ba" id="f653-f942-4a3b-9f77" name="Automata" primary="false"/>
-            <categoryLink targetId="2440-b64e-cb24-87f0" id="6b5a-a7c0-44ce-b384" name="Cybernetica" primary="false"/>
+            <categoryLink targetId="d8ab-8e21-e193-63ba" id="f653-f942-4a3b-9f77" name="Automata Unit Type" primary="false"/>
+            <categoryLink targetId="2440-b64e-cb24-87f0" id="6b5a-a7c0-44ce-b384" name="Cybernetica Sub-type" primary="false"/>
           </categoryLinks>
         </selectionEntry>
       </selectionEntries>
@@ -3376,7 +3376,7 @@ This unit may be upgraded freely as described in their profile, though they may 
     </selectionEntry>
     <selectionEntry id="0750-2aed-2d36-8a82" name="Ursarax Cohort" publicationId="bde1-6db1-163b-3b76" page="41" hidden="false" collective="false" import="true" type="unit">
       <categoryLinks>
-        <categoryLink id="8c6d-9086-eab1-a7e1" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="8c6d-9086-eab1-a7e1" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="2087-99e6-1519-5bf2" name="Ursarax" publicationId="bde1-6db1-163b-3b76" page="41" hidden="false" collective="false" import="true" type="model">
@@ -3418,7 +3418,7 @@ This unit may be upgraded freely as described in their profile, though they may 
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="45"/>
           </costs>
           <categoryLinks>
-            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="b2ef-c319-4a6d-8d70" name="Infantry" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="b2ef-c319-4a6d-8d70" name="Infantry Unit Type" primary="false"/>
           </categoryLinks>
         </selectionEntry>
       </selectionEntries>
@@ -3620,9 +3620,9 @@ This unit may be upgraded freely as described in their profile, though they may 
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="125"/>
           </costs>
           <categoryLinks>
-            <categoryLink targetId="d8ab-8e21-e193-63ba" id="11be-2438-4c9a-a28b" name="Automata" primary="false"/>
-            <categoryLink targetId="4303-1348-cce4-9501" id="9970-338f-4b04-8d10" name="Antigrav" primary="false"/>
-            <categoryLink targetId="2440-b64e-cb24-87f0" id="52b3-8b0b-4a04-bb52" name="Cybernetica" primary="false"/>
+            <categoryLink targetId="d8ab-8e21-e193-63ba" id="11be-2438-4c9a-a28b" name="Automata Unit Type" primary="false"/>
+            <categoryLink targetId="4303-1348-cce4-9501" id="9970-338f-4b04-8d10" name="Antigrav Sub-type" primary="false"/>
+            <categoryLink targetId="2440-b64e-cb24-87f0" id="52b3-8b0b-4a04-bb52" name="Cybernetica Sub-type" primary="false"/>
           </categoryLinks>
         </selectionEntry>
       </selectionEntries>
@@ -3632,7 +3632,7 @@ This unit may be upgraded freely as described in their profile, though they may 
     </selectionEntry>
     <selectionEntry id="356f-a88b-1d13-3700" name="Myrmidon Destructor Host" publicationId="bde1-6db1-163b-3b76" page="47" hidden="false" collective="false" import="true" type="unit">
       <categoryLinks>
-        <categoryLink id="dd54-d5d1-0a67-2cc1" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="dd54-d5d1-0a67-2cc1" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="300d-bc70-c03a-6048" name="Heavy Sub-type" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
       </categoryLinks>
       <selectionEntries>
@@ -3669,8 +3669,8 @@ This unit may be upgraded freely as described in their profile, though they may 
           </infoLinks>
           <categoryLinks>
             <categoryLink id="2d1a-287f-ad7c-773b" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
-            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="233d-f37c-423d-8c68" name="Infantry" primary="false"/>
-            <categoryLink targetId="9231-183c-b97b-63f9" id="d1df-0575-4fc2-94ae" name="Heavy" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="233d-f37c-423d-8c68" name="Infantry Unit Type" primary="false"/>
+            <categoryLink targetId="9231-183c-b97b-63f9" id="d1df-0575-4fc2-94ae" name="Heavy Sub-type" primary="false"/>
           </categoryLinks>
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
@@ -3711,8 +3711,8 @@ This unit may be upgraded freely as described in their profile, though they may 
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="40"/>
           </costs>
           <categoryLinks>
-            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="78cd-01bb-41ac-9bcd" name="Infantry" primary="false"/>
-            <categoryLink targetId="9231-183c-b97b-63f9" id="2729-da9b-4e60-8ed8" name="Heavy" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="78cd-01bb-41ac-9bcd" name="Infantry Unit Type" primary="false"/>
+            <categoryLink targetId="9231-183c-b97b-63f9" id="2729-da9b-4e60-8ed8" name="Heavy Sub-type" primary="false"/>
           </categoryLinks>
         </selectionEntry>
       </selectionEntries>
@@ -3952,7 +3952,7 @@ This unit may be upgraded freely as described in their profile, though they may 
           </infoLinks>
           <categoryLinks>
             <categoryLink id="be91-18eb-a67a-8b36" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
-            <categoryLink targetId="0ea2-efb5-b7af-226e" id="0cd3-da12-4555-a924" name="Fast" primary="false"/>
+            <categoryLink targetId="0ea2-efb5-b7af-226e" id="0cd3-da12-4555-a924" name="Fast Sub-type" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="ce42-140a-6427-9dfd" name="Hull (Front) Mounted Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="0540-4761-0685-b2f2">
@@ -4290,7 +4290,7 @@ At the beginning of each of the controlling player’s Shooting phases for the r
       <categoryLinks>
         <categoryLink id="35ea-4280-934d-b8e0" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
         <categoryLink id="b65c-4e4f-9056-3390" name="Monstrous Sub-type" hidden="false" targetId="7d95-f9d1-440a-67bd" primary="false"/>
-        <categoryLink id="1048-d3fc-35af-c693" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="1048-d3fc-35af-c693" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="75ce-3f3b-dc4a-ecad" name="Heavy Sub-type" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
         <categoryLink id="d4ac-5be1-aa59-90ad" name="Feudal Hierarchy (On Abeyant)" hidden="false" targetId="4c2b-03e9-abb7-7209" primary="false"/>
       </categoryLinks>
@@ -4939,7 +4939,7 @@ removed as a casualty.�</characteristic>
       <categoryLinks>
         <categoryLink id="4189-3144-1000-df23" name="Heavy Sub-type" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
         <categoryLink id="f4be-0d9a-9547-9567" name="Line Sub-type" hidden="false" targetId="6399-5c65-7833-1025" primary="false"/>
-        <categoryLink id="77ac-25a2-4098-2aaa" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="77ac-25a2-4098-2aaa" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="7646-d53c-b6ea-2dd9" name="Tech-thralls" publicationId="3886-76e5-438f-159f" page="3" hidden="false" collective="false" import="true" type="model">
@@ -4973,9 +4973,9 @@ removed as a casualty.�</characteristic>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="3"/>
           </costs>
           <categoryLinks>
-            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="9fc2-ff75-4daf-bd18" name="Infantry" primary="false"/>
-            <categoryLink targetId="9231-183c-b97b-63f9" id="bfad-cff1-4c21-91cd" name="Heavy" primary="false"/>
-            <categoryLink targetId="6399-5c65-7833-1025" id="4b40-6895-4706-9c71" name="Line" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="9fc2-ff75-4daf-bd18" name="Infantry Unit Type" primary="false"/>
+            <categoryLink targetId="9231-183c-b97b-63f9" id="bfad-cff1-4c21-91cd" name="Heavy Sub-type" primary="false"/>
+            <categoryLink targetId="6399-5c65-7833-1025" id="4b40-6895-4706-9c71" name="Line Sub-type" primary="false"/>
           </categoryLinks>
         </selectionEntry>
       </selectionEntries>
@@ -5201,8 +5201,8 @@ removed as a casualty.�</characteristic>
                 </profile>
               </profiles>
               <categoryLinks>
-                <categoryLink id="2df0-2483-3a5e-8085" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-                <categoryLink targetId="0faa-1bab-2901-4330" id="6e2f-4eb1-458f-a47c" name="Automated Artillery" primary="false"/>
+                <categoryLink id="2df0-2483-3a5e-8085" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+                <categoryLink targetId="0faa-1bab-2901-4330" id="6e2f-4eb1-458f-a47c" name="Automated Artillery Sub-type" primary="false"/>
               </categoryLinks>
               <selectionEntries>
                 <selectionEntry id="1386-c057-9ea5-145e" name="2x Heavy Bolters" hidden="false" collective="true" import="true" type="upgrade">
@@ -5227,8 +5227,8 @@ removed as a casualty.�</characteristic>
                 <constraint field="selections" scope="parent" value="5" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8a2e-e807-a19e-b33f" type="max"/>
               </constraints>
               <categoryLinks>
-                <categoryLink id="ec82-d57c-d5ce-99f8" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-                <categoryLink targetId="0faa-1bab-2901-4330" id="ffef-2859-47b2-b2fa" name="Automated Artillery" primary="false"/>
+                <categoryLink id="ec82-d57c-d5ce-99f8" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+                <categoryLink targetId="0faa-1bab-2901-4330" id="ffef-2859-47b2-b2fa" name="Automated Artillery Sub-type" primary="false"/>
               </categoryLinks>
               <selectionEntries>
                 <selectionEntry id="2cf8-ce3c-b1c7-c8b6" name="2x Lascannons" hidden="false" collective="true" import="true" type="upgrade">
@@ -5257,8 +5257,8 @@ removed as a casualty.�</characteristic>
                 <constraint field="selections" scope="parent" value="5" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eaaa-62af-a7c7-4068" type="max"/>
               </constraints>
               <categoryLinks>
-                <categoryLink id="610c-3f5f-7274-2ffa" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-                <categoryLink targetId="0faa-1bab-2901-4330" id="1a54-5606-476b-837d" name="Automated Artillery" primary="false"/>
+                <categoryLink id="610c-3f5f-7274-2ffa" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+                <categoryLink targetId="0faa-1bab-2901-4330" id="1a54-5606-476b-837d" name="Automated Artillery Sub-type" primary="false"/>
               </categoryLinks>
               <selectionEntries>
                 <selectionEntry id="e38b-ee5c-b099-3c11" name="Hyperios Missile Launcher" hidden="false" collective="true" import="true" type="upgrade">
@@ -5462,7 +5462,7 @@ Additionally, each time Inar Satarael makes a successful Invulnable Save on a ro
         <categoryLink id="2ea0-1231-e5ff-56ea" name="Reinforced Sub-type" hidden="false" targetId="9b0d-738c-10e4-4ec1" primary="false"/>
         <categoryLink id="b478-a64a-ef2a-f8ab" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
         <categoryLink id="eae4-b808-6715-48a1" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
-        <categoryLink targetId="7b0a-a743-a8da-3a39" id="76d6-a2f2-49eb-a4f1" name="Transport" primary="false"/>
+        <categoryLink targetId="7b0a-a743-a8da-3a39" id="76d6-a2f2-49eb-a4f1" name="Transport Sub-type" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="f662-ff23-526d-859f" name="2) Pintle mounted Weapon:" hidden="false" collective="false" import="true">

--- a/2022 - Mechanicum.cat
+++ b/2022 - Mechanicum.cat
@@ -2208,6 +2208,7 @@
           </infoLinks>
           <categoryLinks>
             <categoryLink id="0811-7d31-715c-ef42" name="Automata Unit Type" hidden="false" targetId="d8ab-8e21-e193-63ba" primary="false"/>
+            <categoryLink targetId="8745-b21e-8576-7c30" id="3f5a-4b6e-4abf-bb95" name="Guardian" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="5d44-26bf-c747-c100" name="Any Servo-automata may take one of the following:" hidden="false" collective="false" import="true">
@@ -2256,8 +2257,6 @@
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5"/>
           </costs>
-          <comment>!BSC Errors from 20240328-1346
-Could not find type or subtype &apos;Guardian&apos;</comment>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
@@ -2985,9 +2984,8 @@ This unit may be upgraded freely as described in their profile, though they may 
             <categoryLink targetId="d8ab-8e21-e193-63ba" id="3aab-8a87-4cab-8b51" name="Automata" primary="false"/>
             <categoryLink targetId="9231-183c-b97b-63f9" id="29de-3763-462e-9365" name="Heavy" primary="false"/>
             <categoryLink targetId="6399-5c65-7833-1025" id="ec59-b2aa-43d5-9746" name="Line" primary="false"/>
+            <categoryLink targetId="8745-b21e-8576-7c30" id="5c5c-1ed0-45e5-80d6" name="Guardian" primary="false"/>
           </categoryLinks>
-          <comment>!BSC Errors from 20240328-1346
-Could not find type or subtype &apos;Guardian&apos;</comment>
         </selectionEntry>
         <selectionEntry id="89ed-ac7c-70ea-754b" name="Scyllax Combat Array" publicationId="bde1-6db1-163b-3b76" page="120" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>

--- a/2022 - Mechanicum.cat
+++ b/2022 - Mechanicum.cat
@@ -2256,6 +2256,8 @@
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5"/>
           </costs>
+          <comment>!BSC Errors from 20240328-1346
+Could not find type or subtype &apos;Guardian&apos;</comment>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
@@ -2588,6 +2590,8 @@
           </costs>
           <categoryLinks>
             <categoryLink targetId="4f07-3d45-4f28-a0c6" id="d69-8243-201c-fa43" primary="false" name="Independent Character"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="6c89-6b5f-412f-9f20" name="Infantry" primary="false"/>
+            <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="a638-c3fc-4915-80d7" name="Character" primary="false"/>
           </categoryLinks>
         </selectionEntry>
       </selectionEntries>
@@ -2679,6 +2683,10 @@ This unit may be upgraded freely as described in their profile, though they may 
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="45"/>
           </costs>
+          <categoryLinks>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="0694-0df6-42e9-bed9" name="Infantry" primary="false"/>
+            <categoryLink targetId="9231-183c-b97b-63f9" id="7f03-6079-4fe2-ab1c" name="Heavy" primary="false"/>
+          </categoryLinks>
         </selectionEntry>
         <selectionEntry id="90fe-b909-c0a9-9053" name="Secutor Lord" publicationId="bde1-6db1-163b-3b76" hidden="false" collective="false" import="true" type="model">
           <constraints>
@@ -2723,6 +2731,8 @@ This unit may be upgraded freely as described in their profile, though they may 
           </infoLinks>
           <categoryLinks>
             <categoryLink id="a497-9936-5e88-4943" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="43c4-5f60-46b6-aaaa" name="Infantry" primary="false"/>
+            <categoryLink targetId="9231-183c-b97b-63f9" id="d559-bc95-42d7-81bb" name="Heavy" primary="false"/>
           </categoryLinks>
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
@@ -2885,6 +2895,11 @@ This unit may be upgraded freely as described in their profile, though they may 
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="3"/>
           </costs>
+          <categoryLinks>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="39bc-0638-43f0-89a7" name="Infantry" primary="false"/>
+            <categoryLink targetId="9231-183c-b97b-63f9" id="da71-35a8-434b-8313" name="Heavy" primary="false"/>
+            <categoryLink targetId="6399-5c65-7833-1025" id="6b64-4a5d-4b7c-9065" name="Line" primary="false"/>
+          </categoryLinks>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
@@ -2966,6 +2981,13 @@ This unit may be upgraded freely as described in their profile, though they may 
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25"/>
           </costs>
+          <categoryLinks>
+            <categoryLink targetId="d8ab-8e21-e193-63ba" id="3aab-8a87-4cab-8b51" name="Automata" primary="false"/>
+            <categoryLink targetId="9231-183c-b97b-63f9" id="29de-3763-462e-9365" name="Heavy" primary="false"/>
+            <categoryLink targetId="6399-5c65-7833-1025" id="ec59-b2aa-43d5-9746" name="Line" primary="false"/>
+          </categoryLinks>
+          <comment>!BSC Errors from 20240328-1346
+Could not find type or subtype &apos;Guardian&apos;</comment>
         </selectionEntry>
         <selectionEntry id="89ed-ac7c-70ea-754b" name="Scyllax Combat Array" publicationId="bde1-6db1-163b-3b76" page="120" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
@@ -3344,6 +3366,10 @@ This unit may be upgraded freely as described in their profile, though they may 
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="135"/>
           </costs>
+          <categoryLinks>
+            <categoryLink targetId="d8ab-8e21-e193-63ba" id="f653-f942-4a3b-9f77" name="Automata" primary="false"/>
+            <categoryLink targetId="2440-b64e-cb24-87f0" id="6b5a-a7c0-44ce-b384" name="Cybernetica" primary="false"/>
+          </categoryLinks>
         </selectionEntry>
       </selectionEntries>
       <costs>
@@ -3393,6 +3419,9 @@ This unit may be upgraded freely as described in their profile, though they may 
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="45"/>
           </costs>
+          <categoryLinks>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="b2ef-c319-4a6d-8d70" name="Infantry" primary="false"/>
+          </categoryLinks>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
@@ -3592,6 +3621,11 @@ This unit may be upgraded freely as described in their profile, though they may 
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="125"/>
           </costs>
+          <categoryLinks>
+            <categoryLink targetId="d8ab-8e21-e193-63ba" id="11be-2438-4c9a-a28b" name="Automata" primary="false"/>
+            <categoryLink targetId="4303-1348-cce4-9501" id="9970-338f-4b04-8d10" name="Antigrav" primary="false"/>
+            <categoryLink targetId="2440-b64e-cb24-87f0" id="52b3-8b0b-4a04-bb52" name="Cybernetica" primary="false"/>
+          </categoryLinks>
         </selectionEntry>
       </selectionEntries>
       <costs>
@@ -3637,6 +3671,8 @@ This unit may be upgraded freely as described in their profile, though they may 
           </infoLinks>
           <categoryLinks>
             <categoryLink id="2d1a-287f-ad7c-773b" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="233d-f37c-423d-8c68" name="Infantry" primary="false"/>
+            <categoryLink targetId="9231-183c-b97b-63f9" id="d1df-0575-4fc2-94ae" name="Heavy" primary="false"/>
           </categoryLinks>
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
@@ -3676,6 +3712,10 @@ This unit may be upgraded freely as described in their profile, though they may 
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="40"/>
           </costs>
+          <categoryLinks>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="78cd-01bb-41ac-9bcd" name="Infantry" primary="false"/>
+            <categoryLink targetId="9231-183c-b97b-63f9" id="2729-da9b-4e60-8ed8" name="Heavy" primary="false"/>
+          </categoryLinks>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
@@ -3914,6 +3954,7 @@ This unit may be upgraded freely as described in their profile, though they may 
           </infoLinks>
           <categoryLinks>
             <categoryLink id="be91-18eb-a67a-8b36" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+            <categoryLink targetId="0ea2-efb5-b7af-226e" id="0cd3-da12-4555-a924" name="Fast" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="ce42-140a-6427-9dfd" name="Hull (Front) Mounted Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="0540-4761-0685-b2f2">
@@ -4933,6 +4974,11 @@ removed as a casualty.�</characteristic>
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="3"/>
           </costs>
+          <categoryLinks>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="9fc2-ff75-4daf-bd18" name="Infantry" primary="false"/>
+            <categoryLink targetId="9231-183c-b97b-63f9" id="bfad-cff1-4c21-91cd" name="Heavy" primary="false"/>
+            <categoryLink targetId="6399-5c65-7833-1025" id="4b40-6895-4706-9c71" name="Line" primary="false"/>
+          </categoryLinks>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
@@ -5158,6 +5204,7 @@ removed as a casualty.�</characteristic>
               </profiles>
               <categoryLinks>
                 <categoryLink id="2df0-2483-3a5e-8085" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+                <categoryLink targetId="0faa-1bab-2901-4330" id="6e2f-4eb1-458f-a47c" name="Automated Artillery" primary="false"/>
               </categoryLinks>
               <selectionEntries>
                 <selectionEntry id="1386-c057-9ea5-145e" name="2x Heavy Bolters" hidden="false" collective="true" import="true" type="upgrade">
@@ -5183,6 +5230,7 @@ removed as a casualty.�</characteristic>
               </constraints>
               <categoryLinks>
                 <categoryLink id="ec82-d57c-d5ce-99f8" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+                <categoryLink targetId="0faa-1bab-2901-4330" id="ffef-2859-47b2-b2fa" name="Automated Artillery" primary="false"/>
               </categoryLinks>
               <selectionEntries>
                 <selectionEntry id="2cf8-ce3c-b1c7-c8b6" name="2x Lascannons" hidden="false" collective="true" import="true" type="upgrade">
@@ -5212,6 +5260,7 @@ removed as a casualty.�</characteristic>
               </constraints>
               <categoryLinks>
                 <categoryLink id="610c-3f5f-7274-2ffa" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+                <categoryLink targetId="0faa-1bab-2901-4330" id="1a54-5606-476b-837d" name="Automated Artillery" primary="false"/>
               </categoryLinks>
               <selectionEntries>
                 <selectionEntry id="e38b-ee5c-b099-3c11" name="Hyperios Missile Launcher" hidden="false" collective="true" import="true" type="upgrade">
@@ -5415,6 +5464,7 @@ Additionally, each time Inar Satarael makes a successful Invulnable Save on a ro
         <categoryLink id="2ea0-1231-e5ff-56ea" name="Reinforced Sub-type:" hidden="false" targetId="9b0d-738c-10e4-4ec1" primary="false"/>
         <categoryLink id="b478-a64a-ef2a-f8ab" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
         <categoryLink id="eae4-b808-6715-48a1" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
+        <categoryLink targetId="7b0a-a743-a8da-3a39" id="76d6-a2f2-49eb-a4f1" name="Transport" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="f662-ff23-526d-859f" name="2) Pintle mounted Weapon:" hidden="false" collective="false" import="true">

--- a/2022 - Titan Legions.cat
+++ b/2022 - Titan Legions.cat
@@ -222,7 +222,7 @@
     <selectionEntry id="b08e-55fe-3e1d-913b" name="Secutarii Axiarch" publicationId="bde1-6db1-163b-3b76" page="66" hidden="false" collective="false" import="true" type="unit">
       <categoryLinks>
         <categoryLink id="f5bd-8b5c-1e1e-4b5b" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
-        <categoryLink id="bba2-2d6a-595b-788e" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="bba2-2d6a-595b-788e" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="4978-c880-3f1d-2466" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
       </categoryLinks>
       <selectionEntries>
@@ -487,7 +487,7 @@
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="60"/>
           </costs>
           <categoryLinks>
-            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="aeff-4817-4f96-93ce" name="Infantry" primary="false"/>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="aeff-4817-4f96-93ce" name="Infantry Unit Type" primary="false"/>
             <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="c5bd-e04c-41c9-b3ce" name="Character" primary="false"/>
           </categoryLinks>
         </selectionEntry>
@@ -505,7 +505,7 @@
         </infoLink>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="99ff-110c-e9cb-7051" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="99ff-110c-e9cb-7051" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="3488-49bf-3eb4-eb5b" name="Titan Legion Min Troop/LoW" hidden="false" targetId="4086-0589-f010-e688" primary="false"/>
       </categoryLinks>
       <selectionEntries>
@@ -535,8 +535,6 @@
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="12"/>
           </costs>
           <categoryLinks/>
-          <comment>!BSC Errors from 20240328-1346
-Could not find type or subtype &apos;Intantry&apos;</comment>
         </selectionEntry>
         <selectionEntry id="7e53-3d8b-5f85-993e" name="Hoplite Alpha" hidden="false" collective="false" import="true" type="model">
           <constraints>
@@ -566,8 +564,6 @@ Could not find type or subtype &apos;Intantry&apos;</comment>
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
           </costs>
-          <comment>!BSC Errors from 20240328-1346
-Could not find type or subtype &apos;Infanty&apos;</comment>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
@@ -680,7 +676,7 @@ Could not find type or subtype &apos;Infanty&apos;</comment>
         </infoLink>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="0bb4-9db7-e8b6-b2a5" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="0bb4-9db7-e8b6-b2a5" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="0d75-9bd2-a9ea-be2a" name="Titan Legion Min Troop/LoW" hidden="false" targetId="4086-0589-f010-e688" primary="false"/>
       </categoryLinks>
       <selectionEntries>
@@ -710,8 +706,6 @@ Could not find type or subtype &apos;Infanty&apos;</comment>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10"/>
           </costs>
           <categoryLinks/>
-          <comment>!BSC Errors from 20240328-1346
-Could not find type or subtype &apos;Intantry&apos;</comment>
         </selectionEntry>
         <selectionEntry id="59a0-bcc7-8dce-8ab0" name="Peltast Alpha" hidden="false" collective="false" import="true" type="model">
           <constraints>
@@ -741,8 +735,6 @@ Could not find type or subtype &apos;Intantry&apos;</comment>
           <categoryLinks>
             <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="f110-17bd-4d28-acc5" name="Character" primary="false"/>
           </categoryLinks>
-          <comment>!BSC Errors from 20240328-1346
-Could not find type or subtype &apos;Infanty&apos;</comment>
         </selectionEntry>
         <selectionEntry id="aeed-1c2a-2b6d-8def" name="Additionally Hammershot ammunition for Galvanic Casters" hidden="false" collective="false" import="true" type="upgrade">
           <modifiers>

--- a/2022 - Titan Legions.cat
+++ b/2022 - Titan Legions.cat
@@ -486,6 +486,10 @@
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="60"/>
           </costs>
+          <categoryLinks>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="aeff-4817-4f96-93ce" name="Infantry" primary="false"/>
+            <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="c5bd-e04c-41c9-b3ce" name="Character" primary="false"/>
+          </categoryLinks>
         </selectionEntry>
       </selectionEntries>
       <costs>
@@ -530,6 +534,9 @@
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="12"/>
           </costs>
+          <categoryLinks/>
+          <comment>!BSC Errors from 20240328-1346
+Could not find type or subtype &apos;Intantry&apos;</comment>
         </selectionEntry>
         <selectionEntry id="7e53-3d8b-5f85-993e" name="Hoplite Alpha" hidden="false" collective="false" import="true" type="model">
           <constraints>
@@ -559,6 +566,8 @@
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
           </costs>
+          <comment>!BSC Errors from 20240328-1346
+Could not find type or subtype &apos;Infanty&apos;</comment>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
@@ -700,6 +709,9 @@
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10"/>
           </costs>
+          <categoryLinks/>
+          <comment>!BSC Errors from 20240328-1346
+Could not find type or subtype &apos;Intantry&apos;</comment>
         </selectionEntry>
         <selectionEntry id="59a0-bcc7-8dce-8ab0" name="Peltast Alpha" hidden="false" collective="false" import="true" type="model">
           <constraints>
@@ -726,6 +738,11 @@
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
           </costs>
+          <categoryLinks>
+            <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="f110-17bd-4d28-acc5" name="Character" primary="false"/>
+          </categoryLinks>
+          <comment>!BSC Errors from 20240328-1346
+Could not find type or subtype &apos;Infanty&apos;</comment>
         </selectionEntry>
         <selectionEntry id="aeed-1c2a-2b6d-8def" name="Additionally Hammershot ammunition for Galvanic Casters" hidden="false" collective="false" import="true" type="upgrade">
           <modifiers>


### PR DESCRIPTION
This sets the categories on all models that have a profile or profile link as a direct descendent. This will allow us to check, for example, the number of infantry models in a given unit for #3152 .

It's also an improvement in data quality, and highlights some errors in the existing data like misspellings or missing unit types.