### PR TITLE
Don't import all on other legions in AL.

### DIFF
--- a/2022 - LA - Alpha Legion.cat
+++ b/2022 - LA - Alpha Legion.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="9c06-1c61-d01d-8445" name="LA - XX: Alpha Legion" revision="55" battleScribeVersion="2.03" authorName="Alphalas" authorContact="BSData Developers Discord" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="70" type="catalogue">
+<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="9c06-1c61-d01d-8445" name="LA - XX: Alpha Legion" revision="56" battleScribeVersion="2.03" authorName="Alphalas" authorContact="BSData Developers Discord" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="70" type="catalogue">
   <categoryEntries>
     <categoryEntry id="2275-5253-2421-7383" name="Rewards of Trechery" hidden="false">
       <modifiers>
@@ -8280,22 +8280,22 @@ A weapon with this special rule may not be used to make Shooting Attacks as part
   </sharedSelectionEntryGroups>
   <catalogueLinks>
     <catalogueLink id="2f60-18fb-e6ed-8574" name="Legions Astartes" targetId="6393-649c-7213-a327" type="catalogue" importRootEntries="true"/>
-    <catalogueLink id="22ab-29e1-22f3-7cff" name="LA -   I: Dark Angels" targetId="ee5e-198e-1b19-4b9f" type="catalogue" importRootEntries="true"/>
-    <catalogueLink id="a164-9b86-cdff-a77e" name="LA -   III: Emperor&apos;s Children" targetId="72ba-61c2-37ad-c785" type="catalogue" importRootEntries="true"/>
-    <catalogueLink id="f3da-bf4c-5557-55ca" name="LA -   IV: Iron Warriors" targetId="2ee4-57ed-db44-8a63" type="catalogue" importRootEntries="true"/>
-    <catalogueLink id="a765-0d93-a1aa-429d" name="LA -   V: White Scars" targetId="caa9-c50e-8eed-2259" type="catalogue" importRootEntries="true"/>
-    <catalogueLink id="deaf-52e5-4b05-f2d6" name="LA -   VI: Space Wolves" targetId="ca15-13de-89cb-bbb2" type="catalogue" importRootEntries="true"/>
-    <catalogueLink id="7d3f-8f37-29e5-3a1e" name="LA -   VII: Imperial Fists" targetId="8866-00ec-715f-f21a" type="catalogue" importRootEntries="true"/>
-    <catalogueLink id="e854-80e6-908e-88db" name="LA -   VIII: Night Lords" targetId="36dc-14fc-8872-476b" type="catalogue" importRootEntries="true"/>
-    <catalogueLink id="d048-e6d9-e40e-8363" name="LA -  IX: Blood Angels" targetId="cd4d-8765-5387-8409" type="catalogue" importRootEntries="true"/>
-    <catalogueLink id="7ea8-b20e-d38f-def3" name="LA -  X: Iron Hands" targetId="b73e-125f-db29-17f2" type="catalogue" importRootEntries="true"/>
-    <catalogueLink id="1ab3-19e2-4e09-4cef" name="LA -  XII: World Eaters" targetId="d901-0eca-48b5-304a" type="catalogue" importRootEntries="true"/>
-    <catalogueLink id="e1d9-0e0d-dd7c-564b" name="LA -  XIII: Ultramarines" targetId="68ae-9855-b56a-95e6" type="catalogue" importRootEntries="true"/>
-    <catalogueLink id="8bd2-e90a-499a-652d" name="LA -  XIV: Death Guard" targetId="d228-55e8-b58c-1b77" type="catalogue" importRootEntries="true"/>
-    <catalogueLink id="cb9a-9b14-8dcf-910f" name="LA -  XV: Thousand Sons" targetId="abac-8dd1-df65-e253" type="catalogue" importRootEntries="true"/>
-    <catalogueLink id="3289-8848-fef8-7f7a" name="LA -  XVI: Sons of Horus" targetId="62c7-42f4-5523-af1b" type="catalogue" importRootEntries="true"/>
-    <catalogueLink id="4c19-55ad-bb7b-187c" name="LA -  XVII: Word Bearers" targetId="1df7-bbbc-b70e-6a3f" type="catalogue" importRootEntries="true"/>
-    <catalogueLink id="615e-dbe4-e349-94ca" name="LA -  XVIII: Salamanders" targetId="3547-84d8-d789-bab7" type="catalogue" importRootEntries="true"/>
-    <catalogueLink id="0fd7-0093-a46a-ad80" name="LA - XIX: Raven Guard" targetId="d21e-9c80-a7f8-728c" type="catalogue" importRootEntries="true"/>
+    <catalogueLink id="22ab-29e1-22f3-7cff" name="LA -   I: Dark Angels" targetId="ee5e-198e-1b19-4b9f" type="catalogue" importRootEntries="false"/>
+    <catalogueLink id="a164-9b86-cdff-a77e" name="LA -   III: Emperor&apos;s Children" targetId="72ba-61c2-37ad-c785" type="catalogue" importRootEntries="false"/>
+    <catalogueLink id="f3da-bf4c-5557-55ca" name="LA -   IV: Iron Warriors" targetId="2ee4-57ed-db44-8a63" type="catalogue" importRootEntries="false"/>
+    <catalogueLink id="a765-0d93-a1aa-429d" name="LA -   V: White Scars" targetId="caa9-c50e-8eed-2259" type="catalogue" importRootEntries="false"/>
+    <catalogueLink id="deaf-52e5-4b05-f2d6" name="LA -   VI: Space Wolves" targetId="ca15-13de-89cb-bbb2" type="catalogue" importRootEntries="false"/>
+    <catalogueLink id="7d3f-8f37-29e5-3a1e" name="LA -   VII: Imperial Fists" targetId="8866-00ec-715f-f21a" type="catalogue" importRootEntries="false"/>
+    <catalogueLink id="e854-80e6-908e-88db" name="LA -   VIII: Night Lords" targetId="36dc-14fc-8872-476b" type="catalogue" importRootEntries="false"/>
+    <catalogueLink id="d048-e6d9-e40e-8363" name="LA -  IX: Blood Angels" targetId="cd4d-8765-5387-8409" type="catalogue" importRootEntries="false"/>
+    <catalogueLink id="7ea8-b20e-d38f-def3" name="LA -  X: Iron Hands" targetId="b73e-125f-db29-17f2" type="catalogue" importRootEntries="false"/>
+    <catalogueLink id="1ab3-19e2-4e09-4cef" name="LA -  XII: World Eaters" targetId="d901-0eca-48b5-304a" type="catalogue" importRootEntries="false"/>
+    <catalogueLink id="e1d9-0e0d-dd7c-564b" name="LA -  XIII: Ultramarines" targetId="68ae-9855-b56a-95e6" type="catalogue" importRootEntries="false"/>
+    <catalogueLink id="8bd2-e90a-499a-652d" name="LA -  XIV: Death Guard" targetId="d228-55e8-b58c-1b77" type="catalogue" importRootEntries="false"/>
+    <catalogueLink id="cb9a-9b14-8dcf-910f" name="LA -  XV: Thousand Sons" targetId="abac-8dd1-df65-e253" type="catalogue" importRootEntries="false"/>
+    <catalogueLink id="3289-8848-fef8-7f7a" name="LA -  XVI: Sons of Horus" targetId="62c7-42f4-5523-af1b" type="catalogue" importRootEntries="false"/>
+    <catalogueLink id="4c19-55ad-bb7b-187c" name="LA -  XVII: Word Bearers" targetId="1df7-bbbc-b70e-6a3f" type="catalogue" importRootEntries="false"/>
+    <catalogueLink id="615e-dbe4-e349-94ca" name="LA -  XVIII: Salamanders" targetId="3547-84d8-d789-bab7" type="catalogue" importRootEntries="false"/>
+    <catalogueLink id="0fd7-0093-a46a-ad80" name="LA - XIX: Raven Guard" targetId="d21e-9c80-a7f8-728c" type="catalogue" importRootEntries="false"/>
   </catalogueLinks>
 </catalogue>


### PR DESCRIPTION
#3276

I don't know why alpha legion imported all root entries from other cats, but I've unchecked that setting. I tested at least one treachery unit inclusion, and it seemed to work. I assume we've added all the legion specific units as root entries to alpha legion, but if we did need this import, this will break some.
