### PR TITLE
Enforce max 3 on veletarii

### DIFF
--- a/2022 - LI - Solar Auxilia.cat
+++ b/2022 - LI - Solar Auxilia.cat
@@ -2728,458 +2728,513 @@
       </modifiers>
       <constraints>
         <constraint field="selections" scope="parent" value="-1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ca24-f640-593d-b537" type="max"/>
-        <constraint type="min" value="1" field="selections" scope="self" shared="true" id="297b-656f-3c1c-8c5c"/>
-        <constraint type="max" value="3" field="selections" scope="self" shared="true" id="d497-66f1-6c32-3517"/>
       </constraints>
       <categoryLinks>
         <categoryLink id="4ee4-cb02-24f5-137f" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="43e3-5243-c97d-3eda" name="Close-order Sub-type" hidden="false" targetId="0af0-ea84-09d7-2b1f" primary="false"/>
         <categoryLink name="SA or IM Unit" hidden="false" id="b65c-3d61-86-e4eb" targetId="4aca-2849-7f41-0200" primary="false"/>
       </categoryLinks>
-      <selectionEntries>
-        <selectionEntry id="7474-ec3d-98de-d2e0" name="Veletaris Command Section" hidden="false" collective="false" import="true" type="unit">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2e7c-cc82-0b71-2b49" type="max"/>
-          </constraints>
-          <infoLinks>
-            <infoLink id="1d78-77e6-4fc9-1277" name="Tercio" hidden="false" targetId="6516-f81d-457b-a2cc" type="rule"/>
-            <infoLink id="a7e9-5843-7d41-821a" name="Stubborn" hidden="false" targetId="7989-1f2c-a43d-82ae" type="rule">
-              <modifiers>
-                <modifier type="set" field="hidden" value="true">
-                  <conditions>
-                    <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fe04-c096-f846-a6fd" type="equalTo"/>
-                  </conditions>
-                </modifier>
-              </modifiers>
-            </infoLink>
-            <infoLink id="b2f4-5cdf-e6b3-1008" name="Furious Charge (X)" hidden="false" targetId="2821-9269-862f-0554" type="rule">
-              <modifiers>
-                <modifier type="set" field="name" value="Furious Charge (1)"/>
-                <modifier type="set" field="hidden" value="true">
-                  <conditions>
-                    <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bfd2-7016-f5fe-be6a" type="equalTo"/>
-                  </conditions>
-                </modifier>
-              </modifiers>
-            </infoLink>
-            <infoLink id="5453-3686-610e-6266" name="Counter-Attack (X)" hidden="false" targetId="fd6d-2a76-10e0-936a" type="rule">
-              <modifiers>
-                <modifier type="set" field="name" value="Counter-Attack (1) (while &apos;In Formation&apos;)"/>
-                <modifier type="set" field="hidden" value="true">
-                  <conditions>
-                    <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="021e-6841-7375-7862" type="equalTo"/>
-                  </conditions>
-                </modifier>
-              </modifiers>
-            </infoLink>
-          </infoLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
+      </costs>
+      <selectionEntryGroups>
+        <selectionEntryGroup name="Tercio Units" id="8864-71e2-2283-28f8" hidden="false" flatten="true">
           <selectionEntries>
-            <selectionEntry id="b232-3a78-7275-2fa1" name="Veletarii First Prime" hidden="false" collective="false" import="true" type="model">
+            <selectionEntry type="unit" import="true" name="Veletaris Vanguard Section" hidden="false" id="0508-f8a6-3996-bf39" collective="false">
               <constraints>
-                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7235-781c-a3b9-ba87" type="min"/>
-                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fb9f-a73e-40b8-b198" type="max"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="320c-fc49-63d4-126a" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
               </constraints>
-              <profiles>
-                <profile id="4606-e745-412d-313c" name="Veletarii First Prime" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName="Unit">
+              <infoLinks>
+                <infoLink name="Tercio" id="02e8-2b87-bcad-28b5" hidden="false" targetId="6516-f81d-457b-a2cc" type="rule"/>
+                <infoLink name="Stubborn" id="937f-538b-f46c-b895" hidden="false" targetId="7989-1f2c-a43d-82ae" type="rule">
                   <modifiers>
-                    <modifier type="set" field="e593-6b3c-f169-04f0" value="3+">
+                    <modifier type="set" value="true" field="hidden">
                       <conditions>
-                        <condition field="selections" scope="b232-3a78-7275-2fa1" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="523c-d7fb-5288-fe13" type="equalTo"/>
-                      </conditions>
-                    </modifier>
-                    <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Infantry (Heavy, Character, Line)">
-                      <conditionGroups>
-                        <conditionGroup type="and">
-                          <conditions>
-                            <condition field="selections" scope="force" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a09b-28bd-8ffc-f4f0" type="equalTo"/>
-                            <condition field="selections" scope="primary-category" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9b5d-fac7-799b-d7e7" type="instanceOf"/>
-                          </conditions>
-                        </conditionGroup>
-                      </conditionGroups>
-                    </modifier>
-                    <modifier type="increment" field="e8a6-1da9-d384-8727" value="1">
-                      <conditions>
-                        <condition field="selections" scope="force" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fe04-c096-f846-a6fd" type="equalTo"/>
+                        <condition type="equalTo" value="0" field="selections" scope="force" childId="fe04-c096-f846-a6fd" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
                       </conditions>
                     </modifier>
                   </modifiers>
-                  <characteristics>
-                    <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Heavy, Character)</characteristic>
-                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">6</characteristic>
-                    <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
-                    <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
-                    <characteristic name="S" typeId="e478-41d4-a092-48a8">3</characteristic>
-                    <characteristic name="T" typeId="c32b-5fdd-3fbe-9b1f">3</characteristic>
-                    <characteristic name="W" typeId="57ee-1126-32a9-5672">1</characteristic>
-                    <characteristic name="I" typeId="62d3-22d7-2d49-52dc">4</characteristic>
-                    <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">2</characteristic>
-                    <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">8</characteristic>
-                    <characteristic name="Save" typeId="e593-6b3c-f169-04f0">4+</characteristic>
-                  </characteristics>
-                </profile>
-              </profiles>
-              <categoryLinks>
-                <categoryLink id="1278-bf88-ac56-9920" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="c68b-e63c-4de7-a247" name="Infantry Unit Type" primary="false"/>
-                <categoryLink targetId="9231-183c-b97b-63f9" id="95bf-a49f-432a-b6c4" name="Heavy Sub-type" primary="false"/>
-              </categoryLinks>
-              <selectionEntryGroups>
-                <selectionEntryGroup id="1cb1-052d-9cfe-0fc5" name="Armour" hidden="false" collective="false" import="true" defaultSelectionEntryId="09b8-e985-c536-4684">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d23a-c6f3-609c-e6d3" type="min"/>
-                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ff47-cdc2-d411-fc6e" type="max"/>
-                  </constraints>
-                  <entryLinks>
-                    <entryLink id="09b8-e985-c536-4684" name="Reinforced Void Armour" hidden="false" collective="false" import="true" targetId="cc63-5cc3-212a-3d4c" type="selectionEntry"/>
-                    <entryLink id="c593-dd64-e385-685d" name="Heavy Void Armour" hidden="false" collective="false" import="true" targetId="523c-d7fb-5288-fe13" type="selectionEntry">
-                      <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10"/>
-                      </costs>
-                    </entryLink>
-                  </entryLinks>
-                </selectionEntryGroup>
-                <selectionEntryGroup id="5f6e-e0a3-6584-f494" name="Weapons" hidden="false" collective="false" import="true" defaultSelectionEntryId="c6f7-69d2-456a-b8d9">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e40d-91f3-e8a0-e5ad" type="min"/>
-                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2b13-4a75-39ef-867a" type="max"/>
-                  </constraints>
-                  <selectionEntries>
-                    <selectionEntry id="2483-2a53-a4fc-0bba" name="Pistol and Combat weapon (Sub-menu)" hidden="false" collective="false" import="true" type="upgrade">
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a3b3-8bb4-0098-0d34" type="max"/>
-                      </constraints>
-                      <selectionEntryGroups>
-                        <selectionEntryGroup id="8903-0c12-c67c-6c4c" name="Close Combat" hidden="false" collective="false" import="true">
-                          <constraints>
-                            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dfe5-99cd-467c-ff16" type="min"/>
-                            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e847-9abf-caab-4cf9" type="max"/>
-                          </constraints>
-                          <entryLinks>
-                            <entryLink id="170b-a81a-5a77-0e88" name="Close Combat Weapon" hidden="false" collective="false" import="true" targetId="3d50-2f85-06ff-6aee" type="selectionEntry"/>
-                            <entryLink id="16e5-8246-891f-8de5" name="Power Fist" hidden="false" collective="false" import="true" targetId="768d-b89b-7328-d749" type="selectionEntry">
-                              <costs>
-                                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10"/>
-                              </costs>
-                            </entryLink>
-                            <entryLink id="f1c0-a394-e45d-a4ec" name="Power Sword" hidden="false" collective="false" import="true" targetId="a3cd-aa97-a148-2309" type="selectionEntry">
-                              <costs>
-                                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5"/>
-                              </costs>
-                            </entryLink>
-                            <entryLink id="fc64-47bd-0881-a0ef" name="Power Maul" hidden="false" collective="false" import="true" targetId="0df4-c67e-cf64-82e0" type="selectionEntry">
-                              <costs>
-                                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5"/>
-                              </costs>
-                            </entryLink>
-                            <entryLink id="4288-156c-ce79-201b" name="Power Lance" hidden="false" collective="false" import="true" targetId="a4c8-c8ff-87f2-1ac9" type="selectionEntry">
-                              <costs>
-                                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5"/>
-                              </costs>
-                            </entryLink>
-                            <entryLink id="6297-0651-3479-fd1e" name="Power Axe" hidden="false" collective="false" import="true" targetId="c066-2ace-f68c-e440" type="selectionEntry">
-                              <costs>
-                                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5"/>
-                              </costs>
-                            </entryLink>
-                            <entryLink id="4663-cacd-0e30-b4a8" name="Charnabal Tabar" hidden="false" collective="false" import="true" targetId="4611-c33e-f360-7246" type="selectionEntry">
-                              <costs>
-                                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5"/>
-                              </costs>
-                            </entryLink>
-                            <entryLink id="7e2b-d303-6f50-3a75" name="Charnabal Sabre" hidden="false" collective="false" import="true" targetId="30c2-57eb-5bbe-be0b" type="selectionEntry">
-                              <costs>
-                                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5"/>
-                              </costs>
-                            </entryLink>
-                            <entryLink id="080b-b2d3-eef8-2805" name="Charnabal Glaive" hidden="false" collective="false" import="true" targetId="c07c-35e6-4616-ef25" type="selectionEntry">
-                              <costs>
-                                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5"/>
-                              </costs>
-                            </entryLink>
-                          </entryLinks>
-                        </selectionEntryGroup>
-                        <selectionEntryGroup id="de9f-b846-c818-9e80" name="Pistol" hidden="false" collective="false" import="true">
-                          <constraints>
-                            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ba1f-c478-e955-e07a" type="min"/>
-                            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fea1-f3b9-7440-3ef3" type="max"/>
-                          </constraints>
-                          <entryLinks>
-                            <entryLink id="3cec-d192-84c1-be5c" name="Blast Pistol" hidden="false" collective="false" import="true" targetId="2460-375d-31f4-4bdf" type="selectionEntry"/>
-                            <entryLink id="756a-9edc-dc66-cb15" name="Plasma Pistol" hidden="false" collective="false" import="true" targetId="717f-cf0a-1593-4bd8" type="selectionEntry">
-                              <costs>
-                                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5"/>
-                              </costs>
-                            </entryLink>
-                            <entryLink id="169e-e211-463c-7c7e" name="Hand Flamer" hidden="false" collective="false" import="true" targetId="e337-adf4-a11f-0280" type="selectionEntry"/>
-                            <entryLink id="beb5-3ca5-021a-2e18" name="Needle Pistol" hidden="false" collective="false" import="true" targetId="fdd4-06c7-4608-b07f" type="selectionEntry"/>
-                          </entryLinks>
-                        </selectionEntryGroup>
-                      </selectionEntryGroups>
-                      <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
-                      </costs>
-                    </selectionEntry>
-                  </selectionEntries>
-                  <entryLinks>
-                    <entryLink id="c6f7-69d2-456a-b8d9" name="Volkite Charger" hidden="false" collective="false" import="true" targetId="6f6e-ad55-e093-6503" type="selectionEntry">
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b14b-febd-135f-7e81" type="max"/>
-                      </constraints>
-                    </entryLink>
-                    <entryLink id="368f-951d-08c8-d113" name="Autorifle" hidden="true" collective="false" import="true" targetId="57dd-dff6-d173-3bf1" type="selectionEntry">
-                      <modifiers>
-                        <modifier type="set" field="hidden" value="false">
-                          <conditions>
-                            <condition field="selections" scope="force" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bfd2-7016-f5fe-be6a" type="equalTo"/>
-                          </conditions>
-                        </modifier>
-                      </modifiers>
-                    </entryLink>
-                    <entryLink id="6692-32f8-3dc3-efdd" name="Lascarbine" hidden="true" collective="false" import="true" targetId="d68e-ce5a-000c-c322" type="selectionEntry">
-                      <modifiers>
-                        <modifier type="set" field="hidden" value="false">
-                          <conditions>
-                            <condition field="selections" scope="force" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bfd2-7016-f5fe-be6a" type="equalTo"/>
-                          </conditions>
-                        </modifier>
-                      </modifiers>
-                    </entryLink>
-                    <entryLink id="2f18-1856-ea68-e609" name="Lasgun" hidden="true" collective="false" import="true" targetId="376e-c5d6-99c3-49c9" type="selectionEntry">
-                      <modifiers>
-                        <modifier type="set" field="hidden" value="false">
-                          <conditions>
-                            <condition field="selections" scope="force" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bfd2-7016-f5fe-be6a" type="equalTo"/>
-                          </conditions>
-                        </modifier>
-                      </modifiers>
-                    </entryLink>
-                    <entryLink id="5b7e-d47a-78d7-9ee4" name="Shotgun" hidden="true" collective="false" import="true" targetId="f0aa-947f-f493-f566" type="selectionEntry">
-                      <modifiers>
-                        <modifier type="set" field="hidden" value="false">
-                          <conditions>
-                            <condition field="selections" scope="force" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bfd2-7016-f5fe-be6a" type="equalTo"/>
-                          </conditions>
-                        </modifier>
-                      </modifiers>
-                    </entryLink>
-                    <entryLink id="ef2b-1095-f302-9f72" name="Stubcarbine" hidden="true" collective="false" import="true" targetId="a7cc-88cb-c6e8-6d4c" type="selectionEntry">
-                      <modifiers>
-                        <modifier type="set" field="hidden" value="false">
-                          <conditions>
-                            <condition field="selections" scope="force" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bfd2-7016-f5fe-be6a" type="equalTo"/>
-                          </conditions>
-                        </modifier>
-                      </modifiers>
-                    </entryLink>
-                  </entryLinks>
-                </selectionEntryGroup>
-              </selectionEntryGroups>
-              <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-          <selectionEntryGroups>
-            <selectionEntryGroup id="d7bc-047c-b7f1-9422" name="Dedicated Transports" hidden="false" collective="false" import="true">
-              <modifiers>
-                <modifier type="set" field="b644-9665-219f-541e" value="1">
-                  <conditions>
-                    <condition field="selections" scope="force" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d9a0-4875-fb75-f9a9" type="equalTo"/>
-                  </conditions>
-                </modifier>
-                <modifier type="set" field="hidden" value="true">
-                  <conditions>
-                    <condition field="selections" scope="force" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7b69-bf2f-4547-e83b" type="atLeast"/>
-                  </conditions>
-                </modifier>
-              </modifiers>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f8a3-daac-d0ed-7e9c" type="max"/>
-                <constraint field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b644-9665-219f-541e" type="min"/>
-              </constraints>
-              <entryLinks>
-                <entryLink id="c098-ae34-d830-e5c8" name="Aurox Transport" hidden="false" collective="false" import="true" targetId="071b-79e5-7b5b-c9cd" type="selectionEntry"/>
-                <entryLink id="2921-ecce-fcdf-7f51" name="Dracosan Armoured Transport" hidden="false" collective="false" import="true" targetId="496b-a01b-3726-0a44" type="selectionEntry"/>
-                <entryLink id="d762-7404-b6a5-a152" name="Arvus Transport" hidden="true" collective="false" import="true" targetId="5041-9403-02b7-af14" type="selectionEntry">
+                </infoLink>
+                <infoLink name="Furious Charge (X)" id="c709-ae6e-bd71-f029" hidden="false" targetId="2821-9269-862f-0554" type="rule">
                   <modifiers>
-                    <modifier type="set" field="hidden" value="false">
+                    <modifier type="set" value="Furious Charge (1)" field="name"/>
+                    <modifier type="set" value="true" field="hidden">
                       <conditions>
-                        <condition field="selections" scope="force" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a09b-28bd-8ffc-f4f0" type="equalTo"/>
+                        <condition type="equalTo" value="0" field="selections" scope="force" childId="bfd2-7016-f5fe-be6a" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
                       </conditions>
                     </modifier>
                   </modifiers>
-                </entryLink>
-              </entryLinks>
-            </selectionEntryGroup>
-            <selectionEntryGroup id="ff50-83d5-369f-f7ca" name="One Veletarii in the unit may be upgraded to have a:" hidden="false" collective="false" import="true">
-              <entryLinks>
-                <entryLink id="4974-cc0e-dd7a-942d" name="Auxilia Vexilla" hidden="false" collective="false" import="true" targetId="6f5a-bf56-4bee-ce7e" type="selectionEntry">
-                  <constraints>
-                    <constraint field="selections" scope="7474-ec3d-98de-d2e0" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4a91-f7ee-a5f9-6c26" type="max"/>
-                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="98fe-f299-2629-87f2" type="max"/>
-                  </constraints>
-                  <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5"/>
-                  </costs>
-                </entryLink>
-                <entryLink id="556b-e589-fcad-8e2d" name="Command Vox" hidden="false" collective="false" import="true" targetId="7ac4-c39b-5c48-63cb" type="selectionEntry">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b250-635e-c7c0-77ca" type="max"/>
-                    <constraint field="selections" scope="7474-ec3d-98de-d2e0" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="385b-529a-0b82-17ed" type="max"/>
-                  </constraints>
-                  <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10"/>
-                  </costs>
-                </entryLink>
-              </entryLinks>
-            </selectionEntryGroup>
-            <selectionEntryGroup id="092d-2397-8f02-c431" name="Veletarii" hidden="false" collective="false" import="true" defaultSelectionEntryId="c39a-711f-3566-712d">
-              <constraints>
-                <constraint field="selections" scope="parent" value="4" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1168-de26-e5bc-3a25" type="min"/>
-                <constraint field="selections" scope="parent" value="9" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="47ed-c168-0aa5-e59a" type="max"/>
-              </constraints>
+                </infoLink>
+                <infoLink name="Counter-Attack (X)" id="3f58-02ec-f7f5-0b68" hidden="false" targetId="fd6d-2a76-10e0-936a" type="rule">
+                  <modifiers>
+                    <modifier type="set" value="Counter-Attack (1) (while &apos;In Formation&apos;)" field="name"/>
+                    <modifier type="set" value="true" field="hidden">
+                      <conditions>
+                        <condition type="equalTo" value="0" field="selections" scope="force" childId="021e-6841-7375-7862" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                </infoLink>
+              </infoLinks>
               <selectionEntries>
-                <selectionEntry id="0e92-6f2e-8f92-40bf" name="Veletarii w/ Power Sword" hidden="false" collective="false" import="true" type="model">
+                <selectionEntry type="model" import="true" name="Veletarii Prime" hidden="false" id="8a38-1a5e-e4c7-7b74" collective="false">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="9" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1011-7d26-c096-6d0c" type="max"/>
-                  </constraints>
-                  <infoLinks>
-                    <infoLink id="d55c-a815-fca3-ee7a" name="Veletarii" hidden="false" targetId="f81e-a329-ec72-2a89" type="profile"/>
-                  </infoLinks>
-                  <entryLinks>
-                    <entryLink id="7813-f295-65eb-b35f" name="Reinforced Void Armour" hidden="false" collective="false" import="true" targetId="5e45-2a38-759c-3147" type="selectionEntry">
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4c81-045a-711c-ee5f" type="min"/>
-                        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7e45-6a3e-227b-f839" type="max"/>
-                      </constraints>
-                    </entryLink>
-                    <entryLink id="bc0d-4263-e761-362c" name="Power Sword" hidden="false" collective="false" import="true" targetId="fa06-cac0-3d98-125e" type="selectionEntry">
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5ee6-ad3d-fbd6-9ce2" type="min"/>
-                        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7b42-c7af-536f-1a12" type="max"/>
-                      </constraints>
-                    </entryLink>
-                  </entryLinks>
-                  <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="13"/>
-                  </costs>
-                  <categoryLinks>
-                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="da5d-531c-4a24-b7e6" name="Infantry Unit Type" primary="false"/>
-                    <categoryLink targetId="9231-183c-b97b-63f9" id="9e8e-cfdf-4797-85b8" name="Heavy Sub-type" primary="false"/>
-                  </categoryLinks>
-                </selectionEntry>
-                <selectionEntry id="6e26-de36-1442-bf11" name="Veletarii w/ Power Lance" hidden="false" collective="false" import="true" type="model">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="9" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ff05-f5f1-0f4d-d019" type="max"/>
-                  </constraints>
-                  <infoLinks>
-                    <infoLink id="c3fa-1bf1-90fe-5ff3" name="Veletarii" hidden="false" targetId="f81e-a329-ec72-2a89" type="profile"/>
-                  </infoLinks>
-                  <entryLinks>
-                    <entryLink id="1b0d-a335-3362-5ab9" name="Reinforced Void Armour" hidden="false" collective="false" import="true" targetId="5e45-2a38-759c-3147" type="selectionEntry">
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b850-3d19-2843-f45b" type="min"/>
-                        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9ac9-2bea-a1ac-e521" type="max"/>
-                      </constraints>
-                    </entryLink>
-                    <entryLink id="2df3-e0a8-3bc6-7a98" name="Power Lance" hidden="false" collective="false" import="true" targetId="fca3-4ec1-c581-1ba3" type="selectionEntry">
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2e44-4502-dc02-2ac7" type="min"/>
-                        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="43a2-b9b7-ba34-ccc1" type="max"/>
-                      </constraints>
-                    </entryLink>
-                  </entryLinks>
-                  <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="13"/>
-                  </costs>
-                  <categoryLinks>
-                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="7540-5336-4847-b983" name="Infantry Unit Type" primary="false"/>
-                    <categoryLink targetId="9231-183c-b97b-63f9" id="68b3-64f4-4caa-ba98" name="Heavy Sub-type" primary="false"/>
-                  </categoryLinks>
-                </selectionEntry>
-                <selectionEntry id="2ccc-2dc8-9580-f134" name="Veletarii w/ Power Maul" hidden="false" collective="false" import="true" type="model">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="9" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1af2-bcc2-ec38-96e0" type="max"/>
-                  </constraints>
-                  <infoLinks>
-                    <infoLink id="e672-dd79-0784-b7ec" name="Veletarii" hidden="false" targetId="f81e-a329-ec72-2a89" type="profile"/>
-                  </infoLinks>
-                  <entryLinks>
-                    <entryLink id="e3c0-8a39-04e0-fcd0" name="Reinforced Void Armour" hidden="false" collective="false" import="true" targetId="5e45-2a38-759c-3147" type="selectionEntry">
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4393-23a5-622a-565c" type="min"/>
-                        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="766c-b0dd-63f4-8749" type="max"/>
-                      </constraints>
-                    </entryLink>
-                    <entryLink id="8e07-7cb6-b23b-38c0" name="Power Maul" hidden="false" collective="false" import="true" targetId="98e8-f217-dea9-0493" type="selectionEntry">
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1199-a8e3-7d40-6024" type="min"/>
-                        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8056-3f5e-23d8-60f6" type="max"/>
-                      </constraints>
-                    </entryLink>
-                  </entryLinks>
-                  <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="13"/>
-                  </costs>
-                  <categoryLinks>
-                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="a09f-5726-4cb7-80fd" name="Infantry Unit Type" primary="false"/>
-                    <categoryLink targetId="9231-183c-b97b-63f9" id="a5f9-e2a7-4afc-9773" name="Heavy Sub-type" primary="false"/>
-                  </categoryLinks>
-                </selectionEntry>
-                <selectionEntry id="c39a-711f-3566-712d" name="Veletarii w/ Volkite Charger" hidden="false" collective="false" import="true" type="model">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="9" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="60ff-babf-7da4-a70a" type="max"/>
-                  </constraints>
-                  <infoLinks>
-                    <infoLink id="b46b-492a-7e17-61de" name="Veletarii" hidden="false" targetId="f81e-a329-ec72-2a89" type="profile"/>
-                  </infoLinks>
-                  <entryLinks>
-                    <entryLink id="c08b-1081-4d6d-f920" name="Reinforced Void Armour" hidden="false" collective="false" import="true" targetId="5e45-2a38-759c-3147" type="selectionEntry">
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1e47-3793-f822-eba7" type="min"/>
-                        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="752c-e144-240e-5882" type="max"/>
-                      </constraints>
-                    </entryLink>
-                    <entryLink id="1194-fd3e-fab0-b679" name="Volkite Charger" hidden="false" collective="false" import="true" targetId="5c82-c306-9c5c-5908" type="selectionEntry">
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0cbd-ee32-eb57-dd46" type="min"/>
-                        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b864-28ca-4f90-c6ec" type="max"/>
-                      </constraints>
-                    </entryLink>
-                  </entryLinks>
-                  <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="8"/>
-                  </costs>
-                  <categoryLinks>
-                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="22fb-ac5b-423d-9dcb" name="Infantry Unit Type" primary="false"/>
-                    <categoryLink targetId="9231-183c-b97b-63f9" id="8e3d-b560-4e82-9a41" name="Heavy Sub-type" primary="false"/>
-                  </categoryLinks>
-                </selectionEntry>
-                <selectionEntry id="0797-e0e8-65b9-9a4a" name="Veletarii w/ Power Axe" hidden="false" collective="false" import="true" type="model">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="9" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="acd6-dd94-5d41-dfcf" type="max"/>
+                    <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="7d95-bd41-cd6d-dbb8" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="21c4-3237-8fd8-6b1a" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
                   </constraints>
                   <profiles>
-                    <profile id="f81e-a329-ec72-2a89" name="Veletarii" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName="Unit">
+                    <profile name="Veletarii Prime" typeId="4bb2-cb95-e6c8-5a21" typeName="Unit" hidden="false" id="cb33-c30a-4e39-8a83">
+                      <characteristics>
+                        <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Heavy, Character)</characteristic>
+                        <characteristic name="Move" typeId="893e-2d76-8f04-44e5">6</characteristic>
+                        <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
+                        <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
+                        <characteristic name="S" typeId="e478-41d4-a092-48a8">3</characteristic>
+                        <characteristic name="T" typeId="c32b-5fdd-3fbe-9b1f">3</characteristic>
+                        <characteristic name="W" typeId="57ee-1126-32a9-5672">1</characteristic>
+                        <characteristic name="I" typeId="62d3-22d7-2d49-52dc">4</characteristic>
+                        <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">2</characteristic>
+                        <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">7</characteristic>
+                        <characteristic name="Save" typeId="e593-6b3c-f169-04f0">4+</characteristic>
+                      </characteristics>
                       <modifiers>
-                        <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Infantry (Heavy, Line)">
+                        <modifier type="set" value="3+" field="e593-6b3c-f169-04f0">
+                          <conditions>
+                            <condition type="equalTo" value="1" field="selections" scope="8a38-1a5e-e4c7-7b74" childId="523c-d7fb-5288-fe13" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
+                          </conditions>
+                        </modifier>
+                        <modifier type="set" value="Infantry (Heavy, Character, Line)" field="ddd7-6f5c-a939-b69e">
+                          <conditions>
+                            <condition type="equalTo" value="1" field="selections" scope="force" childId="a09b-28bd-8ffc-f4f0" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
+                          </conditions>
+                        </modifier>
+                        <modifier type="increment" value="1" field="e8a6-1da9-d384-8727">
+                          <conditions>
+                            <condition type="equalTo" value="1" field="selections" scope="force" childId="fe04-c096-f846-a6fd" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
+                          </conditions>
+                        </modifier>
+                      </modifiers>
+                    </profile>
+                  </profiles>
+                  <categoryLinks>
+                    <categoryLink name="Character" hidden="false" id="1616-4d93-a1d7-8b9b" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
+                    <categoryLink name="Infantry Unit Type" hidden="false" id="8fa1-01d6-460d-85e3" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+                    <categoryLink name="Heavy Sub-type" hidden="false" id="00f5-66cf-4ee6-ad5e" targetId="9231-183c-b97b-63f9" primary="false"/>
+                  </categoryLinks>
+                  <selectionEntryGroups>
+                    <selectionEntryGroup name="Armour" id="cb16-77f4-dd20-bb13" hidden="false" collective="false" import="true" defaultSelectionEntryId="76fe-62a6-e1f1-1fe4">
+                      <constraints>
+                        <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="5c13-4982-aa42-5fbd" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                        <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="b2bb-199f-f6c1-653a" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                      </constraints>
+                      <entryLinks>
+                        <entryLink import="true" name="Reinforced Void Armour" hidden="false" id="76fe-62a6-e1f1-1fe4" collective="false" targetId="cc63-5cc3-212a-3d4c" type="selectionEntry"/>
+                        <entryLink import="true" name="Heavy Void Armour" hidden="false" id="9568-3bbc-7925-8ede" collective="false" targetId="523c-d7fb-5288-fe13" type="selectionEntry">
+                          <costs>
+                            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10"/>
+                          </costs>
+                        </entryLink>
+                      </entryLinks>
+                    </selectionEntryGroup>
+                    <selectionEntryGroup name="Weapons" id="8209-4fe4-4776-72e1" hidden="false" collective="false" import="true" defaultSelectionEntryId="6ea0-84ee-7815-bae7">
+                      <constraints>
+                        <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="db44-9689-19d2-8916" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                        <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="cdda-c8ec-31aa-dae6" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                      </constraints>
+                      <selectionEntries>
+                        <selectionEntry type="upgrade" import="true" name="Pistol and Combat weapon (Sub-menu)" hidden="false" id="17f8-33d8-7a8e-d2d3" collective="false">
+                          <constraints>
+                            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="3141-ace3-17ec-2ccb" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                          </constraints>
+                          <selectionEntryGroups>
+                            <selectionEntryGroup name="Close Combat" id="e132-e9a1-d271-c31c" hidden="false" collective="false" import="true">
+                              <constraints>
+                                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="2087-7cbd-fdd5-1967" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="3d92-4432-7320-a20e" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                              </constraints>
+                              <entryLinks>
+                                <entryLink import="true" name="Close Combat Weapon" hidden="false" id="db0c-0408-266a-69b8" collective="false" targetId="3d50-2f85-06ff-6aee" type="selectionEntry"/>
+                                <entryLink import="true" name="Power Fist" hidden="false" id="04d9-5d7c-cc56-c516" collective="false" targetId="768d-b89b-7328-d749" type="selectionEntry">
+                                  <costs>
+                                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10"/>
+                                  </costs>
+                                </entryLink>
+                                <entryLink import="true" name="Charnabal Glaive" hidden="false" id="b387-1955-3a7a-d83e" collective="false" targetId="c07c-35e6-4616-ef25" type="selectionEntry">
+                                  <costs>
+                                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5"/>
+                                  </costs>
+                                </entryLink>
+                                <entryLink import="true" name="Charnabal Sabre" hidden="false" id="476e-1342-7ad6-6acd" collective="false" targetId="30c2-57eb-5bbe-be0b" type="selectionEntry">
+                                  <costs>
+                                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5"/>
+                                  </costs>
+                                </entryLink>
+                                <entryLink import="true" name="Charnabal Tabar" hidden="false" id="ba00-b80b-ff5f-454b" collective="false" targetId="4611-c33e-f360-7246" type="selectionEntry">
+                                  <costs>
+                                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5"/>
+                                  </costs>
+                                </entryLink>
+                                <entryLink import="true" name="Power Axe" hidden="false" id="f34c-2276-3ca5-ea74" collective="false" targetId="c066-2ace-f68c-e440" type="selectionEntry">
+                                  <costs>
+                                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5"/>
+                                  </costs>
+                                </entryLink>
+                                <entryLink import="true" name="Power Lance" hidden="false" id="31a6-eb34-633e-b9e9" collective="false" targetId="a4c8-c8ff-87f2-1ac9" type="selectionEntry">
+                                  <costs>
+                                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5"/>
+                                  </costs>
+                                </entryLink>
+                                <entryLink import="true" name="Power Maul" hidden="false" id="28db-b636-fe67-44c0" collective="false" targetId="0df4-c67e-cf64-82e0" type="selectionEntry">
+                                  <costs>
+                                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5"/>
+                                  </costs>
+                                </entryLink>
+                                <entryLink import="true" name="Power Sword" hidden="false" id="db7b-030d-71ea-6048" collective="false" targetId="a3cd-aa97-a148-2309" type="selectionEntry">
+                                  <costs>
+                                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5"/>
+                                  </costs>
+                                </entryLink>
+                              </entryLinks>
+                            </selectionEntryGroup>
+                            <selectionEntryGroup name="Pistol" id="7b84-2ff8-147f-3b19" hidden="false" collective="false" import="true">
+                              <constraints>
+                                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="a1c8-e9cd-da61-dba7" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="127e-4de8-c90b-7e9d" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                              </constraints>
+                              <entryLinks>
+                                <entryLink import="true" name="Blast Pistol" hidden="false" id="cc2e-cd0b-a758-f758" collective="false" targetId="2460-375d-31f4-4bdf" type="selectionEntry"/>
+                                <entryLink import="true" name="Plasma Pistol" hidden="false" id="614f-7648-8233-9baa" collective="false" targetId="717f-cf0a-1593-4bd8" type="selectionEntry">
+                                  <costs>
+                                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5"/>
+                                  </costs>
+                                </entryLink>
+                                <entryLink import="true" name="Hand Flamer" hidden="false" id="b258-fb3d-4ff0-e1d3" collective="false" targetId="e337-adf4-a11f-0280" type="selectionEntry"/>
+                                <entryLink import="true" name="Needle Pistol" hidden="false" id="ed06-92b3-1104-f2b2" collective="false" targetId="fdd4-06c7-4608-b07f" type="selectionEntry"/>
+                              </entryLinks>
+                            </selectionEntryGroup>
+                          </selectionEntryGroups>
+                          <costs>
+                            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
+                          </costs>
+                        </selectionEntry>
+                      </selectionEntries>
+                      <entryLinks>
+                        <entryLink import="true" name="Rotor Cannon" hidden="false" id="6ea0-84ee-7815-bae7" collective="false" targetId="5ce3-3aa5-3f5e-9ead" type="selectionEntry">
+                          <constraints>
+                            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="04b9-516e-995e-7f6d" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                          </constraints>
+                        </entryLink>
+                      </entryLinks>
+                    </selectionEntryGroup>
+                  </selectionEntryGroups>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+              <selectionEntryGroups>
+                <selectionEntryGroup name="One Veletarii in the unit may be upgraded to have a:" id="198b-a4ad-7b6d-1dc8" hidden="false" collective="false" import="true">
+                  <entryLinks>
+                    <entryLink import="true" name="Auxilia Vexilla" hidden="false" id="9674-f0d4-f267-7237" collective="false" targetId="6f5a-bf56-4bee-ce7e" type="selectionEntry">
+                      <constraints>
+                        <constraint type="max" value="1" field="selections" scope="0508-f8a6-3996-bf39" shared="true" id="ecf8-95ff-2a7b-78b7" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
+                        <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="84ff-7828-0759-8d72" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                      </constraints>
+                      <costs>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink import="true" name="Vox Interlock" hidden="false" id="4a13-7a1a-c494-3778" collective="false" targetId="c04e-5624-3615-0660" type="selectionEntry">
+                      <constraints>
+                        <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="c17a-1874-6f13-7ac5" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                        <constraint type="max" value="1" field="selections" scope="0508-f8a6-3996-bf39" shared="true" id="c45f-c5bd-291a-35ea" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
+                      </constraints>
+                      <costs>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5"/>
+                      </costs>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup name="Veletarii" id="fc3c-5b58-1b10-490c" hidden="false" collective="false" import="true" defaultSelectionEntryId="e5b2-9536-03f8-39e2">
+                  <modifiers>
+                    <modifier type="set" value="14" field="186f-d90b-b0a3-a953">
+                      <conditions>
+                        <condition type="atLeast" value="1" field="selections" scope="force" childId="7b69-bf2f-4547-e83b" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint type="min" value="9" field="selections" scope="parent" shared="true" id="a823-12af-48c0-814c" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                    <constraint type="max" value="19" field="selections" scope="parent" shared="true" id="186f-d90b-b0a3-a953" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                  </constraints>
+                  <selectionEntries>
+                    <selectionEntry type="model" import="true" name="Veletarii w/ Heavy Flamer" hidden="false" id="0f0e-36a9-75e4-e822" collective="false">
+                      <constraints>
+                        <constraint type="max" value="19" field="selections" scope="parent" shared="true" id="ae4a-69d7-d994-4e44" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                      </constraints>
+                      <profiles>
+                        <profile name="Veletarii" typeId="4bb2-cb95-e6c8-5a21" typeName="Unit" hidden="false" id="79eb-30bc-5135-39c2">
+                          <characteristics>
+                            <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Heavy)</characteristic>
+                            <characteristic name="Move" typeId="893e-2d76-8f04-44e5">6</characteristic>
+                            <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
+                            <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
+                            <characteristic name="S" typeId="e478-41d4-a092-48a8">3</characteristic>
+                            <characteristic name="T" typeId="c32b-5fdd-3fbe-9b1f">3</characteristic>
+                            <characteristic name="W" typeId="57ee-1126-32a9-5672">1</characteristic>
+                            <characteristic name="I" typeId="62d3-22d7-2d49-52dc">4</characteristic>
+                            <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">1</characteristic>
+                            <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">6</characteristic>
+                            <characteristic name="Save" typeId="e593-6b3c-f169-04f0">4+</characteristic>
+                          </characteristics>
+                          <modifiers>
+                            <modifier type="set" value="Infantry (Heavy, Line)" field="ddd7-6f5c-a939-b69e">
+                              <conditions>
+                                <condition type="equalTo" value="1" field="selections" scope="force" childId="a09b-28bd-8ffc-f4f0" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
+                              </conditions>
+                            </modifier>
+                            <modifier type="increment" value="1" field="e8a6-1da9-d384-8727">
+                              <conditions>
+                                <condition type="equalTo" value="1" field="selections" scope="force" childId="fe04-c096-f846-a6fd" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
+                              </conditions>
+                            </modifier>
+                          </modifiers>
+                        </profile>
+                      </profiles>
+                      <entryLinks>
+                        <entryLink import="true" name="Reinforced Void Armour" hidden="false" id="cff6-2ad3-9b93-06c9" collective="false" targetId="5e45-2a38-759c-3147" type="selectionEntry">
+                          <constraints>
+                            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="12a9-d57b-b62a-5fe6" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="f56c-38c0-9008-c9db" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                          </constraints>
+                        </entryLink>
+                        <entryLink import="true" name="Heavy Flamer" hidden="false" id="2e19-2169-3914-ade2" collective="false" targetId="aab4-9e33-94f0-5815" type="selectionEntry">
+                          <constraints>
+                            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="6be6-b728-a83f-eeb3" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="6123-c08d-7ebf-da59" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                          </constraints>
+                        </entryLink>
+                      </entryLinks>
+                      <costs>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="8"/>
+                      </costs>
+                      <categoryLinks>
+                        <categoryLink name="Infantry Unit Type" hidden="false" id="6f23-5f3d-4711-95f0" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+                        <categoryLink name="Heavy Sub-type" hidden="false" id="1dc5-a978-4d98-9614" targetId="9231-183c-b97b-63f9" primary="false"/>
+                      </categoryLinks>
+                    </selectionEntry>
+                    <selectionEntry type="model" import="true" name="Veletarii w/ Rotor Cannon" hidden="false" id="e5b2-9536-03f8-39e2" collective="false">
+                      <constraints>
+                        <constraint type="max" value="19" field="selections" scope="parent" shared="true" id="8159-a918-f3f2-197e" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                      </constraints>
+                      <infoLinks>
+                        <infoLink name="Veletarii" id="ba61-2722-958c-a365" hidden="false" targetId="79eb-30bc-5135-39c2" type="profile"/>
+                      </infoLinks>
+                      <entryLinks>
+                        <entryLink import="true" name="Reinforced Void Armour" hidden="false" id="3521-9e7d-3143-b74d" collective="false" targetId="5e45-2a38-759c-3147" type="selectionEntry">
+                          <constraints>
+                            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="e02f-c48d-a30f-c3e9" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="4be1-117f-a611-624b" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                          </constraints>
+                        </entryLink>
+                        <entryLink import="true" name="Rotor Cannon" hidden="false" id="f1a6-adb7-32f3-afd8" collective="false" targetId="37ec-a4b4-de7a-acf3" type="selectionEntry">
+                          <constraints>
+                            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="f2e7-18f8-fb8f-10a4" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="8ee6-77fc-533a-adb9" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                          </constraints>
+                        </entryLink>
+                      </entryLinks>
+                      <costs>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="8"/>
+                      </costs>
+                      <categoryLinks>
+                        <categoryLink name="Infantry Unit Type" hidden="false" id="bfc0-d686-421b-a079" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+                        <categoryLink name="Heavy Sub-type" hidden="false" id="48de-c21c-48be-b669" targetId="9231-183c-b97b-63f9" primary="false"/>
+                      </categoryLinks>
+                    </selectionEntry>
+                  </selectionEntries>
+                </selectionEntryGroup>
+                <selectionEntryGroup name="Dedicated Transports" id="fff9-2e72-ff3f-0ad1" hidden="false" collective="false" import="true">
+                  <modifiers>
+                    <modifier type="set" value="1" field="1fbd-1e19-1a43-dbbc">
+                      <conditions>
+                        <condition type="equalTo" value="1" field="selections" scope="force" childId="d9a0-4875-fb75-f9a9" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="set" value="true" field="hidden">
+                      <conditions>
+                        <condition type="atLeast" value="1" field="selections" scope="force" childId="7b69-bf2f-4547-e83b" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="cf07-414c-ccae-aa89" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                    <constraint type="min" value="0" field="selections" scope="parent" shared="true" id="1fbd-1e19-1a43-dbbc" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink import="true" name="Aurox Transport" hidden="false" id="f6c3-f0c8-ca42-3008" collective="false" targetId="071b-79e5-7b5b-c9cd" type="selectionEntry">
+                      <modifiers>
+                        <modifier type="set" value="true" field="hidden">
+                          <conditions>
+                            <condition type="greaterThan" value="10" field="selections" scope="0508-f8a6-3996-bf39" childId="model" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
+                          </conditions>
+                        </modifier>
+                      </modifiers>
+                    </entryLink>
+                    <entryLink import="true" name="Dracosan Armoured Transport" hidden="false" id="0283-38af-c423-c5ac" collective="false" targetId="496b-a01b-3726-0a44" type="selectionEntry"/>
+                    <entryLink import="true" name="Arvus Transport" hidden="true" id="228d-6e69-4957-fa2a" collective="false" targetId="5041-9403-02b7-af14" type="selectionEntry">
+                      <modifiers>
+                        <modifier type="set" value="false" field="hidden">
                           <conditionGroups>
                             <conditionGroup type="and">
                               <conditions>
-                                <condition field="selections" scope="force" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a09b-28bd-8ffc-f4f0" type="equalTo"/>
-                                <condition field="selections" scope="primary-category" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9b5d-fac7-799b-d7e7" type="instanceOf"/>
+                                <condition type="equalTo" value="1" field="selections" scope="force" childId="a09b-28bd-8ffc-f4f0" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
+                                <condition type="atMost" value="12" field="selections" scope="0508-f8a6-3996-bf39" childId="model" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
                               </conditions>
                             </conditionGroup>
                           </conditionGroups>
                         </modifier>
-                        <modifier type="increment" field="e8a6-1da9-d384-8727" value="1">
-                          <conditions>
-                            <condition field="selections" scope="force" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fe04-c096-f846-a6fd" type="equalTo"/>
-                          </conditions>
-                        </modifier>
                       </modifiers>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+              <entryLinks>
+                <entryLink import="true" name="Krak Grenades" hidden="false" id="46bf-4bad-5b67-f596" collective="false" targetId="99df-2421-acf7-a5ad" type="selectionEntry">
+                  <constraints>
+                    <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="2834-b30d-f46c-df5e" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="9754-bf95-fea0-d512" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                  </constraints>
+                </entryLink>
+                <entryLink import="true" name="Frag Grenades" hidden="false" id="2312-7a47-525a-0b39" collective="false" targetId="cf9c-327b-3449-00d7" type="selectionEntry">
+                  <constraints>
+                    <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="557e-b345-e27b-e8e5" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="45be-a386-6e50-871e" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                  </constraints>
+                </entryLink>
+                <entryLink import="true" name="Fear (Feral Cohort)" hidden="false" id="809e-68c0-d82f-f51a" collective="false" targetId="aefe-eff6-2961-a445" type="selectionEntry"/>
+              </entryLinks>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="18"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry type="unit" import="true" name="Hermes Veletaris Squadron" hidden="false" id="8c69-57dc-440c-b706" page="181" publicationId="d882-d2a-5da1-92c4">
+              <categoryLinks>
+                <categoryLink name="Unit:" hidden="false" id="bcc6-6674-41b6-9e30" targetId="36c3-e85e-97cc-c503" primary="false"/>
+              </categoryLinks>
+              <costs>
+                <cost name="Pts" id="cf49-c219-3829-e19c" hidden="false" typeId="d2ee-04cb-5f8a-2642" value="17"/>
+              </costs>
+              <selectionEntries>
+                <selectionEntry type="model" import="true" name="Hermes Veletarii Sentinel" hidden="false" id="adab-c06b-41b9-ab59" page="181" publicationId="d882-d2a-5da1-92c4" defaultAmount="2">
+                  <profiles>
+                    <profile name="Hermes Veletarii Sentinel" typeId="4bb2-cb95-e6c8-5a21" typeName="Unit" hidden="false" id="7818-24b8-4e17-9253" publicationId="d882-d2a-5da1-92c4" page="181">
                       <characteristics>
-                        <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Heavy)</characteristic>
+                        <characteristic name="Unit Type" id="d447-3b56-d87-7b95" hidden="false" typeId="ddd7-6f5c-a939-b69e">Cavalry (Mechanised) + (Heavy) from Reinforced Void Armor</characteristic>
+                        <characteristic name="Move" id="c960-d1fc-64e0-4e7" hidden="false" typeId="893e-2d76-8f04-44e5">8</characteristic>
+                        <characteristic name="WS" id="74cc-b0a-7c3e-cb2d" hidden="false" typeId="cc42-7ed5-7092-5c84">4</characteristic>
+                        <characteristic name="BS" id="2ce9-bed4-de68-3093" hidden="false" typeId="74ae-c840-0036-d244">4</characteristic>
+                        <characteristic name="S" id="3901-e3d7-af1f-52e2" hidden="false" typeId="e478-41d4-a092-48a8">5</characteristic>
+                        <characteristic name="T" id="dd4a-e8d6-8076-3250" hidden="false" typeId="c32b-5fdd-3fbe-9b1f">5</characteristic>
+                        <characteristic name="W" id="6fe3-d1ce-8b75-3f76" hidden="false" typeId="57ee-1126-32a9-5672">2</characteristic>
+                        <characteristic name="I" id="97d3-b78e-b847-a8d5" hidden="false" typeId="62d3-22d7-2d49-52dc">3</characteristic>
+                        <characteristic name="A" id="f63a-dc0a-2716-87ff" hidden="false" typeId="f111-2ce5-dd12-d6b0">1</characteristic>
+                        <characteristic name="Ld" id="32f7-626e-240f-3c34" hidden="false" typeId="e8a6-1da9-d384-8727">7</characteristic>
+                        <characteristic name="Save" id="a6d-9526-512e-4484" hidden="false" typeId="e593-6b3c-f169-04f0">3+</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <costs>
+                    <cost name="Pts" id="8fb3-e75f-fa3d-625e" hidden="false" typeId="d2ee-04cb-5f8a-2642" value="24"/>
+                  </costs>
+                  <constraints>
+                    <constraint type="min" value="2" field="selections" scope="parent" shared="true" id="a577-c13c-2a0c-734b" includeChildSelections="false"/>
+                    <constraint type="max" value="6" field="selections" scope="parent" shared="true" id="ad54-b3d5-1e2f-31d1" includeChildSelections="false"/>
+                  </constraints>
+                  <selectionEntryGroups>
+                    <selectionEntryGroup name="Hermes Veletarii Sentinel" id="5437-cf9e-80c1-fcc8" hidden="false" defaultSelectionEntryId="3348-965-dae-36d3">
+                      <entryLinks>
+                        <entryLink import="true" name="Volkite Caliver" hidden="false" id="3348-965-dae-36d3" type="selectionEntry" targetId="9250-490f-abeb-b901" defaultAmount="1"/>
+                        <entryLink import="true" name="Heavy Flamer" hidden="false" id="8308-cf39-a9f3-4c8c" type="selectionEntry" targetId="5507-b432-3b4c-df12"/>
+                      </entryLinks>
+                      <constraints>
+                        <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="5572-b0d4-1a98-c166-min" includeChildSelections="false"/>
+                        <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="5572-b0d4-1a98-c166-max" includeChildSelections="false"/>
+                      </constraints>
+                    </selectionEntryGroup>
+                  </selectionEntryGroups>
+                  <entryLinks>
+                    <entryLink import="true" name="Laspistol" hidden="false" id="d0be-a42d-68d6-1238" type="selectionEntry" targetId="654d-be88-b0a8-7ae5">
+                      <constraints>
+                        <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="e3de-7fc9-a99f-e898"/>
+                        <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="ee12-77f8-1a77-49b7"/>
+                      </constraints>
+                    </entryLink>
+                    <entryLink import="true" name="Reinforced Void Armour" hidden="false" id="3021-ea0-271d-6c57" type="selectionEntry" targetId="cc63-5cc3-212a-3d4c">
+                      <constraints>
+                        <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="eb2b-114a-1a7-ffc4"/>
+                        <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="860d-bbaf-25ed-4138"/>
+                      </constraints>
+                    </entryLink>
+                  </entryLinks>
+                  <comment>Didn&apos;t make a wargear item for the sentinel, since it&apos;s covered by the equipment and statline.</comment>
+                  <categoryLinks>
+                    <categoryLink name="Cavalry Unit Type" hidden="false" id="311e-5b08-fdb5-ac6" targetId="6d79-a3e4-381f-7b0f" primary="false"/>
+                    <categoryLink name="Mechanised Unit Sub-type" hidden="false" id="e5fb-8548-d531-a3ef" targetId="e929-a5c3-451c-6f19" primary="false"/>
+                    <categoryLink name="Heavy Sub-type" hidden="false" id="3d27-d430-43a8-1031" targetId="9231-183c-b97b-63f9" primary="false"/>
+                  </categoryLinks>
+                </selectionEntry>
+              </selectionEntries>
+              <constraints>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="de14-3f73-cea1-40f9" includeChildSelections="false"/>
+              </constraints>
+            </selectionEntry>
+            <selectionEntry type="unit" import="true" name="Veletaris Command Section" hidden="false" id="7474-ec3d-98de-d2e0" collective="false">
+              <constraints>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="2e7c-cc82-0b71-2b49" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+              </constraints>
+              <infoLinks>
+                <infoLink name="Tercio" id="1d78-77e6-4fc9-1277" hidden="false" targetId="6516-f81d-457b-a2cc" type="rule"/>
+                <infoLink name="Stubborn" id="a7e9-5843-7d41-821a" hidden="false" targetId="7989-1f2c-a43d-82ae" type="rule">
+                  <modifiers>
+                    <modifier type="set" value="true" field="hidden">
+                      <conditions>
+                        <condition type="equalTo" value="0" field="selections" scope="force" childId="fe04-c096-f846-a6fd" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                </infoLink>
+                <infoLink name="Furious Charge (X)" id="b2f4-5cdf-e6b3-1008" hidden="false" targetId="2821-9269-862f-0554" type="rule">
+                  <modifiers>
+                    <modifier type="set" value="Furious Charge (1)" field="name"/>
+                    <modifier type="set" value="true" field="hidden">
+                      <conditions>
+                        <condition type="equalTo" value="0" field="selections" scope="force" childId="bfd2-7016-f5fe-be6a" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                </infoLink>
+                <infoLink name="Counter-Attack (X)" id="5453-3686-610e-6266" hidden="false" targetId="fd6d-2a76-10e0-936a" type="rule">
+                  <modifiers>
+                    <modifier type="set" value="Counter-Attack (1) (while &apos;In Formation&apos;)" field="name"/>
+                    <modifier type="set" value="true" field="hidden">
+                      <conditions>
+                        <condition type="equalTo" value="0" field="selections" scope="force" childId="021e-6841-7375-7862" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                </infoLink>
+              </infoLinks>
+              <selectionEntries>
+                <selectionEntry type="model" import="true" name="Veletarii First Prime" hidden="false" id="b232-3a78-7275-2fa1" collective="false">
+                  <constraints>
+                    <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="7235-781c-a3b9-ba87" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="fb9f-a73e-40b8-b198" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                  </constraints>
+                  <profiles>
+                    <profile name="Veletarii First Prime" typeId="4bb2-cb95-e6c8-5a21" typeName="Unit" hidden="false" id="4606-e745-412d-313c">
+                      <characteristics>
+                        <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Heavy, Character)</characteristic>
                         <characteristic name="Move" typeId="893e-2d76-8f04-44e5">6</characteristic>
                         <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
                         <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
@@ -3187,541 +3242,686 @@
                         <characteristic name="T" typeId="c32b-5fdd-3fbe-9b1f">3</characteristic>
                         <characteristic name="W" typeId="57ee-1126-32a9-5672">1</characteristic>
                         <characteristic name="I" typeId="62d3-22d7-2d49-52dc">4</characteristic>
-                        <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">1</characteristic>
-                        <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">6</characteristic>
+                        <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">2</characteristic>
+                        <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">8</characteristic>
                         <characteristic name="Save" typeId="e593-6b3c-f169-04f0">4+</characteristic>
                       </characteristics>
+                      <modifiers>
+                        <modifier type="set" value="3+" field="e593-6b3c-f169-04f0">
+                          <conditions>
+                            <condition type="equalTo" value="1" field="selections" scope="b232-3a78-7275-2fa1" childId="523c-d7fb-5288-fe13" shared="true" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                          </conditions>
+                        </modifier>
+                        <modifier type="set" value="Infantry (Heavy, Character, Line)" field="ddd7-6f5c-a939-b69e">
+                          <conditionGroups>
+                            <conditionGroup type="and">
+                              <conditions>
+                                <condition type="equalTo" value="1" field="selections" scope="force" childId="a09b-28bd-8ffc-f4f0" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
+                                <condition type="instanceOf" value="1" field="selections" scope="primary-category" childId="9b5d-fac7-799b-d7e7" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
+                              </conditions>
+                            </conditionGroup>
+                          </conditionGroups>
+                        </modifier>
+                        <modifier type="increment" value="1" field="e8a6-1da9-d384-8727">
+                          <conditions>
+                            <condition type="equalTo" value="1" field="selections" scope="force" childId="fe04-c096-f846-a6fd" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
+                          </conditions>
+                        </modifier>
+                      </modifiers>
                     </profile>
                   </profiles>
-                  <entryLinks>
-                    <entryLink id="055e-5cf5-89a9-e7ea" name="Reinforced Void Armour" hidden="false" collective="false" import="true" targetId="5e45-2a38-759c-3147" type="selectionEntry">
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="38f7-cabd-896b-2aea" type="min"/>
-                        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="423a-b89f-e1df-11cb" type="max"/>
-                      </constraints>
-                    </entryLink>
-                    <entryLink id="2e05-3f3c-d294-a0de" name="Power Axe" hidden="false" collective="false" import="true" targetId="ef98-66ac-fcaf-c15d" type="selectionEntry">
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3f32-e47b-ffe5-702b" type="min"/>
-                        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e991-3ef1-3e7f-3cfb" type="max"/>
-                      </constraints>
-                    </entryLink>
-                  </entryLinks>
-                  <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="13"/>
-                  </costs>
                   <categoryLinks>
-                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="41ec-9595-4956-87b5" name="Infantry Unit Type" primary="false"/>
-                    <categoryLink targetId="9231-183c-b97b-63f9" id="bfd9-9a27-46f5-aa92" name="Heavy Sub-type" primary="false"/>
+                    <categoryLink name="Character" hidden="false" id="1278-bf88-ac56-9920" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
+                    <categoryLink name="Infantry Unit Type" hidden="false" id="c68b-e63c-4de7-a247" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+                    <categoryLink name="Heavy Sub-type" hidden="false" id="95bf-a49f-432a-b6c4" targetId="9231-183c-b97b-63f9" primary="false"/>
                   </categoryLinks>
-                </selectionEntry>
-                <selectionEntry id="3d9e-0a04-4a3b-de52" name="Veletarii w/ Autorifle" hidden="true" collective="false" import="true" type="model">
-                  <modifiers>
-                    <modifier type="set" field="hidden" value="false">
-                      <conditions>
-                        <condition field="selections" scope="force" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bfd2-7016-f5fe-be6a" type="equalTo"/>
-                      </conditions>
-                    </modifier>
-                  </modifiers>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="9" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a240-87f4-1ad8-9ce2" type="max"/>
-                  </constraints>
-                  <infoLinks>
-                    <infoLink id="d542-cb70-04d1-4169" name="Veletarii" hidden="false" targetId="f81e-a329-ec72-2a89" type="profile"/>
-                  </infoLinks>
-                  <entryLinks>
-                    <entryLink id="8cab-3f02-5d79-fd31" name="Reinforced Void Armour" hidden="false" collective="false" import="true" targetId="5e45-2a38-759c-3147" type="selectionEntry">
+                  <selectionEntryGroups>
+                    <selectionEntryGroup name="Armour" id="1cb1-052d-9cfe-0fc5" hidden="false" collective="false" import="true" defaultSelectionEntryId="09b8-e985-c536-4684">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="48bc-750f-42f4-7974" type="min"/>
-                        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6f44-e603-b0c9-4c91" type="max"/>
+                        <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="d23a-c6f3-609c-e6d3" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                        <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="ff47-cdc2-d411-fc6e" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
                       </constraints>
-                    </entryLink>
-                    <entryLink id="8483-ace0-9e9d-8341" name="Autorifle" hidden="false" collective="false" import="true" targetId="f3ff-0995-248a-5243" type="selectionEntry">
+                      <entryLinks>
+                        <entryLink import="true" name="Reinforced Void Armour" hidden="false" id="09b8-e985-c536-4684" collective="false" targetId="cc63-5cc3-212a-3d4c" type="selectionEntry"/>
+                        <entryLink import="true" name="Heavy Void Armour" hidden="false" id="c593-dd64-e385-685d" collective="false" targetId="523c-d7fb-5288-fe13" type="selectionEntry">
+                          <costs>
+                            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10"/>
+                          </costs>
+                        </entryLink>
+                      </entryLinks>
+                    </selectionEntryGroup>
+                    <selectionEntryGroup name="Weapons" id="5f6e-e0a3-6584-f494" hidden="false" collective="false" import="true" defaultSelectionEntryId="c6f7-69d2-456a-b8d9">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dd2e-b2a1-dbf2-35f6" type="min"/>
-                        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c1e9-162a-47ac-a884" type="max"/>
+                        <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="e40d-91f3-e8a0-e5ad" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                        <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="2b13-4a75-39ef-867a" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
                       </constraints>
-                    </entryLink>
-                  </entryLinks>
+                      <selectionEntries>
+                        <selectionEntry type="upgrade" import="true" name="Pistol and Combat weapon (Sub-menu)" hidden="false" id="2483-2a53-a4fc-0bba" collective="false">
+                          <constraints>
+                            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="a3b3-8bb4-0098-0d34" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                          </constraints>
+                          <selectionEntryGroups>
+                            <selectionEntryGroup name="Close Combat" id="8903-0c12-c67c-6c4c" hidden="false" collective="false" import="true">
+                              <constraints>
+                                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="dfe5-99cd-467c-ff16" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="e847-9abf-caab-4cf9" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                              </constraints>
+                              <entryLinks>
+                                <entryLink import="true" name="Close Combat Weapon" hidden="false" id="170b-a81a-5a77-0e88" collective="false" targetId="3d50-2f85-06ff-6aee" type="selectionEntry"/>
+                                <entryLink import="true" name="Power Fist" hidden="false" id="16e5-8246-891f-8de5" collective="false" targetId="768d-b89b-7328-d749" type="selectionEntry">
+                                  <costs>
+                                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10"/>
+                                  </costs>
+                                </entryLink>
+                                <entryLink import="true" name="Power Sword" hidden="false" id="f1c0-a394-e45d-a4ec" collective="false" targetId="a3cd-aa97-a148-2309" type="selectionEntry">
+                                  <costs>
+                                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5"/>
+                                  </costs>
+                                </entryLink>
+                                <entryLink import="true" name="Power Maul" hidden="false" id="fc64-47bd-0881-a0ef" collective="false" targetId="0df4-c67e-cf64-82e0" type="selectionEntry">
+                                  <costs>
+                                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5"/>
+                                  </costs>
+                                </entryLink>
+                                <entryLink import="true" name="Power Lance" hidden="false" id="4288-156c-ce79-201b" collective="false" targetId="a4c8-c8ff-87f2-1ac9" type="selectionEntry">
+                                  <costs>
+                                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5"/>
+                                  </costs>
+                                </entryLink>
+                                <entryLink import="true" name="Power Axe" hidden="false" id="6297-0651-3479-fd1e" collective="false" targetId="c066-2ace-f68c-e440" type="selectionEntry">
+                                  <costs>
+                                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5"/>
+                                  </costs>
+                                </entryLink>
+                                <entryLink import="true" name="Charnabal Tabar" hidden="false" id="4663-cacd-0e30-b4a8" collective="false" targetId="4611-c33e-f360-7246" type="selectionEntry">
+                                  <costs>
+                                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5"/>
+                                  </costs>
+                                </entryLink>
+                                <entryLink import="true" name="Charnabal Sabre" hidden="false" id="7e2b-d303-6f50-3a75" collective="false" targetId="30c2-57eb-5bbe-be0b" type="selectionEntry">
+                                  <costs>
+                                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5"/>
+                                  </costs>
+                                </entryLink>
+                                <entryLink import="true" name="Charnabal Glaive" hidden="false" id="080b-b2d3-eef8-2805" collective="false" targetId="c07c-35e6-4616-ef25" type="selectionEntry">
+                                  <costs>
+                                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5"/>
+                                  </costs>
+                                </entryLink>
+                              </entryLinks>
+                            </selectionEntryGroup>
+                            <selectionEntryGroup name="Pistol" id="de9f-b846-c818-9e80" hidden="false" collective="false" import="true">
+                              <constraints>
+                                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="ba1f-c478-e955-e07a" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="fea1-f3b9-7440-3ef3" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                              </constraints>
+                              <entryLinks>
+                                <entryLink import="true" name="Blast Pistol" hidden="false" id="3cec-d192-84c1-be5c" collective="false" targetId="2460-375d-31f4-4bdf" type="selectionEntry"/>
+                                <entryLink import="true" name="Plasma Pistol" hidden="false" id="756a-9edc-dc66-cb15" collective="false" targetId="717f-cf0a-1593-4bd8" type="selectionEntry">
+                                  <costs>
+                                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5"/>
+                                  </costs>
+                                </entryLink>
+                                <entryLink import="true" name="Hand Flamer" hidden="false" id="169e-e211-463c-7c7e" collective="false" targetId="e337-adf4-a11f-0280" type="selectionEntry"/>
+                                <entryLink import="true" name="Needle Pistol" hidden="false" id="beb5-3ca5-021a-2e18" collective="false" targetId="fdd4-06c7-4608-b07f" type="selectionEntry"/>
+                              </entryLinks>
+                            </selectionEntryGroup>
+                          </selectionEntryGroups>
+                          <costs>
+                            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
+                          </costs>
+                        </selectionEntry>
+                      </selectionEntries>
+                      <entryLinks>
+                        <entryLink import="true" name="Volkite Charger" hidden="false" id="c6f7-69d2-456a-b8d9" collective="false" targetId="6f6e-ad55-e093-6503" type="selectionEntry">
+                          <constraints>
+                            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="b14b-febd-135f-7e81" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                          </constraints>
+                        </entryLink>
+                        <entryLink import="true" name="Autorifle" hidden="true" id="368f-951d-08c8-d113" collective="false" targetId="57dd-dff6-d173-3bf1" type="selectionEntry">
+                          <modifiers>
+                            <modifier type="set" value="false" field="hidden">
+                              <conditions>
+                                <condition type="equalTo" value="1" field="selections" scope="force" childId="bfd2-7016-f5fe-be6a" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
+                              </conditions>
+                            </modifier>
+                          </modifiers>
+                        </entryLink>
+                        <entryLink import="true" name="Lascarbine" hidden="true" id="6692-32f8-3dc3-efdd" collective="false" targetId="d68e-ce5a-000c-c322" type="selectionEntry">
+                          <modifiers>
+                            <modifier type="set" value="false" field="hidden">
+                              <conditions>
+                                <condition type="equalTo" value="1" field="selections" scope="force" childId="bfd2-7016-f5fe-be6a" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
+                              </conditions>
+                            </modifier>
+                          </modifiers>
+                        </entryLink>
+                        <entryLink import="true" name="Lasgun" hidden="true" id="2f18-1856-ea68-e609" collective="false" targetId="376e-c5d6-99c3-49c9" type="selectionEntry">
+                          <modifiers>
+                            <modifier type="set" value="false" field="hidden">
+                              <conditions>
+                                <condition type="equalTo" value="1" field="selections" scope="force" childId="bfd2-7016-f5fe-be6a" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
+                              </conditions>
+                            </modifier>
+                          </modifiers>
+                        </entryLink>
+                        <entryLink import="true" name="Shotgun" hidden="true" id="5b7e-d47a-78d7-9ee4" collective="false" targetId="f0aa-947f-f493-f566" type="selectionEntry">
+                          <modifiers>
+                            <modifier type="set" value="false" field="hidden">
+                              <conditions>
+                                <condition type="equalTo" value="1" field="selections" scope="force" childId="bfd2-7016-f5fe-be6a" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
+                              </conditions>
+                            </modifier>
+                          </modifiers>
+                        </entryLink>
+                        <entryLink import="true" name="Stubcarbine" hidden="true" id="ef2b-1095-f302-9f72" collective="false" targetId="a7cc-88cb-c6e8-6d4c" type="selectionEntry">
+                          <modifiers>
+                            <modifier type="set" value="false" field="hidden">
+                              <conditions>
+                                <condition type="equalTo" value="1" field="selections" scope="force" childId="bfd2-7016-f5fe-be6a" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
+                              </conditions>
+                            </modifier>
+                          </modifiers>
+                        </entryLink>
+                      </entryLinks>
+                    </selectionEntryGroup>
+                  </selectionEntryGroups>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="8"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
                   </costs>
-                  <categoryLinks>
-                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="678c-1f1f-4ffe-bc29" name="Infantry Unit Type" primary="false"/>
-                    <categoryLink targetId="9231-183c-b97b-63f9" id="42c2-a51c-4b49-a73f" name="Heavy Sub-type" primary="false"/>
-                  </categoryLinks>
-                </selectionEntry>
-                <selectionEntry id="9323-ccf8-496d-ec8f" name="Veletarii w/ Lascarbine" hidden="true" collective="false" import="true" type="model">
-                  <modifiers>
-                    <modifier type="set" field="hidden" value="false">
-                      <conditions>
-                        <condition field="selections" scope="force" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bfd2-7016-f5fe-be6a" type="equalTo"/>
-                      </conditions>
-                    </modifier>
-                  </modifiers>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="9" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="280a-f343-5c76-96be" type="max"/>
-                  </constraints>
-                  <infoLinks>
-                    <infoLink id="bea6-1566-1daa-d125" name="Veletarii" hidden="false" targetId="f81e-a329-ec72-2a89" type="profile"/>
-                  </infoLinks>
-                  <entryLinks>
-                    <entryLink id="f00f-1751-4a33-86f4" name="Reinforced Void Armour" hidden="false" collective="false" import="true" targetId="5e45-2a38-759c-3147" type="selectionEntry">
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="98df-bd7a-d227-d92d" type="min"/>
-                        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cea9-8b92-3d5b-e7df" type="max"/>
-                      </constraints>
-                    </entryLink>
-                    <entryLink id="4c8c-306a-c8d8-1767" name="Lascarbine" hidden="true" collective="false" import="true" targetId="3335-928e-aef8-ca0f" type="selectionEntry">
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="220d-8415-e669-d137" type="min"/>
-                        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8d1d-d5f7-9f3a-f872" type="max"/>
-                      </constraints>
-                    </entryLink>
-                  </entryLinks>
-                  <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="8"/>
-                  </costs>
-                  <categoryLinks>
-                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="123c-6d08-491f-8922" name="Infantry Unit Type" primary="false"/>
-                    <categoryLink targetId="9231-183c-b97b-63f9" id="185b-0ae6-4b5d-9e60" name="Heavy Sub-type" primary="false"/>
-                  </categoryLinks>
-                </selectionEntry>
-                <selectionEntry id="957e-31e3-8b91-a469" name="Veletarii w/ Lasgun" hidden="true" collective="false" import="true" type="model">
-                  <modifiers>
-                    <modifier type="set" field="hidden" value="false">
-                      <conditions>
-                        <condition field="selections" scope="force" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bfd2-7016-f5fe-be6a" type="equalTo"/>
-                      </conditions>
-                    </modifier>
-                  </modifiers>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="9" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="33c4-2ecd-2399-57b3" type="max"/>
-                  </constraints>
-                  <infoLinks>
-                    <infoLink id="6ff5-6ca2-b290-6622" name="Veletarii" hidden="false" targetId="f81e-a329-ec72-2a89" type="profile"/>
-                  </infoLinks>
-                  <entryLinks>
-                    <entryLink id="c32b-b35c-12af-84f8" name="Reinforced Void Armour" hidden="false" collective="false" import="true" targetId="5e45-2a38-759c-3147" type="selectionEntry">
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b1da-6738-9967-3a12" type="min"/>
-                        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="05e9-d99b-39ab-aa4d" type="max"/>
-                      </constraints>
-                    </entryLink>
-                    <entryLink id="e4b8-b9ad-437d-d298" name="Lasgun" hidden="true" collective="false" import="true" targetId="0b4e-2811-0529-f22f" type="selectionEntry">
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c8ad-ac62-bade-0204" type="min"/>
-                        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9579-3643-3602-dc2b" type="max"/>
-                      </constraints>
-                    </entryLink>
-                  </entryLinks>
-                  <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="8"/>
-                  </costs>
-                  <categoryLinks>
-                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="52c2-d432-4ffa-8fca" name="Infantry Unit Type" primary="false"/>
-                    <categoryLink targetId="9231-183c-b97b-63f9" id="fe39-c692-4547-bbce" name="Heavy Sub-type" primary="false"/>
-                  </categoryLinks>
-                </selectionEntry>
-                <selectionEntry id="5b3a-4395-95a9-9851" name="Veletarii w/ Shotgun" hidden="true" collective="false" import="true" type="model">
-                  <modifiers>
-                    <modifier type="set" field="hidden" value="false">
-                      <conditions>
-                        <condition field="selections" scope="force" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bfd2-7016-f5fe-be6a" type="equalTo"/>
-                      </conditions>
-                    </modifier>
-                  </modifiers>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="9" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6ad4-ac3d-65f6-873f" type="max"/>
-                  </constraints>
-                  <infoLinks>
-                    <infoLink id="5dcb-b922-a27e-c565" name="Veletarii" hidden="false" targetId="f81e-a329-ec72-2a89" type="profile"/>
-                  </infoLinks>
-                  <entryLinks>
-                    <entryLink id="f5da-c8b8-77e0-0e71" name="Reinforced Void Armour" hidden="false" collective="false" import="true" targetId="5e45-2a38-759c-3147" type="selectionEntry">
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="07fd-35c3-56cf-4d40" type="min"/>
-                        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4ba5-87a4-d385-afda" type="max"/>
-                      </constraints>
-                    </entryLink>
-                    <entryLink id="6fb8-be9d-223b-a677" name="Shotgun" hidden="true" collective="false" import="true" targetId="2dba-5646-1049-c134" type="selectionEntry">
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8891-72ec-9711-6f8a" type="max"/>
-                        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3e38-185b-a71c-bda1" type="min"/>
-                      </constraints>
-                    </entryLink>
-                  </entryLinks>
-                  <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="8"/>
-                  </costs>
-                  <categoryLinks>
-                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="d42f-a701-478d-9506" name="Infantry Unit Type" primary="false"/>
-                    <categoryLink targetId="9231-183c-b97b-63f9" id="f200-f456-4ece-a5d4" name="Heavy Sub-type" primary="false"/>
-                  </categoryLinks>
-                </selectionEntry>
-                <selectionEntry id="fa18-90d2-821e-4291" name="Veletarii w/ Stubcarbine" hidden="true" collective="false" import="true" type="model">
-                  <modifiers>
-                    <modifier type="set" field="hidden" value="false">
-                      <conditions>
-                        <condition field="selections" scope="force" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bfd2-7016-f5fe-be6a" type="equalTo"/>
-                      </conditions>
-                    </modifier>
-                  </modifiers>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="9" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9153-294f-4c90-b9c8" type="max"/>
-                  </constraints>
-                  <infoLinks>
-                    <infoLink id="dbae-36d4-0282-452f" name="Veletarii" hidden="false" targetId="f81e-a329-ec72-2a89" type="profile"/>
-                  </infoLinks>
-                  <entryLinks>
-                    <entryLink id="e44d-614f-0b13-036f" name="Reinforced Void Armour" hidden="false" collective="false" import="true" targetId="5e45-2a38-759c-3147" type="selectionEntry">
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9c2c-c821-54bb-f018" type="min"/>
-                        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="75d3-fc67-d617-ff4b" type="max"/>
-                      </constraints>
-                    </entryLink>
-                    <entryLink id="9f9c-ee08-8cbd-9b0a" name="Stubcarbine" hidden="true" collective="false" import="true" targetId="090f-d3b8-9e92-40e3" type="selectionEntry">
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a7a9-164b-a7f8-138b" type="min"/>
-                        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6488-cbb7-80fd-d7b3" type="max"/>
-                      </constraints>
-                    </entryLink>
-                  </entryLinks>
-                  <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="8"/>
-                  </costs>
-                  <categoryLinks>
-                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="a55c-660d-42fc-aac5" name="Infantry Unit Type" primary="false"/>
-                    <categoryLink targetId="9231-183c-b97b-63f9" id="8a20-14c5-4324-b20d" name="Heavy Sub-type" primary="false"/>
-                  </categoryLinks>
                 </selectionEntry>
               </selectionEntries>
-            </selectionEntryGroup>
-          </selectionEntryGroups>
-          <entryLinks>
-            <entryLink id="e84f-f6d2-80c7-db89" name="Volkite Charger" hidden="false" collective="false" import="true" targetId="6f6e-ad55-e093-6503" type="selectionEntry">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9fb7-613c-30f7-a40a" type="min"/>
-                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="15ce-dbc8-f64d-f873" type="max"/>
-              </constraints>
-            </entryLink>
-            <entryLink id="6bc5-f9e9-44a1-f883" name="Krak Grenades" hidden="false" collective="false" import="true" targetId="99df-2421-acf7-a5ad" type="selectionEntry">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="efba-2f98-ca93-40a1" type="min"/>
-                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8817-bd09-9a91-8456" type="max"/>
-              </constraints>
-            </entryLink>
-            <entryLink id="4207-ba86-a98a-98b2" name="Frag Grenades" hidden="false" collective="false" import="true" targetId="cf9c-327b-3449-00d7" type="selectionEntry">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ebd8-f5f6-d2dc-2e17" type="min"/>
-                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5dfe-f341-dc77-0d07" type="max"/>
-              </constraints>
-            </entryLink>
-            <entryLink id="6d79-07e1-b369-3180" name="Fear (Feral Cohort)" hidden="false" collective="false" import="true" targetId="aefe-eff6-2961-a445" type="selectionEntry"/>
-          </entryLinks>
-          <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="58"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="c51e-5dce-2d97-4a99" name="Veletaris Storm Section" hidden="false" collective="false" import="true" type="unit">
-          <constraints>
-            <constraint field="selections" scope="parent" value="3" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b8d7-d27c-2841-12af" type="max"/>
-            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a8bc-6d7a-6118-1894" type="min"/>
-          </constraints>
-          <infoLinks>
-            <infoLink id="2cfb-f9ab-abd0-e95e" name="Tercio" hidden="false" targetId="6516-f81d-457b-a2cc" type="rule"/>
-            <infoLink id="2a7d-4e36-e916-0565" name="Stubborn" hidden="false" targetId="7989-1f2c-a43d-82ae" type="rule">
-              <modifiers>
-                <modifier type="set" field="hidden" value="true">
-                  <conditions>
-                    <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fe04-c096-f846-a6fd" type="equalTo"/>
-                  </conditions>
-                </modifier>
-              </modifiers>
-            </infoLink>
-            <infoLink id="28bb-179e-31cc-2877" name="Furious Charge (X)" hidden="false" targetId="2821-9269-862f-0554" type="rule">
-              <modifiers>
-                <modifier type="set" field="name" value="Furious Charge (1)"/>
-                <modifier type="set" field="hidden" value="true">
-                  <conditions>
-                    <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bfd2-7016-f5fe-be6a" type="equalTo"/>
-                  </conditions>
-                </modifier>
-              </modifiers>
-            </infoLink>
-            <infoLink id="afd1-a46a-1010-97f3" name="Counter-Attack (X)" hidden="false" targetId="fd6d-2a76-10e0-936a" type="rule">
-              <modifiers>
-                <modifier type="set" field="name" value="Counter-Attack (1) (while &apos;In Formation&apos;)"/>
-                <modifier type="set" field="hidden" value="true">
-                  <conditions>
-                    <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="021e-6841-7375-7862" type="equalTo"/>
-                  </conditions>
-                </modifier>
-              </modifiers>
-            </infoLink>
-          </infoLinks>
-          <selectionEntries>
-            <selectionEntry id="06be-2459-ac34-8782" name="Veletarii Prime" hidden="false" collective="false" import="true" type="model">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="642d-bbad-ee60-8168" type="min"/>
-                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8fc2-cd7e-de95-18b5" type="max"/>
-              </constraints>
-              <profiles>
-                <profile id="ae88-d4d6-6f08-f4fb" name="Veletarii Prime" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName="Unit">
+              <selectionEntryGroups>
+                <selectionEntryGroup name="Dedicated Transports" id="d7bc-047c-b7f1-9422" hidden="false" collective="false" import="true">
                   <modifiers>
-                    <modifier type="set" field="e593-6b3c-f169-04f0" value="3+">
+                    <modifier type="set" value="1" field="b644-9665-219f-541e">
                       <conditions>
-                        <condition field="selections" scope="06be-2459-ac34-8782" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="523c-d7fb-5288-fe13" type="equalTo"/>
+                        <condition type="equalTo" value="1" field="selections" scope="force" childId="d9a0-4875-fb75-f9a9" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
                       </conditions>
                     </modifier>
-                    <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Infantry (Heavy, Character, Line)">
+                    <modifier type="set" value="true" field="hidden">
                       <conditions>
-                        <condition field="selections" scope="force" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a09b-28bd-8ffc-f4f0" type="equalTo"/>
-                      </conditions>
-                    </modifier>
-                    <modifier type="increment" field="e8a6-1da9-d384-8727" value="1">
-                      <conditions>
-                        <condition field="selections" scope="force" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fe04-c096-f846-a6fd" type="equalTo"/>
+                        <condition type="atLeast" value="1" field="selections" scope="force" childId="7b69-bf2f-4547-e83b" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
                       </conditions>
                     </modifier>
                   </modifiers>
-                  <characteristics>
-                    <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Heavy, Character)</characteristic>
-                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">6</characteristic>
-                    <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
-                    <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
-                    <characteristic name="S" typeId="e478-41d4-a092-48a8">3</characteristic>
-                    <characteristic name="T" typeId="c32b-5fdd-3fbe-9b1f">3</characteristic>
-                    <characteristic name="W" typeId="57ee-1126-32a9-5672">1</characteristic>
-                    <characteristic name="I" typeId="62d3-22d7-2d49-52dc">4</characteristic>
-                    <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">2</characteristic>
-                    <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">7</characteristic>
-                    <characteristic name="Save" typeId="e593-6b3c-f169-04f0">4+</characteristic>
-                  </characteristics>
-                </profile>
-              </profiles>
-              <categoryLinks>
-                <categoryLink id="6ba0-d806-4ca8-1add" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="aa8d-3d92-43b7-92f0" name="Infantry Unit Type" primary="false"/>
-                <categoryLink targetId="9231-183c-b97b-63f9" id="06b4-6138-47bc-8318" name="Heavy Sub-type" primary="false"/>
-              </categoryLinks>
-              <selectionEntryGroups>
-                <selectionEntryGroup id="7420-8069-6ac7-b72b" name="Armour" hidden="false" collective="false" import="true" defaultSelectionEntryId="1d16-82e9-d8f6-943e">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="18c7-99ad-9f41-eadc" type="min"/>
-                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3fd4-ea25-c1da-c39d" type="max"/>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="f8a3-daac-d0ed-7e9c" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                    <constraint type="min" value="0" field="selections" scope="parent" shared="true" id="b644-9665-219f-541e" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
                   </constraints>
                   <entryLinks>
-                    <entryLink id="1d16-82e9-d8f6-943e" name="Reinforced Void Armour" hidden="false" collective="false" import="true" targetId="cc63-5cc3-212a-3d4c" type="selectionEntry"/>
-                    <entryLink id="10f6-20a4-55d3-6565" name="Heavy Void Armour" hidden="false" collective="false" import="true" targetId="523c-d7fb-5288-fe13" type="selectionEntry">
+                    <entryLink import="true" name="Aurox Transport" hidden="false" id="c098-ae34-d830-e5c8" collective="false" targetId="071b-79e5-7b5b-c9cd" type="selectionEntry"/>
+                    <entryLink import="true" name="Dracosan Armoured Transport" hidden="false" id="2921-ecce-fcdf-7f51" collective="false" targetId="496b-a01b-3726-0a44" type="selectionEntry"/>
+                    <entryLink import="true" name="Arvus Transport" hidden="true" id="d762-7404-b6a5-a152" collective="false" targetId="5041-9403-02b7-af14" type="selectionEntry">
+                      <modifiers>
+                        <modifier type="set" value="false" field="hidden">
+                          <conditions>
+                            <condition type="equalTo" value="1" field="selections" scope="force" childId="a09b-28bd-8ffc-f4f0" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
+                          </conditions>
+                        </modifier>
+                      </modifiers>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup name="One Veletarii in the unit may be upgraded to have a:" id="ff50-83d5-369f-f7ca" hidden="false" collective="false" import="true">
+                  <entryLinks>
+                    <entryLink import="true" name="Auxilia Vexilla" hidden="false" id="4974-cc0e-dd7a-942d" collective="false" targetId="6f5a-bf56-4bee-ce7e" type="selectionEntry">
+                      <constraints>
+                        <constraint type="max" value="1" field="selections" scope="7474-ec3d-98de-d2e0" shared="true" id="4a91-f7ee-a5f9-6c26" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
+                        <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="98fe-f299-2629-87f2" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                      </constraints>
+                      <costs>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink import="true" name="Command Vox" hidden="false" id="556b-e589-fcad-8e2d" collective="false" targetId="7ac4-c39b-5c48-63cb" type="selectionEntry">
+                      <constraints>
+                        <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="b250-635e-c7c0-77ca" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                        <constraint type="max" value="1" field="selections" scope="7474-ec3d-98de-d2e0" shared="true" id="385b-529a-0b82-17ed" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
+                      </constraints>
                       <costs>
                         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10"/>
                       </costs>
                     </entryLink>
                   </entryLinks>
                 </selectionEntryGroup>
-                <selectionEntryGroup id="054e-9398-2176-c36e" name="Weapons" hidden="false" collective="false" import="true" defaultSelectionEntryId="0c3c-546a-a159-5ae4">
+                <selectionEntryGroup name="Veletarii" id="092d-2397-8f02-c431" hidden="false" collective="false" import="true" defaultSelectionEntryId="c39a-711f-3566-712d">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="903f-32af-4b86-9ee7" type="min"/>
-                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c69e-58eb-fbdb-bb77" type="max"/>
+                    <constraint type="min" value="4" field="selections" scope="parent" shared="true" id="1168-de26-e5bc-3a25" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                    <constraint type="max" value="9" field="selections" scope="parent" shared="true" id="47ed-c168-0aa5-e59a" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
                   </constraints>
                   <selectionEntries>
-                    <selectionEntry id="b0be-c9c2-e8a1-8a04" name="Pistol and Combat weapon (Sub-menu)" hidden="false" collective="false" import="true" type="upgrade">
+                    <selectionEntry type="model" import="true" name="Veletarii w/ Power Sword" hidden="false" id="0e92-6f2e-8f92-40bf" collective="false">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c1ff-7f3f-fbf5-a017" type="max"/>
+                        <constraint type="max" value="9" field="selections" scope="parent" shared="true" id="1011-7d26-c096-6d0c" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
                       </constraints>
-                      <selectionEntryGroups>
-                        <selectionEntryGroup id="0582-ef1e-1f15-f504" name="Close Combat" hidden="false" collective="false" import="true">
+                      <infoLinks>
+                        <infoLink name="Veletarii" id="d55c-a815-fca3-ee7a" hidden="false" targetId="f81e-a329-ec72-2a89" type="profile"/>
+                      </infoLinks>
+                      <entryLinks>
+                        <entryLink import="true" name="Reinforced Void Armour" hidden="false" id="7813-f295-65eb-b35f" collective="false" targetId="5e45-2a38-759c-3147" type="selectionEntry">
                           <constraints>
-                            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2d55-d1f5-ccc5-e653" type="min"/>
-                            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9d1d-2c20-3aad-d5fe" type="max"/>
+                            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="4c81-045a-711c-ee5f" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="7e45-6a3e-227b-f839" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
                           </constraints>
-                          <entryLinks>
-                            <entryLink id="7285-fa9b-a0ba-26ce" name="Close Combat Weapon" hidden="false" collective="false" import="true" targetId="3d50-2f85-06ff-6aee" type="selectionEntry"/>
-                            <entryLink id="8442-e1bb-8f7b-ebb1" name="Power Fist" hidden="false" collective="false" import="true" targetId="768d-b89b-7328-d749" type="selectionEntry">
-                              <costs>
-                                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10"/>
-                              </costs>
-                            </entryLink>
-                            <entryLink id="1cfd-0777-a4c9-3f6d" name="Storm Axe" hidden="false" collective="false" import="true" targetId="e09b-73c8-2340-4604" type="selectionEntry">
-                              <costs>
-                                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5"/>
-                              </costs>
-                            </entryLink>
-                            <entryLink id="1203-868c-1ee4-133b" name="Charnabal Glaive" hidden="false" collective="false" import="true" targetId="c07c-35e6-4616-ef25" type="selectionEntry">
-                              <costs>
-                                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5"/>
-                              </costs>
-                            </entryLink>
-                            <entryLink id="d8c0-fb87-038d-6c1d" name="Charnabal Sabre" hidden="false" collective="false" import="true" targetId="30c2-57eb-5bbe-be0b" type="selectionEntry">
-                              <costs>
-                                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5"/>
-                              </costs>
-                            </entryLink>
-                            <entryLink id="cecd-7c8b-50c8-3bbe" name="Charnabal Tabar" hidden="false" collective="false" import="true" targetId="4611-c33e-f360-7246" type="selectionEntry">
-                              <costs>
-                                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5"/>
-                              </costs>
-                            </entryLink>
-                            <entryLink id="12e9-27b3-af59-5530" name="Power Axe" hidden="false" collective="false" import="true" targetId="c066-2ace-f68c-e440" type="selectionEntry">
-                              <costs>
-                                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5"/>
-                              </costs>
-                            </entryLink>
-                            <entryLink id="062e-cbe7-6853-eb05" name="Power Lance" hidden="false" collective="false" import="true" targetId="a4c8-c8ff-87f2-1ac9" type="selectionEntry">
-                              <costs>
-                                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5"/>
-                              </costs>
-                            </entryLink>
-                            <entryLink id="fd68-62d0-decd-9121" name="Power Maul" hidden="false" collective="false" import="true" targetId="0df4-c67e-cf64-82e0" type="selectionEntry">
-                              <costs>
-                                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5"/>
-                              </costs>
-                            </entryLink>
-                            <entryLink id="dfcc-1003-6ecd-5021" name="Power Sword" hidden="false" collective="false" import="true" targetId="a3cd-aa97-a148-2309" type="selectionEntry">
-                              <costs>
-                                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5"/>
-                              </costs>
-                            </entryLink>
-                          </entryLinks>
-                        </selectionEntryGroup>
-                        <selectionEntryGroup id="a9db-cc4a-d2c4-e419" name="Pistol" hidden="false" collective="false" import="true">
+                        </entryLink>
+                        <entryLink import="true" name="Power Sword" hidden="false" id="bc0d-4263-e761-362c" collective="false" targetId="fa06-cac0-3d98-125e" type="selectionEntry">
                           <constraints>
-                            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b95b-73fa-7c0d-0de2" type="min"/>
-                            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e56b-333f-e00b-77b4" type="max"/>
+                            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="5ee6-ad3d-fbd6-9ce2" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="7b42-c7af-536f-1a12" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
                           </constraints>
-                          <entryLinks>
-                            <entryLink id="3c62-15f8-c427-a075" name="Blast Pistol" hidden="false" collective="false" import="true" targetId="2460-375d-31f4-4bdf" type="selectionEntry"/>
-                            <entryLink id="0818-8375-670a-dfa7" name="Plasma Pistol" hidden="false" collective="false" import="true" targetId="717f-cf0a-1593-4bd8" type="selectionEntry">
-                              <costs>
-                                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5"/>
-                              </costs>
-                            </entryLink>
-                            <entryLink id="9d01-8c72-f666-e0ef" name="Hand Flamer" hidden="false" collective="false" import="true" targetId="e337-adf4-a11f-0280" type="selectionEntry"/>
-                            <entryLink id="b766-d386-1e55-719b" name="Needle Pistol" hidden="false" collective="false" import="true" targetId="fdd4-06c7-4608-b07f" type="selectionEntry"/>
-                          </entryLinks>
-                        </selectionEntryGroup>
-                      </selectionEntryGroups>
+                        </entryLink>
+                      </entryLinks>
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="13"/>
                       </costs>
+                      <categoryLinks>
+                        <categoryLink name="Infantry Unit Type" hidden="false" id="da5d-531c-4a24-b7e6" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+                        <categoryLink name="Heavy Sub-type" hidden="false" id="9e8e-cfdf-4797-85b8" targetId="9231-183c-b97b-63f9" primary="false"/>
+                      </categoryLinks>
+                    </selectionEntry>
+                    <selectionEntry type="model" import="true" name="Veletarii w/ Power Lance" hidden="false" id="6e26-de36-1442-bf11" collective="false">
+                      <constraints>
+                        <constraint type="max" value="9" field="selections" scope="parent" shared="true" id="ff05-f5f1-0f4d-d019" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                      </constraints>
+                      <infoLinks>
+                        <infoLink name="Veletarii" id="c3fa-1bf1-90fe-5ff3" hidden="false" targetId="f81e-a329-ec72-2a89" type="profile"/>
+                      </infoLinks>
+                      <entryLinks>
+                        <entryLink import="true" name="Reinforced Void Armour" hidden="false" id="1b0d-a335-3362-5ab9" collective="false" targetId="5e45-2a38-759c-3147" type="selectionEntry">
+                          <constraints>
+                            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="b850-3d19-2843-f45b" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="9ac9-2bea-a1ac-e521" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                          </constraints>
+                        </entryLink>
+                        <entryLink import="true" name="Power Lance" hidden="false" id="2df3-e0a8-3bc6-7a98" collective="false" targetId="fca3-4ec1-c581-1ba3" type="selectionEntry">
+                          <constraints>
+                            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="2e44-4502-dc02-2ac7" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="43a2-b9b7-ba34-ccc1" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                          </constraints>
+                        </entryLink>
+                      </entryLinks>
+                      <costs>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="13"/>
+                      </costs>
+                      <categoryLinks>
+                        <categoryLink name="Infantry Unit Type" hidden="false" id="7540-5336-4847-b983" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+                        <categoryLink name="Heavy Sub-type" hidden="false" id="68b3-64f4-4caa-ba98" targetId="9231-183c-b97b-63f9" primary="false"/>
+                      </categoryLinks>
+                    </selectionEntry>
+                    <selectionEntry type="model" import="true" name="Veletarii w/ Power Maul" hidden="false" id="2ccc-2dc8-9580-f134" collective="false">
+                      <constraints>
+                        <constraint type="max" value="9" field="selections" scope="parent" shared="true" id="1af2-bcc2-ec38-96e0" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                      </constraints>
+                      <infoLinks>
+                        <infoLink name="Veletarii" id="e672-dd79-0784-b7ec" hidden="false" targetId="f81e-a329-ec72-2a89" type="profile"/>
+                      </infoLinks>
+                      <entryLinks>
+                        <entryLink import="true" name="Reinforced Void Armour" hidden="false" id="e3c0-8a39-04e0-fcd0" collective="false" targetId="5e45-2a38-759c-3147" type="selectionEntry">
+                          <constraints>
+                            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="4393-23a5-622a-565c" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="766c-b0dd-63f4-8749" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                          </constraints>
+                        </entryLink>
+                        <entryLink import="true" name="Power Maul" hidden="false" id="8e07-7cb6-b23b-38c0" collective="false" targetId="98e8-f217-dea9-0493" type="selectionEntry">
+                          <constraints>
+                            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="1199-a8e3-7d40-6024" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="8056-3f5e-23d8-60f6" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                          </constraints>
+                        </entryLink>
+                      </entryLinks>
+                      <costs>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="13"/>
+                      </costs>
+                      <categoryLinks>
+                        <categoryLink name="Infantry Unit Type" hidden="false" id="a09f-5726-4cb7-80fd" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+                        <categoryLink name="Heavy Sub-type" hidden="false" id="a5f9-e2a7-4afc-9773" targetId="9231-183c-b97b-63f9" primary="false"/>
+                      </categoryLinks>
+                    </selectionEntry>
+                    <selectionEntry type="model" import="true" name="Veletarii w/ Volkite Charger" hidden="false" id="c39a-711f-3566-712d" collective="false">
+                      <constraints>
+                        <constraint type="max" value="9" field="selections" scope="parent" shared="true" id="60ff-babf-7da4-a70a" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                      </constraints>
+                      <infoLinks>
+                        <infoLink name="Veletarii" id="b46b-492a-7e17-61de" hidden="false" targetId="f81e-a329-ec72-2a89" type="profile"/>
+                      </infoLinks>
+                      <entryLinks>
+                        <entryLink import="true" name="Reinforced Void Armour" hidden="false" id="c08b-1081-4d6d-f920" collective="false" targetId="5e45-2a38-759c-3147" type="selectionEntry">
+                          <constraints>
+                            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="1e47-3793-f822-eba7" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="752c-e144-240e-5882" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                          </constraints>
+                        </entryLink>
+                        <entryLink import="true" name="Volkite Charger" hidden="false" id="1194-fd3e-fab0-b679" collective="false" targetId="5c82-c306-9c5c-5908" type="selectionEntry">
+                          <constraints>
+                            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="0cbd-ee32-eb57-dd46" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="b864-28ca-4f90-c6ec" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                          </constraints>
+                        </entryLink>
+                      </entryLinks>
+                      <costs>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="8"/>
+                      </costs>
+                      <categoryLinks>
+                        <categoryLink name="Infantry Unit Type" hidden="false" id="22fb-ac5b-423d-9dcb" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+                        <categoryLink name="Heavy Sub-type" hidden="false" id="8e3d-b560-4e82-9a41" targetId="9231-183c-b97b-63f9" primary="false"/>
+                      </categoryLinks>
+                    </selectionEntry>
+                    <selectionEntry type="model" import="true" name="Veletarii w/ Power Axe" hidden="false" id="0797-e0e8-65b9-9a4a" collective="false">
+                      <constraints>
+                        <constraint type="max" value="9" field="selections" scope="parent" shared="true" id="acd6-dd94-5d41-dfcf" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                      </constraints>
+                      <profiles>
+                        <profile name="Veletarii" typeId="4bb2-cb95-e6c8-5a21" typeName="Unit" hidden="false" id="f81e-a329-ec72-2a89">
+                          <characteristics>
+                            <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Heavy)</characteristic>
+                            <characteristic name="Move" typeId="893e-2d76-8f04-44e5">6</characteristic>
+                            <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
+                            <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
+                            <characteristic name="S" typeId="e478-41d4-a092-48a8">3</characteristic>
+                            <characteristic name="T" typeId="c32b-5fdd-3fbe-9b1f">3</characteristic>
+                            <characteristic name="W" typeId="57ee-1126-32a9-5672">1</characteristic>
+                            <characteristic name="I" typeId="62d3-22d7-2d49-52dc">4</characteristic>
+                            <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">1</characteristic>
+                            <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">6</characteristic>
+                            <characteristic name="Save" typeId="e593-6b3c-f169-04f0">4+</characteristic>
+                          </characteristics>
+                          <modifiers>
+                            <modifier type="set" value="Infantry (Heavy, Line)" field="ddd7-6f5c-a939-b69e">
+                              <conditionGroups>
+                                <conditionGroup type="and">
+                                  <conditions>
+                                    <condition type="equalTo" value="1" field="selections" scope="force" childId="a09b-28bd-8ffc-f4f0" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
+                                    <condition type="instanceOf" value="1" field="selections" scope="primary-category" childId="9b5d-fac7-799b-d7e7" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
+                                  </conditions>
+                                </conditionGroup>
+                              </conditionGroups>
+                            </modifier>
+                            <modifier type="increment" value="1" field="e8a6-1da9-d384-8727">
+                              <conditions>
+                                <condition type="equalTo" value="1" field="selections" scope="force" childId="fe04-c096-f846-a6fd" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
+                              </conditions>
+                            </modifier>
+                          </modifiers>
+                        </profile>
+                      </profiles>
+                      <entryLinks>
+                        <entryLink import="true" name="Reinforced Void Armour" hidden="false" id="055e-5cf5-89a9-e7ea" collective="false" targetId="5e45-2a38-759c-3147" type="selectionEntry">
+                          <constraints>
+                            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="38f7-cabd-896b-2aea" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="423a-b89f-e1df-11cb" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                          </constraints>
+                        </entryLink>
+                        <entryLink import="true" name="Power Axe" hidden="false" id="2e05-3f3c-d294-a0de" collective="false" targetId="ef98-66ac-fcaf-c15d" type="selectionEntry">
+                          <constraints>
+                            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="3f32-e47b-ffe5-702b" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="e991-3ef1-3e7f-3cfb" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                          </constraints>
+                        </entryLink>
+                      </entryLinks>
+                      <costs>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="13"/>
+                      </costs>
+                      <categoryLinks>
+                        <categoryLink name="Infantry Unit Type" hidden="false" id="41ec-9595-4956-87b5" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+                        <categoryLink name="Heavy Sub-type" hidden="false" id="bfd9-9a27-46f5-aa92" targetId="9231-183c-b97b-63f9" primary="false"/>
+                      </categoryLinks>
+                    </selectionEntry>
+                    <selectionEntry type="model" import="true" name="Veletarii w/ Autorifle" hidden="true" id="3d9e-0a04-4a3b-de52" collective="false">
+                      <modifiers>
+                        <modifier type="set" value="false" field="hidden">
+                          <conditions>
+                            <condition type="equalTo" value="1" field="selections" scope="force" childId="bfd2-7016-f5fe-be6a" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
+                          </conditions>
+                        </modifier>
+                      </modifiers>
+                      <constraints>
+                        <constraint type="max" value="9" field="selections" scope="parent" shared="true" id="a240-87f4-1ad8-9ce2" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                      </constraints>
+                      <infoLinks>
+                        <infoLink name="Veletarii" id="d542-cb70-04d1-4169" hidden="false" targetId="f81e-a329-ec72-2a89" type="profile"/>
+                      </infoLinks>
+                      <entryLinks>
+                        <entryLink import="true" name="Reinforced Void Armour" hidden="false" id="8cab-3f02-5d79-fd31" collective="false" targetId="5e45-2a38-759c-3147" type="selectionEntry">
+                          <constraints>
+                            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="48bc-750f-42f4-7974" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="6f44-e603-b0c9-4c91" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                          </constraints>
+                        </entryLink>
+                        <entryLink import="true" name="Autorifle" hidden="false" id="8483-ace0-9e9d-8341" collective="false" targetId="f3ff-0995-248a-5243" type="selectionEntry">
+                          <constraints>
+                            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="dd2e-b2a1-dbf2-35f6" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="c1e9-162a-47ac-a884" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                          </constraints>
+                        </entryLink>
+                      </entryLinks>
+                      <costs>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="8"/>
+                      </costs>
+                      <categoryLinks>
+                        <categoryLink name="Infantry Unit Type" hidden="false" id="678c-1f1f-4ffe-bc29" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+                        <categoryLink name="Heavy Sub-type" hidden="false" id="42c2-a51c-4b49-a73f" targetId="9231-183c-b97b-63f9" primary="false"/>
+                      </categoryLinks>
+                    </selectionEntry>
+                    <selectionEntry type="model" import="true" name="Veletarii w/ Lascarbine" hidden="true" id="9323-ccf8-496d-ec8f" collective="false">
+                      <modifiers>
+                        <modifier type="set" value="false" field="hidden">
+                          <conditions>
+                            <condition type="equalTo" value="1" field="selections" scope="force" childId="bfd2-7016-f5fe-be6a" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
+                          </conditions>
+                        </modifier>
+                      </modifiers>
+                      <constraints>
+                        <constraint type="max" value="9" field="selections" scope="parent" shared="true" id="280a-f343-5c76-96be" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                      </constraints>
+                      <infoLinks>
+                        <infoLink name="Veletarii" id="bea6-1566-1daa-d125" hidden="false" targetId="f81e-a329-ec72-2a89" type="profile"/>
+                      </infoLinks>
+                      <entryLinks>
+                        <entryLink import="true" name="Reinforced Void Armour" hidden="false" id="f00f-1751-4a33-86f4" collective="false" targetId="5e45-2a38-759c-3147" type="selectionEntry">
+                          <constraints>
+                            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="98df-bd7a-d227-d92d" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="cea9-8b92-3d5b-e7df" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                          </constraints>
+                        </entryLink>
+                        <entryLink import="true" name="Lascarbine" hidden="true" id="4c8c-306a-c8d8-1767" collective="false" targetId="3335-928e-aef8-ca0f" type="selectionEntry">
+                          <constraints>
+                            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="220d-8415-e669-d137" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="8d1d-d5f7-9f3a-f872" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                          </constraints>
+                        </entryLink>
+                      </entryLinks>
+                      <costs>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="8"/>
+                      </costs>
+                      <categoryLinks>
+                        <categoryLink name="Infantry Unit Type" hidden="false" id="123c-6d08-491f-8922" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+                        <categoryLink name="Heavy Sub-type" hidden="false" id="185b-0ae6-4b5d-9e60" targetId="9231-183c-b97b-63f9" primary="false"/>
+                      </categoryLinks>
+                    </selectionEntry>
+                    <selectionEntry type="model" import="true" name="Veletarii w/ Lasgun" hidden="true" id="957e-31e3-8b91-a469" collective="false">
+                      <modifiers>
+                        <modifier type="set" value="false" field="hidden">
+                          <conditions>
+                            <condition type="equalTo" value="1" field="selections" scope="force" childId="bfd2-7016-f5fe-be6a" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
+                          </conditions>
+                        </modifier>
+                      </modifiers>
+                      <constraints>
+                        <constraint type="max" value="9" field="selections" scope="parent" shared="true" id="33c4-2ecd-2399-57b3" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                      </constraints>
+                      <infoLinks>
+                        <infoLink name="Veletarii" id="6ff5-6ca2-b290-6622" hidden="false" targetId="f81e-a329-ec72-2a89" type="profile"/>
+                      </infoLinks>
+                      <entryLinks>
+                        <entryLink import="true" name="Reinforced Void Armour" hidden="false" id="c32b-b35c-12af-84f8" collective="false" targetId="5e45-2a38-759c-3147" type="selectionEntry">
+                          <constraints>
+                            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="b1da-6738-9967-3a12" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="05e9-d99b-39ab-aa4d" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                          </constraints>
+                        </entryLink>
+                        <entryLink import="true" name="Lasgun" hidden="true" id="e4b8-b9ad-437d-d298" collective="false" targetId="0b4e-2811-0529-f22f" type="selectionEntry">
+                          <constraints>
+                            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="c8ad-ac62-bade-0204" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="9579-3643-3602-dc2b" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                          </constraints>
+                        </entryLink>
+                      </entryLinks>
+                      <costs>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="8"/>
+                      </costs>
+                      <categoryLinks>
+                        <categoryLink name="Infantry Unit Type" hidden="false" id="52c2-d432-4ffa-8fca" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+                        <categoryLink name="Heavy Sub-type" hidden="false" id="fe39-c692-4547-bbce" targetId="9231-183c-b97b-63f9" primary="false"/>
+                      </categoryLinks>
+                    </selectionEntry>
+                    <selectionEntry type="model" import="true" name="Veletarii w/ Shotgun" hidden="true" id="5b3a-4395-95a9-9851" collective="false">
+                      <modifiers>
+                        <modifier type="set" value="false" field="hidden">
+                          <conditions>
+                            <condition type="equalTo" value="1" field="selections" scope="force" childId="bfd2-7016-f5fe-be6a" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
+                          </conditions>
+                        </modifier>
+                      </modifiers>
+                      <constraints>
+                        <constraint type="max" value="9" field="selections" scope="parent" shared="true" id="6ad4-ac3d-65f6-873f" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                      </constraints>
+                      <infoLinks>
+                        <infoLink name="Veletarii" id="5dcb-b922-a27e-c565" hidden="false" targetId="f81e-a329-ec72-2a89" type="profile"/>
+                      </infoLinks>
+                      <entryLinks>
+                        <entryLink import="true" name="Reinforced Void Armour" hidden="false" id="f5da-c8b8-77e0-0e71" collective="false" targetId="5e45-2a38-759c-3147" type="selectionEntry">
+                          <constraints>
+                            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="07fd-35c3-56cf-4d40" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="4ba5-87a4-d385-afda" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                          </constraints>
+                        </entryLink>
+                        <entryLink import="true" name="Shotgun" hidden="true" id="6fb8-be9d-223b-a677" collective="false" targetId="2dba-5646-1049-c134" type="selectionEntry">
+                          <constraints>
+                            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="8891-72ec-9711-6f8a" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="3e38-185b-a71c-bda1" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                          </constraints>
+                        </entryLink>
+                      </entryLinks>
+                      <costs>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="8"/>
+                      </costs>
+                      <categoryLinks>
+                        <categoryLink name="Infantry Unit Type" hidden="false" id="d42f-a701-478d-9506" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+                        <categoryLink name="Heavy Sub-type" hidden="false" id="f200-f456-4ece-a5d4" targetId="9231-183c-b97b-63f9" primary="false"/>
+                      </categoryLinks>
+                    </selectionEntry>
+                    <selectionEntry type="model" import="true" name="Veletarii w/ Stubcarbine" hidden="true" id="fa18-90d2-821e-4291" collective="false">
+                      <modifiers>
+                        <modifier type="set" value="false" field="hidden">
+                          <conditions>
+                            <condition type="equalTo" value="1" field="selections" scope="force" childId="bfd2-7016-f5fe-be6a" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
+                          </conditions>
+                        </modifier>
+                      </modifiers>
+                      <constraints>
+                        <constraint type="max" value="9" field="selections" scope="parent" shared="true" id="9153-294f-4c90-b9c8" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                      </constraints>
+                      <infoLinks>
+                        <infoLink name="Veletarii" id="dbae-36d4-0282-452f" hidden="false" targetId="f81e-a329-ec72-2a89" type="profile"/>
+                      </infoLinks>
+                      <entryLinks>
+                        <entryLink import="true" name="Reinforced Void Armour" hidden="false" id="e44d-614f-0b13-036f" collective="false" targetId="5e45-2a38-759c-3147" type="selectionEntry">
+                          <constraints>
+                            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="9c2c-c821-54bb-f018" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="75d3-fc67-d617-ff4b" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                          </constraints>
+                        </entryLink>
+                        <entryLink import="true" name="Stubcarbine" hidden="true" id="9f9c-ee08-8cbd-9b0a" collective="false" targetId="090f-d3b8-9e92-40e3" type="selectionEntry">
+                          <constraints>
+                            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="a7a9-164b-a7f8-138b" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="6488-cbb7-80fd-d7b3" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                          </constraints>
+                        </entryLink>
+                      </entryLinks>
+                      <costs>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="8"/>
+                      </costs>
+                      <categoryLinks>
+                        <categoryLink name="Infantry Unit Type" hidden="false" id="a55c-660d-42fc-aac5" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+                        <categoryLink name="Heavy Sub-type" hidden="false" id="8a20-14c5-4324-b20d" targetId="9231-183c-b97b-63f9" primary="false"/>
+                      </categoryLinks>
                     </selectionEntry>
                   </selectionEntries>
-                  <entryLinks>
-                    <entryLink id="0c3c-546a-a159-5ae4" name="Volkite Charger" hidden="false" collective="false" import="true" targetId="6f6e-ad55-e093-6503" type="selectionEntry">
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="26c1-1df0-618a-c436" type="max"/>
-                      </constraints>
-                    </entryLink>
-                    <entryLink id="bd7e-f170-1d8a-f3a7" name="Autorifle" hidden="true" collective="false" import="true" targetId="57dd-dff6-d173-3bf1" type="selectionEntry">
-                      <modifiers>
-                        <modifier type="set" field="hidden" value="false">
-                          <conditions>
-                            <condition field="selections" scope="force" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bfd2-7016-f5fe-be6a" type="equalTo"/>
-                          </conditions>
-                        </modifier>
-                      </modifiers>
-                    </entryLink>
-                    <entryLink id="ff64-08cb-bcb3-7816" name="Lascarbine" hidden="true" collective="false" import="true" targetId="d68e-ce5a-000c-c322" type="selectionEntry">
-                      <modifiers>
-                        <modifier type="set" field="hidden" value="false">
-                          <conditions>
-                            <condition field="selections" scope="force" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bfd2-7016-f5fe-be6a" type="equalTo"/>
-                          </conditions>
-                        </modifier>
-                      </modifiers>
-                    </entryLink>
-                    <entryLink id="6d6c-39f7-9cfe-6eff" name="Lasgun" hidden="true" collective="false" import="true" targetId="376e-c5d6-99c3-49c9" type="selectionEntry">
-                      <modifiers>
-                        <modifier type="set" field="hidden" value="false">
-                          <conditions>
-                            <condition field="selections" scope="force" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bfd2-7016-f5fe-be6a" type="equalTo"/>
-                          </conditions>
-                        </modifier>
-                      </modifiers>
-                    </entryLink>
-                    <entryLink id="46f0-ce63-4b7c-ab18" name="Shotgun" hidden="true" collective="false" import="true" targetId="f0aa-947f-f493-f566" type="selectionEntry">
-                      <modifiers>
-                        <modifier type="set" field="hidden" value="false">
-                          <conditions>
-                            <condition field="selections" scope="force" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bfd2-7016-f5fe-be6a" type="equalTo"/>
-                          </conditions>
-                        </modifier>
-                      </modifiers>
-                    </entryLink>
-                    <entryLink id="2885-b8c9-56fa-bc3b" name="Stubcarbine" hidden="true" collective="false" import="true" targetId="a7cc-88cb-c6e8-6d4c" type="selectionEntry">
-                      <modifiers>
-                        <modifier type="set" field="hidden" value="false">
-                          <conditions>
-                            <condition field="selections" scope="force" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bfd2-7016-f5fe-be6a" type="equalTo"/>
-                          </conditions>
-                        </modifier>
-                      </modifiers>
-                    </entryLink>
-                  </entryLinks>
                 </selectionEntryGroup>
               </selectionEntryGroups>
+              <entryLinks>
+                <entryLink import="true" name="Volkite Charger" hidden="false" id="e84f-f6d2-80c7-db89" collective="false" targetId="6f6e-ad55-e093-6503" type="selectionEntry">
+                  <constraints>
+                    <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="9fb7-613c-30f7-a40a" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="15ce-dbc8-f64d-f873" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                  </constraints>
+                </entryLink>
+                <entryLink import="true" name="Krak Grenades" hidden="false" id="6bc5-f9e9-44a1-f883" collective="false" targetId="99df-2421-acf7-a5ad" type="selectionEntry">
+                  <constraints>
+                    <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="efba-2f98-ca93-40a1" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="8817-bd09-9a91-8456" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                  </constraints>
+                </entryLink>
+                <entryLink import="true" name="Frag Grenades" hidden="false" id="4207-ba86-a98a-98b2" collective="false" targetId="cf9c-327b-3449-00d7" type="selectionEntry">
+                  <constraints>
+                    <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="ebd8-f5f6-d2dc-2e17" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="5dfe-f341-dc77-0d07" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                  </constraints>
+                </entryLink>
+                <entryLink import="true" name="Fear (Feral Cohort)" hidden="false" id="6d79-07e1-b369-3180" collective="false" targetId="aefe-eff6-2961-a445" type="selectionEntry"/>
+              </entryLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="58"/>
               </costs>
             </selectionEntry>
-          </selectionEntries>
-          <selectionEntryGroups>
-            <selectionEntryGroup id="3574-b038-e96e-b6b8" name="One Veletarii in the unit may be upgraded to have a:" hidden="false" collective="false" import="true">
-              <entryLinks>
-                <entryLink id="e07d-482d-e110-3b53" name="Auxilia Vexilla" hidden="false" collective="false" import="true" targetId="6f5a-bf56-4bee-ce7e" type="selectionEntry">
-                  <constraints>
-                    <constraint field="selections" scope="c51e-5dce-2d97-4a99" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2210-1568-7fdb-417b" type="max"/>
-                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d136-2095-a0a0-0648" type="max"/>
-                  </constraints>
-                  <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5"/>
-                  </costs>
-                </entryLink>
-                <entryLink id="3824-01fb-b996-4ed8" name="Vox Interlock" hidden="false" collective="false" import="true" targetId="c04e-5624-3615-0660" type="selectionEntry">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="94b6-f2c2-699e-639f" type="max"/>
-                    <constraint field="selections" scope="c51e-5dce-2d97-4a99" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9efb-a913-ba86-58e0" type="max"/>
-                  </constraints>
-                  <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5"/>
-                  </costs>
-                </entryLink>
-              </entryLinks>
-            </selectionEntryGroup>
-            <selectionEntryGroup id="4651-997b-ff30-b4d5" name="Veletarii" hidden="false" collective="false" import="true" defaultSelectionEntryId="9194-cb55-09ee-7817">
-              <modifiers>
-                <modifier type="set" field="2bc0-0b6e-c467-60cf" value="14">
-                  <conditions>
-                    <condition field="selections" scope="force" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7b69-bf2f-4547-e83b" type="atLeast"/>
-                  </conditions>
-                </modifier>
-              </modifiers>
+            <selectionEntry type="unit" import="true" name="Veletaris Storm Section" hidden="false" id="c51e-5dce-2d97-4a99" collective="false">
               <constraints>
-                <constraint field="selections" scope="parent" value="9" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b37d-f60a-d458-10a1" type="min"/>
-                <constraint field="selections" scope="parent" value="19" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2bc0-0b6e-c467-60cf" type="max"/>
+                <constraint type="max" value="3" field="selections" scope="parent" shared="true" id="b8d7-d27c-2841-12af" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="a8bc-6d7a-6118-1894" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
               </constraints>
+              <infoLinks>
+                <infoLink name="Tercio" id="2cfb-f9ab-abd0-e95e" hidden="false" targetId="6516-f81d-457b-a2cc" type="rule"/>
+                <infoLink name="Stubborn" id="2a7d-4e36-e916-0565" hidden="false" targetId="7989-1f2c-a43d-82ae" type="rule">
+                  <modifiers>
+                    <modifier type="set" value="true" field="hidden">
+                      <conditions>
+                        <condition type="equalTo" value="0" field="selections" scope="force" childId="fe04-c096-f846-a6fd" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                </infoLink>
+                <infoLink name="Furious Charge (X)" id="28bb-179e-31cc-2877" hidden="false" targetId="2821-9269-862f-0554" type="rule">
+                  <modifiers>
+                    <modifier type="set" value="Furious Charge (1)" field="name"/>
+                    <modifier type="set" value="true" field="hidden">
+                      <conditions>
+                        <condition type="equalTo" value="0" field="selections" scope="force" childId="bfd2-7016-f5fe-be6a" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                </infoLink>
+                <infoLink name="Counter-Attack (X)" id="afd1-a46a-1010-97f3" hidden="false" targetId="fd6d-2a76-10e0-936a" type="rule">
+                  <modifiers>
+                    <modifier type="set" value="Counter-Attack (1) (while &apos;In Formation&apos;)" field="name"/>
+                    <modifier type="set" value="true" field="hidden">
+                      <conditions>
+                        <condition type="equalTo" value="0" field="selections" scope="force" childId="021e-6841-7375-7862" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                </infoLink>
+              </infoLinks>
               <selectionEntries>
-                <selectionEntry id="2b18-d508-d843-fdc5" name="Veletarii w/ Storm axe" hidden="false" collective="false" import="true" type="model">
+                <selectionEntry type="model" import="true" name="Veletarii Prime" hidden="false" id="06be-2459-ac34-8782" collective="false">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="19" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f26a-65cc-92b7-799d" type="max"/>
+                    <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="642d-bbad-ee60-8168" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="8fc2-cd7e-de95-18b5" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
                   </constraints>
                   <profiles>
-                    <profile id="9d8f-243d-7020-9043" name="Veletarii" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName="Unit">
-                      <modifiers>
-                        <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Infantry (Heavy, Line)">
-                          <conditions>
-                            <condition field="selections" scope="force" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a09b-28bd-8ffc-f4f0" type="equalTo"/>
-                          </conditions>
-                        </modifier>
-                        <modifier type="increment" field="e8a6-1da9-d384-8727" value="1">
-                          <conditions>
-                            <condition field="selections" scope="force" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fe04-c096-f846-a6fd" type="equalTo"/>
-                          </conditions>
-                        </modifier>
-                      </modifiers>
+                    <profile name="Veletarii Prime" typeId="4bb2-cb95-e6c8-5a21" typeName="Unit" hidden="false" id="ae88-d4d6-6f08-f4fb">
                       <characteristics>
-                        <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Heavy)</characteristic>
+                        <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Heavy, Character)</characteristic>
                         <characteristic name="Move" typeId="893e-2d76-8f04-44e5">6</characteristic>
                         <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
                         <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
@@ -3729,779 +3929,585 @@
                         <characteristic name="T" typeId="c32b-5fdd-3fbe-9b1f">3</characteristic>
                         <characteristic name="W" typeId="57ee-1126-32a9-5672">1</characteristic>
                         <characteristic name="I" typeId="62d3-22d7-2d49-52dc">4</characteristic>
-                        <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">1</characteristic>
-                        <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">6</characteristic>
+                        <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">2</characteristic>
+                        <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">7</characteristic>
                         <characteristic name="Save" typeId="e593-6b3c-f169-04f0">4+</characteristic>
                       </characteristics>
-                    </profile>
-                  </profiles>
-                  <entryLinks>
-                    <entryLink id="65ad-96cd-aab3-9e56" name="Reinforced Void Armour" hidden="false" collective="false" import="true" targetId="5e45-2a38-759c-3147" type="selectionEntry">
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="09e3-5303-3b5a-b381" type="min"/>
-                        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0358-77f8-81c5-8406" type="max"/>
-                      </constraints>
-                    </entryLink>
-                    <entryLink id="7eba-5376-ba86-c37c" name="Storm Axe" hidden="false" collective="false" import="true" targetId="c305-a3f1-5c2f-ae37" type="selectionEntry">
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6c11-7b5c-21bb-35ea" type="min"/>
-                        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eb04-ca4b-ea88-7ddc" type="max"/>
-                      </constraints>
-                    </entryLink>
-                  </entryLinks>
-                  <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="13"/>
-                  </costs>
-                  <categoryLinks>
-                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="07f8-8827-4d4d-a2b6" name="Infantry Unit Type" primary="false"/>
-                    <categoryLink targetId="9231-183c-b97b-63f9" id="3c04-a03b-4798-a9f1" name="Heavy Sub-type" primary="false"/>
-                  </categoryLinks>
-                </selectionEntry>
-                <selectionEntry id="9194-cb55-09ee-7817" name="Veletarii w/ Volkite Charger" hidden="false" collective="false" import="true" type="model">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="19" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7830-a3c4-533b-64f9" type="max"/>
-                  </constraints>
-                  <infoLinks>
-                    <infoLink id="5343-2659-8851-807c" name="Veletarii" hidden="false" targetId="9d8f-243d-7020-9043" type="profile"/>
-                  </infoLinks>
-                  <entryLinks>
-                    <entryLink id="c9bf-b8d7-8964-568d" name="Reinforced Void Armour" hidden="false" collective="false" import="true" targetId="5e45-2a38-759c-3147" type="selectionEntry">
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="019a-021c-0b4f-e3b7" type="min"/>
-                        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a926-6a19-cb7d-3ec3" type="max"/>
-                      </constraints>
-                    </entryLink>
-                    <entryLink id="0733-55b6-c813-9ad1" name="Volkite Charger" hidden="false" collective="false" import="true" targetId="5c82-c306-9c5c-5908" type="selectionEntry">
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8898-6b2f-4134-e2d4" type="min"/>
-                        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a2b2-915b-82e3-7581" type="max"/>
-                      </constraints>
-                    </entryLink>
-                  </entryLinks>
-                  <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="8"/>
-                  </costs>
-                  <categoryLinks>
-                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="d7c8-7590-4f0d-9f98" name="Infantry Unit Type" primary="false"/>
-                    <categoryLink targetId="9231-183c-b97b-63f9" id="8b6f-f985-403b-a672" name="Heavy Sub-type" primary="false"/>
-                  </categoryLinks>
-                </selectionEntry>
-                <selectionEntry id="c110-0436-5b73-08f7" name="Veletarii w/ Autorifle" hidden="true" collective="false" import="true" type="model">
-                  <modifiers>
-                    <modifier type="set" field="hidden" value="false">
-                      <conditions>
-                        <condition field="selections" scope="force" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bfd2-7016-f5fe-be6a" type="equalTo"/>
-                      </conditions>
-                    </modifier>
-                  </modifiers>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="19" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fbc5-f77f-7524-b253" type="max"/>
-                  </constraints>
-                  <infoLinks>
-                    <infoLink id="15f7-3ee7-6ff3-e02b" name="Veletarii" hidden="false" targetId="9d8f-243d-7020-9043" type="profile"/>
-                  </infoLinks>
-                  <entryLinks>
-                    <entryLink id="e8cb-4095-06ee-d6be" name="Reinforced Void Armour" hidden="false" collective="false" import="true" targetId="5e45-2a38-759c-3147" type="selectionEntry">
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b3b7-30ef-7148-7393" type="min"/>
-                        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2255-df8f-6841-2b80" type="max"/>
-                      </constraints>
-                    </entryLink>
-                    <entryLink id="1c76-8a9c-d6c8-5f46" name="Autorifle" hidden="false" collective="false" import="true" targetId="f3ff-0995-248a-5243" type="selectionEntry">
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7e03-316e-bf1f-6b89" type="min"/>
-                        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c1b2-06c5-d460-196e" type="max"/>
-                      </constraints>
-                    </entryLink>
-                  </entryLinks>
-                  <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="8"/>
-                  </costs>
-                  <categoryLinks>
-                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="468f-3b13-4401-b378" name="Infantry Unit Type" primary="false"/>
-                    <categoryLink targetId="9231-183c-b97b-63f9" id="004b-b83d-4a38-98f5" name="Heavy Sub-type" primary="false"/>
-                  </categoryLinks>
-                </selectionEntry>
-                <selectionEntry id="0d2b-3943-df76-12a2" name="Veletarii w/ Lascarbine" hidden="true" collective="false" import="true" type="model">
-                  <modifiers>
-                    <modifier type="set" field="hidden" value="false">
-                      <conditions>
-                        <condition field="selections" scope="force" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bfd2-7016-f5fe-be6a" type="equalTo"/>
-                      </conditions>
-                    </modifier>
-                  </modifiers>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="19" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1c56-e743-0984-112d" type="max"/>
-                  </constraints>
-                  <infoLinks>
-                    <infoLink id="9f19-a6db-14c6-80b5" name="Veletarii" hidden="false" targetId="9d8f-243d-7020-9043" type="profile"/>
-                  </infoLinks>
-                  <entryLinks>
-                    <entryLink id="768b-152a-f0f6-ae77" name="Reinforced Void Armour" hidden="false" collective="false" import="true" targetId="5e45-2a38-759c-3147" type="selectionEntry">
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3f01-b641-bdc9-ef2c" type="min"/>
-                        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="01e1-7a25-84c7-f8f7" type="max"/>
-                      </constraints>
-                    </entryLink>
-                    <entryLink id="2e61-38fb-d08f-32f4" name="Lascarbine" hidden="false" collective="false" import="true" targetId="3335-928e-aef8-ca0f" type="selectionEntry">
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e27c-b98c-e221-bf0d" type="min"/>
-                        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8ea2-7f4c-f9c6-4cf7" type="max"/>
-                      </constraints>
-                    </entryLink>
-                  </entryLinks>
-                  <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="8"/>
-                  </costs>
-                  <categoryLinks>
-                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="1ab6-3841-492b-bbdd" name="Infantry Unit Type" primary="false"/>
-                    <categoryLink targetId="9231-183c-b97b-63f9" id="6343-81d6-4fbf-a868" name="Heavy Sub-type" primary="false"/>
-                  </categoryLinks>
-                </selectionEntry>
-                <selectionEntry id="6e53-e90b-d8a4-5158" name="Veletarii w/ Lasrifle" hidden="true" collective="false" import="true" type="model">
-                  <modifiers>
-                    <modifier type="set" field="hidden" value="false">
-                      <conditions>
-                        <condition field="selections" scope="force" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bfd2-7016-f5fe-be6a" type="equalTo"/>
-                      </conditions>
-                    </modifier>
-                  </modifiers>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="19" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a723-a4e7-ee19-7a01" type="max"/>
-                  </constraints>
-                  <infoLinks>
-                    <infoLink id="fdbf-49f5-3975-4a76" name="Veletarii" hidden="false" targetId="9d8f-243d-7020-9043" type="profile"/>
-                  </infoLinks>
-                  <entryLinks>
-                    <entryLink id="770b-f9df-b0db-ca79" name="Reinforced Void Armour" hidden="false" collective="false" import="true" targetId="5e45-2a38-759c-3147" type="selectionEntry">
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="50dd-4da5-6a47-65ea" type="min"/>
-                        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0c8e-ddb6-0772-4953" type="max"/>
-                      </constraints>
-                    </entryLink>
-                    <entryLink id="bb81-6079-38f0-1c3f" name="Lasrifle" hidden="false" collective="false" import="true" targetId="2449-dc45-3441-b471" type="selectionEntry">
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ed71-67de-0d33-612e" type="min"/>
-                        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ffc7-1049-2c65-95ef" type="max"/>
-                      </constraints>
-                    </entryLink>
-                  </entryLinks>
-                  <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="8"/>
-                  </costs>
-                  <categoryLinks>
-                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="c5fd-b27a-4353-8829" name="Infantry Unit Type" primary="false"/>
-                    <categoryLink targetId="9231-183c-b97b-63f9" id="ed9c-67f7-47f5-b458" name="Heavy Sub-type" primary="false"/>
-                  </categoryLinks>
-                </selectionEntry>
-                <selectionEntry id="b70f-a612-df9c-7d7f" name="Veletarii w/ Shotgun" hidden="true" collective="false" import="true" type="model">
-                  <modifiers>
-                    <modifier type="set" field="hidden" value="false">
-                      <conditions>
-                        <condition field="selections" scope="force" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bfd2-7016-f5fe-be6a" type="equalTo"/>
-                      </conditions>
-                    </modifier>
-                  </modifiers>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="19" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fd75-247a-9822-8998" type="max"/>
-                  </constraints>
-                  <infoLinks>
-                    <infoLink id="fe22-0e51-a725-dd37" name="Veletarii" hidden="false" targetId="9d8f-243d-7020-9043" type="profile"/>
-                  </infoLinks>
-                  <entryLinks>
-                    <entryLink id="22b9-26fa-8761-c585" name="Reinforced Void Armour" hidden="false" collective="false" import="true" targetId="5e45-2a38-759c-3147" type="selectionEntry">
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6107-ff65-d516-2b51" type="min"/>
-                        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d90d-aec6-2d9e-77a0" type="max"/>
-                      </constraints>
-                    </entryLink>
-                    <entryLink id="b155-d040-4b17-b92b" name="Shotgun" hidden="false" collective="false" import="true" targetId="2dba-5646-1049-c134" type="selectionEntry">
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ff27-75d4-ea49-c249" type="min"/>
-                        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="13eb-fb9a-4566-259b" type="max"/>
-                      </constraints>
-                    </entryLink>
-                  </entryLinks>
-                  <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="8"/>
-                  </costs>
-                  <categoryLinks>
-                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="1b45-74cb-4613-91a0" name="Infantry Unit Type" primary="false"/>
-                    <categoryLink targetId="9231-183c-b97b-63f9" id="50ca-be6e-420a-b6d0" name="Heavy Sub-type" primary="false"/>
-                  </categoryLinks>
-                </selectionEntry>
-                <selectionEntry id="df5d-e57c-15b3-cfa8" name="Veletarii w/ Stubcarbine" hidden="true" collective="false" import="true" type="model">
-                  <modifiers>
-                    <modifier type="set" field="hidden" value="false">
-                      <conditions>
-                        <condition field="selections" scope="force" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bfd2-7016-f5fe-be6a" type="equalTo"/>
-                      </conditions>
-                    </modifier>
-                  </modifiers>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="19" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f8d9-6a9a-4cee-d321" type="max"/>
-                  </constraints>
-                  <infoLinks>
-                    <infoLink id="f7df-4db9-bd86-6078" name="Veletarii" hidden="false" targetId="9d8f-243d-7020-9043" type="profile"/>
-                  </infoLinks>
-                  <entryLinks>
-                    <entryLink id="d6c2-be71-2aa9-ceb1" name="Reinforced Void Armour" hidden="false" collective="false" import="true" targetId="5e45-2a38-759c-3147" type="selectionEntry">
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="589b-6cd5-2f5e-c667" type="min"/>
-                        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a7a3-be34-d200-afe6" type="max"/>
-                      </constraints>
-                    </entryLink>
-                    <entryLink id="50c2-4666-b056-557a" name="Stubcarbine" hidden="false" collective="false" import="true" targetId="090f-d3b8-9e92-40e3" type="selectionEntry">
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3f0d-bb63-7c24-8aa1" type="min"/>
-                        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a441-89b2-088d-9b23" type="max"/>
-                      </constraints>
-                    </entryLink>
-                  </entryLinks>
-                  <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="8"/>
-                  </costs>
-                  <categoryLinks>
-                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="ef1f-eca1-4550-b3aa" name="Infantry Unit Type" primary="false"/>
-                    <categoryLink targetId="9231-183c-b97b-63f9" id="f3fe-c8f7-4d3e-8a39" name="Heavy Sub-type" primary="false"/>
-                  </categoryLinks>
-                </selectionEntry>
-              </selectionEntries>
-            </selectionEntryGroup>
-            <selectionEntryGroup id="ee9d-04a6-b522-4047" name="Dedicated Transports" hidden="false" collective="false" import="true">
-              <modifiers>
-                <modifier type="set" field="0bde-0b51-92cd-f722" value="1">
-                  <conditions>
-                    <condition field="selections" scope="force" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d9a0-4875-fb75-f9a9" type="equalTo"/>
-                  </conditions>
-                </modifier>
-                <modifier type="set" field="hidden" value="true">
-                  <conditions>
-                    <condition field="selections" scope="force" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7b69-bf2f-4547-e83b" type="atLeast"/>
-                  </conditions>
-                </modifier>
-              </modifiers>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="20b7-845c-7c4e-9a24" type="max"/>
-                <constraint field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0bde-0b51-92cd-f722" type="min"/>
-              </constraints>
-              <entryLinks>
-                <entryLink id="44bd-6025-ca3d-2610" name="Aurox Transport" hidden="false" collective="false" import="true" targetId="071b-79e5-7b5b-c9cd" type="selectionEntry">
-                  <modifiers>
-                    <modifier type="set" field="hidden" value="true">
-                      <conditions>
-                        <condition field="selections" scope="c51e-5dce-2d97-4a99" value="10" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="greaterThan"/>
-                      </conditions>
-                    </modifier>
-                  </modifiers>
-                </entryLink>
-                <entryLink id="8662-58a1-6d55-4a14" name="Dracosan Armoured Transport" hidden="false" collective="false" import="true" targetId="496b-a01b-3726-0a44" type="selectionEntry"/>
-                <entryLink id="a9b5-fbc5-24f3-4e1f" name="Arvus Transport" hidden="true" collective="false" import="true" targetId="5041-9403-02b7-af14" type="selectionEntry">
-                  <modifiers>
-                    <modifier type="set" field="hidden" value="false">
-                      <conditionGroups>
-                        <conditionGroup type="and">
-                          <conditions>
-                            <condition field="selections" scope="force" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a09b-28bd-8ffc-f4f0" type="equalTo"/>
-                            <condition field="selections" scope="c51e-5dce-2d97-4a99" value="12" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="atMost"/>
-                          </conditions>
-                        </conditionGroup>
-                      </conditionGroups>
-                    </modifier>
-                  </modifiers>
-                </entryLink>
-              </entryLinks>
-            </selectionEntryGroup>
-          </selectionEntryGroups>
-          <entryLinks>
-            <entryLink id="cd2c-65ee-ec87-b0c5" name="Volkite Charger" hidden="false" collective="false" import="true" targetId="6f6e-ad55-e093-6503" type="selectionEntry">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="76b3-ceea-e3cb-51f8" type="min"/>
-                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0c72-1301-3f2e-a57f" type="max"/>
-              </constraints>
-            </entryLink>
-            <entryLink id="3950-d910-eeaa-6dcc" name="Krak Grenades" hidden="false" collective="false" import="true" targetId="99df-2421-acf7-a5ad" type="selectionEntry">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="26f1-eb9d-995d-3c90" type="min"/>
-                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4cbf-7147-4bf7-3226" type="max"/>
-              </constraints>
-            </entryLink>
-            <entryLink id="c04a-fa04-8eff-0c77" name="Frag Grenades" hidden="false" collective="false" import="true" targetId="cf9c-327b-3449-00d7" type="selectionEntry">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d2a6-c1b8-9484-88c9" type="min"/>
-                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="604e-86c2-0c1c-1870" type="max"/>
-              </constraints>
-            </entryLink>
-            <entryLink id="0dfb-d07a-521b-ee4f" name="Fear (Feral Cohort)" hidden="false" collective="false" import="true" targetId="aefe-eff6-2961-a445" type="selectionEntry"/>
-          </entryLinks>
-          <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="18"/>
-          </costs>
-          <modifierGroups>
-            <modifierGroup type="and">
-              <modifiers>
-                <modifier type="set" value="2" field="b8d7-d27c-2841-12af"/>
-                <modifier type="set" value="0" field="a8bc-6d7a-6118-1894"/>
-              </modifiers>
-              <conditions>
-                <condition type="atLeast" value="1" field="selections" scope="parent" childId="8c69-57dc-440c-b706" shared="true" includeChildSelections="false"/>
-              </conditions>
-            </modifierGroup>
-          </modifierGroups>
-        </selectionEntry>
-        <selectionEntry id="0508-f8a6-3996-bf39" name="Veletaris Vanguard Section" hidden="false" collective="false" import="true" type="unit">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="320c-fc49-63d4-126a" type="max"/>
-          </constraints>
-          <infoLinks>
-            <infoLink id="02e8-2b87-bcad-28b5" name="Tercio" hidden="false" targetId="6516-f81d-457b-a2cc" type="rule"/>
-            <infoLink id="937f-538b-f46c-b895" name="Stubborn" hidden="false" targetId="7989-1f2c-a43d-82ae" type="rule">
-              <modifiers>
-                <modifier type="set" field="hidden" value="true">
-                  <conditions>
-                    <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fe04-c096-f846-a6fd" type="equalTo"/>
-                  </conditions>
-                </modifier>
-              </modifiers>
-            </infoLink>
-            <infoLink id="c709-ae6e-bd71-f029" name="Furious Charge (X)" hidden="false" targetId="2821-9269-862f-0554" type="rule">
-              <modifiers>
-                <modifier type="set" field="name" value="Furious Charge (1)"/>
-                <modifier type="set" field="hidden" value="true">
-                  <conditions>
-                    <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bfd2-7016-f5fe-be6a" type="equalTo"/>
-                  </conditions>
-                </modifier>
-              </modifiers>
-            </infoLink>
-            <infoLink id="3f58-02ec-f7f5-0b68" name="Counter-Attack (X)" hidden="false" targetId="fd6d-2a76-10e0-936a" type="rule">
-              <modifiers>
-                <modifier type="set" field="name" value="Counter-Attack (1) (while &apos;In Formation&apos;)"/>
-                <modifier type="set" field="hidden" value="true">
-                  <conditions>
-                    <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="021e-6841-7375-7862" type="equalTo"/>
-                  </conditions>
-                </modifier>
-              </modifiers>
-            </infoLink>
-          </infoLinks>
-          <selectionEntries>
-            <selectionEntry id="8a38-1a5e-e4c7-7b74" name="Veletarii Prime" hidden="false" collective="false" import="true" type="model">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7d95-bd41-cd6d-dbb8" type="min"/>
-                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="21c4-3237-8fd8-6b1a" type="max"/>
-              </constraints>
-              <profiles>
-                <profile id="cb33-c30a-4e39-8a83" name="Veletarii Prime" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName="Unit">
-                  <modifiers>
-                    <modifier type="set" field="e593-6b3c-f169-04f0" value="3+">
-                      <conditions>
-                        <condition field="selections" scope="8a38-1a5e-e4c7-7b74" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="523c-d7fb-5288-fe13" type="equalTo"/>
-                      </conditions>
-                    </modifier>
-                    <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Infantry (Heavy, Character, Line)">
-                      <conditions>
-                        <condition field="selections" scope="force" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a09b-28bd-8ffc-f4f0" type="equalTo"/>
-                      </conditions>
-                    </modifier>
-                    <modifier type="increment" field="e8a6-1da9-d384-8727" value="1">
-                      <conditions>
-                        <condition field="selections" scope="force" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fe04-c096-f846-a6fd" type="equalTo"/>
-                      </conditions>
-                    </modifier>
-                  </modifiers>
-                  <characteristics>
-                    <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Heavy, Character)</characteristic>
-                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">6</characteristic>
-                    <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
-                    <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
-                    <characteristic name="S" typeId="e478-41d4-a092-48a8">3</characteristic>
-                    <characteristic name="T" typeId="c32b-5fdd-3fbe-9b1f">3</characteristic>
-                    <characteristic name="W" typeId="57ee-1126-32a9-5672">1</characteristic>
-                    <characteristic name="I" typeId="62d3-22d7-2d49-52dc">4</characteristic>
-                    <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">2</characteristic>
-                    <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">7</characteristic>
-                    <characteristic name="Save" typeId="e593-6b3c-f169-04f0">4+</characteristic>
-                  </characteristics>
-                </profile>
-              </profiles>
-              <categoryLinks>
-                <categoryLink id="1616-4d93-a1d7-8b9b" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
-                <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="8fa1-01d6-460d-85e3" name="Infantry Unit Type" primary="false"/>
-                <categoryLink targetId="9231-183c-b97b-63f9" id="00f5-66cf-4ee6-ad5e" name="Heavy Sub-type" primary="false"/>
-              </categoryLinks>
-              <selectionEntryGroups>
-                <selectionEntryGroup id="cb16-77f4-dd20-bb13" name="Armour" hidden="false" collective="false" import="true" defaultSelectionEntryId="76fe-62a6-e1f1-1fe4">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5c13-4982-aa42-5fbd" type="min"/>
-                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b2bb-199f-f6c1-653a" type="max"/>
-                  </constraints>
-                  <entryLinks>
-                    <entryLink id="76fe-62a6-e1f1-1fe4" name="Reinforced Void Armour" hidden="false" collective="false" import="true" targetId="cc63-5cc3-212a-3d4c" type="selectionEntry"/>
-                    <entryLink id="9568-3bbc-7925-8ede" name="Heavy Void Armour" hidden="false" collective="false" import="true" targetId="523c-d7fb-5288-fe13" type="selectionEntry">
-                      <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10"/>
-                      </costs>
-                    </entryLink>
-                  </entryLinks>
-                </selectionEntryGroup>
-                <selectionEntryGroup id="8209-4fe4-4776-72e1" name="Weapons" hidden="false" collective="false" import="true" defaultSelectionEntryId="6ea0-84ee-7815-bae7">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="db44-9689-19d2-8916" type="min"/>
-                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cdda-c8ec-31aa-dae6" type="max"/>
-                  </constraints>
-                  <selectionEntries>
-                    <selectionEntry id="17f8-33d8-7a8e-d2d3" name="Pistol and Combat weapon (Sub-menu)" hidden="false" collective="false" import="true" type="upgrade">
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3141-ace3-17ec-2ccb" type="max"/>
-                      </constraints>
-                      <selectionEntryGroups>
-                        <selectionEntryGroup id="e132-e9a1-d271-c31c" name="Close Combat" hidden="false" collective="false" import="true">
-                          <constraints>
-                            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2087-7cbd-fdd5-1967" type="min"/>
-                            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3d92-4432-7320-a20e" type="max"/>
-                          </constraints>
-                          <entryLinks>
-                            <entryLink id="db0c-0408-266a-69b8" name="Close Combat Weapon" hidden="false" collective="false" import="true" targetId="3d50-2f85-06ff-6aee" type="selectionEntry"/>
-                            <entryLink id="04d9-5d7c-cc56-c516" name="Power Fist" hidden="false" collective="false" import="true" targetId="768d-b89b-7328-d749" type="selectionEntry">
-                              <costs>
-                                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10"/>
-                              </costs>
-                            </entryLink>
-                            <entryLink id="b387-1955-3a7a-d83e" name="Charnabal Glaive" hidden="false" collective="false" import="true" targetId="c07c-35e6-4616-ef25" type="selectionEntry">
-                              <costs>
-                                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5"/>
-                              </costs>
-                            </entryLink>
-                            <entryLink id="476e-1342-7ad6-6acd" name="Charnabal Sabre" hidden="false" collective="false" import="true" targetId="30c2-57eb-5bbe-be0b" type="selectionEntry">
-                              <costs>
-                                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5"/>
-                              </costs>
-                            </entryLink>
-                            <entryLink id="ba00-b80b-ff5f-454b" name="Charnabal Tabar" hidden="false" collective="false" import="true" targetId="4611-c33e-f360-7246" type="selectionEntry">
-                              <costs>
-                                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5"/>
-                              </costs>
-                            </entryLink>
-                            <entryLink id="f34c-2276-3ca5-ea74" name="Power Axe" hidden="false" collective="false" import="true" targetId="c066-2ace-f68c-e440" type="selectionEntry">
-                              <costs>
-                                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5"/>
-                              </costs>
-                            </entryLink>
-                            <entryLink id="31a6-eb34-633e-b9e9" name="Power Lance" hidden="false" collective="false" import="true" targetId="a4c8-c8ff-87f2-1ac9" type="selectionEntry">
-                              <costs>
-                                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5"/>
-                              </costs>
-                            </entryLink>
-                            <entryLink id="28db-b636-fe67-44c0" name="Power Maul" hidden="false" collective="false" import="true" targetId="0df4-c67e-cf64-82e0" type="selectionEntry">
-                              <costs>
-                                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5"/>
-                              </costs>
-                            </entryLink>
-                            <entryLink id="db7b-030d-71ea-6048" name="Power Sword" hidden="false" collective="false" import="true" targetId="a3cd-aa97-a148-2309" type="selectionEntry">
-                              <costs>
-                                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5"/>
-                              </costs>
-                            </entryLink>
-                          </entryLinks>
-                        </selectionEntryGroup>
-                        <selectionEntryGroup id="7b84-2ff8-147f-3b19" name="Pistol" hidden="false" collective="false" import="true">
-                          <constraints>
-                            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a1c8-e9cd-da61-dba7" type="min"/>
-                            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="127e-4de8-c90b-7e9d" type="max"/>
-                          </constraints>
-                          <entryLinks>
-                            <entryLink id="cc2e-cd0b-a758-f758" name="Blast Pistol" hidden="false" collective="false" import="true" targetId="2460-375d-31f4-4bdf" type="selectionEntry"/>
-                            <entryLink id="614f-7648-8233-9baa" name="Plasma Pistol" hidden="false" collective="false" import="true" targetId="717f-cf0a-1593-4bd8" type="selectionEntry">
-                              <costs>
-                                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5"/>
-                              </costs>
-                            </entryLink>
-                            <entryLink id="b258-fb3d-4ff0-e1d3" name="Hand Flamer" hidden="false" collective="false" import="true" targetId="e337-adf4-a11f-0280" type="selectionEntry"/>
-                            <entryLink id="ed06-92b3-1104-f2b2" name="Needle Pistol" hidden="false" collective="false" import="true" targetId="fdd4-06c7-4608-b07f" type="selectionEntry"/>
-                          </entryLinks>
-                        </selectionEntryGroup>
-                      </selectionEntryGroups>
-                      <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
-                      </costs>
-                    </selectionEntry>
-                  </selectionEntries>
-                  <entryLinks>
-                    <entryLink id="6ea0-84ee-7815-bae7" name="Rotor Cannon" hidden="false" collective="false" import="true" targetId="5ce3-3aa5-3f5e-9ead" type="selectionEntry">
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="04b9-516e-995e-7f6d" type="max"/>
-                      </constraints>
-                    </entryLink>
-                  </entryLinks>
-                </selectionEntryGroup>
-              </selectionEntryGroups>
-              <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-          <selectionEntryGroups>
-            <selectionEntryGroup id="198b-a4ad-7b6d-1dc8" name="One Veletarii in the unit may be upgraded to have a:" hidden="false" collective="false" import="true">
-              <entryLinks>
-                <entryLink id="9674-f0d4-f267-7237" name="Auxilia Vexilla" hidden="false" collective="false" import="true" targetId="6f5a-bf56-4bee-ce7e" type="selectionEntry">
-                  <constraints>
-                    <constraint field="selections" scope="0508-f8a6-3996-bf39" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ecf8-95ff-2a7b-78b7" type="max"/>
-                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="84ff-7828-0759-8d72" type="max"/>
-                  </constraints>
-                  <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5"/>
-                  </costs>
-                </entryLink>
-                <entryLink id="4a13-7a1a-c494-3778" name="Vox Interlock" hidden="false" collective="false" import="true" targetId="c04e-5624-3615-0660" type="selectionEntry">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c17a-1874-6f13-7ac5" type="max"/>
-                    <constraint field="selections" scope="0508-f8a6-3996-bf39" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c45f-c5bd-291a-35ea" type="max"/>
-                  </constraints>
-                  <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5"/>
-                  </costs>
-                </entryLink>
-              </entryLinks>
-            </selectionEntryGroup>
-            <selectionEntryGroup id="fc3c-5b58-1b10-490c" name="Veletarii" hidden="false" collective="false" import="true" defaultSelectionEntryId="e5b2-9536-03f8-39e2">
-              <modifiers>
-                <modifier type="set" field="186f-d90b-b0a3-a953" value="14">
-                  <conditions>
-                    <condition field="selections" scope="force" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7b69-bf2f-4547-e83b" type="atLeast"/>
-                  </conditions>
-                </modifier>
-              </modifiers>
-              <constraints>
-                <constraint field="selections" scope="parent" value="9" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a823-12af-48c0-814c" type="min"/>
-                <constraint field="selections" scope="parent" value="19" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="186f-d90b-b0a3-a953" type="max"/>
-              </constraints>
-              <selectionEntries>
-                <selectionEntry id="0f0e-36a9-75e4-e822" name="Veletarii w/ Heavy Flamer" hidden="false" collective="false" import="true" type="model">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="19" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ae4a-69d7-d994-4e44" type="max"/>
-                  </constraints>
-                  <profiles>
-                    <profile id="79eb-30bc-5135-39c2" name="Veletarii" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName="Unit">
                       <modifiers>
-                        <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Infantry (Heavy, Line)">
+                        <modifier type="set" value="3+" field="e593-6b3c-f169-04f0">
                           <conditions>
-                            <condition field="selections" scope="force" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a09b-28bd-8ffc-f4f0" type="equalTo"/>
+                            <condition type="equalTo" value="1" field="selections" scope="06be-2459-ac34-8782" childId="523c-d7fb-5288-fe13" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
                           </conditions>
                         </modifier>
-                        <modifier type="increment" field="e8a6-1da9-d384-8727" value="1">
+                        <modifier type="set" value="Infantry (Heavy, Character, Line)" field="ddd7-6f5c-a939-b69e">
                           <conditions>
-                            <condition field="selections" scope="force" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fe04-c096-f846-a6fd" type="equalTo"/>
+                            <condition type="equalTo" value="1" field="selections" scope="force" childId="a09b-28bd-8ffc-f4f0" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
+                          </conditions>
+                        </modifier>
+                        <modifier type="increment" value="1" field="e8a6-1da9-d384-8727">
+                          <conditions>
+                            <condition type="equalTo" value="1" field="selections" scope="force" childId="fe04-c096-f846-a6fd" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
                           </conditions>
                         </modifier>
                       </modifiers>
-                      <characteristics>
-                        <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Heavy)</characteristic>
-                        <characteristic name="Move" typeId="893e-2d76-8f04-44e5">6</characteristic>
-                        <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
-                        <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
-                        <characteristic name="S" typeId="e478-41d4-a092-48a8">3</characteristic>
-                        <characteristic name="T" typeId="c32b-5fdd-3fbe-9b1f">3</characteristic>
-                        <characteristic name="W" typeId="57ee-1126-32a9-5672">1</characteristic>
-                        <characteristic name="I" typeId="62d3-22d7-2d49-52dc">4</characteristic>
-                        <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">1</characteristic>
-                        <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">6</characteristic>
-                        <characteristic name="Save" typeId="e593-6b3c-f169-04f0">4+</characteristic>
-                      </characteristics>
                     </profile>
                   </profiles>
-                  <entryLinks>
-                    <entryLink id="cff6-2ad3-9b93-06c9" name="Reinforced Void Armour" hidden="false" collective="false" import="true" targetId="5e45-2a38-759c-3147" type="selectionEntry">
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="12a9-d57b-b62a-5fe6" type="min"/>
-                        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f56c-38c0-9008-c9db" type="max"/>
-                      </constraints>
-                    </entryLink>
-                    <entryLink id="2e19-2169-3914-ade2" name="Heavy Flamer" hidden="false" collective="false" import="true" targetId="aab4-9e33-94f0-5815" type="selectionEntry">
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6be6-b728-a83f-eeb3" type="min"/>
-                        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6123-c08d-7ebf-da59" type="max"/>
-                      </constraints>
-                    </entryLink>
-                  </entryLinks>
-                  <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="8"/>
-                  </costs>
                   <categoryLinks>
-                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="6f23-5f3d-4711-95f0" name="Infantry Unit Type" primary="false"/>
-                    <categoryLink targetId="9231-183c-b97b-63f9" id="1dc5-a978-4d98-9614" name="Heavy Sub-type" primary="false"/>
+                    <categoryLink name="Character" hidden="false" id="6ba0-d806-4ca8-1add" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
+                    <categoryLink name="Infantry Unit Type" hidden="false" id="aa8d-3d92-43b7-92f0" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+                    <categoryLink name="Heavy Sub-type" hidden="false" id="06b4-6138-47bc-8318" targetId="9231-183c-b97b-63f9" primary="false"/>
                   </categoryLinks>
-                </selectionEntry>
-                <selectionEntry id="e5b2-9536-03f8-39e2" name="Veletarii w/ Rotor Cannon" hidden="false" collective="false" import="true" type="model">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="19" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8159-a918-f3f2-197e" type="max"/>
-                  </constraints>
-                  <infoLinks>
-                    <infoLink id="ba61-2722-958c-a365" name="Veletarii" hidden="false" targetId="79eb-30bc-5135-39c2" type="profile"/>
-                  </infoLinks>
-                  <entryLinks>
-                    <entryLink id="3521-9e7d-3143-b74d" name="Reinforced Void Armour" hidden="false" collective="false" import="true" targetId="5e45-2a38-759c-3147" type="selectionEntry">
+                  <selectionEntryGroups>
+                    <selectionEntryGroup name="Armour" id="7420-8069-6ac7-b72b" hidden="false" collective="false" import="true" defaultSelectionEntryId="1d16-82e9-d8f6-943e">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e02f-c48d-a30f-c3e9" type="min"/>
-                        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4be1-117f-a611-624b" type="max"/>
+                        <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="18c7-99ad-9f41-eadc" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                        <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="3fd4-ea25-c1da-c39d" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
                       </constraints>
-                    </entryLink>
-                    <entryLink id="f1a6-adb7-32f3-afd8" name="Rotor Cannon" hidden="false" collective="false" import="true" targetId="37ec-a4b4-de7a-acf3" type="selectionEntry">
+                      <entryLinks>
+                        <entryLink import="true" name="Reinforced Void Armour" hidden="false" id="1d16-82e9-d8f6-943e" collective="false" targetId="cc63-5cc3-212a-3d4c" type="selectionEntry"/>
+                        <entryLink import="true" name="Heavy Void Armour" hidden="false" id="10f6-20a4-55d3-6565" collective="false" targetId="523c-d7fb-5288-fe13" type="selectionEntry">
+                          <costs>
+                            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10"/>
+                          </costs>
+                        </entryLink>
+                      </entryLinks>
+                    </selectionEntryGroup>
+                    <selectionEntryGroup name="Weapons" id="054e-9398-2176-c36e" hidden="false" collective="false" import="true" defaultSelectionEntryId="0c3c-546a-a159-5ae4">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f2e7-18f8-fb8f-10a4" type="min"/>
-                        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8ee6-77fc-533a-adb9" type="max"/>
+                        <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="903f-32af-4b86-9ee7" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                        <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="c69e-58eb-fbdb-bb77" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
                       </constraints>
-                    </entryLink>
-                  </entryLinks>
+                      <selectionEntries>
+                        <selectionEntry type="upgrade" import="true" name="Pistol and Combat weapon (Sub-menu)" hidden="false" id="b0be-c9c2-e8a1-8a04" collective="false">
+                          <constraints>
+                            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="c1ff-7f3f-fbf5-a017" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                          </constraints>
+                          <selectionEntryGroups>
+                            <selectionEntryGroup name="Close Combat" id="0582-ef1e-1f15-f504" hidden="false" collective="false" import="true">
+                              <constraints>
+                                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="2d55-d1f5-ccc5-e653" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="9d1d-2c20-3aad-d5fe" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                              </constraints>
+                              <entryLinks>
+                                <entryLink import="true" name="Close Combat Weapon" hidden="false" id="7285-fa9b-a0ba-26ce" collective="false" targetId="3d50-2f85-06ff-6aee" type="selectionEntry"/>
+                                <entryLink import="true" name="Power Fist" hidden="false" id="8442-e1bb-8f7b-ebb1" collective="false" targetId="768d-b89b-7328-d749" type="selectionEntry">
+                                  <costs>
+                                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10"/>
+                                  </costs>
+                                </entryLink>
+                                <entryLink import="true" name="Storm Axe" hidden="false" id="1cfd-0777-a4c9-3f6d" collective="false" targetId="e09b-73c8-2340-4604" type="selectionEntry">
+                                  <costs>
+                                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5"/>
+                                  </costs>
+                                </entryLink>
+                                <entryLink import="true" name="Charnabal Glaive" hidden="false" id="1203-868c-1ee4-133b" collective="false" targetId="c07c-35e6-4616-ef25" type="selectionEntry">
+                                  <costs>
+                                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5"/>
+                                  </costs>
+                                </entryLink>
+                                <entryLink import="true" name="Charnabal Sabre" hidden="false" id="d8c0-fb87-038d-6c1d" collective="false" targetId="30c2-57eb-5bbe-be0b" type="selectionEntry">
+                                  <costs>
+                                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5"/>
+                                  </costs>
+                                </entryLink>
+                                <entryLink import="true" name="Charnabal Tabar" hidden="false" id="cecd-7c8b-50c8-3bbe" collective="false" targetId="4611-c33e-f360-7246" type="selectionEntry">
+                                  <costs>
+                                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5"/>
+                                  </costs>
+                                </entryLink>
+                                <entryLink import="true" name="Power Axe" hidden="false" id="12e9-27b3-af59-5530" collective="false" targetId="c066-2ace-f68c-e440" type="selectionEntry">
+                                  <costs>
+                                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5"/>
+                                  </costs>
+                                </entryLink>
+                                <entryLink import="true" name="Power Lance" hidden="false" id="062e-cbe7-6853-eb05" collective="false" targetId="a4c8-c8ff-87f2-1ac9" type="selectionEntry">
+                                  <costs>
+                                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5"/>
+                                  </costs>
+                                </entryLink>
+                                <entryLink import="true" name="Power Maul" hidden="false" id="fd68-62d0-decd-9121" collective="false" targetId="0df4-c67e-cf64-82e0" type="selectionEntry">
+                                  <costs>
+                                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5"/>
+                                  </costs>
+                                </entryLink>
+                                <entryLink import="true" name="Power Sword" hidden="false" id="dfcc-1003-6ecd-5021" collective="false" targetId="a3cd-aa97-a148-2309" type="selectionEntry">
+                                  <costs>
+                                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5"/>
+                                  </costs>
+                                </entryLink>
+                              </entryLinks>
+                            </selectionEntryGroup>
+                            <selectionEntryGroup name="Pistol" id="a9db-cc4a-d2c4-e419" hidden="false" collective="false" import="true">
+                              <constraints>
+                                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="b95b-73fa-7c0d-0de2" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="e56b-333f-e00b-77b4" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                              </constraints>
+                              <entryLinks>
+                                <entryLink import="true" name="Blast Pistol" hidden="false" id="3c62-15f8-c427-a075" collective="false" targetId="2460-375d-31f4-4bdf" type="selectionEntry"/>
+                                <entryLink import="true" name="Plasma Pistol" hidden="false" id="0818-8375-670a-dfa7" collective="false" targetId="717f-cf0a-1593-4bd8" type="selectionEntry">
+                                  <costs>
+                                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5"/>
+                                  </costs>
+                                </entryLink>
+                                <entryLink import="true" name="Hand Flamer" hidden="false" id="9d01-8c72-f666-e0ef" collective="false" targetId="e337-adf4-a11f-0280" type="selectionEntry"/>
+                                <entryLink import="true" name="Needle Pistol" hidden="false" id="b766-d386-1e55-719b" collective="false" targetId="fdd4-06c7-4608-b07f" type="selectionEntry"/>
+                              </entryLinks>
+                            </selectionEntryGroup>
+                          </selectionEntryGroups>
+                          <costs>
+                            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
+                          </costs>
+                        </selectionEntry>
+                      </selectionEntries>
+                      <entryLinks>
+                        <entryLink import="true" name="Volkite Charger" hidden="false" id="0c3c-546a-a159-5ae4" collective="false" targetId="6f6e-ad55-e093-6503" type="selectionEntry">
+                          <constraints>
+                            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="26c1-1df0-618a-c436" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                          </constraints>
+                        </entryLink>
+                        <entryLink import="true" name="Autorifle" hidden="true" id="bd7e-f170-1d8a-f3a7" collective="false" targetId="57dd-dff6-d173-3bf1" type="selectionEntry">
+                          <modifiers>
+                            <modifier type="set" value="false" field="hidden">
+                              <conditions>
+                                <condition type="equalTo" value="1" field="selections" scope="force" childId="bfd2-7016-f5fe-be6a" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
+                              </conditions>
+                            </modifier>
+                          </modifiers>
+                        </entryLink>
+                        <entryLink import="true" name="Lascarbine" hidden="true" id="ff64-08cb-bcb3-7816" collective="false" targetId="d68e-ce5a-000c-c322" type="selectionEntry">
+                          <modifiers>
+                            <modifier type="set" value="false" field="hidden">
+                              <conditions>
+                                <condition type="equalTo" value="1" field="selections" scope="force" childId="bfd2-7016-f5fe-be6a" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
+                              </conditions>
+                            </modifier>
+                          </modifiers>
+                        </entryLink>
+                        <entryLink import="true" name="Lasgun" hidden="true" id="6d6c-39f7-9cfe-6eff" collective="false" targetId="376e-c5d6-99c3-49c9" type="selectionEntry">
+                          <modifiers>
+                            <modifier type="set" value="false" field="hidden">
+                              <conditions>
+                                <condition type="equalTo" value="1" field="selections" scope="force" childId="bfd2-7016-f5fe-be6a" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
+                              </conditions>
+                            </modifier>
+                          </modifiers>
+                        </entryLink>
+                        <entryLink import="true" name="Shotgun" hidden="true" id="46f0-ce63-4b7c-ab18" collective="false" targetId="f0aa-947f-f493-f566" type="selectionEntry">
+                          <modifiers>
+                            <modifier type="set" value="false" field="hidden">
+                              <conditions>
+                                <condition type="equalTo" value="1" field="selections" scope="force" childId="bfd2-7016-f5fe-be6a" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
+                              </conditions>
+                            </modifier>
+                          </modifiers>
+                        </entryLink>
+                        <entryLink import="true" name="Stubcarbine" hidden="true" id="2885-b8c9-56fa-bc3b" collective="false" targetId="a7cc-88cb-c6e8-6d4c" type="selectionEntry">
+                          <modifiers>
+                            <modifier type="set" value="false" field="hidden">
+                              <conditions>
+                                <condition type="equalTo" value="1" field="selections" scope="force" childId="bfd2-7016-f5fe-be6a" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
+                              </conditions>
+                            </modifier>
+                          </modifiers>
+                        </entryLink>
+                      </entryLinks>
+                    </selectionEntryGroup>
+                  </selectionEntryGroups>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="8"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
                   </costs>
-                  <categoryLinks>
-                    <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="bfc0-d686-421b-a079" name="Infantry Unit Type" primary="false"/>
-                    <categoryLink targetId="9231-183c-b97b-63f9" id="48de-c21c-48be-b669" name="Heavy Sub-type" primary="false"/>
-                  </categoryLinks>
                 </selectionEntry>
               </selectionEntries>
-            </selectionEntryGroup>
-            <selectionEntryGroup id="fff9-2e72-ff3f-0ad1" name="Dedicated Transports" hidden="false" collective="false" import="true">
-              <modifiers>
-                <modifier type="set" field="1fbd-1e19-1a43-dbbc" value="1">
-                  <conditions>
-                    <condition field="selections" scope="force" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d9a0-4875-fb75-f9a9" type="equalTo"/>
-                  </conditions>
-                </modifier>
-                <modifier type="set" field="hidden" value="true">
-                  <conditions>
-                    <condition field="selections" scope="force" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7b69-bf2f-4547-e83b" type="atLeast"/>
-                  </conditions>
-                </modifier>
-              </modifiers>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cf07-414c-ccae-aa89" type="max"/>
-                <constraint field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1fbd-1e19-1a43-dbbc" type="min"/>
-              </constraints>
-              <entryLinks>
-                <entryLink id="f6c3-f0c8-ca42-3008" name="Aurox Transport" hidden="false" collective="false" import="true" targetId="071b-79e5-7b5b-c9cd" type="selectionEntry">
+              <selectionEntryGroups>
+                <selectionEntryGroup name="One Veletarii in the unit may be upgraded to have a:" id="3574-b038-e96e-b6b8" hidden="false" collective="false" import="true">
+                  <entryLinks>
+                    <entryLink import="true" name="Auxilia Vexilla" hidden="false" id="e07d-482d-e110-3b53" collective="false" targetId="6f5a-bf56-4bee-ce7e" type="selectionEntry">
+                      <constraints>
+                        <constraint type="max" value="1" field="selections" scope="c51e-5dce-2d97-4a99" shared="true" id="2210-1568-7fdb-417b" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
+                        <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="d136-2095-a0a0-0648" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                      </constraints>
+                      <costs>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink import="true" name="Vox Interlock" hidden="false" id="3824-01fb-b996-4ed8" collective="false" targetId="c04e-5624-3615-0660" type="selectionEntry">
+                      <constraints>
+                        <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="94b6-f2c2-699e-639f" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                        <constraint type="max" value="1" field="selections" scope="c51e-5dce-2d97-4a99" shared="true" id="9efb-a913-ba86-58e0" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
+                      </constraints>
+                      <costs>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5"/>
+                      </costs>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup name="Veletarii" id="4651-997b-ff30-b4d5" hidden="false" collective="false" import="true" defaultSelectionEntryId="9194-cb55-09ee-7817">
                   <modifiers>
-                    <modifier type="set" field="hidden" value="true">
+                    <modifier type="set" value="14" field="2bc0-0b6e-c467-60cf">
                       <conditions>
-                        <condition field="selections" scope="0508-f8a6-3996-bf39" value="10" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="greaterThan"/>
+                        <condition type="atLeast" value="1" field="selections" scope="force" childId="7b69-bf2f-4547-e83b" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
                       </conditions>
                     </modifier>
                   </modifiers>
-                </entryLink>
-                <entryLink id="0283-38af-c423-c5ac" name="Dracosan Armoured Transport" hidden="false" collective="false" import="true" targetId="496b-a01b-3726-0a44" type="selectionEntry"/>
-                <entryLink id="228d-6e69-4957-fa2a" name="Arvus Transport" hidden="true" collective="false" import="true" targetId="5041-9403-02b7-af14" type="selectionEntry">
-                  <modifiers>
-                    <modifier type="set" field="hidden" value="false">
-                      <conditionGroups>
-                        <conditionGroup type="and">
+                  <constraints>
+                    <constraint type="min" value="9" field="selections" scope="parent" shared="true" id="b37d-f60a-d458-10a1" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                    <constraint type="max" value="19" field="selections" scope="parent" shared="true" id="2bc0-0b6e-c467-60cf" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                  </constraints>
+                  <selectionEntries>
+                    <selectionEntry type="model" import="true" name="Veletarii w/ Storm axe" hidden="false" id="2b18-d508-d843-fdc5" collective="false">
+                      <constraints>
+                        <constraint type="max" value="19" field="selections" scope="parent" shared="true" id="f26a-65cc-92b7-799d" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                      </constraints>
+                      <profiles>
+                        <profile name="Veletarii" typeId="4bb2-cb95-e6c8-5a21" typeName="Unit" hidden="false" id="9d8f-243d-7020-9043">
+                          <characteristics>
+                            <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Heavy)</characteristic>
+                            <characteristic name="Move" typeId="893e-2d76-8f04-44e5">6</characteristic>
+                            <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
+                            <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
+                            <characteristic name="S" typeId="e478-41d4-a092-48a8">3</characteristic>
+                            <characteristic name="T" typeId="c32b-5fdd-3fbe-9b1f">3</characteristic>
+                            <characteristic name="W" typeId="57ee-1126-32a9-5672">1</characteristic>
+                            <characteristic name="I" typeId="62d3-22d7-2d49-52dc">4</characteristic>
+                            <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">1</characteristic>
+                            <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">6</characteristic>
+                            <characteristic name="Save" typeId="e593-6b3c-f169-04f0">4+</characteristic>
+                          </characteristics>
+                          <modifiers>
+                            <modifier type="set" value="Infantry (Heavy, Line)" field="ddd7-6f5c-a939-b69e">
+                              <conditions>
+                                <condition type="equalTo" value="1" field="selections" scope="force" childId="a09b-28bd-8ffc-f4f0" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
+                              </conditions>
+                            </modifier>
+                            <modifier type="increment" value="1" field="e8a6-1da9-d384-8727">
+                              <conditions>
+                                <condition type="equalTo" value="1" field="selections" scope="force" childId="fe04-c096-f846-a6fd" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
+                              </conditions>
+                            </modifier>
+                          </modifiers>
+                        </profile>
+                      </profiles>
+                      <entryLinks>
+                        <entryLink import="true" name="Reinforced Void Armour" hidden="false" id="65ad-96cd-aab3-9e56" collective="false" targetId="5e45-2a38-759c-3147" type="selectionEntry">
+                          <constraints>
+                            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="09e3-5303-3b5a-b381" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="0358-77f8-81c5-8406" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                          </constraints>
+                        </entryLink>
+                        <entryLink import="true" name="Storm Axe" hidden="false" id="7eba-5376-ba86-c37c" collective="false" targetId="c305-a3f1-5c2f-ae37" type="selectionEntry">
+                          <constraints>
+                            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="6c11-7b5c-21bb-35ea" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="eb04-ca4b-ea88-7ddc" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                          </constraints>
+                        </entryLink>
+                      </entryLinks>
+                      <costs>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="13"/>
+                      </costs>
+                      <categoryLinks>
+                        <categoryLink name="Infantry Unit Type" hidden="false" id="07f8-8827-4d4d-a2b6" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+                        <categoryLink name="Heavy Sub-type" hidden="false" id="3c04-a03b-4798-a9f1" targetId="9231-183c-b97b-63f9" primary="false"/>
+                      </categoryLinks>
+                    </selectionEntry>
+                    <selectionEntry type="model" import="true" name="Veletarii w/ Volkite Charger" hidden="false" id="9194-cb55-09ee-7817" collective="false">
+                      <constraints>
+                        <constraint type="max" value="19" field="selections" scope="parent" shared="true" id="7830-a3c4-533b-64f9" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                      </constraints>
+                      <infoLinks>
+                        <infoLink name="Veletarii" id="5343-2659-8851-807c" hidden="false" targetId="9d8f-243d-7020-9043" type="profile"/>
+                      </infoLinks>
+                      <entryLinks>
+                        <entryLink import="true" name="Reinforced Void Armour" hidden="false" id="c9bf-b8d7-8964-568d" collective="false" targetId="5e45-2a38-759c-3147" type="selectionEntry">
+                          <constraints>
+                            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="019a-021c-0b4f-e3b7" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="a926-6a19-cb7d-3ec3" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                          </constraints>
+                        </entryLink>
+                        <entryLink import="true" name="Volkite Charger" hidden="false" id="0733-55b6-c813-9ad1" collective="false" targetId="5c82-c306-9c5c-5908" type="selectionEntry">
+                          <constraints>
+                            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="8898-6b2f-4134-e2d4" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="a2b2-915b-82e3-7581" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                          </constraints>
+                        </entryLink>
+                      </entryLinks>
+                      <costs>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="8"/>
+                      </costs>
+                      <categoryLinks>
+                        <categoryLink name="Infantry Unit Type" hidden="false" id="d7c8-7590-4f0d-9f98" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+                        <categoryLink name="Heavy Sub-type" hidden="false" id="8b6f-f985-403b-a672" targetId="9231-183c-b97b-63f9" primary="false"/>
+                      </categoryLinks>
+                    </selectionEntry>
+                    <selectionEntry type="model" import="true" name="Veletarii w/ Autorifle" hidden="true" id="c110-0436-5b73-08f7" collective="false">
+                      <modifiers>
+                        <modifier type="set" value="false" field="hidden">
                           <conditions>
-                            <condition field="selections" scope="force" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a09b-28bd-8ffc-f4f0" type="equalTo"/>
-                            <condition field="selections" scope="0508-f8a6-3996-bf39" value="12" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="atMost"/>
+                            <condition type="equalTo" value="1" field="selections" scope="force" childId="bfd2-7016-f5fe-be6a" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
                           </conditions>
-                        </conditionGroup>
-                      </conditionGroups>
+                        </modifier>
+                      </modifiers>
+                      <constraints>
+                        <constraint type="max" value="19" field="selections" scope="parent" shared="true" id="fbc5-f77f-7524-b253" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                      </constraints>
+                      <infoLinks>
+                        <infoLink name="Veletarii" id="15f7-3ee7-6ff3-e02b" hidden="false" targetId="9d8f-243d-7020-9043" type="profile"/>
+                      </infoLinks>
+                      <entryLinks>
+                        <entryLink import="true" name="Reinforced Void Armour" hidden="false" id="e8cb-4095-06ee-d6be" collective="false" targetId="5e45-2a38-759c-3147" type="selectionEntry">
+                          <constraints>
+                            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="b3b7-30ef-7148-7393" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="2255-df8f-6841-2b80" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                          </constraints>
+                        </entryLink>
+                        <entryLink import="true" name="Autorifle" hidden="false" id="1c76-8a9c-d6c8-5f46" collective="false" targetId="f3ff-0995-248a-5243" type="selectionEntry">
+                          <constraints>
+                            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="7e03-316e-bf1f-6b89" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="c1b2-06c5-d460-196e" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                          </constraints>
+                        </entryLink>
+                      </entryLinks>
+                      <costs>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="8"/>
+                      </costs>
+                      <categoryLinks>
+                        <categoryLink name="Infantry Unit Type" hidden="false" id="468f-3b13-4401-b378" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+                        <categoryLink name="Heavy Sub-type" hidden="false" id="004b-b83d-4a38-98f5" targetId="9231-183c-b97b-63f9" primary="false"/>
+                      </categoryLinks>
+                    </selectionEntry>
+                    <selectionEntry type="model" import="true" name="Veletarii w/ Lascarbine" hidden="true" id="0d2b-3943-df76-12a2" collective="false">
+                      <modifiers>
+                        <modifier type="set" value="false" field="hidden">
+                          <conditions>
+                            <condition type="equalTo" value="1" field="selections" scope="force" childId="bfd2-7016-f5fe-be6a" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
+                          </conditions>
+                        </modifier>
+                      </modifiers>
+                      <constraints>
+                        <constraint type="max" value="19" field="selections" scope="parent" shared="true" id="1c56-e743-0984-112d" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                      </constraints>
+                      <infoLinks>
+                        <infoLink name="Veletarii" id="9f19-a6db-14c6-80b5" hidden="false" targetId="9d8f-243d-7020-9043" type="profile"/>
+                      </infoLinks>
+                      <entryLinks>
+                        <entryLink import="true" name="Reinforced Void Armour" hidden="false" id="768b-152a-f0f6-ae77" collective="false" targetId="5e45-2a38-759c-3147" type="selectionEntry">
+                          <constraints>
+                            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="3f01-b641-bdc9-ef2c" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="01e1-7a25-84c7-f8f7" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                          </constraints>
+                        </entryLink>
+                        <entryLink import="true" name="Lascarbine" hidden="false" id="2e61-38fb-d08f-32f4" collective="false" targetId="3335-928e-aef8-ca0f" type="selectionEntry">
+                          <constraints>
+                            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="e27c-b98c-e221-bf0d" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="8ea2-7f4c-f9c6-4cf7" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                          </constraints>
+                        </entryLink>
+                      </entryLinks>
+                      <costs>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="8"/>
+                      </costs>
+                      <categoryLinks>
+                        <categoryLink name="Infantry Unit Type" hidden="false" id="1ab6-3841-492b-bbdd" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+                        <categoryLink name="Heavy Sub-type" hidden="false" id="6343-81d6-4fbf-a868" targetId="9231-183c-b97b-63f9" primary="false"/>
+                      </categoryLinks>
+                    </selectionEntry>
+                    <selectionEntry type="model" import="true" name="Veletarii w/ Lasrifle" hidden="true" id="6e53-e90b-d8a4-5158" collective="false">
+                      <modifiers>
+                        <modifier type="set" value="false" field="hidden">
+                          <conditions>
+                            <condition type="equalTo" value="1" field="selections" scope="force" childId="bfd2-7016-f5fe-be6a" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
+                          </conditions>
+                        </modifier>
+                      </modifiers>
+                      <constraints>
+                        <constraint type="max" value="19" field="selections" scope="parent" shared="true" id="a723-a4e7-ee19-7a01" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                      </constraints>
+                      <infoLinks>
+                        <infoLink name="Veletarii" id="fdbf-49f5-3975-4a76" hidden="false" targetId="9d8f-243d-7020-9043" type="profile"/>
+                      </infoLinks>
+                      <entryLinks>
+                        <entryLink import="true" name="Reinforced Void Armour" hidden="false" id="770b-f9df-b0db-ca79" collective="false" targetId="5e45-2a38-759c-3147" type="selectionEntry">
+                          <constraints>
+                            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="50dd-4da5-6a47-65ea" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="0c8e-ddb6-0772-4953" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                          </constraints>
+                        </entryLink>
+                        <entryLink import="true" name="Lasrifle" hidden="false" id="bb81-6079-38f0-1c3f" collective="false" targetId="2449-dc45-3441-b471" type="selectionEntry">
+                          <constraints>
+                            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="ed71-67de-0d33-612e" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="ffc7-1049-2c65-95ef" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                          </constraints>
+                        </entryLink>
+                      </entryLinks>
+                      <costs>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="8"/>
+                      </costs>
+                      <categoryLinks>
+                        <categoryLink name="Infantry Unit Type" hidden="false" id="c5fd-b27a-4353-8829" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+                        <categoryLink name="Heavy Sub-type" hidden="false" id="ed9c-67f7-47f5-b458" targetId="9231-183c-b97b-63f9" primary="false"/>
+                      </categoryLinks>
+                    </selectionEntry>
+                    <selectionEntry type="model" import="true" name="Veletarii w/ Shotgun" hidden="true" id="b70f-a612-df9c-7d7f" collective="false">
+                      <modifiers>
+                        <modifier type="set" value="false" field="hidden">
+                          <conditions>
+                            <condition type="equalTo" value="1" field="selections" scope="force" childId="bfd2-7016-f5fe-be6a" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
+                          </conditions>
+                        </modifier>
+                      </modifiers>
+                      <constraints>
+                        <constraint type="max" value="19" field="selections" scope="parent" shared="true" id="fd75-247a-9822-8998" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                      </constraints>
+                      <infoLinks>
+                        <infoLink name="Veletarii" id="fe22-0e51-a725-dd37" hidden="false" targetId="9d8f-243d-7020-9043" type="profile"/>
+                      </infoLinks>
+                      <entryLinks>
+                        <entryLink import="true" name="Reinforced Void Armour" hidden="false" id="22b9-26fa-8761-c585" collective="false" targetId="5e45-2a38-759c-3147" type="selectionEntry">
+                          <constraints>
+                            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="6107-ff65-d516-2b51" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="d90d-aec6-2d9e-77a0" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                          </constraints>
+                        </entryLink>
+                        <entryLink import="true" name="Shotgun" hidden="false" id="b155-d040-4b17-b92b" collective="false" targetId="2dba-5646-1049-c134" type="selectionEntry">
+                          <constraints>
+                            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="ff27-75d4-ea49-c249" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="13eb-fb9a-4566-259b" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                          </constraints>
+                        </entryLink>
+                      </entryLinks>
+                      <costs>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="8"/>
+                      </costs>
+                      <categoryLinks>
+                        <categoryLink name="Infantry Unit Type" hidden="false" id="1b45-74cb-4613-91a0" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+                        <categoryLink name="Heavy Sub-type" hidden="false" id="50ca-be6e-420a-b6d0" targetId="9231-183c-b97b-63f9" primary="false"/>
+                      </categoryLinks>
+                    </selectionEntry>
+                    <selectionEntry type="model" import="true" name="Veletarii w/ Stubcarbine" hidden="true" id="df5d-e57c-15b3-cfa8" collective="false">
+                      <modifiers>
+                        <modifier type="set" value="false" field="hidden">
+                          <conditions>
+                            <condition type="equalTo" value="1" field="selections" scope="force" childId="bfd2-7016-f5fe-be6a" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
+                          </conditions>
+                        </modifier>
+                      </modifiers>
+                      <constraints>
+                        <constraint type="max" value="19" field="selections" scope="parent" shared="true" id="f8d9-6a9a-4cee-d321" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                      </constraints>
+                      <infoLinks>
+                        <infoLink name="Veletarii" id="f7df-4db9-bd86-6078" hidden="false" targetId="9d8f-243d-7020-9043" type="profile"/>
+                      </infoLinks>
+                      <entryLinks>
+                        <entryLink import="true" name="Reinforced Void Armour" hidden="false" id="d6c2-be71-2aa9-ceb1" collective="false" targetId="5e45-2a38-759c-3147" type="selectionEntry">
+                          <constraints>
+                            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="589b-6cd5-2f5e-c667" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="a7a3-be34-d200-afe6" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                          </constraints>
+                        </entryLink>
+                        <entryLink import="true" name="Stubcarbine" hidden="false" id="50c2-4666-b056-557a" collective="false" targetId="090f-d3b8-9e92-40e3" type="selectionEntry">
+                          <constraints>
+                            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="3f0d-bb63-7c24-8aa1" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="a441-89b2-088d-9b23" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                          </constraints>
+                        </entryLink>
+                      </entryLinks>
+                      <costs>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="8"/>
+                      </costs>
+                      <categoryLinks>
+                        <categoryLink name="Infantry Unit Type" hidden="false" id="ef1f-eca1-4550-b3aa" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+                        <categoryLink name="Heavy Sub-type" hidden="false" id="f3fe-c8f7-4d3e-8a39" targetId="9231-183c-b97b-63f9" primary="false"/>
+                      </categoryLinks>
+                    </selectionEntry>
+                  </selectionEntries>
+                </selectionEntryGroup>
+                <selectionEntryGroup name="Dedicated Transports" id="ee9d-04a6-b522-4047" hidden="false" collective="false" import="true">
+                  <modifiers>
+                    <modifier type="set" value="1" field="0bde-0b51-92cd-f722">
+                      <conditions>
+                        <condition type="equalTo" value="1" field="selections" scope="force" childId="d9a0-4875-fb75-f9a9" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="set" value="true" field="hidden">
+                      <conditions>
+                        <condition type="atLeast" value="1" field="selections" scope="force" childId="7b69-bf2f-4547-e83b" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
+                      </conditions>
                     </modifier>
                   </modifiers>
-                </entryLink>
-              </entryLinks>
-            </selectionEntryGroup>
-          </selectionEntryGroups>
-          <entryLinks>
-            <entryLink id="46bf-4bad-5b67-f596" name="Krak Grenades" hidden="false" collective="false" import="true" targetId="99df-2421-acf7-a5ad" type="selectionEntry">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2834-b30d-f46c-df5e" type="min"/>
-                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9754-bf95-fea0-d512" type="max"/>
-              </constraints>
-            </entryLink>
-            <entryLink id="2312-7a47-525a-0b39" name="Frag Grenades" hidden="false" collective="false" import="true" targetId="cf9c-327b-3449-00d7" type="selectionEntry">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="557e-b345-e27b-e8e5" type="min"/>
-                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="45be-a386-6e50-871e" type="max"/>
-              </constraints>
-            </entryLink>
-            <entryLink id="809e-68c0-d82f-f51a" name="Fear (Feral Cohort)" hidden="false" collective="false" import="true" targetId="aefe-eff6-2961-a445" type="selectionEntry"/>
-          </entryLinks>
-          <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="18"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry type="unit" import="true" name="Hermes Veletaris Squadron" hidden="false" id="8c69-57dc-440c-b706" page="181" publicationId="d882-d2a-5da1-92c4">
-          <categoryLinks>
-            <categoryLink name="Unit:" hidden="false" id="bcc6-6674-41b6-9e30" targetId="36c3-e85e-97cc-c503" primary="false"/>
-          </categoryLinks>
-          <costs>
-            <cost name="Pts" id="cf49-c219-3829-e19c" hidden="false" typeId="d2ee-04cb-5f8a-2642" value="17"/>
-          </costs>
-          <selectionEntries>
-            <selectionEntry type="model" import="true" name="Hermes Veletarii Sentinel" hidden="false" id="adab-c06b-41b9-ab59" page="181" publicationId="d882-d2a-5da1-92c4" defaultAmount="2">
-              <profiles>
-                <profile name="Hermes Veletarii Sentinel" typeId="4bb2-cb95-e6c8-5a21" typeName="Unit" hidden="false" id="7818-24b8-4e17-9253" publicationId="d882-d2a-5da1-92c4" page="181">
-                  <characteristics>
-                    <characteristic name="Unit Type" id="d447-3b56-d87-7b95" hidden="false" typeId="ddd7-6f5c-a939-b69e">Cavalry (Mechanised) + (Heavy) from Reinforced Void Armor</characteristic>
-                    <characteristic name="Move" id="c960-d1fc-64e0-4e7" hidden="false" typeId="893e-2d76-8f04-44e5">8</characteristic>
-                    <characteristic name="WS" id="74cc-b0a-7c3e-cb2d" hidden="false" typeId="cc42-7ed5-7092-5c84">4</characteristic>
-                    <characteristic name="BS" id="2ce9-bed4-de68-3093" hidden="false" typeId="74ae-c840-0036-d244">4</characteristic>
-                    <characteristic name="S" id="3901-e3d7-af1f-52e2" hidden="false" typeId="e478-41d4-a092-48a8">5</characteristic>
-                    <characteristic name="T" id="dd4a-e8d6-8076-3250" hidden="false" typeId="c32b-5fdd-3fbe-9b1f">5</characteristic>
-                    <characteristic name="W" id="6fe3-d1ce-8b75-3f76" hidden="false" typeId="57ee-1126-32a9-5672">2</characteristic>
-                    <characteristic name="I" id="97d3-b78e-b847-a8d5" hidden="false" typeId="62d3-22d7-2d49-52dc">3</characteristic>
-                    <characteristic name="A" id="f63a-dc0a-2716-87ff" hidden="false" typeId="f111-2ce5-dd12-d6b0">1</characteristic>
-                    <characteristic name="Ld" id="32f7-626e-240f-3c34" hidden="false" typeId="e8a6-1da9-d384-8727">7</characteristic>
-                    <characteristic name="Save" id="a6d-9526-512e-4484" hidden="false" typeId="e593-6b3c-f169-04f0">3+</characteristic>
-                  </characteristics>
-                </profile>
-              </profiles>
-              <costs>
-                <cost name="Pts" id="8fb3-e75f-fa3d-625e" hidden="false" typeId="d2ee-04cb-5f8a-2642" value="24"/>
-              </costs>
-              <constraints>
-                <constraint type="min" value="2" field="selections" scope="parent" shared="true" id="a577-c13c-2a0c-734b" includeChildSelections="false"/>
-                <constraint type="max" value="6" field="selections" scope="parent" shared="true" id="ad54-b3d5-1e2f-31d1" includeChildSelections="false"/>
-              </constraints>
-              <selectionEntryGroups>
-                <selectionEntryGroup name="Hermes Veletarii Sentinel" id="5437-cf9e-80c1-fcc8" hidden="false" defaultSelectionEntryId="3348-965-dae-36d3">
-                  <entryLinks>
-                    <entryLink import="true" name="Volkite Caliver" hidden="false" id="3348-965-dae-36d3" type="selectionEntry" targetId="9250-490f-abeb-b901" defaultAmount="1"/>
-                    <entryLink import="true" name="Heavy Flamer" hidden="false" id="8308-cf39-a9f3-4c8c" type="selectionEntry" targetId="5507-b432-3b4c-df12"/>
-                  </entryLinks>
                   <constraints>
-                    <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="5572-b0d4-1a98-c166-min" includeChildSelections="false"/>
-                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="5572-b0d4-1a98-c166-max" includeChildSelections="false"/>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="20b7-845c-7c4e-9a24" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                    <constraint type="min" value="0" field="selections" scope="parent" shared="true" id="0bde-0b51-92cd-f722" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
                   </constraints>
+                  <entryLinks>
+                    <entryLink import="true" name="Aurox Transport" hidden="false" id="44bd-6025-ca3d-2610" collective="false" targetId="071b-79e5-7b5b-c9cd" type="selectionEntry">
+                      <modifiers>
+                        <modifier type="set" value="true" field="hidden">
+                          <conditions>
+                            <condition type="greaterThan" value="10" field="selections" scope="c51e-5dce-2d97-4a99" childId="model" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
+                          </conditions>
+                        </modifier>
+                      </modifiers>
+                    </entryLink>
+                    <entryLink import="true" name="Dracosan Armoured Transport" hidden="false" id="8662-58a1-6d55-4a14" collective="false" targetId="496b-a01b-3726-0a44" type="selectionEntry"/>
+                    <entryLink import="true" name="Arvus Transport" hidden="true" id="a9b5-fbc5-24f3-4e1f" collective="false" targetId="5041-9403-02b7-af14" type="selectionEntry">
+                      <modifiers>
+                        <modifier type="set" value="false" field="hidden">
+                          <conditionGroups>
+                            <conditionGroup type="and">
+                              <conditions>
+                                <condition type="equalTo" value="1" field="selections" scope="force" childId="a09b-28bd-8ffc-f4f0" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
+                                <condition type="atMost" value="12" field="selections" scope="c51e-5dce-2d97-4a99" childId="model" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
+                              </conditions>
+                            </conditionGroup>
+                          </conditionGroups>
+                        </modifier>
+                      </modifiers>
+                    </entryLink>
+                  </entryLinks>
                 </selectionEntryGroup>
               </selectionEntryGroups>
               <entryLinks>
-                <entryLink import="true" name="Laspistol" hidden="false" id="d0be-a42d-68d6-1238" type="selectionEntry" targetId="654d-be88-b0a8-7ae5">
+                <entryLink import="true" name="Volkite Charger" hidden="false" id="cd2c-65ee-ec87-b0c5" collective="false" targetId="6f6e-ad55-e093-6503" type="selectionEntry">
                   <constraints>
-                    <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="e3de-7fc9-a99f-e898"/>
-                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="ee12-77f8-1a77-49b7"/>
+                    <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="76b3-ceea-e3cb-51f8" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="0c72-1301-3f2e-a57f" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
                   </constraints>
                 </entryLink>
-                <entryLink import="true" name="Reinforced Void Armour" hidden="false" id="3021-ea0-271d-6c57" type="selectionEntry" targetId="cc63-5cc3-212a-3d4c">
+                <entryLink import="true" name="Krak Grenades" hidden="false" id="3950-d910-eeaa-6dcc" collective="false" targetId="99df-2421-acf7-a5ad" type="selectionEntry">
                   <constraints>
-                    <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="eb2b-114a-1a7-ffc4"/>
-                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="860d-bbaf-25ed-4138"/>
+                    <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="26f1-eb9d-995d-3c90" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="4cbf-7147-4bf7-3226" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
                   </constraints>
                 </entryLink>
+                <entryLink import="true" name="Frag Grenades" hidden="false" id="c04a-fa04-8eff-0c77" collective="false" targetId="cf9c-327b-3449-00d7" type="selectionEntry">
+                  <constraints>
+                    <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="d2a6-c1b8-9484-88c9" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="604e-86c2-0c1c-1870" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                  </constraints>
+                </entryLink>
+                <entryLink import="true" name="Fear (Feral Cohort)" hidden="false" id="0dfb-d07a-521b-ee4f" collective="false" targetId="aefe-eff6-2961-a445" type="selectionEntry"/>
               </entryLinks>
-              <comment>Didn&apos;t make a wargear item for the sentinel, since it&apos;s covered by the equipment and statline.</comment>
-              <categoryLinks>
-                <categoryLink name="Cavalry Unit Type" hidden="false" id="311e-5b08-fdb5-ac6" targetId="6d79-a3e4-381f-7b0f" primary="false"/>
-                <categoryLink name="Mechanised Unit Sub-type" hidden="false" id="e5fb-8548-d531-a3ef" targetId="e929-a5c3-451c-6f19" primary="false"/>
-                <categoryLink name="Heavy Sub-type" hidden="false" id="3d27-d430-43a8-1031" targetId="9231-183c-b97b-63f9" primary="false"/>
-              </categoryLinks>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="18"/>
+              </costs>
+              <modifierGroups>
+                <modifierGroup type="and">
+                  <modifiers>
+                    <modifier type="set" value="2" field="b8d7-d27c-2841-12af"/>
+                    <modifier type="set" value="0" field="a8bc-6d7a-6118-1894"/>
+                  </modifiers>
+                  <conditions>
+                    <condition type="atLeast" value="1" field="selections" scope="parent" childId="8c69-57dc-440c-b706" shared="true" includeChildSelections="false"/>
+                  </conditions>
+                </modifierGroup>
+              </modifierGroups>
             </selectionEntry>
           </selectionEntries>
           <constraints>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="de14-3f73-cea1-40f9" includeChildSelections="false"/>
+            <constraint type="max" value="3" field="selections" scope="self" shared="true" id="d497-66f1-6c32-3517"/>
+            <constraint type="min" value="1" field="selections" scope="self" shared="true" id="297b-656f-3c1c-8c5c"/>
           </constraints>
-        </selectionEntry>
-      </selectionEntries>
-      <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
-      </costs>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
     </selectionEntry>
     <selectionEntry id="c032-86a2-3757-80e4" name="Surgeon-Primus Aevos Jovan" hidden="false" collective="false" import="true" type="unit">
       <constraints>


### PR DESCRIPTION
Using "Max 3 in self" doesn't work, so I've redone the logic per Giloushaker's suggestion. It will break existing lists in both editors I believe. Giloushaker can patch NR to fix it, but it'll still be a problem for battlescribe. We could also come up with a different validator, but this one is tricky. It's
Max 3:
0-1 veletaris command section
1-3 storm section, unless hermes, in which case 0-2
0-1 hermes, which modifies the storm section.
0-1 veletaris vanguard section

The other option would be to reduce max storm section for command section and vanguard section, like I'm currently doing with hermes. That should work...