### PR TITLE
fix for #3313 (Aug Transport)

### DIFF
--- a/2022 - BG - Blackshields.cat
+++ b/2022 - BG - Blackshields.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" library="false" id="cd55-5578-4b1a-67a0" name="BG - Blackshields" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="104" revision="3" battleScribeVersion="2.03" type="catalogue">
+<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" library="false" id="cd55-5578-4b1a-67a0" name="BG - Blackshields" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="104" revision="4" battleScribeVersion="2.03" type="catalogue">
   <sharedSelectionEntryGroups>
     <selectionEntryGroup name="Retinue" hidden="false" id="5b3d-ea70-4774-c23d" collective="false" import="true">
       <comment>template_id_be38-a066-4f8e-ae54</comment>
@@ -185,11 +185,11 @@ In addition, an army whose Warlord has this Trait may make an additional Reactio
         <categoryLink name="Unit:" hidden="false" id="7a2e-7a12-edc0-de60" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
       <infoLinks>
-        <infoLink name="Augmetic Transport Bay" id="5a50-f80b-a03b-6e88" hidden="true" type="rule" targetId="75c-d3e8-2f12-2749">
+        <infoLink name="Augmetic Transport Bay" id="5a50-f80b-a03b-6e88" hidden="false" type="rule" targetId="75c-d3e8-2f12-2749">
           <modifiers>
-            <modifier type="set" value="false" field="hidden">
+            <modifier type="set" value="true" field="hidden">
               <conditions>
-                <condition type="atLeast" value="1" field="selections" scope="force" childId="be5b-1edf-8b27-2e1e" shared="true" includeChildSelections="true"/>
+                <condition type="equalTo" value="0" field="selections" scope="force" childId="be5b-1edf-8b27-2e1e" shared="true" includeChildSelections="true"/>
               </conditions>
             </modifier>
           </modifiers>
@@ -319,11 +319,11 @@ In addition, an army whose Warlord has this Trait may make an additional Reactio
         <categoryLink name="Unit:" hidden="false" id="a713-8350-7a25-478f" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
       <infoLinks>
-        <infoLink name="Augmetic Transport Bay" id="7e78-18cc-79e2-fa4b" hidden="true" type="rule" targetId="75c-d3e8-2f12-2749">
+        <infoLink name="Augmetic Transport Bay" id="7e78-18cc-79e2-fa4b" hidden="false" type="rule" targetId="75c-d3e8-2f12-2749">
           <modifiers>
-            <modifier type="set" value="false" field="hidden">
+            <modifier type="set" value="true" field="hidden">
               <conditions>
-                <condition type="atLeast" value="1" field="selections" scope="force" childId="be5b-1edf-8b27-2e1e" shared="true" includeChildSelections="true"/>
+                <condition type="equalTo" value="0" field="selections" scope="force" childId="be5b-1edf-8b27-2e1e" shared="true" includeChildSelections="true"/>
               </conditions>
             </modifier>
           </modifiers>
@@ -445,11 +445,11 @@ In addition, an army whose Warlord has this Trait may make an additional Reactio
         <categoryLink name="Unit:" hidden="false" id="fb6c-ea2e-19ed-257f" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
       <infoLinks>
-        <infoLink name="Augmetic Transport Bay" id="7e2-4e99-dcfe-6f01" hidden="true" type="rule" targetId="75c-d3e8-2f12-2749">
+        <infoLink name="Augmetic Transport Bay" id="7e2-4e99-dcfe-6f01" hidden="false" type="rule" targetId="75c-d3e8-2f12-2749">
           <modifiers>
-            <modifier type="set" value="false" field="hidden">
+            <modifier type="set" value="true" field="hidden">
               <conditions>
-                <condition type="atLeast" value="1" field="selections" scope="force" childId="be5b-1edf-8b27-2e1e" shared="true" includeChildSelections="true"/>
+                <condition type="equalTo" value="0" field="selections" scope="force" childId="be5b-1edf-8b27-2e1e" shared="true" includeChildSelections="true"/>
               </conditions>
             </modifier>
           </modifiers>
@@ -615,11 +615,11 @@ In addition, an army whose Warlord has this Trait may make an additional Reactio
         <categoryLink name="Unit:" hidden="false" id="e99b-6481-b1a-68cd" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
       <infoLinks>
-        <infoLink name="Augmetic Transport Bay" id="8d7a-35fb-69c6-4ec8" hidden="true" type="rule" targetId="75c-d3e8-2f12-2749">
+        <infoLink name="Augmetic Transport Bay" id="8d7a-35fb-69c6-4ec8" hidden="false" type="rule" targetId="75c-d3e8-2f12-2749">
           <modifiers>
-            <modifier type="set" value="false" field="hidden">
+            <modifier type="set" value="true" field="hidden">
               <conditions>
-                <condition type="atLeast" value="1" field="selections" scope="force" childId="be5b-1edf-8b27-2e1e" shared="true" includeChildSelections="true"/>
+                <condition type="equalTo" value="0" field="selections" scope="force" childId="be5b-1edf-8b27-2e1e" shared="true" includeChildSelections="true"/>
               </conditions>
             </modifier>
           </modifiers>
@@ -669,11 +669,11 @@ In addition, an army whose Warlord has this Trait may make an additional Reactio
         <categoryLink name="Unit:" hidden="false" id="9d93-1d4d-453c-ab1c" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
       <infoLinks>
-        <infoLink name="Augmetic Transport Bay" id="8733-809c-d553-83db" hidden="true" type="rule" targetId="75c-d3e8-2f12-2749">
+        <infoLink name="Augmetic Transport Bay" id="8733-809c-d553-83db" hidden="false" type="rule" targetId="75c-d3e8-2f12-2749">
           <modifiers>
-            <modifier type="set" value="false" field="hidden">
+            <modifier type="set" value="true" field="hidden">
               <conditions>
-                <condition type="atLeast" value="1" field="selections" scope="force" childId="be5b-1edf-8b27-2e1e" shared="true" includeChildSelections="true"/>
+                <condition type="equalTo" value="0" field="selections" scope="force" childId="be5b-1edf-8b27-2e1e" shared="true" includeChildSelections="true"/>
               </conditions>
             </modifier>
           </modifiers>
@@ -703,11 +703,11 @@ In addition, an army whose Warlord has this Trait may make an additional Reactio
         <categoryLink name="Unit:" hidden="false" id="fbdf-9674-8376-7d79" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
       <infoLinks>
-        <infoLink name="Augmetic Transport Bay" id="7154-1181-dbd-5cb3" hidden="true" type="rule" targetId="75c-d3e8-2f12-2749">
+        <infoLink name="Augmetic Transport Bay" id="7154-1181-dbd-5cb3" hidden="false" type="rule" targetId="75c-d3e8-2f12-2749">
           <modifiers>
-            <modifier type="set" value="false" field="hidden">
+            <modifier type="set" value="true" field="hidden">
               <conditions>
-                <condition type="atLeast" value="1" field="selections" scope="force" childId="be5b-1edf-8b27-2e1e" shared="true" includeChildSelections="true"/>
+                <condition type="equalTo" value="0" field="selections" scope="force" childId="be5b-1edf-8b27-2e1e" shared="true" includeChildSelections="true"/>
               </conditions>
             </modifier>
           </modifiers>
@@ -734,11 +734,11 @@ In addition, an army whose Warlord has this Trait may make an additional Reactio
         <categoryLink name="Unit:" hidden="false" id="54a3-21e-2cf3-bd46" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
       <infoLinks>
-        <infoLink name="Augmetic Transport Bay" id="9da4-c9dd-adff-87e3" hidden="true" type="rule" targetId="75c-d3e8-2f12-2749">
+        <infoLink name="Augmetic Transport Bay" id="9da4-c9dd-adff-87e3" hidden="false" type="rule" targetId="75c-d3e8-2f12-2749">
           <modifiers>
-            <modifier type="set" value="false" field="hidden">
+            <modifier type="set" value="true" field="hidden">
               <conditions>
-                <condition type="atLeast" value="1" field="selections" scope="force" childId="be5b-1edf-8b27-2e1e" shared="true" includeChildSelections="true"/>
+                <condition type="equalTo" value="0" field="selections" scope="force" childId="be5b-1edf-8b27-2e1e" shared="true" includeChildSelections="true"/>
               </conditions>
             </modifier>
           </modifiers>
@@ -765,11 +765,11 @@ In addition, an army whose Warlord has this Trait may make an additional Reactio
         <categoryLink name="Heavy Support:" hidden="false" id="52ff-d671-a73-510d" targetId="7031-469a-1aeb-eab0" primary="true"/>
       </categoryLinks>
       <infoLinks>
-        <infoLink name="Augmetic Transport Bay" id="4145-a939-69bd-119b" hidden="true" type="rule" targetId="75c-d3e8-2f12-2749">
+        <infoLink name="Augmetic Transport Bay" id="4145-a939-69bd-119b" hidden="false" type="rule" targetId="75c-d3e8-2f12-2749">
           <modifiers>
-            <modifier type="set" value="false" field="hidden">
+            <modifier type="set" value="true" field="hidden">
               <conditions>
-                <condition type="atLeast" value="1" field="selections" scope="force" childId="be5b-1edf-8b27-2e1e" shared="true" includeChildSelections="true"/>
+                <condition type="equalTo" value="0" field="selections" scope="force" childId="be5b-1edf-8b27-2e1e" shared="true" includeChildSelections="true"/>
               </conditions>
             </modifier>
           </modifiers>
@@ -796,11 +796,11 @@ In addition, an army whose Warlord has this Trait may make an additional Reactio
         <categoryLink name="Heavy Support:" hidden="false" id="1ba6-be37-deb8-24d7" targetId="7031-469a-1aeb-eab0" primary="true"/>
       </categoryLinks>
       <infoLinks>
-        <infoLink name="Augmetic Transport Bay" id="3e17-a4f-3393-49e8" hidden="true" type="rule" targetId="75c-d3e8-2f12-2749">
+        <infoLink name="Augmetic Transport Bay" id="3e17-a4f-3393-49e8" hidden="false" type="rule" targetId="75c-d3e8-2f12-2749">
           <modifiers>
-            <modifier type="set" value="false" field="hidden">
+            <modifier type="set" value="true" field="hidden">
               <conditions>
-                <condition type="atLeast" value="1" field="selections" scope="force" childId="be5b-1edf-8b27-2e1e" shared="true" includeChildSelections="true"/>
+                <condition type="equalTo" value="0" field="selections" scope="force" childId="be5b-1edf-8b27-2e1e" shared="true" includeChildSelections="true"/>
               </conditions>
             </modifier>
           </modifiers>
@@ -873,11 +873,11 @@ In addition, an army whose Warlord has this Trait may make an additional Reactio
         <categoryLink name="Unit:" hidden="false" id="6c56-ac49-c22-ca8c" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
       <infoLinks>
-        <infoLink name="Augmetic Transport Bay" id="df7e-bb79-6d6a-afa1" hidden="true" type="rule" targetId="75c-d3e8-2f12-2749">
+        <infoLink name="Augmetic Transport Bay" id="df7e-bb79-6d6a-afa1" hidden="false" type="rule" targetId="75c-d3e8-2f12-2749">
           <modifiers>
-            <modifier type="set" value="false" field="hidden">
+            <modifier type="set" value="true" field="hidden">
               <conditions>
-                <condition type="atLeast" value="1" field="selections" scope="force" childId="be5b-1edf-8b27-2e1e" shared="true" includeChildSelections="true"/>
+                <condition type="equalTo" value="0" field="selections" scope="force" childId="be5b-1edf-8b27-2e1e" shared="true" includeChildSelections="true"/>
               </conditions>
             </modifier>
           </modifiers>
@@ -1091,11 +1091,11 @@ In addition, an army whose Warlord has this Trait may make an additional Reactio
         <categoryLink name="Unit:" hidden="false" id="c33b-fc99-7a89-ebc6" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
       <infoLinks>
-        <infoLink name="Augmetic Transport Bay" id="57b2-7650-a3c2-db71" hidden="true" type="rule" targetId="75c-d3e8-2f12-2749">
+        <infoLink name="Augmetic Transport Bay" id="57b2-7650-a3c2-db71" hidden="false" type="rule" targetId="75c-d3e8-2f12-2749">
           <modifiers>
-            <modifier type="set" value="false" field="hidden">
+            <modifier type="set" value="true" field="hidden">
               <conditions>
-                <condition type="atLeast" value="1" field="selections" scope="force" childId="be5b-1edf-8b27-2e1e" shared="true" includeChildSelections="true"/>
+                <condition type="equalTo" value="0" field="selections" scope="force" childId="be5b-1edf-8b27-2e1e" shared="true" includeChildSelections="true"/>
               </conditions>
             </modifier>
           </modifiers>
@@ -1175,11 +1175,11 @@ In addition, an army whose Warlord has this Trait may make an additional Reactio
         <categoryLink name="Unit:" hidden="false" id="9cb8-8d3-7d1a-2d74" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
       <infoLinks>
-        <infoLink name="Augmetic Transport Bay" id="6fb8-d938-70f4-ceed" hidden="true" type="rule" targetId="75c-d3e8-2f12-2749">
+        <infoLink name="Augmetic Transport Bay" id="6fb8-d938-70f4-ceed" hidden="false" type="rule" targetId="75c-d3e8-2f12-2749">
           <modifiers>
-            <modifier type="set" value="false" field="hidden">
+            <modifier type="set" value="true" field="hidden">
               <conditions>
-                <condition type="atLeast" value="1" field="selections" scope="force" childId="be5b-1edf-8b27-2e1e" shared="true" includeChildSelections="true"/>
+                <condition type="equalTo" value="0" field="selections" scope="force" childId="be5b-1edf-8b27-2e1e" shared="true" includeChildSelections="true"/>
               </conditions>
             </modifier>
           </modifiers>
@@ -1583,11 +1583,11 @@ In addition, an army whose Warlord has this Trait may make an additional Reactio
         <categoryLink name="Unit:" hidden="false" id="ca4b-c30b-2639-bb9b" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
       <infoLinks>
-        <infoLink name="Augmetic Transport Bay" id="be06-1733-ee8a-b0c3" hidden="true" type="rule" targetId="75c-d3e8-2f12-2749">
+        <infoLink name="Augmetic Transport Bay" id="be06-1733-ee8a-b0c3" hidden="false" type="rule" targetId="75c-d3e8-2f12-2749">
           <modifiers>
-            <modifier type="set" value="false" field="hidden">
+            <modifier type="set" value="true" field="hidden">
               <conditions>
-                <condition type="atLeast" value="1" field="selections" scope="force" childId="be5b-1edf-8b27-2e1e" shared="true" includeChildSelections="true"/>
+                <condition type="equalTo" value="0" field="selections" scope="force" childId="be5b-1edf-8b27-2e1e" shared="true" includeChildSelections="true"/>
               </conditions>
             </modifier>
           </modifiers>
@@ -1636,11 +1636,11 @@ In addition, an army whose Warlord has this Trait may make an additional Reactio
         <categoryLink name="Unit:" hidden="false" id="b0ae-a33d-ad34-1971" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
       <infoLinks>
-        <infoLink name="Augmetic Transport Bay" id="b96c-5289-1965-565e" hidden="true" type="rule" targetId="75c-d3e8-2f12-2749">
+        <infoLink name="Augmetic Transport Bay" id="b96c-5289-1965-565e" hidden="false" type="rule" targetId="75c-d3e8-2f12-2749">
           <modifiers>
-            <modifier type="set" value="false" field="hidden">
+            <modifier type="set" value="true" field="hidden">
               <conditions>
-                <condition type="atLeast" value="1" field="selections" scope="force" childId="be5b-1edf-8b27-2e1e" shared="true" includeChildSelections="true"/>
+                <condition type="equalTo" value="0" field="selections" scope="force" childId="be5b-1edf-8b27-2e1e" shared="true" includeChildSelections="true"/>
               </conditions>
             </modifier>
           </modifiers>
@@ -1773,11 +1773,11 @@ In addition, an army whose Warlord has this Trait may make an additional Reactio
         <categoryLink name="Unit:" hidden="false" id="1aa3-151c-cd56-42c5" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
       <infoLinks>
-        <infoLink name="Augmetic Transport Bay" id="f093-7a51-46b9-4a69" hidden="true" type="rule" targetId="75c-d3e8-2f12-2749">
+        <infoLink name="Augmetic Transport Bay" id="f093-7a51-46b9-4a69" hidden="false" type="rule" targetId="75c-d3e8-2f12-2749">
           <modifiers>
-            <modifier type="set" value="false" field="hidden">
+            <modifier type="set" value="true" field="hidden">
               <conditions>
-                <condition type="atLeast" value="1" field="selections" scope="force" childId="be5b-1edf-8b27-2e1e" shared="true" includeChildSelections="true"/>
+                <condition type="equalTo" value="0" field="selections" scope="force" childId="be5b-1edf-8b27-2e1e" shared="true" includeChildSelections="true"/>
               </conditions>
             </modifier>
           </modifiers>

--- a/2022 - Mech Library.cat
+++ b/2022 - Mech Library.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="3129-da35-55e0-642d" name="Mech Library" revision="48" battleScribeVersion="2.03" library="true" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="67" type="catalogue">
+<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="3129-da35-55e0-642d" name="Mech Library" revision="49" battleScribeVersion="2.03" library="true" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="67" type="catalogue">
   <categoryEntries>
     <categoryEntry id="4086-0589-f010-e688" name="Titan Legion Min Troop/LoW" hidden="false"/>
     <categoryEntry id="57a1-ae47-ff1b-36e4" name="Cybertheurgist" publicationId="bde1-6db1-163b-3b76" page="92-96" hidden="false"/>
@@ -6530,11 +6530,11 @@ A unit composed entirely of models with Utan jump boosters may not Run. During R
           <entryLinks>
             <entryLink id="8b9c-7b44-0aad-a79a" name="Triaros Armoured Conveyor" hidden="false" collective="false" import="true" targetId="2484-a122-76a2-b142" type="selectionEntry">
               <infoLinks>
-                <infoLink name="Augmetic Transport Bay" id="b8e9-c593-6e54-687b" hidden="true" type="rule" targetId="75c-d3e8-2f12-2749">
+                <infoLink name="Augmetic Transport Bay" id="b8e9-c593-6e54-687b" hidden="false" type="rule" targetId="75c-d3e8-2f12-2749">
                   <modifiers>
-                    <modifier type="set" value="false" field="hidden">
+                    <modifier type="set" value="true" field="hidden">
                       <conditions>
-                        <condition type="atLeast" value="1" field="selections" scope="force" childId="be5b-1edf-8b27-2e1e" shared="true" includeChildSelections="true"/>
+                        <condition type="equalTo" value="0" field="selections" scope="force" childId="be5b-1edf-8b27-2e1e" shared="true" includeChildSelections="true"/>
                       </conditions>
                     </modifier>
                   </modifiers>


### PR DESCRIPTION
Augmetic Transport rule non Black shield factions #3313

Just edited all the entries to reverse the logic to fix it. BS doesn't like a rule that isn't hidden, but the rule link being hidden with a modifier to unhide it. These should be left as not hidden and the hide modifier added to the entry.