### PR TITLE
Remove bolt pistol option for imperial militia wardens

### DIFF
--- a/2022 - Imperialis Militia.cat
+++ b/2022 - Imperialis Militia.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="f84d-94cf-5ce6-b393" name="Imperialis Militia" revision="42" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="71" type="catalogue">
+<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="f84d-94cf-5ce6-b393" name="Imperialis Militia" revision="46" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="71" type="catalogue">
   <categoryEntries>
     <categoryEntry id="58b3-196a-9732-2165" name="Rogue Psyker Daemons Restriction" publicationId="48c2-d023-0069-001a" page="15" hidden="false">
       <modifiers>
@@ -10048,11 +10048,6 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
                 <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ba89-cb56-a36e-54fe" type="max"/>
               </constraints>
               <entryLinks>
-                <entryLink id="9aaa-6ea2-0db7-17c7" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="e5ae-6872-37aa-8600" type="selectionEntry">
-                  <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2"/>
-                  </costs>
-                </entryLink>
                 <entryLink id="e526-0ee3-1062-7b45" name="Blast Pistol" hidden="false" collective="false" import="true" targetId="2460-375d-31f4-4bdf" type="selectionEntry">
                   <costs>
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2"/>


### PR DESCRIPTION
Miltia wardens cannot have bolt pistol option as shown here:
![image](https://github.com/user-attachments/assets/9a676e89-1f9c-4780-beb6-d3804c130d9b)

## Fixed Units
Imperialis Militia Rogue Psyker.

## Test Case

It has not been tested, but as its a minor change it should not be a big issue.
