### PR TITLE
Beta garmon new units wave 1

### DIFF
--- a/2022 - LA - Sons of Horus.cat
+++ b/2022 - LA - Sons of Horus.cat
@@ -5299,7 +5299,7 @@
                     <characteristic name="Range" id="7df9-be76-14e8-722d" hidden="false" typeId="95ba-cda7-b831-6066">-</characteristic>
                     <characteristic name="Strength" id="1ec4-1062-ec82-c269" hidden="false" typeId="24d9-b8e1-a355-2458">User</characteristic>
                     <characteristic name="AP" id="908-5de2-15c1-11d2" hidden="false" typeId="f7a6-e0d8-7973-cd8d">2</characteristic>
-                    <characteristic name="Type" id="70ae-90b6-8b13-4337" hidden="false" typeId="2f86-c8b4-b3b4-3ff9">Melee, Fleshbane, Murderous Strike (6+)</characteristic>
+                    <characteristic name="Type" id="70ae-90b6-8b13-4337" hidden="false" typeId="2f86-c8b4-b3b4-3ff9">Melee, Fleshbane, Murderous Strike (6+)</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
@@ -5324,7 +5324,7 @@
             <profile name="By the Hunter’s Moon" hidden="false" id="8ec6-cbd9-6f39-2f0c" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait" publicationId="d882-d2a-5da1-92c4" page="192">
               <characteristics>
                 <characteristic name="Text" id="ced4-eba-6755-a9ca" hidden="false" typeId="c68e-2cda-b67b-baca">If chosen as the army’s Warlord, Tybalt Marr automatically has the By the Hunter’s Moon Warlord Trait and may not select any other.
-By the Hunter’s Moon – Once per battle, at the end of his controlling player’s Movement phase, Tybalt Marr can conduct a Shock Assault. When he does so, each enemy unit within 12&quot; of Tybalt Marr must take a Pinning test. 
+By the Hunter’s Moon – Once per battle, at the end of his controlling player’s Movement phase, Tybalt Marr can conduct a Shock Assault. When he does so, each enemy unit within 12&quot; of Tybalt Marr must take a Pinning test. 
 In addition, an army whose Warlord has this trait may make an additional Reaction during the Assault phase as long as the Warlord has not been removed as a casualty.</characteristic>
               </characteristics>
             </profile>

--- a/2022 - LA - Sons of Horus.cat
+++ b/2022 - LA - Sons of Horus.cat
@@ -3109,6 +3109,7 @@
         <categoryLink id="dd19-c149-942f-a5b3" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
       </categoryLinks>
     </entryLink>
+    <entryLink import="true" name="Horus Aximand" hidden="false" id="cf96-20ed-cd69-347c" targetId="7ed0-7d06-406c-abd9" type="selectionEntry"/>
   </entryLinks>
   <sharedSelectionEntries>
     <selectionEntry id="0c73-9141-d1b4-6a40" name="Chieftain Squad" hidden="false" collective="false" import="true" type="unit">
@@ -5192,56 +5193,33 @@
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="c3db-b014-dfaa-d189" name="Tybalt Marr" publicationId="d0df-7166-5cd3-89fd" page="92" hidden="false" collective="false" import="true" type="unit">
+    <selectionEntry id="c3db-b014-dfaa-d189" name="Tybalt Marr" publicationId="d882-d2a-5da1-92c4" page="192" hidden="false" collective="false" import="true" type="unit">
       <constraints>
         <constraint field="selections" scope="roster" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ecb0-3e9c-e3b6-fde7" type="max"/>
       </constraints>
       <infoLinks>
         <infoLink id="8b6d-35f3-191d-2ae6" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule"/>
+        <infoLink name="Legiones Astartes (X)" hidden="false" type="rule" targetId="ffcb-13b4-9b4c-84da" id="4c6a-c188-4c33-8ddf">
+          <modifiers>
+            <modifier type="set" field="name" value="Legiones Astartes (Sons of Horus)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink name="Master of the Legion" hidden="false" type="rule" targetId="c772-87ea-d49c-c7ba" id="60a1-b316-41b5-b061"/>
+        <infoLink name="Hatred (X)" hidden="false" type="rule" targetId="dc0b-fe69-6b71-e0a4" id="547c-f3e1-4b87-a5bd">
+          <modifiers>
+            <modifier type="set" field="name" value="Hatred (Shattered Legions)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink name="Traitor" hidden="false" type="rule" targetId="eff2-8b0e-21da-2f0d" id="1092-c19e-4b65-9dcb"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="773d-17eb-9834-2e2a" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="d4f8-7cfd-49ff-ca02" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink targetId="36c3-e85e-97cc-c503" name="Unit:" primary="false" id="43e1-e69b-439b-ac0f"/>
+        <categoryLink targetId="4f85-eb33-30c9-8f51" primary="true" id="2ba0-4682-47b7-a1c2" name="HQ"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="2095-6d87-7bf5-f840" name="The Culling Blade" hidden="false" collective="false" import="true" type="upgrade">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9b3a-542c-9f64-43fd" type="max"/>
-            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6677-0feb-f086-8037" type="min"/>
-          </constraints>
-          <profiles>
-            <profile id="5472-3591-df1c-a996" name="The Culling Blade" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
-              <characteristics>
-                <characteristic name="Range" typeId="95ba-cda7-b831-6066">-</characteristic>
-                <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">5</characteristic>
-                <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">-</characteristic>
-                <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Melee, Breaching (5+)., Murderous Strike (5+), Duellist&apos;s Edge (1), Master-crafted</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
-          <infoLinks>
-            <infoLink id="70dd-29b5-f2ac-7708" name="Master-crafted" hidden="false" targetId="6de0-55b0-bf21-48b9" type="rule"/>
-            <infoLink id="1a2d-c26e-cea1-2765" name="Breaching (X)" hidden="false" targetId="a760-f736-1bf3-fa3c" type="rule">
-              <modifiers>
-                <modifier type="set" field="name" value="Breaching (5+)"/>
-              </modifiers>
-            </infoLink>
-            <infoLink id="877d-a1ab-2147-6daf" name="Murderous Strike (X)" hidden="false" targetId="93b9-1454-0e7c-42ae" type="rule">
-              <modifiers>
-                <modifier type="set" field="name" value="Murderous Strike (5+)"/>
-              </modifiers>
-            </infoLink>
-            <infoLink id="2be1-f255-4992-5f54" name="Duellist’s Edge (X)" hidden="false" targetId="7bf3-86ce-04c2-e6ba" type="rule">
-              <modifiers>
-                <modifier type="set" field="name" value="Duellist’s Edge (1)"/>
-              </modifiers>
-            </infoLink>
-          </infoLinks>
-          <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry type="model" import="true" name="Tybalt Marr" hidden="false" id="da20-54b1-fdb-9659">
+        <selectionEntry type="model" import="true" name="Tybalt Marr" hidden="false" id="da20-54b1-fdb-9659" page="192" publicationId="d882-d2a-5da1-92c4">
           <categoryLinks>
             <categoryLink targetId="4f07-3d45-4f28-a0c6" id="d42-4abd-3e06-f45" primary="false" name="Independent Character"/>
             <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="6c7d-d51d-432f-a82f" name="Infantry Unit Type" primary="false"/>
@@ -5253,68 +5231,104 @@
             <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="50ac-86a9-d0c3-2314"/>
           </constraints>
           <profiles>
-            <profile id="20e6-7fa0-e03b-84cb" name="Tybalt Marr" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName="Unit">
+            <profile id="20e6-7fa0-e03b-84cb" name="Tybalt Marr" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName="Unit" publicationId="d882-d2a-5da1-92c4" page="192">
               <characteristics>
                 <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Character, Unique)</characteristic>
                 <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7</characteristic>
-                <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">5</characteristic>
+                <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">6</characteristic>
                 <characteristic name="BS" typeId="74ae-c840-0036-d244">5</characteristic>
                 <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
                 <characteristic name="T" typeId="c32b-5fdd-3fbe-9b1f">4</characteristic>
                 <characteristic name="W" typeId="57ee-1126-32a9-5672">3</characteristic>
                 <characteristic name="I" typeId="62d3-22d7-2d49-52dc">5</characteristic>
-                <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">3</characteristic>
+                <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">4</characteristic>
                 <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">10</characteristic>
                 <characteristic name="Save" typeId="e593-6b3c-f169-04f0">2+</characteristic>
               </characteristics>
             </profile>
           </profiles>
+          <entryLinks>
+            <entryLink name="Banestrike bolter" hidden="false" type="selectionEntry" targetId="6865-354c-0880-ee5f" id="f3bc-a747-47d1-b7d0">
+              <constraints>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="8729-2039-47e3-a897"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="2bce-b5ed-4f39-abe6"/>
+              </constraints>
+            </entryLink>
+            <entryLink name="Bolt pistol" hidden="false" type="selectionEntry" targetId="e5ae-6872-37aa-8600" id="2188-b6db-4a1f-b757">
+              <constraints>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="e2ce-d612-45af-b65f"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="2984-f7f0-4b78-a427"/>
+              </constraints>
+            </entryLink>
+            <entryLink name="Iron halo" hidden="false" type="selectionEntry" targetId="b081-bf3c-f43d-4bd5" id="d3dc-28d6-436d-b873">
+              <constraints>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="2fcf-8ffb-4f9d-b930"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="d20b-5b36-4454-9b0c"/>
+              </constraints>
+            </entryLink>
+            <entryLink name="Frag grenades" hidden="false" type="selectionEntry" targetId="cf9c-327b-3449-00d7" id="9767-361b-4a97-8a10">
+              <constraints>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="7f42-3f88-436d-959d"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="4d04-989b-4881-9185"/>
+              </constraints>
+            </entryLink>
+            <entryLink name="Krak grenades" hidden="false" type="selectionEntry" targetId="99df-2421-acf7-a5ad" id="514a-c949-4d48-ab10">
+              <constraints>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="82dd-f240-49ba-a885"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="b725-8e5d-48e1-b7ea"/>
+              </constraints>
+            </entryLink>
+            <entryLink import="true" name="Artificer Armour" hidden="false" id="dac0-477b-9e13-a353" collective="false" targetId="583e-62cb-53f1-f952" type="selectionEntry">
+              <constraints>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="a115-8f9f-39a0-30ad" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="897b-6f25-e7f8-e75a" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+              </constraints>
+            </entryLink>
+          </entryLinks>
+          <comment>
+</comment>
+          <selectionEntries>
+            <selectionEntry type="upgrade" import="true" name="The Culling Blade" hidden="false" id="f708-8325-4f0e-dbc3">
+              <constraints>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="3484-b242-dce3-665-min" includeChildSelections="false"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="3484-b242-dce3-665-max" includeChildSelections="false"/>
+              </constraints>
+              <profiles>
+                <profile name="New Profile" hidden="false" id="f7a3-3bb2-d828-3dce" page="192" publicationId="d882-d2a-5da1-92c4" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+                  <characteristics>
+                    <characteristic name="Range" id="7df9-be76-14e8-722d" hidden="false" typeId="95ba-cda7-b831-6066">-</characteristic>
+                    <characteristic name="Strength" id="1ec4-1062-ec82-c269" hidden="false" typeId="24d9-b8e1-a355-2458">User</characteristic>
+                    <characteristic name="AP" id="908-5de2-15c1-11d2" hidden="false" typeId="f7a6-e0d8-7973-cd8d">2</characteristic>
+                    <characteristic name="Type" id="70ae-90b6-8b13-4337" hidden="false" typeId="2f86-c8b4-b3b4-3ff9">Melee, Fleshbane, Murderous Strike (6+)</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <infoLinks>
+                <infoLink name="Fleshbane" id="fef5-ffde-d4e8-d97a" hidden="false" type="rule" targetId="40cd-9505-253c-e76f"/>
+                <infoLink name="Murderous Strike (X)" id="ad8a-4425-ecc6-8f11" hidden="false" type="rule" targetId="93b9-1454-0e7c-42ae">
+                  <modifiers>
+                    <modifier type="set" value="Murderous Strike (6+)" field="name"/>
+                  </modifiers>
+                </infoLink>
+              </infoLinks>
+            </selectionEntry>
+          </selectionEntries>
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
-        <entryLink id="3d80-bb4b-a338-1dfd" name="Banestrike Bolter" hidden="false" collective="false" import="true" targetId="6865-354c-0880-ee5f" type="selectionEntry">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a844-395b-2fc8-778a" type="min"/>
-            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d165-ac5d-f854-3f4e" type="max"/>
-          </constraints>
-        </entryLink>
-        <entryLink id="4b62-a476-4e9c-aaf4" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="e5ae-6872-37aa-8600" type="selectionEntry">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7af3-a824-7d02-d2f9" type="max"/>
-            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cfb4-ca62-5028-c016" type="min"/>
-          </constraints>
-        </entryLink>
-        <entryLink id="dac0-477b-9e13-a353" name="Artificer Armour" hidden="false" collective="false" import="true" targetId="583e-62cb-53f1-f952" type="selectionEntry">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a115-8f9f-39a0-30ad" type="max"/>
-            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="897b-6f25-e7f8-e75a" type="min"/>
-          </constraints>
-        </entryLink>
-        <entryLink id="674e-472c-04d3-bf50" name="Iron Halo" hidden="false" collective="false" import="true" targetId="b081-bf3c-f43d-4bd5" type="selectionEntry">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="125d-6670-0228-4400" type="max"/>
-            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c783-5790-0c2b-ccb9" type="min"/>
-          </constraints>
-        </entryLink>
-        <entryLink id="513d-254f-0c57-77ec" name="Frag Grenades" hidden="false" collective="false" import="true" targetId="cf9c-327b-3449-00d7" type="selectionEntry">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="82b4-e53e-8e87-58fa" type="min"/>
-            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6574-afa2-ff46-b34c" type="max"/>
-          </constraints>
-        </entryLink>
-        <entryLink id="11d9-cec7-c3b1-7a6e" name="Krak Grenades" hidden="false" collective="false" import="true" targetId="99df-2421-acf7-a5ad" type="selectionEntry">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2f38-ca61-86e7-b1a5" type="min"/>
-            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="aa27-d393-180e-c5e7" type="max"/>
-          </constraints>
-        </entryLink>
         <entryLink id="3fc5-0ceb-c9f6-ab2b" name="Warlord" hidden="false" collective="false" import="true" targetId="0176-56a3-d590-b103" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2c7d-51de-08ef-ce26" type="max"/>
           </constraints>
-          <entryLinks>
-            <entryLink id="7a0e-8ef9-0003-ad42" name="The Armour of Pride" hidden="false" collective="false" import="true" targetId="5cda-4256-f20a-9764" type="selectionEntry"/>
-          </entryLinks>
+          <profiles>
+            <profile name="By the Hunter’s Moon" hidden="false" id="8ec6-cbd9-6f39-2f0c" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait" publicationId="d882-d2a-5da1-92c4" page="192">
+              <characteristics>
+                <characteristic name="Text" id="ced4-eba-6755-a9ca" hidden="false" typeId="c68e-2cda-b67b-baca">If chosen as the army’s Warlord, Tybalt Marr automatically has the By the Hunter’s Moon Warlord Trait and may not select any other.
+By the Hunter’s Moon – Once per battle, at the end of his controlling player’s Movement phase, Tybalt Marr can conduct a Shock Assault. When he does so, each enemy unit within 12&quot; of Tybalt Marr must take a Pinning test. 
+In addition, an army whose Warlord has this trait may make an additional Reaction during the Assault phase as long as the Warlord has not been removed as a casualty.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
         </entryLink>
         <entryLink id="4383-2955-67f1-bb4c" name="Retinue" hidden="false" collective="false" import="true" targetId="b574-7838-ac21-b8f6" type="selectionEntryGroup"/>
         <entryLink id="c58c-b25c-fefb-9473" name="Master of the Legion" hidden="false" collective="false" import="true" targetId="0068-6b0a-0086-3d6b" type="selectionEntry">
@@ -5325,7 +5339,7 @@
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="160"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="af3a-334f-152f-d55f" name="Reaver Aggressor Squad" hidden="false" collective="false" import="true" type="unit">
@@ -6230,6 +6244,142 @@ Blood and Honour – When a Wound is allocated to Vheren Ashurhaddon by his cont
       <costs>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="205"/>
       </costs>
+    </selectionEntry>
+    <selectionEntry name="Horus Aximand" type="unit" id="7ed0-7d06-406c-abd9" page="190" publicationId="d882-d2a-5da1-92c4">
+      <categoryLinks>
+        <categoryLink targetId="36c3-e85e-97cc-c503" name="Unit:" primary="false" id="59d3-27f7-43fe-9d46"/>
+        <categoryLink targetId="4f85-eb33-30c9-8f51" primary="true" id="3e23-d3b6-4c17-8379" name="HQ"/>
+      </categoryLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="170"/>
+      </costs>
+      <selectionEntries>
+        <selectionEntry type="model" name="Horus Aximand" id="1351-8bd4-4882-9719" page="190" publicationId="d882-d2a-5da1-92c4">
+          <profiles>
+            <profile id="afb1-b8bf-4b62-92c1" name="Horus Aximand" typeId="4bb2-cb95-e6c8-5a21" typeName="Unit" publicationId="d882-d2a-5da1-92c4" page="190">
+              <characteristics>
+                <characteristic typeId="893e-2d76-8f04-44e5" name="Move">7</characteristic>
+                <characteristic typeId="cc42-7ed5-7092-5c84" name="WS">6</characteristic>
+                <characteristic typeId="74ae-c840-0036-d244" name="BS">5</characteristic>
+                <characteristic typeId="e478-41d4-a092-48a8" name="S">4</characteristic>
+                <characteristic typeId="c32b-5fdd-3fbe-9b1f" name="T">4</characteristic>
+                <characteristic typeId="57ee-1126-32a9-5672" name="W">3</characteristic>
+                <characteristic typeId="62d3-22d7-2d49-52dc" name="I">5</characteristic>
+                <characteristic typeId="f111-2ce5-dd12-d6b0" name="A">4</characteristic>
+                <characteristic typeId="e8a6-1da9-d384-8727" name="Ld">9</characteristic>
+                <characteristic typeId="e593-6b3c-f169-04f0" name="Save">2+</characteristic>
+                <characteristic typeId="ddd7-6f5c-a939-b69e" name="Unit Type">Infantry (Character, Unique)</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <constraints>
+            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="fe10-fd65-4da2-9242"/>
+            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="f095-1a5f-44c5-b624"/>
+          </constraints>
+          <entryLinks>
+            <entryLink name="Banestrike bolter" hidden="false" type="selectionEntry" targetId="6865-354c-0880-ee5f" id="661b-0109-4343-861e">
+              <constraints>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="127f-aa77-4824-92af"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="5fcd-c83b-4e49-ac81"/>
+              </constraints>
+            </entryLink>
+            <entryLink name="Iron halo" hidden="false" type="selectionEntry" targetId="b081-bf3c-f43d-4bd5" id="a12e-fe1f-4a09-874c">
+              <constraints>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="0693-fa82-4f5b-ab40"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="2502-e704-4875-85fc"/>
+              </constraints>
+            </entryLink>
+            <entryLink name="Frag grenades" hidden="false" type="selectionEntry" targetId="cf9c-327b-3449-00d7" id="5c40-0aaa-4c4d-9f2b">
+              <constraints>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="8eaf-4060-4942-a5d0"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="9f15-d6ff-4363-987a"/>
+              </constraints>
+            </entryLink>
+            <entryLink name="Krak grenades" hidden="false" type="selectionEntry" targetId="99df-2421-acf7-a5ad" id="43ef-d0bb-4fe9-bf22">
+              <constraints>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="2b0b-75ca-4663-aa9f"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="2dda-d5b4-49ba-a2b1"/>
+              </constraints>
+            </entryLink>
+          </entryLinks>
+          <comment>
+</comment>
+          <categoryLinks>
+            <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="3a68-c48b-4613-bab4" name="Infantry" primary="false"/>
+            <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="3a39-5179-4b56-85e4" name="Character" primary="false"/>
+            <categoryLink targetId="aa94-5c65-d1f1-46a4" id="76a6-8678-4247-a7cd" name="Unique" primary="false"/>
+          </categoryLinks>
+          <selectionEntries>
+            <selectionEntry type="upgrade" import="true" name="Mourn-it-all" hidden="false" id="108c-7be9-b1a0-8837">
+              <constraints>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="8cda-7785-2367-9604-min" includeChildSelections="false"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="8cda-7785-2367-9604-max" includeChildSelections="false"/>
+              </constraints>
+              <profiles>
+                <profile name="Mourn-it-all" hidden="false" id="8cc3-89d6-4d75-1685" typeId="1a1a-e592-2849-a5c0" typeName="Weapon" publicationId="d882-d2a-5da1-92c4" page="191">
+                  <characteristics>
+                    <characteristic name="Range" id="bfe1-aaac-a281-f8b6" hidden="false" typeId="95ba-cda7-b831-6066">-</characteristic>
+                    <characteristic name="Strength" id="f4ac-eed9-a615-423" hidden="false" typeId="24d9-b8e1-a355-2458">+1</characteristic>
+                    <characteristic name="AP" id="5d6c-9ffc-80c5-4501" hidden="false" typeId="f7a6-e0d8-7973-cd8d">2</characteristic>
+                    <characteristic name="Type" id="f750-ff58-928-5644" hidden="false" typeId="2f86-c8b4-b3b4-3ff9">Melee, Master-crafted, Murderous Strike (5+)</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <infoLinks>
+                <infoLink name="Master-crafted" id="11fa-6fd8-a6c0-723f" hidden="false" type="rule" targetId="6de0-55b0-bf21-48b9"/>
+                <infoLink name="Murderous Strike (X)" id="6e8a-d43a-f619-2e53" hidden="false" type="rule" targetId="93b9-1454-0e7c-42ae">
+                  <modifiers>
+                    <modifier type="set" value="Murderous Strike (5+)" field="name"/>
+                  </modifiers>
+                </infoLink>
+              </infoLinks>
+            </selectionEntry>
+            <selectionEntry type="upgrade" import="true" name="Castigatus Combat Shield" hidden="false" id="f026-9776-7836-9c95">
+              <constraints>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="7f8a-e651-260b-9d91-min" includeChildSelections="false"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="7f8a-e651-260b-9d91-max" includeChildSelections="false"/>
+              </constraints>
+              <profiles>
+                <profile name="Castigatus Combat Shield" hidden="false" id="975d-6283-59c2-8b5e" typeId="2a1f-7837-f0ef-be44" typeName="Wargear Item" page="191" publicationId="d882-d2a-5da1-92c4">
+                  <characteristics>
+                    <characteristic name="Description" id="fb73-ce9e-a865-2c2d" hidden="false" typeId="347e-ee4a-764f-6be3">A Castigatus combat shield provides a 5+ Invulnerable Save and each time a successful Invulnerable Saving Throw is made for a model with a Castigatus combat shield against a melee attack, the unit that made that attack suffers asingle Str 4 AP - hit. A model with a Castigatus combat shield cannot claim bonus attacks for having more than one melee weapon, or make attacks during the Assault phase using a weapon with the Two-handed special rule.
+Invulnerable Saves granted by a Castigatus combat shield do not stack with other Invulnerable Saves, but can benefit from rules (such as cyber-familiar) that specifically increase existing saves. If a model has another Invulnerable Save then the controlling player must choose which one to use.</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntry>
+      </selectionEntries>
+      <infoLinks>
+        <infoLink name="Legiones Astartes (X)" hidden="false" type="rule" targetId="ffcb-13b4-9b4c-84da" id="0361-d368-4a46-9632">
+          <modifiers>
+            <modifier type="set" field="name" value="Legiones Astartes (Sons of Horus)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink name="Master of the Legion" hidden="false" type="rule" targetId="c772-87ea-d49c-c7ba" id="46e1-a18c-4134-a046"/>
+        <infoLink name="Relentless" hidden="false" type="rule" targetId="7adf-ac9a-5035-522d" id="c6d9-902f-4e8b-8d69"/>
+        <infoLink name="Traitor" hidden="false" type="rule" targetId="eff2-8b0e-21da-2f0d" id="81da-5594-47c3-b093"/>
+      </infoLinks>
+      <entryLinks>
+        <entryLink import="true" name="Warlord" hidden="false" id="381f-2bc8-8a74-2cad" type="selectionEntry" targetId="0176-56a3-d590-b103">
+          <profiles>
+            <profile name="Little Horus" hidden="false" id="9c0a-3c18-7db3-1f59" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait" publicationId="d882-d2a-5da1-92c4" page="190">
+              <characteristics>
+                <characteristic name="Text" id="cefd-af49-ec65-af16" hidden="false" typeId="c68e-2cda-b67b-baca">If chosen as the army’s Warlord, Horus Aximand automatically has the Little Horus Warlord Trait and may not select any other.
+Little Horus – The first time in any battle when Horus Aximand is reduced to 0 Wounds for any reason, he is not removed as a casualty, but instead remains inplay and regains D3 Wounds. This has no effect against attacks or rules which remove the model as a casualty without inflicting Wounds or against attacks with the Instant Death special rule.
+In addition, an army whose Warlord has this Trait may make an additional Reaction during the Shooting phase as long as the Warlord has not been removed as a casualty.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+        </entryLink>
+        <entryLink import="true" name="Retinue" hidden="false" id="1a57-3c15-2c9a-48cb" collective="false" targetId="b574-7838-ac21-b8f6" type="selectionEntryGroup"/>
+      </entryLinks>
+      <rules>
+        <rule name="Haunted" id="eb36-7380-6bad-1660" hidden="false" publicationId="d882-d2a-5da1-92c4" page="191">
+          <description>If Garviel Loken is removed as a casualty whilst locked in combat with Horus Aximand or any unit he has joined then Horus Aximand’s controlling player gains +1 bonus Victory point in addition to any others that might be gained from this; this bonus is increased to +2 bonus Victory points if Garviel Loken is removed as a casualty while Engaged in a Challenge with Horus Aximand.</description>
+        </rule>
+      </rules>
     </selectionEntry>
   </sharedSelectionEntries>
   <sharedSelectionEntryGroups>

--- a/2022 - LI - Solar Auxilia.cat
+++ b/2022 - LI - Solar Auxilia.cat
@@ -4100,19 +4100,19 @@
           <selectionEntries>
             <selectionEntry type="model" import="true" name="Hermes Veletarii Sentinel" hidden="false" id="adab-c06b-41b9-ab59" page="181" publicationId="d882-d2a-5da1-92c4" defaultAmount="2">
               <profiles>
-                <profile name="Hermes Veletarii Sentinel" typeId="4bb2-cb95-e6c8-5a21" typeName="Unit" hidden="false" id="7818-24b8-4e17-9253">
+                <profile name="Hermes Veletarii Sentinel" typeId="4bb2-cb95-e6c8-5a21" typeName="Unit" hidden="false" id="7818-24b8-4e17-9253" publicationId="d882-d2a-5da1-92c4" page="181">
                   <characteristics>
-                    <characteristic name="Move" id="46a6-1972-6308-fba3" hidden="false" typeId="893e-2d76-8f04-44e5">8</characteristic>
-                    <characteristic name="WS" id="91b0-3c90-4652-193f" hidden="false" typeId="cc42-7ed5-7092-5c84">4</characteristic>
-                    <characteristic name="BS" id="5b3f-914f-5d27-c5b6" hidden="false" typeId="74ae-c840-0036-d244">4</characteristic>
-                    <characteristic name="S" id="52c4-3fab-3d86-3bae" hidden="false" typeId="e478-41d4-a092-48a8">5</characteristic>
-                    <characteristic name="T" id="fa4f-3b4e-d92b-88e0" hidden="false" typeId="c32b-5fdd-3fbe-9b1f">5</characteristic>
-                    <characteristic name="W" id="dda7-4c80-e10f-d22a" hidden="false" typeId="57ee-1126-32a9-5672">2</characteristic>
-                    <characteristic name="I" id="4b06-3351-3be8-1f44" hidden="false" typeId="62d3-22d7-2d49-52dc">3</characteristic>
-                    <characteristic name="A" id="8003-c75c-412d-fb44" hidden="false" typeId="f111-2ce5-dd12-d6b0">1</characteristic>
-                    <characteristic name="Ld" id="ab34-8938-9374-8b8e" hidden="false" typeId="e8a6-1da9-d384-8727">7</characteristic>
-                    <characteristic name="Save" id="a4e-5b91-d2c4-e851" hidden="false" typeId="e593-6b3c-f169-04f0">3+</characteristic>
-                    <characteristic name="Unit Type" id="6267-38b8-34f1-edb4" hidden="false" typeId="ddd7-6f5c-a939-b69e"/>
+                    <characteristic name="Unit Type" id="d447-3b56-d87-7b95" hidden="false" typeId="ddd7-6f5c-a939-b69e">Cavalry (Mechanised) + (Heavy) from Reinforced Void Armor</characteristic>
+                    <characteristic name="Move" id="c960-d1fc-64e0-4e7" hidden="false" typeId="893e-2d76-8f04-44e5">8</characteristic>
+                    <characteristic name="WS" id="74cc-b0a-7c3e-cb2d" hidden="false" typeId="cc42-7ed5-7092-5c84">4</characteristic>
+                    <characteristic name="BS" id="2ce9-bed4-de68-3093" hidden="false" typeId="74ae-c840-0036-d244">4</characteristic>
+                    <characteristic name="S" id="3901-e3d7-af1f-52e2" hidden="false" typeId="e478-41d4-a092-48a8">5</characteristic>
+                    <characteristic name="T" id="dd4a-e8d6-8076-3250" hidden="false" typeId="c32b-5fdd-3fbe-9b1f">5</characteristic>
+                    <characteristic name="W" id="6fe3-d1ce-8b75-3f76" hidden="false" typeId="57ee-1126-32a9-5672">2</characteristic>
+                    <characteristic name="I" id="97d3-b78e-b847-a8d5" hidden="false" typeId="62d3-22d7-2d49-52dc">3</characteristic>
+                    <characteristic name="A" id="f63a-dc0a-2716-87ff" hidden="false" typeId="f111-2ce5-dd12-d6b0">1</characteristic>
+                    <characteristic name="Ld" id="32f7-626e-240f-3c34" hidden="false" typeId="e8a6-1da9-d384-8727">7</characteristic>
+                    <characteristic name="Save" id="a6d-9526-512e-4484" hidden="false" typeId="e593-6b3c-f169-04f0">3+</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
@@ -4150,6 +4150,11 @@
                 </entryLink>
               </entryLinks>
               <comment>Didn&apos;t make a wargear item for the sentinel, since it&apos;s covered by the equipment and statline.</comment>
+              <categoryLinks>
+                <categoryLink name="Cavalry Unit Type" hidden="false" id="311e-5b08-fdb5-ac6" targetId="6d79-a3e4-381f-7b0f" primary="false"/>
+                <categoryLink name="Mechanised Unit Sub-type" hidden="false" id="e5fb-8548-d531-a3ef" targetId="e929-a5c3-451c-6f19" primary="false"/>
+                <categoryLink name="Heavy Sub-type" hidden="false" id="3d27-d430-43a8-1031" targetId="9231-183c-b97b-63f9" primary="false"/>
+              </categoryLinks>
             </selectionEntry>
           </selectionEntries>
           <constraints>

--- a/2022 - LI - Solar Auxilia.cat
+++ b/2022 - LI - Solar Auxilia.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="6af7-3fee-5bc1-7533" name="LI - Solar Auxilia" revision="29" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="70" type="catalogue">
+<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="6af7-3fee-5bc1-7533" name="LI - Solar Auxilia" revision="30" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="70" type="catalogue">
   <categoryEntries>
     <categoryEntry id="19f3-8727-02db-3ce5" name="Static Artillery" hidden="false">
       <rules>
@@ -789,6 +789,7 @@
         <categoryLink name="SA or IM Unit" hidden="false" id="4766-fcbf-87b4-1a86" targetId="4aca-2849-7f41-0200" primary="false"/>
       </categoryLinks>
     </entryLink>
+    <entryLink import="true" name="Hermes Light Sentinel Squadron" hidden="false" id="bbfd-1946-109f-2ccb" targetId="5ad9-7ffe-4a41-8f57" type="selectionEntry"/>
   </entryLinks>
   <sharedSelectionEntries>
     <selectionEntry id="9dd4-325a-c1cb-fac2" name="Legate Marshal" hidden="false" collective="false" import="true" type="unit">
@@ -3699,6 +3700,17 @@
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="18"/>
           </costs>
+          <modifierGroups>
+            <modifierGroup type="and">
+              <modifiers>
+                <modifier type="set" value="2" field="b8d7-d27c-2841-12af"/>
+                <modifier type="set" value="0" field="a8bc-6d7a-6118-1894"/>
+              </modifiers>
+              <conditions>
+                <condition type="atLeast" value="1" field="selections" scope="parent" childId="8c69-57dc-440c-b706" shared="true" includeChildSelections="false"/>
+              </conditions>
+            </modifierGroup>
+          </modifierGroups>
         </selectionEntry>
         <selectionEntry id="0508-f8a6-3996-bf39" name="Veletaris Vanguard Section" hidden="false" collective="false" import="true" type="unit">
           <constraints>
@@ -4077,6 +4089,72 @@
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="18"/>
           </costs>
+        </selectionEntry>
+        <selectionEntry type="unit" import="true" name="Hermes Veletaris Squadron" hidden="false" id="8c69-57dc-440c-b706" page="181" publicationId="d882-d2a-5da1-92c4">
+          <categoryLinks>
+            <categoryLink name="Unit:" hidden="false" id="bcc6-6674-41b6-9e30" targetId="36c3-e85e-97cc-c503" primary="false"/>
+          </categoryLinks>
+          <costs>
+            <cost name="Pts" id="cf49-c219-3829-e19c" hidden="false" typeId="d2ee-04cb-5f8a-2642" value="17"/>
+          </costs>
+          <selectionEntries>
+            <selectionEntry type="model" import="true" name="Hermes Veletarii Sentinel" hidden="false" id="adab-c06b-41b9-ab59" page="181" publicationId="d882-d2a-5da1-92c4" defaultAmount="2">
+              <profiles>
+                <profile name="Hermes Veletarii Sentinel" typeId="4bb2-cb95-e6c8-5a21" typeName="Unit" hidden="false" id="7818-24b8-4e17-9253">
+                  <characteristics>
+                    <characteristic name="Move" id="46a6-1972-6308-fba3" hidden="false" typeId="893e-2d76-8f04-44e5">8</characteristic>
+                    <characteristic name="WS" id="91b0-3c90-4652-193f" hidden="false" typeId="cc42-7ed5-7092-5c84">4</characteristic>
+                    <characteristic name="BS" id="5b3f-914f-5d27-c5b6" hidden="false" typeId="74ae-c840-0036-d244">4</characteristic>
+                    <characteristic name="S" id="52c4-3fab-3d86-3bae" hidden="false" typeId="e478-41d4-a092-48a8">5</characteristic>
+                    <characteristic name="T" id="fa4f-3b4e-d92b-88e0" hidden="false" typeId="c32b-5fdd-3fbe-9b1f">5</characteristic>
+                    <characteristic name="W" id="dda7-4c80-e10f-d22a" hidden="false" typeId="57ee-1126-32a9-5672">2</characteristic>
+                    <characteristic name="I" id="4b06-3351-3be8-1f44" hidden="false" typeId="62d3-22d7-2d49-52dc">3</characteristic>
+                    <characteristic name="A" id="8003-c75c-412d-fb44" hidden="false" typeId="f111-2ce5-dd12-d6b0">1</characteristic>
+                    <characteristic name="Ld" id="ab34-8938-9374-8b8e" hidden="false" typeId="e8a6-1da9-d384-8727">7</characteristic>
+                    <characteristic name="Save" id="a4e-5b91-d2c4-e851" hidden="false" typeId="e593-6b3c-f169-04f0">3+</characteristic>
+                    <characteristic name="Unit Type" id="6267-38b8-34f1-edb4" hidden="false" typeId="ddd7-6f5c-a939-b69e"/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name="Pts" id="8fb3-e75f-fa3d-625e" hidden="false" typeId="d2ee-04cb-5f8a-2642" value="24"/>
+              </costs>
+              <constraints>
+                <constraint type="min" value="2" field="selections" scope="parent" shared="true" id="a577-c13c-2a0c-734b" includeChildSelections="false"/>
+                <constraint type="max" value="6" field="selections" scope="parent" shared="true" id="ad54-b3d5-1e2f-31d1" includeChildSelections="false"/>
+              </constraints>
+              <selectionEntryGroups>
+                <selectionEntryGroup name="Hermes Light Sentinel Weapon Option" id="5437-cf9e-80c1-fcc8" hidden="false">
+                  <entryLinks>
+                    <entryLink import="true" name="Volkite Caliver" hidden="false" id="3348-965-dae-36d3" type="selectionEntry" targetId="9250-490f-abeb-b901" defaultAmount="1"/>
+                    <entryLink import="true" name="Heavy Flamer" hidden="false" id="8308-cf39-a9f3-4c8c" type="selectionEntry" targetId="5507-b432-3b4c-df12"/>
+                  </entryLinks>
+                  <constraints>
+                    <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="5572-b0d4-1a98-c166-min" includeChildSelections="false"/>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="5572-b0d4-1a98-c166-max" includeChildSelections="false"/>
+                  </constraints>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+              <entryLinks>
+                <entryLink import="true" name="Laspistol" hidden="false" id="d0be-a42d-68d6-1238" type="selectionEntry" targetId="654d-be88-b0a8-7ae5">
+                  <constraints>
+                    <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="e3de-7fc9-a99f-e898"/>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="ee12-77f8-1a77-49b7"/>
+                  </constraints>
+                </entryLink>
+                <entryLink import="true" name="Reinforced Void Armour" hidden="false" id="3021-ea0-271d-6c57" type="selectionEntry" targetId="cc63-5cc3-212a-3d4c">
+                  <constraints>
+                    <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="eb2b-114a-1a7-ffc4"/>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="860d-bbaf-25ed-4138"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
+              <comment>Didn&apos;t make a wargear item for the sentinel, since it&apos;s covered by the equipment and statline.</comment>
+            </selectionEntry>
+          </selectionEntries>
+          <constraints>
+            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="de14-3f73-cea1-40f9" includeChildSelections="false"/>
+          </constraints>
         </selectionEntry>
       </selectionEntries>
       <costs>
@@ -11435,6 +11513,213 @@ If a Weapon Destroyed result is repaired, that weapon may not be used to attack 
       <costs>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5"/>
       </costs>
+    </selectionEntry>
+    <selectionEntry name="Hermes Light Sentinel Squadron" type="unit" id="5ad9-7ffe-4a41-8f57" page="180" publicationId="d882-d2a-5da1-92c4">
+      <categoryLinks>
+        <categoryLink targetId="36c3-e85e-97cc-c503" name="Unit:" primary="false" id="b6e0-0310-41f1-8d43"/>
+        <categoryLink targetId="20ef-cd01-a8da-376e" primary="true" id="de92-02d2-4a19-baf3" name="Fast Attack"/>
+      </categoryLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="14"/>
+      </costs>
+      <selectionEntries>
+        <selectionEntry type="model" name="Hermes Light Sentinel" id="b834-2881-4d5f-bea5" page="180" publicationId="d882-d2a-5da1-92c4">
+          <profiles>
+            <profile id="3898-8d8a-4692-98d6" name="Hermes Light Sentinel" typeId="4bb2-cb95-e6c8-5a21" typeName="Unit">
+              <characteristics>
+                <characteristic typeId="893e-2d76-8f04-44e5" name="Move">10</characteristic>
+                <characteristic typeId="cc42-7ed5-7092-5c84" name="WS">3</characteristic>
+                <characteristic typeId="74ae-c840-0036-d244" name="BS">3</characteristic>
+                <characteristic typeId="e478-41d4-a092-48a8" name="S">5</characteristic>
+                <characteristic typeId="c32b-5fdd-3fbe-9b1f" name="T">5</characteristic>
+                <characteristic typeId="57ee-1126-32a9-5672" name="W">2</characteristic>
+                <characteristic typeId="62d3-22d7-2d49-52dc" name="I">3</characteristic>
+                <characteristic typeId="f111-2ce5-dd12-d6b0" name="A">1</characteristic>
+                <characteristic typeId="e8a6-1da9-d384-8727" name="Ld">7</characteristic>
+                <characteristic typeId="e593-6b3c-f169-04f0" name="Save">4+</characteristic>
+                <characteristic typeId="ddd7-6f5c-a939-b69e" name="Unit Type">Cavalry (Mechanised, Skirmish)</characteristic>
+              </characteristics>
+            </profile>
+            <profile name="Hermes Light Sentinel" hidden="false" id="d0d2-4cda-588-1a1f" typeId="2a1f-7837-f0ef-be44" typeName="Wargear Item" publicationId="d882-d2a-5da1-92c4" page="180">
+              <characteristics>
+                <characteristic name="Description" id="749b-9a53-747-b9c9" hidden="false" typeId="347e-ee4a-764f-6be3">When a model with a Hermes Light Sentinel chooses to Run, it gains the Shrouded (5+) special rule
+until the start of the controlling player’s next turn.</characteristic>
+              </characteristics>
+              <comment>Left off the multi-laser bit, as we&apos;re covering that in wargear.</comment>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="18"/>
+          </costs>
+          <constraints>
+            <constraint type="min" value="2" field="selections" scope="parent" shared="true" id="b1ba-c654-45f0-9261"/>
+            <constraint type="max" value="6" field="selections" scope="parent" shared="true" id="6033-bec8-479f-b185"/>
+          </constraints>
+          <entryLinks>
+            <entryLink name="Laspistol" hidden="false" type="selectionEntry" targetId="654d-be88-b0a8-7ae5" id="eabd-1f3d-4025-a131">
+              <constraints>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="6758-9859-4e0d-931f"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="a3ad-f702-4caa-8a2b"/>
+              </constraints>
+            </entryLink>
+            <entryLink name="Void armour" hidden="false" type="selectionEntry" targetId="6112-2c54-ceb5-a24d" id="b17e-c1c2-41a3-a61f">
+              <constraints>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="8b21-5f1a-49d1-b0dd"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="9a85-bec6-4451-8170"/>
+              </constraints>
+            </entryLink>
+          </entryLinks>
+          <selectionEntryGroups>
+            <selectionEntryGroup name="Hermes Light Sentinel Weapon Option" id="e4ae-7e1e-7ad1-6b13" hidden="false">
+              <selectionEntries>
+                <selectionEntry type="upgrade" import="true" name="Hermes Grenade Launcher" hidden="false" id="730c-990d-888d-6b7b" publicationId="d882-d2a-5da1-92c4" page="180">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5"/>
+                  </costs>
+                  <profiles>
+                    <profile name="Hermes grenade launcher - Frag" hidden="false" id="8ac5-967c-85a5-ea4c" page="180" publicationId="d882-d2a-5da1-92c4" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+                      <characteristics>
+                        <characteristic name="Range" id="30a9-ce05-21ad-b8b4" hidden="false" typeId="95ba-cda7-b831-6066">18&quot;</characteristic>
+                        <characteristic name="Strength" id="3f46-51cc-bf24-f0a" hidden="false" typeId="24d9-b8e1-a355-2458">4</characteristic>
+                        <characteristic name="AP" id="cb9d-ad57-3c12-8ce" hidden="false" typeId="f7a6-e0d8-7973-cd8d">5</characteristic>
+                        <characteristic name="Type" id="db9e-e227-e8ba-5a73" hidden="false" typeId="2f86-c8b4-b3b4-3ff9">Assault 1, Blast (3&quot;), Pinning</characteristic>
+                      </characteristics>
+                    </profile>
+                    <profile name="Hermes grenade launcher - Krak" hidden="false" id="b479-2b10-d436-f660" page="180" publicationId="d882-d2a-5da1-92c4" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+                      <characteristics>
+                        <characteristic name="Range" id="dba6-b007-f145-48b3" hidden="false" typeId="95ba-cda7-b831-6066">18&quot;</characteristic>
+                        <characteristic name="Strength" id="88f0-cd1a-8e7d-da06" hidden="false" typeId="24d9-b8e1-a355-2458">6</characteristic>
+                        <characteristic name="AP" id="b591-5f5c-28a5-b10" hidden="false" typeId="f7a6-e0d8-7973-cd8d">4</characteristic>
+                        <characteristic name="Type" id="259a-38ee-a78c-f199" hidden="false" typeId="2f86-c8b4-b3b4-3ff9">Assault 2</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <infoLinks>
+                    <infoLink name="Pinning" id="3e95-73be-5ff9-7156" hidden="false" type="rule" targetId="1c96-205c-59a0-3cf2"/>
+                    <infoLink name="Blast" id="7762-2a31-60c8-1984" hidden="false" type="rule" targetId="1d9a-73ef-5f4f-8bd8">
+                      <modifiers>
+                        <modifier type="set" value="Blast (3&quot;)" field="name"/>
+                      </modifiers>
+                    </infoLink>
+                  </infoLinks>
+                </selectionEntry>
+              </selectionEntries>
+              <entryLinks>
+                <entryLink import="true" name="Multi-Laser" hidden="false" id="3734-ff28-3da3-d89b" type="selectionEntry" targetId="003b-af4b-0094-f5c3" defaultAmount="1"/>
+              </entryLinks>
+              <constraints>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="da97-7100-22a5-434d-min" includeChildSelections="false"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="da97-7100-22a5-434d-max" includeChildSelections="false"/>
+              </constraints>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <categoryLinks>
+            <categoryLink targetId="6d79-a3e4-381f-7b0f" id="c334-541e-4af1-b917" name="Cavalry" primary="false"/>
+            <categoryLink targetId="e929-a5c3-451c-6f19" id="368f-c96e-415d-9169" name="Mechanised" primary="false"/>
+            <categoryLink targetId="59a4-7b61-600a-c457" id="e0e0-aef0-4000-8758" name="Skirmish" primary="false"/>
+          </categoryLinks>
+        </selectionEntry>
+      </selectionEntries>
+    </selectionEntry>
+    <selectionEntry name="Aethon Heavy Sentinel Squadron" type="unit" id="0393-dd19-4e18-a52c" page="182" publicationId="d882-d2a-5da1-92c4">
+      <categoryLinks>
+        <categoryLink targetId="36c3-e85e-97cc-c503" name="Unit:" primary="false" id="babb-bceb-4152-86bf"/>
+        <categoryLink targetId="7031-469a-1aeb-eab0" primary="true" id="85ad-9c4b-4f0e-9bf9" name="Heavy Support"/>
+      </categoryLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5"/>
+      </costs>
+      <selectionEntries>
+        <selectionEntry type="model" name="Aethon Heavy Sentinel" id="a5e1-d207-48f0-b2cb" page="182" publicationId="d882-d2a-5da1-92c4">
+          <profiles>
+            <profile id="e78f-28b1-400a-820d" name="Aethon Heavy Sentinel" typeId="4bb2-cb95-e6c8-5a21">
+              <characteristics>
+                <characteristic typeId="893e-2d76-8f04-44e5" name="Move">7</characteristic>
+                <characteristic typeId="cc42-7ed5-7092-5c84" name="WS">3</characteristic>
+                <characteristic typeId="74ae-c840-0036-d244" name="BS">3</characteristic>
+                <characteristic typeId="e478-41d4-a092-48a8" name="S">6</characteristic>
+                <characteristic typeId="c32b-5fdd-3fbe-9b1f" name="T">6</characteristic>
+                <characteristic typeId="57ee-1126-32a9-5672" name="W">5</characteristic>
+                <characteristic typeId="62d3-22d7-2d49-52dc" name="I">3</characteristic>
+                <characteristic typeId="f111-2ce5-dd12-d6b0" name="A">2</characteristic>
+                <characteristic typeId="e8a6-1da9-d384-8727" name="Ld">8</characteristic>
+                <characteristic typeId="e593-6b3c-f169-04f0" name="Save">2+</characteristic>
+                <characteristic typeId="ddd7-6f5c-a939-b69e" name="Unit Type">Cavalry (Heavy, Mechanised)</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="65"/>
+          </costs>
+          <constraints>
+            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="34fe-ac20-4a64-9f76"/>
+            <constraint type="max" value="3" field="selections" scope="parent" shared="true" id="a03d-8bb1-496b-893b"/>
+          </constraints>
+          <comment>!BSC Errors from 20240409-1217
+Could not find wargear Aethon Heavy Sentinel
+Could not find wargear in Any model may replace the Aethon Heavy Sentinel’s multi-laser with one of the following:
+Could not find wargear in Any model may replace the Aethon Heavy Sentinel’s Aethon missile battery with:</comment>
+          <selectionEntryGroups>
+            <selectionEntryGroup name="Any model may replace the Aethon Heavy Sentinel’s multi-laser with one of the following:" id="9747-309d-4ac3-a6ab">
+              <entryLinks>
+                <entryLink name="Autocannon" hidden="false" type="selectionEntry" targetId="56b3-de09-9fea-deb6" id="ce0e-3205-495f-a504">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10"/>
+                  </costs>
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="ee2d-9d22-41d7-a656"/>
+                  </constraints>
+                </entryLink>
+                <entryLink name="Volkite culverin" hidden="false" type="selectionEntry" targetId="170d-44e0-455c-8207" id="0db7-4523-4af5-aeb5">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10"/>
+                  </costs>
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="e578-e424-4d55-8e33"/>
+                  </constraints>
+                </entryLink>
+                <entryLink name="Lascannon" hidden="false" type="selectionEntry" targetId="b252-5a86-6e0f-218b" id="1f8d-fd6d-4a32-a566">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20"/>
+                  </costs>
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="61b7-ca4f-487e-a185"/>
+                  </constraints>
+                </entryLink>
+                <entryLink name="Melta lance" hidden="false" type="selectionEntry" targetId="3926-1557-4647-d4a6" id="65a4-59c8-4f63-a402">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25"/>
+                  </costs>
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="e4e8-b017-4655-a74c"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
+              <comment>!BSC Errors from 20240409-1217
+Could not find wargear Heavy incinerator
+	 Checked under Heavy incinerator</comment>
+              <constraints>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="48b9-a9b7-473d-9c65"/>
+              </constraints>
+            </selectionEntryGroup>
+            <selectionEntryGroup name="Any model may replace the Aethon Heavy Sentinel’s Aethon missile battery with:" id="3ecc-6911-4dec-8b31">
+              <comment>!BSC Errors from 20240409-1217
+Could not find wargear 4 Hunter-killer missiles
+	 Checked under 4 Hunter-killer missiles</comment>
+              <constraints>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="2fc6-de32-43af-9115"/>
+              </constraints>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <categoryLinks>
+            <categoryLink targetId="6d79-a3e4-381f-7b0f" id="35a1-d3ae-474e-8d0f" name="Cavalry" primary="false"/>
+            <categoryLink targetId="9231-183c-b97b-63f9" id="f617-8068-434f-8050" name="Heavy" primary="false"/>
+            <categoryLink targetId="e929-a5c3-451c-6f19" id="43cf-a111-4171-b6e5" name="Mechanised" primary="false"/>
+          </categoryLinks>
+        </selectionEntry>
+      </selectionEntries>
+      <comment>!BSC Errors from 20240409-1217
+Could not find rule: None</comment>
     </selectionEntry>
   </sharedSelectionEntries>
   <sharedSelectionEntryGroups>

--- a/2022 - LI - Solar Auxilia.cat
+++ b/2022 - LI - Solar Auxilia.cat
@@ -11660,10 +11660,6 @@ until the start of the controlling player’s next turn.</characteristic>
             <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="34fe-ac20-4a64-9f76"/>
             <constraint type="max" value="3" field="selections" scope="parent" shared="true" id="a03d-8bb1-496b-893b"/>
           </constraints>
-          <comment>!BSC Errors from 20240409-1217
-Could not find wargear Aethon Heavy Sentinel
-Could not find wargear in Any model may replace the Aethon Heavy Sentinel’s multi-laser with one of the following:
-Could not find wargear in Any model may replace the Aethon Heavy Sentinel’s Aethon missile battery with:</comment>
           <selectionEntryGroups>
             <selectionEntryGroup name="Any model may replace the Aethon Heavy Sentinel’s multi-laser with one of the following:" id="9747-309d-4ac3-a6ab">
               <entryLinks>
@@ -11700,17 +11696,11 @@ Could not find wargear in Any model may replace the Aethon Heavy Sentinel’s Ae
                   </constraints>
                 </entryLink>
               </entryLinks>
-              <comment>!BSC Errors from 20240409-1217
-Could not find wargear Heavy incinerator
-	 Checked under Heavy incinerator</comment>
               <constraints>
                 <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="48b9-a9b7-473d-9c65"/>
               </constraints>
             </selectionEntryGroup>
             <selectionEntryGroup name="Any model may replace the Aethon Heavy Sentinel’s Aethon missile battery with:" id="3ecc-6911-4dec-8b31">
-              <comment>!BSC Errors from 20240409-1217
-Could not find wargear 4 Hunter-killer missiles
-	 Checked under 4 Hunter-killer missiles</comment>
               <constraints>
                 <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="2fc6-de32-43af-9115"/>
               </constraints>
@@ -11723,8 +11713,6 @@ Could not find wargear 4 Hunter-killer missiles
           </categoryLinks>
         </selectionEntry>
       </selectionEntries>
-      <comment>!BSC Errors from 20240409-1217
-Could not find rule: None</comment>
     </selectionEntry>
   </sharedSelectionEntries>
   <sharedSelectionEntryGroups>

--- a/2022 - LI - Solar Auxilia.cat
+++ b/2022 - LI - Solar Auxilia.cat
@@ -793,19 +793,10 @@
   </entryLinks>
   <sharedSelectionEntries>
     <selectionEntry id="9dd4-325a-c1cb-fac2" name="Legate Marshal" hidden="false" collective="false" import="true" type="unit">
-      <modifiers>
-        <modifier type="remove" field="category" value="9231-183c-b97b-63f9">
-          <conditions>
-            <condition field="selections" scope="9dd4-325a-c1cb-fac2" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="583e-62cb-53f1-f952" type="equalTo"/>
-          </conditions>
-        </modifier>
-      </modifiers>
       <constraints>
         <constraint field="selections" scope="force" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="154d-0b2b-1215-38bb" type="max"/>
       </constraints>
       <categoryLinks>
-        <categoryLink id="e7bd-8dd9-39fd-4e7d" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="3890-ed31-5e7e-4b77" name="Heavy Sub-type" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
         <categoryLink id="fb94-9780-7cb6-f0d9" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
         <categoryLink name="SA or IM Unit" hidden="false" id="e61e-4d32-7f6f-c86a" targetId="4aca-2849-7f41-0200" primary="false"/>
       </categoryLinks>
@@ -1190,6 +1181,330 @@
             <categoryLink targetId="9231-183c-b97b-63f9" id="4a38-8694-4340-b714" name="Heavy Sub-type" primary="false"/>
             <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="cadf-ce18-4f5a-8b07" name="Character" primary="false"/>
           </categoryLinks>
+          <modifiers>
+            <modifier type="remove" value="9231-183c-b97b-63f9" field="category">
+              <conditions>
+                <condition type="equalTo" value="1" field="selections" scope="9dd4-325a-c1cb-fac2" childId="583e-62cb-53f1-f952" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </selectionEntry>
+        <selectionEntry type="unit" import="true" name="Lifeward Section" hidden="false" id="2a87-dbc1-ad18-9949" publicationId="d882-d2a-5da1-92c4" page="186">
+          <constraints>
+            <constraint type="max" value="1" field="selections" scope="roster" shared="true" id="5fbd-9f4-8099-5f83" includeChildSelections="true"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry type="model" import="true" name="Auxilia Protector" hidden="false" id="4afc-4053-97e8-bc72">
+              <categoryLinks>
+                <categoryLink name="Infantry Unit Type" hidden="false" id="3912-49d3-3bcb-de70" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+                <categoryLink name="Heavy Sub-type" hidden="false" id="e3e8-a3f9-33c3-c21c" targetId="9231-183c-b97b-63f9" primary="false"/>
+              </categoryLinks>
+              <profiles>
+                <profile name="Auxilia Protector" hidden="false" id="3af-5f85-c5bc-9875" publicationId="d882-d2a-5da1-92c4" page="186" typeId="4bb2-cb95-e6c8-5a21" typeName="Unit">
+                  <characteristics>
+                    <characteristic name="Unit Type" id="bc75-1a50-dbad-100f" hidden="false" typeId="ddd7-6f5c-a939-b69e">Infantry (Heavy)</characteristic>
+                    <characteristic name="Move" id="f10e-7724-2f5f-369d" hidden="false" typeId="893e-2d76-8f04-44e5">6</characteristic>
+                    <characteristic name="WS" id="7aa2-c8af-b1fe-94ca" hidden="false" typeId="cc42-7ed5-7092-5c84">4</characteristic>
+                    <characteristic name="BS" id="18e2-451e-943a-ce0e" hidden="false" typeId="74ae-c840-0036-d244">4</characteristic>
+                    <characteristic name="S" id="69ba-ce11-81d1-3381" hidden="false" typeId="e478-41d4-a092-48a8">3</characteristic>
+                    <characteristic name="T" id="e6c4-b9db-d740-4ec4" hidden="false" typeId="c32b-5fdd-3fbe-9b1f">3</characteristic>
+                    <characteristic name="W" id="33a5-d959-5cdd-1814" hidden="false" typeId="57ee-1126-32a9-5672">2</characteristic>
+                    <characteristic name="I" id="4e84-1cf2-2e5d-6165" hidden="false" typeId="62d3-22d7-2d49-52dc">4</characteristic>
+                    <characteristic name="A" id="56e7-f502-245f-c310" hidden="false" typeId="f111-2ce5-dd12-d6b0">2</characteristic>
+                    <characteristic name="Ld" id="167b-80d4-b316-2f53" hidden="false" typeId="e8a6-1da9-d384-8727">8</characteristic>
+                    <characteristic name="Save" id="e1c2-28e2-a787-a590" hidden="false" typeId="e593-6b3c-f169-04f0">3+</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <selectionEntryGroups>
+                <selectionEntryGroup name="May exchange a Laspistol for:" id="aad-3346-9463-68b9" hidden="false" collective="false" import="true" defaultSelectionEntryId="5a58-c3f9-9c1d-46fa">
+                  <constraints>
+                    <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="e27-f24f-ac90-3659" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="ff46-b145-743d-2d33" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink import="true" name="Laspistol" hidden="false" id="1abe-6ea6-fdcb-c159" collective="false" targetId="654d-be88-b0a8-7ae5" type="selectionEntry" defaultAmount="1"/>
+                    <entryLink import="true" name="Blast Pistol" hidden="false" id="fb19-4f8c-2a6c-97ff" collective="false" targetId="2460-375d-31f4-4bdf" type="selectionEntry">
+                      <costs>
+                        <cost name="Pts" id="b74c-a4de-f34d-74d6" hidden="false" typeId="d2ee-04cb-5f8a-2642" value="2"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink import="true" name="Needle Pistol" hidden="false" id="ef3-9bcb-43cc-46db" collective="false" targetId="fdd4-06c7-4608-b07f" type="selectionEntry">
+                      <costs>
+                        <cost name="Pts" id="24ef-e75-a336-d134" hidden="false" typeId="d2ee-04cb-5f8a-2642" value="2"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink import="true" name="Hand Flamer" hidden="false" id="4fe2-71fa-6efc-cee3" collective="false" targetId="e337-adf4-a11f-0280" type="selectionEntry">
+                      <costs>
+                        <cost name="Pts" id="d725-bc63-7d1-20ee" hidden="false" typeId="d2ee-04cb-5f8a-2642" value="2"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink import="true" name="Plasma Pistol" hidden="false" id="9e96-27bd-daa1-6d57" collective="false" targetId="717f-cf0a-1593-4bd8" type="selectionEntry">
+                      <costs>
+                        <cost name="Pts" id="fd4b-4a3a-bcf5-7173" hidden="false" typeId="d2ee-04cb-5f8a-2642" value="5"/>
+                      </costs>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup name="May exchange a Close Combat Weapon for:" id="bebf-6543-57d4-b024" hidden="false" collective="false" import="true" defaultSelectionEntryId="8f78-cfce-3634-a3bd">
+                  <constraints>
+                    <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="707e-d821-cbc7-de32" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="ce06-2280-244d-8c63" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink import="true" name="Close Combat Weapon" hidden="false" id="a201-a1ad-84f7-d173" collective="false" targetId="3d50-2f85-06ff-6aee" type="selectionEntry" defaultAmount="1"/>
+                    <entryLink import="true" name="Power Weapon" hidden="false" id="3062-d2ed-b551-92b8" type="selectionEntry" targetId="d2db-7598-f55f-86fe">
+                      <costs>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink import="true" name="Charnabal Weapon" hidden="false" id="5a20-3322-fd25-8c4" type="selectionEntry" targetId="e749-ba9b-bb76-a7d9">
+                      <costs>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10"/>
+                      </costs>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup name="Lasrifle" id="2f75-e8fb-402a-c2a1" hidden="false">
+                  <entryLinks>
+                    <entryLink import="true" name="Lasrifle" hidden="false" id="3287-8a00-2e4c-e39a" type="selectionEntry" targetId="15f9-817e-275b-c13d" defaultAmount="1">
+                      <constraints>
+                        <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="9384-c3d6-d2f6-c4ee" includeChildSelections="false"/>
+                      </constraints>
+                    </entryLink>
+                    <entryLink import="true" name="Lasrifle with Bayonet" hidden="false" id="9368-712d-fe47-2da1" type="selectionEntry" targetId="2867-ab52-1247-2532">
+                      <costs>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="1"/>
+                      </costs>
+                      <constraints>
+                        <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="cbd1-1ef8-c123-cbfa" includeChildSelections="false"/>
+                      </constraints>
+                    </entryLink>
+                  </entryLinks>
+                  <constraints>
+                    <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="b529-7b76-c0e0-ba47-min" includeChildSelections="false"/>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="b529-7b76-c0e0-ba47-max" includeChildSelections="false"/>
+                  </constraints>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20"/>
+              </costs>
+              <constraints>
+                <constraint type="max" value="10" field="selections" scope="parent" shared="true" id="cfe9-e38-9913-e707" includeChildSelections="false"/>
+              </constraints>
+              <modifiers>
+                <modifier type="decrement" value="1" field="cfe9-e38-9913-e707">
+                  <repeats>
+                    <repeat value="1" repeats="1" field="selections" scope="parent" childId="15bd-9d36-66e6-37c3" shared="true" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <entryLinks>
+                <entryLink import="true" name="Heavy Void Armour" hidden="false" id="c4fc-ed6e-4349-547e" type="selectionEntry" targetId="523c-d7fb-5288-fe13">
+                  <constraints>
+                    <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="dcbe-3a39-cc52-f554-min" includeChildSelections="false"/>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="dcbe-3a39-cc52-f554-max" includeChildSelections="false"/>
+                  </constraints>
+                </entryLink>
+                <entryLink import="true" name="Refractor Field" hidden="false" id="a2a0-3d56-5278-6b7d" type="selectionEntry" targetId="a06a-55a5-070b-1d0e">
+                  <constraints>
+                    <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="7a60-750e-2f36-525-min" includeChildSelections="false"/>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="7a60-750e-2f36-525-max" includeChildSelections="false"/>
+                  </constraints>
+                </entryLink>
+                <entryLink import="true" name="Frag Grenades" hidden="false" id="9255-df14-276f-49e" type="selectionEntry" targetId="cf9c-327b-3449-00d7">
+                  <constraints>
+                    <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="55d0-f8e4-ac8b-8e16-min" includeChildSelections="false"/>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="55d0-f8e4-ac8b-8e16-max" includeChildSelections="false"/>
+                  </constraints>
+                </entryLink>
+                <entryLink import="true" name="Krak Grenades" hidden="false" id="9a4b-45c0-c39b-11ce" type="selectionEntry" targetId="99df-2421-acf7-a5ad">
+                  <constraints>
+                    <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="41bc-80ea-b9fe-db37-min" includeChildSelections="false"/>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="41bc-80ea-b9fe-db37-max" includeChildSelections="false"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
+            </selectionEntry>
+            <selectionEntry type="model" import="true" name="Auxilia Protector w/ Heavy Melee Weapon" hidden="false" id="15bd-9d36-66e6-37c3">
+              <categoryLinks>
+                <categoryLink name="Infantry Unit Type" hidden="false" id="f6e0-4b44-4dfa-6e29" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+                <categoryLink name="Heavy Sub-type" hidden="false" id="68ee-db36-ab7e-d162" targetId="9231-183c-b97b-63f9" primary="false"/>
+              </categoryLinks>
+              <infoLinks>
+                <infoLink name="Auxilia Protector" id="754a-278f-a0f4-8a2f" hidden="false" type="profile" targetId="3af-5f85-c5bc-9875"/>
+              </infoLinks>
+              <selectionEntryGroups>
+                <selectionEntryGroup name="May exchange a Laspistol for:" id="9716-cea0-a3-5d62" hidden="false" collective="false" import="true" defaultSelectionEntryId="5a58-c3f9-9c1d-46fa">
+                  <constraints>
+                    <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="397d-4572-6633-914e" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="48e2-86f8-7628-f6f" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink import="true" name="Laspistol" hidden="false" id="1898-e8f6-9952-9672" collective="false" targetId="654d-be88-b0a8-7ae5" type="selectionEntry" defaultAmount="1"/>
+                    <entryLink import="true" name="Blast Pistol" hidden="false" id="d432-7def-a3c9-bd81" collective="false" targetId="2460-375d-31f4-4bdf" type="selectionEntry">
+                      <costs>
+                        <cost name="Pts" id="5685-81c-ca55-ab86" hidden="false" typeId="d2ee-04cb-5f8a-2642" value="2"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink import="true" name="Needle Pistol" hidden="false" id="21d-e1d8-faf7-16f" collective="false" targetId="fdd4-06c7-4608-b07f" type="selectionEntry">
+                      <costs>
+                        <cost name="Pts" id="2ef4-d8bd-f86c-2d22" hidden="false" typeId="d2ee-04cb-5f8a-2642" value="2"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink import="true" name="Hand Flamer" hidden="false" id="ae82-8b72-ef65-7c00" collective="false" targetId="e337-adf4-a11f-0280" type="selectionEntry">
+                      <costs>
+                        <cost name="Pts" id="ec62-5120-d03c-b14c" hidden="false" typeId="d2ee-04cb-5f8a-2642" value="2"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink import="true" name="Plasma Pistol" hidden="false" id="34df-5636-1a32-8635" collective="false" targetId="717f-cf0a-1593-4bd8" type="selectionEntry">
+                      <costs>
+                        <cost name="Pts" id="6855-290c-4fcf-e16f" hidden="false" typeId="d2ee-04cb-5f8a-2642" value="5"/>
+                      </costs>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup name="Exchanged Lasrifle and CCW for:" id="7e7d-197f-525b-3308" hidden="false" collective="false" import="true" defaultSelectionEntryId="8f78-cfce-3634-a3bd">
+                  <constraints>
+                    <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="6fc2-b286-685a-d0ee" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="9cc7-8205-1a8a-fb29" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink import="true" name="Power Fist" hidden="false" id="1597-15c8-19dd-14e" collective="false" targetId="768d-b89b-7328-d749" type="selectionEntry">
+                      <costs>
+                        <cost name="Pts" id="d098-16ba-f90b-9020" hidden="false" typeId="d2ee-04cb-5f8a-2642" value="15"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink import="true" name="Thunder Hammer" hidden="false" id="e31-827b-9ad3-bd23" type="selectionEntry" targetId="838c-4002-713d-d7c6">
+                      <costs>
+                        <cost name="Pts" id="6d29-a43-ad4-faa6" hidden="false" typeId="d2ee-04cb-5f8a-2642" value="15"/>
+                      </costs>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+              <costs>
+                <cost name="Pts" id="fbc7-be04-a4f5-5740" hidden="false" typeId="d2ee-04cb-5f8a-2642" value="20"/>
+              </costs>
+              <constraints>
+                <constraint type="max" value="10" field="selections" scope="parent" shared="true" id="5f60-dab3-54b7-d2fc" includeChildSelections="false"/>
+                <constraint type="max" value="2" field="selections" scope="parent" shared="true" id="6aa8-4882-6f36-8050" includeChildSelections="false"/>
+              </constraints>
+              <entryLinks>
+                <entryLink import="true" name="Frag Grenades" hidden="false" id="cee6-af50-8b65-610b" type="selectionEntry" targetId="cf9c-327b-3449-00d7">
+                  <constraints>
+                    <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="4887-f5c3-cf4c-f05d-min" includeChildSelections="false"/>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="4887-f5c3-cf4c-f05d-max" includeChildSelections="false"/>
+                  </constraints>
+                </entryLink>
+                <entryLink import="true" name="Heavy Void Armour" hidden="false" id="a5a7-c8a3-1e67-56c8" type="selectionEntry" targetId="523c-d7fb-5288-fe13">
+                  <constraints>
+                    <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="6e89-d45-d7bf-9971-min" includeChildSelections="false"/>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="6e89-d45-d7bf-9971-max" includeChildSelections="false"/>
+                  </constraints>
+                </entryLink>
+                <entryLink import="true" name="Krak Grenades" hidden="false" id="cd87-afc1-68dd-cc9b" type="selectionEntry" targetId="99df-2421-acf7-a5ad">
+                  <constraints>
+                    <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="643d-c702-8a33-2de-min" includeChildSelections="false"/>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="643d-c702-8a33-2de-max" includeChildSelections="false"/>
+                  </constraints>
+                </entryLink>
+                <entryLink import="true" name="Refractor Field" hidden="false" id="3ad4-2e98-b5cc-62b1" type="selectionEntry" targetId="a06a-55a5-070b-1d0e">
+                  <constraints>
+                    <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="907f-f72e-90a3-6799-min" includeChildSelections="false"/>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="907f-f72e-90a3-6799-max" includeChildSelections="false"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
+            </selectionEntry>
+          </selectionEntries>
+          <infoLinks>
+            <infoLink name="Battle-Hardened (X)" id="6136-865d-6034-172" hidden="false" targetId="5c3b-ed0b-4ad0-d547" type="rule">
+              <modifiers>
+                <modifier type="set" value="Battle-Hardened (1)" field="name"/>
+              </modifiers>
+            </infoLink>
+            <infoLink name="Stubborn" id="f040-df01-1e41-c795" hidden="false" targetId="7989-1f2c-a43d-82ae" type="rule"/>
+            <infoLink name="Chosen Warriors" id="668f-863e-cb55-5cde" hidden="false" type="rule" targetId="13d1-9270-6539-08ed"/>
+          </infoLinks>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10"/>
+          </costs>
+          <selectionEntryGroups>
+            <selectionEntryGroup name="One Model may take:" id="8803-c678-5243-68f9" hidden="false">
+              <entryLinks>
+                <entryLink import="true" name="Meltabombs" hidden="false" id="cc74-94b6-2b2a-9e4b" type="selectionEntry" targetId="b9dd-3b21-f3f8-78e3">
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="c617-aa4e-4643-61d" includeChildSelections="false"/>
+                  </constraints>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5"/>
+                  </costs>
+                </entryLink>
+                <entryLink import="true" name="Command Vox" hidden="false" id="ed30-7626-a52d-fad4" type="selectionEntry" targetId="7ac4-c39b-5c48-63cb">
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="5c80-a4d8-907c-29c9" includeChildSelections="false"/>
+                  </constraints>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10"/>
+                  </costs>
+                </entryLink>
+              </entryLinks>
+              <selectionEntryGroups>
+                <selectionEntryGroup name="Vexilla" id="c912-7c36-4e5b-d64c" hidden="false">
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="7119-f8b2-b5c6-b007" includeChildSelections="false"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink import="true" name="Auxilia Vexilla" hidden="false" id="6ab5-818f-b709-eb01" type="selectionEntry" targetId="6f5a-bf56-4bee-ce7e" defaultAmount="1">
+                      <constraints>
+                        <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="b2fd-a90a-8e9b-c2cb" includeChildSelections="false"/>
+                      </constraints>
+                      <costs>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink import="true" name="Cohorts Vexilla" hidden="false" id="a070-d011-19d9-b806" type="selectionEntry" targetId="b66d-ca3f-b0ea-47ef">
+                      <constraints>
+                        <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="9173-6a57-be1-b645" includeChildSelections="false"/>
+                      </constraints>
+                      <costs>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15"/>
+                      </costs>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+            </selectionEntryGroup>
+            <selectionEntryGroup name="Dedicated Transports" id="8b0a-4a90-8277-2a8" hidden="false" collective="false" import="true">
+              <modifiers>
+                <modifier type="set" value="1" field="e805-dab5-e76f-fe37">
+                  <conditions>
+                    <condition type="equalTo" value="1" field="selections" scope="force" childId="d9a0-4875-fb75-f9a9" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
+                  </conditions>
+                </modifier>
+                <modifier type="set" value="true" field="hidden">
+                  <conditions>
+                    <condition type="atLeast" value="1" field="selections" scope="force" childId="7b69-bf2f-4547-e83b" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="9ef5-3cce-523a-8e0d" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                <constraint type="min" value="0" field="selections" scope="parent" shared="true" id="e805-dab5-e76f-fe37" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+              </constraints>
+              <entryLinks>
+                <entryLink import="true" name="Aurox Transport" hidden="false" id="b6f3-8b4c-3bb9-6e92" collective="false" targetId="071b-79e5-7b5b-c9cd" type="selectionEntry"/>
+                <entryLink import="true" name="Dracosan Armoured Transport" hidden="false" id="e17c-ada3-2e33-b4c1" collective="false" targetId="496b-a01b-3726-0a44" type="selectionEntry"/>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <rules>
+            <rule name="Legatine Retinue" id="6a3c-8394-cc95-98a0" hidden="false" publicationId="d882-d2a-5da1-92c4" page="187">
+              <description>A Solar Auxilia Lifeward Section may only be selected as part of a Detachment that includes a Solar Auxilia Legate Marshal. A unit selected in this manner is considered a ‘Retinue Squad’ and the model with the Solar Auxilia Legate Marshal that is part of the same Detachment is referred to as the Retinue Squad’s Leader for the purposes of this special rule. The Retinue Squad does not use up a Force Organisation slot and is considered part of the same unit as the model selected as its Leader. The Retinue Squad must be deployed with its Leader deployed as part of the unit and the Leader may not voluntarily leave the Retinue Squad during play. A Solar Auxilia Lifeward Section may not be selected as part of an army without a Leader.</description>
+            </rule>
+          </rules>
         </selectionEntry>
       </selectionEntries>
       <costs>

--- a/2022 - LI - Solar Auxilia.cat
+++ b/2022 - LI - Solar Auxilia.cat
@@ -8692,7 +8692,7 @@ Once assigned to a unit, the Auxilia Medicae is considered part of that unit and
               <profiles>
                 <profile id="ccb1-43bf-08c2-9169" name="Inferno Cannon" publicationId="15a4-fc68-502d-48a9" page="143" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
                   <characteristics>
-                    <characteristic name="Range" typeId="95ba-cda7-b831-6066">Helstorm</characteristic>
+                    <characteristic name="Range" typeId="95ba-cda7-b831-6066">Hellstorm</characteristic>
                     <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">8</characteristic>
                     <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">4</characteristic>
                     <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Ordnance 1, Torrent (9&quot;), Breaching (6+), Concussive (1)</characteristic>

--- a/raw/books.json
+++ b/raw/books.json
@@ -1,7 +1,28 @@
 [
   {
-    "file_name": "ZwQB9kBXZA3CyHN4.pdf",
-    "pub_id": "2d3f-82d2-9db5-ca6d",
-    "target_file_name": "2022 - LI - Solar Auxilia.cat"
+    "file_name": "The Horus Heresy - The Battle for Beta Garmon.pdf",
+    "pub_id": "d882-d2a-5da1-92c4",
+    "page_ranges": [
+      {
+        "start": 180,
+        "end": 182,
+        "target_file_name": "2022 - LI - Solar Auxilia.cat"
+      },
+      {
+        "start": 190,
+        "end": 192,
+        "target_file_name": "2022 - LA - Sons of Horus.cat"
+      },
+      {
+        "start": 194,
+        "end": 197,
+        "target_file_name": "2022 - Legiones Astartes.cat"
+      },
+      {
+        "start": 200,
+        "end": 203,
+        "target_file_name": "2022 - Legiones Astartes.cat"
+      }
+    ]
   }
 ]


### PR DESCRIPTION
Part of new content #3147
Solar Aux New Units: #3135 
- [x] Light Sentinel
- [x] Medium Sentinel
- [x] Lifewards (Couldn't use bscopy as the pdf made it mad)

Space Marines new Units 
- [x] Horus Aximand - Sons of Horus
- [x] Tybalt Marr - Sons of Horus
- [ ] Hibou Khan - LA Library, import into white scars and shattered legions
- [ ] Shadrak Meduson - LA Library, import into iron hands and shattered legions
- [ ] Endryd Haar - Blackshields 
- [x] Legion Optae - LA, Everybody can take!
- [ ] Legion Company Command Squad - LA, Everybody can take!
- [ ]  Legion Overseer consul - LA, not a new unit per say, but you get the idea. 