### PR TITLE
Fix primarch unit type and force org slot being the same

### DIFF
--- a/2022 - Horus Heresy.gst
+++ b/2022 - Horus Heresy.gst
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<gameSystem xmlns="http://www.battlescribe.net/schema/gameSystemSchema" id="28d4-bd2e-4858-ece6" name="Horus Heresy (2022)" revision="103" battleScribeVersion="2.03" type="gameSystem">
+<gameSystem xmlns="http://www.battlescribe.net/schema/gameSystemSchema" id="28d4-bd2e-4858-ece6" name="Horus Heresy (2022)" revision="104" battleScribeVersion="2.03" type="gameSystem">
   <publications>
     <publication name="Github" hidden="false" id="e2a4-ac85-1bef-22f5" publisherUrl="https://github.com/BSData/horus-heresy" shortName="BSData/horus-heresy"/>
     <publication id="e77a-823a-da94-16b9" name="Warhammer: The Horus Heresy - Age of Darkness Rulebook" shortName="Main Rules" publicationDate="June 2022"/>
@@ -148,21 +148,7 @@
         <infoLink id="8449-7ce9-bf21-5851" name="Fortification" publicationId="d0df-7166-5cd3-89fd" page="103" hidden="false" targetId="11c9-a7b5-30fb-dc0c" type="rule"/>
       </infoLinks>
     </categoryEntry>
-    <categoryEntry id="ad5f-31db-8bc7-5c46" name="Primarch:" hidden="false">
-      <modifiers>
-        <modifier type="set" field="5835-8a51-b8c1-17c4" value="0">
-          <conditionGroups>
-            <conditionGroup type="or">
-              <conditions>
-                <condition field="selections" scope="force" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9289-ff79-2e32-99b2" type="equalTo"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-      </modifiers>
-      <constraints>
-        <constraint field="selections" scope="force" value="-1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="5835-8a51-b8c1-17c4" type="max"/>
-      </constraints>
+    <categoryEntry id="ad5f-31db-8bc7-5c46" name="Primarch Unit Type" hidden="false">
       <rules>
         <rule id="a895-3e13-98e4-b67c" name="Primarch Unit-type" publicationId="e77a-823a-da94-16b9" page="196" hidden="false">
           <description>• All Primarchs have the following special rules: Independent Character, Eternal Warrior, Fearless, It Will Not Die (5+), Bulky (4), and Relentless. In addition, all models with the Primarch unit type always count as Character models.
@@ -259,7 +245,9 @@ During Reactions made in any Phase, a unit equipped with Jump PAcks may not acti
           <description>All models with both the Infantry Unit Type and the Legiones Astartes (Salamanders) in a Detachment using this Rite of War ignore all modifiers to their Leadership when making Pinning tests.</description>
         </rule>
         <rule name="Infantry Unit Type" hidden="false" id="ed36-77cb-5da7-3298" publicationId="e77a-823a-da94-16b9" page="195">
-          <alias>Infantry</alias>
+          <alias>
+            <undefined>Infantry</undefined>
+          </alias>
           <description>An Infantry unit may only include or be joined by models of the Infantry or Primarch Unit Type, unless a special rule states otherwise.</description>
         </rule>
       </rules>
@@ -1336,6 +1324,23 @@ If a Skimmer is Immobilised or Wrecked, its base is removed, if possible. If thi
         </rule>
       </rules>
     </categoryEntry>
+    <categoryEntry name="Primarch:" id="e031-3c2-e3f8-d40a" hidden="false">
+      <comment>Force Org Slot</comment>
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="force" shared="true" id="5835-8a51-b8c1-17c4" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="0" field="5835-8a51-b8c1-17c4">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition type="equalTo" value="1" field="selections" scope="force" childId="9289-ff79-2e32-99b2" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+    </categoryEntry>
   </categoryEntries>
   <forceEntries>
     <forceEntry id="d926-652f-8436-30ce" name="1. Crusade Force Organisation Chart" hidden="false">
@@ -1598,7 +1603,7 @@ If a Skimmer is Immobilised or Wrecked, its base is removed, if possible. If thi
             <constraint field="selections" scope="force" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1a78-0551-84cc-20b0" type="max"/>
           </constraints>
         </categoryLink>
-        <categoryLink id="c5e5-cb96-3835-591a" name="Primarch:" hidden="false" targetId="ad5f-31db-8bc7-5c46" primary="false">
+        <categoryLink id="c5e5-cb96-3835-591a" name="Primarch:" hidden="false" targetId="e031-3c2-e3f8-d40a" primary="false" type="category">
           <modifiers>
             <modifier type="set" field="3210-baff-f554-8019" value="0">
               <conditionGroups>
@@ -2086,7 +2091,7 @@ If a Skimmer is Immobilised or Wrecked, its base is removed, if possible. If thi
             <constraint field="selections" scope="force" value="2" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e0f5-6aa4-8e07-5b51" type="max"/>
           </constraints>
         </categoryLink>
-        <categoryLink id="7526-8c64-9373-5110" name="Primarch:" hidden="false" targetId="ad5f-31db-8bc7-5c46" primary="false">
+        <categoryLink id="7526-8c64-9373-5110" name="Primarch:" hidden="false" targetId="e031-3c2-e3f8-d40a" primary="false" type="category">
           <modifiers>
             <modifier type="set" field="300d-0f17-be7c-1e2b" value="0">
               <conditionGroups>
@@ -6481,7 +6486,6 @@ Fire Point (Front 4)</characteristic>
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="55"/>
           </costs>
-          <categoryLinks/>
         </selectionEntry>
       </selectionEntries>
       <costs>
@@ -6519,7 +6523,6 @@ Hull Mounted (Rear) Heavy Bolter</characteristic>
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="85"/>
           </costs>
-          <categoryLinks/>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
@@ -6598,7 +6601,6 @@ Four single Blast Shields</characteristic>
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="35"/>
           </costs>
-          <categoryLinks/>
         </selectionEntry>
       </selectionEntries>
       <entryLinks>

--- a/2022 - LA - Alpha Legion.cat
+++ b/2022 - LA - Alpha Legion.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="9c06-1c61-d01d-8445" name="LA - XX: Alpha Legion" revision="49" battleScribeVersion="2.03" authorName="Alphalas" authorContact="BSData Developers Discord" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="70" type="catalogue">
+<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="9c06-1c61-d01d-8445" name="LA - XX: Alpha Legion" revision="50" battleScribeVersion="2.03" authorName="Alphalas" authorContact="BSData Developers Discord" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="70" type="catalogue">
   <categoryEntries>
     <categoryEntry id="2275-5253-2421-7383" name="Rewards of Trechery" hidden="false">
       <modifiers>
@@ -108,8 +108,8 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="3a48-ebd5-979a-ab0e" name="Primarch:" hidden="false" targetId="ad5f-31db-8bc7-5c46" primary="true"/>
         <categoryLink id="b56c-b87b-07a2-6437" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink name="Primarch:" hidden="false" id="290c-4c15-3100-699b" targetId="e031-3c2-e3f8-d40a" primary="false"/>
       </categoryLinks>
       <entryLinks>
         <entryLink id="4c84-ff78-6653-f033" name="Retinue" hidden="false" collective="false" import="true" targetId="09f9-933c-a88e-6e38" type="selectionEntryGroup">

--- a/2022 - LA - Blood Angels.cat
+++ b/2022 - LA - Blood Angels.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="cd4d-8765-5387-8409" name="LA -  IX: Blood Angels" revision="41" battleScribeVersion="2.03" authorName="Jon K &quot;Alphalas&quot;" authorContact="Twitter: Alphalas_ Discord: Alphalas#8789" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="67" type="catalogue">
+<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="cd4d-8765-5387-8409" name="LA -  IX: Blood Angels" revision="42" battleScribeVersion="2.03" authorName="Jon K &quot;Alphalas&quot;" authorContact="Twitter: Alphalas_ Discord: Alphalas#8789" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="67" type="catalogue">
   <entryLinks>
     <entryLink id="1900-3f09-f47b-bed2" name="Praetor" hidden="false" collective="false" import="false" targetId="03be-5d55-d05a-771d" type="selectionEntry">
       <comment>template_id_5798-3fc7-4d4c-ad41</comment>
@@ -129,8 +129,8 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="9dac-939c-1711-76ba" name="Primarch:" hidden="false" targetId="ad5f-31db-8bc7-5c46" primary="true"/>
         <categoryLink id="b565-cac7-63e5-fb44" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink name="Primarch:" hidden="false" id="f68-61fe-b339-df0d" targetId="e031-3c2-e3f8-d40a" primary="true"/>
       </categoryLinks>
       <entryLinks>
         <entryLink id="aae5-4d24-fbd7-9939" name="Retinue" hidden="false" collective="false" import="true" targetId="6307-ed53-0ac4-0212" type="selectionEntryGroup">

--- a/2022 - LA - Dark Angels.cat
+++ b/2022 - LA - Dark Angels.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="ee5e-198e-1b19-4b9f" name="LA -   I: Dark Angels" revision="32" battleScribeVersion="2.03" authorName="revivedtitan" authorContact="BSData Developers Discord" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="72" type="catalogue">
+<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="ee5e-198e-1b19-4b9f" name="LA -   I: Dark Angels" revision="33" battleScribeVersion="2.03" authorName="revivedtitan" authorContact="BSData Developers Discord" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="72" type="catalogue">
   <entryLinks>
     <entryLink id="7653-8041-8d1c-c872" name="Dreadwing Interemptor Squad" hidden="false" collective="false" import="false" targetId="3008-e8ed-9e97-71c9" type="selectionEntry">
       <categoryLinks>
@@ -88,7 +88,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="9d97-2b3e-e904-a1c9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="ab33-7225-f48a-340c" name="Primarch:" hidden="false" targetId="ad5f-31db-8bc7-5c46" primary="true"/>
+        <categoryLink name="Primarch:" hidden="false" id="3a26-e559-ccd0-c634" targetId="e031-3c2-e3f8-d40a" primary="true"/>
       </categoryLinks>
       <entryLinks>
         <entryLink id="f6a1-76fb-9dff-b12b" name="Retinue" hidden="false" collective="false" import="true" targetId="66e9-e8f8-5eb6-1cf6" type="selectionEntryGroup"/>

--- a/2022 - LA - Death Guard.cat
+++ b/2022 - LA - Death Guard.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="d228-55e8-b58c-1b77" name="LA -  XIV: Death Guard" revision="31" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="67" type="catalogue">
+<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="d228-55e8-b58c-1b77" name="LA -  XIV: Death Guard" revision="32" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="67" type="catalogue">
   <entryLinks>
     <entryLink id="fb89-32c1-bdc5-2e3d" name="Mortarion" hidden="false" collective="false" import="false" targetId="7427-bdfa-c359-ebb8" type="selectionEntry">
       <modifiers>
@@ -10,8 +10,8 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="44be-4e1f-6984-02f2" name="Primarch:" hidden="false" targetId="ad5f-31db-8bc7-5c46" primary="true"/>
         <categoryLink id="edd2-1a56-37a4-4b58" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink name="Primarch:" hidden="false" id="c2e1-4834-a4e1-1f02" targetId="e031-3c2-e3f8-d40a" primary="true"/>
       </categoryLinks>
       <entryLinks>
         <entryLink id="66ca-39a9-1b99-9840" name="Retinue" hidden="false" collective="false" import="true" targetId="2bcb-6e52-0eb9-9ffe" type="selectionEntryGroup">

--- a/2022 - LA - Emperor's Children.cat
+++ b/2022 - LA - Emperor's Children.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="72ba-61c2-37ad-c785" name="LA -   III: Emperor&apos;s Children" revision="37" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="67" type="catalogue">
+<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="72ba-61c2-37ad-c785" name="LA -   III: Emperor&apos;s Children" revision="38" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="67" type="catalogue">
   <entryLinks>
     <entryLink id="a119-3943-4b8b-b651" name="Captain Lucius" hidden="true" collective="false" import="false" targetId="0707-1e4b-27da-9cd4" type="selectionEntry">
       <modifiers>
@@ -43,8 +43,8 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="d1b1-8747-b31c-93ba" name="Primarch:" hidden="false" targetId="ad5f-31db-8bc7-5c46" primary="true"/>
         <categoryLink id="d25a-accf-b6de-facb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink targetId="e031-3c2-e3f8-d40a" id="186a-7a0a-7ae4-183a" primary="true" name="Primarch:"/>
       </categoryLinks>
       <entryLinks>
         <entryLink id="39cf-7589-ae76-3a78" name="Retinue" hidden="false" collective="false" import="true" targetId="30af-29e4-7637-73ea" type="selectionEntryGroup">
@@ -3070,7 +3070,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="5c74-92e9-4f38-43a3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink targetId="ad5f-31db-8bc7-5c46" id="a1a0-3e30-fae2-1899" primary="true" name="Primarch:"/>
+        <categoryLink targetId="e031-3c2-e3f8-d40a" id="e9eb-bbb4-2d45-258c" primary="true" name="Primarch:"/>
       </categoryLinks>
       <entryLinks>
         <entryLink id="733e-3646-4ae2-b070" name="Retinue" hidden="false" collective="false" import="true" targetId="30af-29e4-7637-73ea" type="selectionEntryGroup">
@@ -3454,7 +3454,7 @@ A unit with this special rule gains +1 to the score used to calculate the winner
                 <conditionGroup type="or">
                   <conditions>
                     <condition field="selections" scope="primary-category" value="3" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="4f85-eb33-30c9-8f51" type="instanceOf"/>
-                    <condition type="instanceOf" value="1" field="selections" scope="primary-category" childId="ad5f-31db-8bc7-5c46" shared="true"/>
+                    <condition type="instanceOf" value="1" field="selections" scope="primary-category" childId="e031-3c2-e3f8-d40a" shared="true"/>
                   </conditions>
                 </conditionGroup>
               </conditionGroups>

--- a/2022 - LA - Imperial Fists.cat
+++ b/2022 - LA - Imperial Fists.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="8866-00ec-715f-f21a" name="LA -   VII: Imperial Fists" revision="32" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="67" type="catalogue">
+<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="8866-00ec-715f-f21a" name="LA -   VII: Imperial Fists" revision="33" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="67" type="catalogue">
   <entryLinks>
     <entryLink id="b3e4-1487-4ab7-7515" name="Alexis Polux" hidden="false" collective="false" import="false" targetId="9229-b4f9-2213-9672" type="selectionEntry">
       <modifiers>
@@ -144,8 +144,8 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="47a6-fca8-5f4d-405a" name="Primarch:" hidden="false" targetId="ad5f-31db-8bc7-5c46" primary="true"/>
         <categoryLink id="e638-6d16-32ac-73f5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink name="Primarch:" hidden="false" id="499b-942e-745a-c9d5" targetId="e031-3c2-e3f8-d40a" primary="true"/>
       </categoryLinks>
       <entryLinks>
         <entryLink id="6b40-1eaa-cd91-0399" name="Retinue" hidden="false" collective="false" import="true" targetId="446f-102e-289b-bdc5" type="selectionEntryGroup">

--- a/2022 - LA - Iron Hands.cat
+++ b/2022 - LA - Iron Hands.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="b73e-125f-db29-17f2" name="LA -  X: Iron Hands" revision="38" battleScribeVersion="2.03" authorName="Figjam Bohica" authorContact="BSData Developers Discord" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="67" type="catalogue">
+<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="b73e-125f-db29-17f2" name="LA -  X: Iron Hands" revision="39" battleScribeVersion="2.03" authorName="Figjam Bohica" authorContact="BSData Developers Discord" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="67" type="catalogue">
   <entryLinks>
     <entryLink id="6107-168e-198e-2e94" name="X: Iron Hands" hidden="false" collective="false" import="false" targetId="bfc9-c99c-bf8a-3917" type="selectionEntry">
       <modifiers>
@@ -107,8 +107,8 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="84ec-691d-8d75-7998" name="Primarch:" hidden="false" targetId="ad5f-31db-8bc7-5c46" primary="true"/>
         <categoryLink id="4198-15b1-372c-89c8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink name="Primarch:" hidden="false" id="e86f-727f-5a53-bc6e" targetId="e031-3c2-e3f8-d40a" primary="true"/>
       </categoryLinks>
       <entryLinks>
         <entryLink id="2ad9-8ddd-07ac-2cd0" name="Retinue" hidden="false" collective="false" import="true" targetId="8a62-e4e2-d57f-5c33" type="selectionEntryGroup">

--- a/2022 - LA - Iron Warriors.cat
+++ b/2022 - LA - Iron Warriors.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="2ee4-57ed-db44-8a63" name="LA -   IV: Iron Warriors" revision="37" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="67" type="catalogue">
+<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="2ee4-57ed-db44-8a63" name="LA -   IV: Iron Warriors" revision="38" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="67" type="catalogue">
   <entryLinks>
     <entryLink id="fe10-3104-0252-96de" name="Nârik Dreygur" hidden="true" collective="false" import="false" targetId="ac97-c8ce-16ba-9c49" type="selectionEntry">
       <modifiers>
@@ -31,8 +31,8 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="4fe3-7aed-a86d-e3a9" name="Primarch:" hidden="false" targetId="ad5f-31db-8bc7-5c46" primary="true"/>
         <categoryLink id="23ea-8f2f-28bd-c663" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink name="Primarch:" hidden="false" id="b18d-f3b9-d9db-84a7" targetId="e031-3c2-e3f8-d40a" primary="true"/>
       </categoryLinks>
       <entryLinks>
         <entryLink id="8c24-60da-1f2e-692f" name="Retinue" hidden="false" collective="false" import="true" targetId="6590-c91a-fceb-8048" type="selectionEntryGroup">
@@ -3182,7 +3182,7 @@
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="135"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="f944-6641-a714-2fe8" name="Perturabo" hidden="false" collective="false" import="true" type="model">
+    <selectionEntry id="f944-6641-a714-2fe8" name="Perturabo" hidden="false" collective="false" import="true" type="unit">
       <modifiers>
         <modifier type="add" field="category" value="7a92-1a29-c087-51c6">
           <conditions>

--- a/2022 - LA - Night Lords.cat
+++ b/2022 - LA - Night Lords.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="36dc-14fc-8872-476b" name="LA -   VIII: Night Lords" revision="38" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="70" type="catalogue">
+<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="36dc-14fc-8872-476b" name="LA -   VIII: Night Lords" revision="39" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="70" type="catalogue">
   <entryLinks>
     <entryLink id="f491-c7fa-f6d3-917d" name="Contekar Terminator Squad" hidden="false" collective="false" import="false" targetId="837e-c3ca-437e-dfbf" type="selectionEntry">
       <modifiers>
@@ -36,7 +36,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="c700-6253-d5c4-b462" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="dead-a3bc-6447-64ea" name="Primarch:" hidden="false" targetId="ad5f-31db-8bc7-5c46" primary="true"/>
+        <categoryLink name="Primarch:" hidden="false" id="aaed-b39a-4407-9ba4" targetId="e031-3c2-e3f8-d40a" primary="true"/>
       </categoryLinks>
       <entryLinks>
         <entryLink id="6585-f156-4a2a-d71c" name="Retinue" hidden="false" collective="false" import="true" targetId="f728-26bf-3c99-1529" type="selectionEntryGroup">

--- a/2022 - LA - Raven Guard.cat
+++ b/2022 - LA - Raven Guard.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="d21e-9c80-a7f8-728c" name="LA - XIX: Raven Guard" revision="28" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="67" type="catalogue">
+<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="d21e-9c80-a7f8-728c" name="LA - XIX: Raven Guard" revision="29" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="67" type="catalogue">
   <entryLinks>
     <entryLink id="84cc-e59c-174e-fb25" name="Mor Deythan Squad" hidden="false" collective="false" import="false" targetId="c268-08ac-5b90-d034" type="selectionEntry">
       <categoryLinks>
@@ -49,8 +49,8 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="f2cb-5a4e-7c3e-733a" name="Primarch:" hidden="false" targetId="ad5f-31db-8bc7-5c46" primary="true"/>
         <categoryLink id="393b-c443-85dd-4f06" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink name="Primarch:" hidden="false" id="ea9f-876a-6b90-52dd" targetId="e031-3c2-e3f8-d40a" primary="true"/>
       </categoryLinks>
       <entryLinks>
         <entryLink id="4a8f-58bb-3473-6a14" name="Retinue" hidden="false" collective="false" import="true" targetId="5a61-7572-048d-9bb4" type="selectionEntryGroup">

--- a/2022 - LA - Salamanders.cat
+++ b/2022 - LA - Salamanders.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="3547-84d8-d789-bab7" name="LA -  XVIII: Salamanders" revision="36" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="72" type="catalogue">
+<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="3547-84d8-d789-bab7" name="LA -  XVIII: Salamanders" revision="37" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="72" type="catalogue">
   <entryLinks>
     <entryLink id="93d2-b1cb-b684-a9b3" name="XVIII: Salamanders" hidden="false" collective="false" import="false" targetId="c805-ca3a-ff93-5e2f" type="selectionEntry">
       <modifiers>
@@ -121,8 +121,8 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="64a8-ba7d-4c9b-3f3e" name="Primarch:" hidden="false" targetId="ad5f-31db-8bc7-5c46" primary="true"/>
         <categoryLink id="6d75-8f0a-3caa-689d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink name="Primarch:" hidden="false" id="ea94-92c4-9b03-7dc7" targetId="e031-3c2-e3f8-d40a" primary="true"/>
       </categoryLinks>
       <entryLinks>
         <entryLink id="bc7a-ac29-6730-32df" name="Retinue" hidden="false" collective="false" import="true" targetId="ec53-0911-52b7-dafa" type="selectionEntryGroup">

--- a/2022 - LA - Sons of Horus.cat
+++ b/2022 - LA - Sons of Horus.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="62c7-42f4-5523-af1b" name="LA -  XVI: Sons of Horus" revision="35" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="67" type="catalogue">
+<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="62c7-42f4-5523-af1b" name="LA -  XVI: Sons of Horus" revision="36" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="67" type="catalogue">
   <entryLinks>
     <entryLink id="c2a2-9b6d-b384-3f43" name="XVI: Sons of Horus" hidden="false" collective="false" import="false" targetId="01b4-57c7-bf61-2abf" type="selectionEntry">
       <modifiers>
@@ -135,8 +135,8 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="2fe4-5c5c-bead-f06e" name="Primarch:" hidden="false" targetId="ad5f-31db-8bc7-5c46" primary="true"/>
         <categoryLink id="734c-b12a-678e-ad6a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink name="Primarch:" hidden="false" id="738-faf-d830-2c52" targetId="e031-3c2-e3f8-d40a" primary="true"/>
       </categoryLinks>
       <entryLinks>
         <entryLink id="9105-b87b-8f32-dee6" name="Retinue" hidden="false" collective="false" import="true" targetId="b574-7838-ac21-b8f6" type="selectionEntryGroup">

--- a/2022 - LA - Space Wolves.cat
+++ b/2022 - LA - Space Wolves.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="ca15-13de-89cb-bbb2" name="LA -   VI: Space Wolves" revision="32" battleScribeVersion="2.03" authorName="Mr_Dark, UrsinePatriarch" authorContact="BSData Developers Discord" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="67" type="catalogue">
+<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="ca15-13de-89cb-bbb2" name="LA -   VI: Space Wolves" revision="33" battleScribeVersion="2.03" authorName="Mr_Dark, UrsinePatriarch" authorContact="BSData Developers Discord" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="67" type="catalogue">
   <entryLinks>
     <entryLink id="ff53-69d9-ec0b-9caa" name="VI: Space Wolves" hidden="false" collective="false" import="false" targetId="4916-965e-8339-44f6" type="selectionEntry">
       <modifiers>
@@ -118,8 +118,8 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="02d9-6d81-e872-d7b7" name="Primarch:" hidden="false" targetId="ad5f-31db-8bc7-5c46" primary="true"/>
         <categoryLink id="1b8f-f807-3d22-80df" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink name="Primarch:" hidden="false" id="d79-1dfa-e04e-6941" targetId="e031-3c2-e3f8-d40a" primary="true"/>
       </categoryLinks>
       <entryLinks>
         <entryLink id="66de-17b9-a9bf-bdd7" name="Retinue" hidden="false" collective="false" import="true" targetId="5408-6204-0336-0ce2" type="selectionEntryGroup">

--- a/2022 - LA - Thousand Sons.cat
+++ b/2022 - LA - Thousand Sons.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="abac-8dd1-df65-e253" name="LA -  XV: Thousand Sons" revision="33" battleScribeVersion="2.03" authorName="Arkangelmark5" authorContact="BSData Developers Discord" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="67" type="catalogue">
+<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="abac-8dd1-df65-e253" name="LA -  XV: Thousand Sons" revision="34" battleScribeVersion="2.03" authorName="Arkangelmark5" authorContact="BSData Developers Discord" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="67" type="catalogue">
   <publications>
     <publication id="f743-7ff9-a2f3-01c7" name="Exemplary Battles of the Age of Darkness: The Axandria IV Incident" shortName="Axandria IV" publisher="Exemplary Battles of the Age of Darkness: The Axandria IV Incident" publicationDate="9/16/2022" publisherUrl="https://www.warhammer-community.com/wp-content/uploads/2022/09/3mVvZrTG9XOWeVxv.pdf"/>
   </publications>
@@ -83,8 +83,8 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="9eae-bf6a-4193-af6b" name="Primarch:" hidden="false" targetId="ad5f-31db-8bc7-5c46" primary="true"/>
         <categoryLink id="922a-8088-b111-6bad" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink name="Primarch:" hidden="false" id="e85f-c6a2-724-e6c6" targetId="e031-3c2-e3f8-d40a" primary="true"/>
       </categoryLinks>
       <entryLinks>
         <entryLink id="6ee1-9e29-92e1-7c95" name="Retinue" hidden="false" collective="false" import="true" targetId="39e7-5296-42e0-fe94" type="selectionEntryGroup">
@@ -4790,7 +4790,6 @@
         <infoLink id="414e-3741-48f2-7114" name="Legiones Astartes (Thousand Sons)" hidden="false" targetId="2377-1d73-44bc-fee2" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="45af-d7ac-39f4-2234" name="Primarch:" hidden="false" targetId="ad5f-31db-8bc7-5c46" primary="false"/>
         <categoryLink id="9f33-3de6-2245-536e" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="930a-fad8-ff6f-4b38" name="LoW &amp; Primarchs (25% Limit)" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false"/>
       </categoryLinks>

--- a/2022 - LA - Ultramarines.cat
+++ b/2022 - LA - Ultramarines.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="68ae-9855-b56a-95e6" name="LA -  XIII: Ultramarines" revision="38" battleScribeVersion="2.03" authorName="Mr_Dark, Alphalas, UrsinePatriarch" authorContact="BSData Developers Discord" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="67" type="catalogue">
+<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="68ae-9855-b56a-95e6" name="LA -  XIII: Ultramarines" revision="39" battleScribeVersion="2.03" authorName="Mr_Dark, Alphalas, UrsinePatriarch" authorContact="BSData Developers Discord" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="67" type="catalogue">
   <entryLinks>
     <entryLink id="76b3-52d9-a195-2b31" name="XIII: Ultramarines" hidden="false" collective="false" import="false" targetId="8e0f-3552-8842-f281" type="selectionEntry">
       <modifiers>
@@ -123,8 +123,8 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="4e41-472d-ebca-f3ce" name="Primarch:" hidden="false" targetId="ad5f-31db-8bc7-5c46" primary="true"/>
         <categoryLink id="9f58-9b7f-011e-d79c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink name="Primarch:" hidden="false" id="6152-f1ae-465c-dd93" targetId="e031-3c2-e3f8-d40a" primary="true"/>
       </categoryLinks>
       <entryLinks>
         <entryLink id="a2d5-2927-b429-ded7" name="Retinue" hidden="false" collective="false" import="true" targetId="f822-e866-658f-a875" type="selectionEntryGroup">

--- a/2022 - LA - White Scars.cat
+++ b/2022 - LA - White Scars.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="caa9-c50e-8eed-2259" name="LA -   V: White Scars" revision="36" battleScribeVersion="2.03" authorName="Mr_Dark, UrsinePatriarch" authorContact="BSData Developers Discord" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="67" type="catalogue">
+<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="caa9-c50e-8eed-2259" name="LA -   V: White Scars" revision="37" battleScribeVersion="2.03" authorName="Mr_Dark, UrsinePatriarch" authorContact="BSData Developers Discord" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="67" type="catalogue">
   <entryLinks>
     <entryLink id="a738-6a11-dfe7-286c" name="V: White Scars" hidden="false" collective="false" import="false" targetId="e01e-5cdd-e512-8353" type="selectionEntry">
       <modifiers>
@@ -123,8 +123,8 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="cb05-ddea-48b7-7034" name="Primarch:" hidden="false" targetId="ad5f-31db-8bc7-5c46" primary="true"/>
         <categoryLink id="f969-cbdf-b170-b089" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink name="Primarch:" hidden="false" id="aa6-e3a6-d77f-83eb" targetId="e031-3c2-e3f8-d40a" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="2b7a-a60d-fbc4-7000" name="Tsolmon Khan" hidden="false" collective="false" import="false" targetId="54fb-d060-193b-675d" type="selectionEntry">

--- a/2022 - LA - Word Bearers.cat
+++ b/2022 - LA - Word Bearers.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="1df7-bbbc-b70e-6a3f" name="LA -  XVII: Word Bearers" revision="34" battleScribeVersion="2.03" authorName="UrsinePatriarch" authorContact="BSData Developers Discord" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="67" type="catalogue">
+<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="1df7-bbbc-b70e-6a3f" name="LA -  XVII: Word Bearers" revision="35" battleScribeVersion="2.03" authorName="UrsinePatriarch" authorContact="BSData Developers Discord" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="67" type="catalogue">
   <categoryEntries>
     <categoryEntry id="821c-0c83-5ed0-ff6b" name="Harbinger of Chaos Restriction" hidden="false">
       <modifiers>
@@ -73,7 +73,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="bd80-e5c5-9f6b-9c59" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="bc01-7a4b-4350-fc46" name="Primarch:" hidden="false" targetId="ad5f-31db-8bc7-5c46" primary="true"/>
+        <categoryLink name="Primarch:" hidden="false" id="dbd2-e3ed-26b4-1bf5" targetId="e031-3c2-e3f8-d40a" primary="true"/>
       </categoryLinks>
       <entryLinks>
         <entryLink id="c07d-7c24-a0ba-e25e" name="Retinue" hidden="false" collective="false" import="true" targetId="bda8-b52d-c914-4ac2" type="selectionEntryGroup">

--- a/2022 - LA - World Eaters.cat
+++ b/2022 - LA - World Eaters.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="d901-0eca-48b5-304a" name="LA -  XII: World Eaters" revision="37" battleScribeVersion="2.03" authorName="UrsinePatriarch" authorContact="BSData Developers Discord" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="72" type="catalogue">
+<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="d901-0eca-48b5-304a" name="LA -  XII: World Eaters" revision="38" battleScribeVersion="2.03" authorName="UrsinePatriarch" authorContact="BSData Developers Discord" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="72" type="catalogue">
   <entryLinks>
     <entryLink id="d647-fd99-73e0-bd57" name="Angron" hidden="false" collective="false" import="false" targetId="6352-8efa-0cc4-cfa7" type="selectionEntry">
       <modifiers>
@@ -10,8 +10,8 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="e3d0-6c05-8d56-6e01" name="Primarch:" hidden="false" targetId="ad5f-31db-8bc7-5c46" primary="true"/>
         <categoryLink id="b212-8e0c-46ce-f3b9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink name="Primarch:" hidden="false" id="874e-a44-c124-cb5e" targetId="e031-3c2-e3f8-d40a" primary="true"/>
       </categoryLinks>
       <entryLinks>
         <entryLink id="9db7-975d-ce99-6f47" name="Retinue" hidden="false" collective="false" import="true" targetId="a01f-cd9e-bd21-853e" type="selectionEntryGroup">
@@ -4523,7 +4523,6 @@
       </infoLinks>
       <categoryLinks>
         <categoryLink id="b990-1902-a070-c6d2" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="a500-e244-4c25-e4aa" name="Primarch:" hidden="false" targetId="ad5f-31db-8bc7-5c46" primary="true"/>
         <categoryLink id="c7ff-aaf0-0516-ca7b" name="LoW &amp; Primarchs (25% Limit)" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false"/>
       </categoryLinks>
       <selectionEntries>

--- a/2022 - LI - Solar Auxilia.cat
+++ b/2022 - LI - Solar Auxilia.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="6af7-3fee-5bc1-7533" name="LI - Solar Auxilia" revision="28" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="70" type="catalogue">
+<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="6af7-3fee-5bc1-7533" name="LI - Solar Auxilia" revision="29" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="70" type="catalogue">
   <categoryEntries>
     <categoryEntry id="19f3-8727-02db-3ce5" name="Static Artillery" hidden="false">
       <rules>
@@ -11280,19 +11280,19 @@ If a Weapon Destroyed result is repaired, that weapon may not be used to attack 
       <selectionEntries>
         <selectionEntry type="model" name="Aethon Heavy Sentinel" id="fc1e-8738-4e75-bf6e" page="1" publicationId="2d3f-82d2-9db5-ca6d">
           <profiles>
-            <profile id="8021-6918-4ee1-b532" name="Aethon Heavy Sentinel" typeId="4bb2-cb95-e6c8-5a21">
+            <profile id="8021-6918-4ee1-b532" name="Aethon Heavy Sentinel" typeId="4bb2-cb95-e6c8-5a21" typeName="Unit" hidden="false">
               <characteristics>
-                <characteristic typeId="893e-2d76-8f04-44e5" name="Move">7</characteristic>
-                <characteristic typeId="cc42-7ed5-7092-5c84" name="WS">3</characteristic>
-                <characteristic typeId="74ae-c840-0036-d244" name="BS">3</characteristic>
-                <characteristic typeId="e478-41d4-a092-48a8" name="S">6</characteristic>
-                <characteristic typeId="c32b-5fdd-3fbe-9b1f" name="T">6</characteristic>
-                <characteristic typeId="57ee-1126-32a9-5672" name="W">5</characteristic>
-                <characteristic typeId="62d3-22d7-2d49-52dc" name="I">3</characteristic>
-                <characteristic typeId="f111-2ce5-dd12-d6b0" name="A">2</characteristic>
-                <characteristic typeId="e8a6-1da9-d384-8727" name="Ld">8</characteristic>
-                <characteristic typeId="e593-6b3c-f169-04f0" name="Save">2+</characteristic>
-                <characteristic typeId="ddd7-6f5c-a939-b69e" name="Unit Type">Cavalry (Heavy, Mechanised)</characteristic>
+                <characteristic name="Unit Type" id="91df-5264-ad86-1f1b" hidden="false" typeId="ddd7-6f5c-a939-b69e">Cavalry (Heavy, Mechanised)</characteristic>
+                <characteristic name="Move" id="ffd7-eb8-d690-bcff" hidden="false" typeId="893e-2d76-8f04-44e5">7</characteristic>
+                <characteristic name="WS" id="ac04-135-a05a-7a14" hidden="false" typeId="cc42-7ed5-7092-5c84">3</characteristic>
+                <characteristic name="BS" id="8827-ef49-383e-6283" hidden="false" typeId="74ae-c840-0036-d244">3</characteristic>
+                <characteristic name="S" id="88bf-8121-ac4b-118e" hidden="false" typeId="e478-41d4-a092-48a8">6</characteristic>
+                <characteristic name="T" id="6ee9-97d9-6e49-9dfd" hidden="false" typeId="c32b-5fdd-3fbe-9b1f">6</characteristic>
+                <characteristic name="W" id="5f14-e209-fb38-59d6" hidden="false" typeId="57ee-1126-32a9-5672">5</characteristic>
+                <characteristic name="I" id="b0fd-fb1e-ef38-38e9" hidden="false" typeId="62d3-22d7-2d49-52dc">3</characteristic>
+                <characteristic name="A" id="cae0-f3f1-2043-cb3d" hidden="false" typeId="f111-2ce5-dd12-d6b0">2</characteristic>
+                <characteristic name="Ld" id="36f4-87d0-14bc-acae" hidden="false" typeId="e8a6-1da9-d384-8727">8</characteristic>
+                <characteristic name="Save" id="323b-a961-5a98-a498" hidden="false" typeId="e593-6b3c-f169-04f0">2+</characteristic>
               </characteristics>
             </profile>
           </profiles>


### PR DESCRIPTION
#3160 had a minor flaw, Primarchs were using the force org slot and unit type as the same thing. This meant that a primarch was now counting as 2 force org slots.
I've fixed this by splitting out the unit type and the force org slot.
