### PR TITLE
Fix Arlatax Weapons

### DIFF
--- a/2022 - Mechanicum.cat
+++ b/2022 - Mechanicum.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="c247-da79-1654-d39e" name="Mechanicum" revision="40" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="70" type="catalogue" publicationId="3886-76e5-438f-159f">
+<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="c247-da79-1654-d39e" name="Mechanicum" revision="41" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="70" type="catalogue" publicationId="3886-76e5-438f-159f">
   <entryLinks>
     <entryLink id="29c6-0ec7-0162-e817" name="Mechanicum" hidden="false" collective="false" import="false" targetId="ddf5-d792-3146-6e9a" type="selectionEntry">
       <modifiers>
@@ -3266,7 +3266,7 @@ This unit may be upgraded freely as described in their profile, though they may 
                     </rule>
                   </rules>
                   <selectionEntries>
-                    <selectionEntry id="2e78-ef5f-0355-37dc" name="Power Blade Array" publicationId="bde1-6db1-163b-3b76" page="122" hidden="false" collective="true" import="true" type="upgrade">
+                    <selectionEntry id="2e78-ef5f-0355-37dc" name="Power Blade Array" publicationId="bde1-6db1-163b-3b76" page="122" hidden="false" collective="false" import="true" type="upgrade">
                       <profiles>
                         <profile id="909d-e3f3-25be-a060" name="Power Blade Array" publicationId="bde1-6db1-163b-3b76" page="122" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
                           <characteristics>
@@ -3287,8 +3287,12 @@ This unit may be upgraded freely as described in their profile, though they may 
                       <costs>
                         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
                       </costs>
+                      <constraints>
+                        <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="738c-b560-5cc3-57f3-min" includeChildSelections="false"/>
+                        <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="738c-b560-5cc3-57f3-max" includeChildSelections="false"/>
+                      </constraints>
                     </selectionEntry>
-                    <selectionEntry id="8f35-0d01-7cc3-b558" name="Light Autocannon" publicationId="bde1-6db1-163b-3b76" page="114" hidden="false" collective="true" import="true" type="upgrade">
+                    <selectionEntry id="8f35-0d01-7cc3-b558" name="Light Autocannon" publicationId="bde1-6db1-163b-3b76" page="114" hidden="false" collective="false" import="true" type="upgrade">
                       <profiles>
                         <profile id="e71b-e137-8d96-bc1d" name="Light Autocannon" publicationId="bde1-6db1-163b-3b76" page="114" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
                           <characteristics>
@@ -3302,6 +3306,10 @@ This unit may be upgraded freely as described in their profile, though they may 
                       <costs>
                         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
                       </costs>
+                      <constraints>
+                        <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="3b36-9dbd-4a13-5fd9-min" includeChildSelections="false"/>
+                        <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="3b36-9dbd-4a13-5fd9-max" includeChildSelections="false"/>
+                      </constraints>
                     </selectionEntry>
                   </selectionEntries>
                   <costs>


### PR DESCRIPTION
Fixes #3150
Before, the arlatax didn't have a min/max on the power blade array and light autocannon profiles. This meant that you needed to/could select a number of them, at least in new recruit. This also had collective set, which might have done something in battlescribe to make it not obvious that you'd need to select it. Without it selected, the profile wouldn't show. 

Now, they are exactly 1 in parent, and I've disabled collective. 