### PR TITLE
Fix missing armor for aquilon terminators

### DIFF
--- a/2022 - LI - Custodes.cat
+++ b/2022 - LI - Custodes.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="2f2b-1f31-c455-1701" name="LI - Custodes" revision="21" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="70" type="catalogue">
+<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="2f2b-1f31-c455-1701" name="LI - Custodes" revision="22" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="70" type="catalogue">
   <categoryEntries>
     <categoryEntry id="ccca-a9de-0cd9-f8be" name="Legio Custodes" hidden="false">
       <infoLinks>
@@ -1188,6 +1188,12 @@
               </conditions>
             </modifier>
           </modifiers>
+        </entryLink>
+        <entryLink import="true" name="Aquilon Pattern Terminator Armour" hidden="false" id="529f-4c58-af34-bd01" type="selectionEntry" targetId="b077-e64b-5a66-7ed2">
+          <constraints>
+            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="8df8-3a7d-e0ed-72ec" includeChildSelections="false"/>
+            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="dcb0-e8b3-93bb-25b5" includeChildSelections="false"/>
+          </constraints>
         </entryLink>
       </entryLinks>
       <costs>


### PR DESCRIPTION
The armor was in the data but not linked. Without this players might be missing that the unit has an invuln.

Please set a title for the PR describing your changes,
fill out the information below, and delete this heading.


## Fixed Units
Aquilon terminator