### PR TITLE
Fix Heavy sentinel in recon company check

### DIFF
--- a/2022 - LI - Solar Auxilia.cat
+++ b/2022 - LI - Solar Auxilia.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="6af7-3fee-5bc1-7533" name="LI - Solar Auxilia" revision="36" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="70" type="catalogue">
+<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="6af7-3fee-5bc1-7533" name="LI - Solar Auxilia" revision="37" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="70" type="catalogue">
   <categoryEntries>
     <categoryEntry id="19f3-8727-02db-3ce5" name="Static Artillery" hidden="false">
       <rules>
@@ -11763,7 +11763,7 @@ If a Weapon Destroyed result is repaired, that weapon may not be used to attack 
           <modifiers>
             <modifier type="set" value="5" field="afdb-a5d1-437b-9b12">
               <conditions>
-                <condition type="equalTo" value="1" field="selections" scope="force" childId="7e09-aae1-d5ff-d43e" shared="true"/>
+                <condition type="equalTo" value="1" field="selections" scope="force" childId="7e09-aae1-d5ff-d43e" shared="true" includeChildSelections="true"/>
               </conditions>
             </modifier>
           </modifiers>


### PR DESCRIPTION
Looks like we forgot a "and all child selections" for the "check if the force has recon company in it" check
