### PR TITLE
Daemons

### DIFF
--- a/2022 - Daemons - Bound Daemons.cat
+++ b/2022 - Daemons - Bound Daemons.cat
@@ -355,7 +355,7 @@ The End and the Death – When fighting in a Challenge, successful Invulnerable 
                     <condition type="notInstanceOf" value="0" field="selections" scope="ancestor" childId="6508-4f6a-0dc1-8f56" shared="true" includeChildSelections="true"/>
                   </conditions>
                 </modifier>
-                <modifier type="append" value="2 - Deflagerate [IT ✓])" field="name">
+                <modifier type="append" value="2 - Deflagrate [IT ✓])" field="name">
                   <conditions>
                     <condition type="instanceOf" value="0" field="selections" scope="ancestor" childId="6508-4f6a-0dc1-8f56" shared="true" includeChildSelections="true"/>
                   </conditions>
@@ -431,7 +431,7 @@ The End and the Death – When fighting in a Challenge, successful Invulnerable 
                     <condition type="notInstanceOf" value="0" field="selections" scope="ancestor" childId="6508-4f6a-0dc1-8f56" shared="true" includeChildSelections="true"/>
                   </conditions>
                 </modifier>
-                <modifier type="append" value="2 - Deflagerate [IT ✓])" field="name">
+                <modifier type="append" value="2 - Deflagrate [IT ✓])" field="name">
                   <conditions>
                     <condition type="instanceOf" value="0" field="selections" scope="ancestor" childId="6508-4f6a-0dc1-8f56" shared="true" includeChildSelections="true"/>
                   </conditions>
@@ -765,7 +765,7 @@ During a Reaction made in any Phase, a player may not choose to activate a model
                     <condition type="notInstanceOf" value="0" field="selections" scope="ancestor" childId="6508-4f6a-0dc1-8f56" shared="true" includeChildSelections="true"/>
                   </conditions>
                 </modifier>
-                <modifier type="append" value="2 - Deflagerate [IT ✓])" field="name">
+                <modifier type="append" value="2 - Deflagrate [IT ✓])" field="name">
                   <conditions>
                     <condition type="instanceOf" value="0" field="selections" scope="ancestor" childId="6508-4f6a-0dc1-8f56" shared="true" includeChildSelections="true"/>
                   </conditions>

--- a/2022 - Daemons - Bound Daemons.cat
+++ b/2022 - Daemons - Bound Daemons.cat
@@ -295,7 +295,7 @@ The End and the Death – When fighting in a Challenge, successful Invulnerable 
       <modifiers>
         <modifier type="add" field="category" value="9231-183c-b97b-63f9">
           <conditions>
-            <condition field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b7db-bf16-47c5-dc05" type="equalTo"/>
+            <condition field="selections" scope="ancestor" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8cf6-d802-d054-6a86" type="instanceOf"/>
           </conditions>
         </modifier>
       </modifiers>
@@ -314,7 +314,7 @@ The End and the Death – When fighting in a Challenge, successful Invulnerable 
               <modifiers>
                 <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Heavy)">
                   <conditions>
-                    <condition field="selections" scope="ancestor" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9231-183c-b97b-63f9" type="instanceOf"/>
+                    <condition field="selections" scope="89f7-b7a1-aab2-e47a" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8cf6-d802-d054-6a86" type="instanceOf"/>
                   </conditions>
                 </modifier>
               </modifiers>
@@ -347,9 +347,24 @@ The End and the Death – When fighting in a Challenge, successful Invulnerable 
             </infoLink>
             <infoLink id="9366-e6e8-3161-e418" name="Traitor" hidden="false" targetId="eff2-8b0e-21da-2f0d" type="rule"/>
             <infoLink id="9c3d-13ec-4b8a-6a23" name="Chosen Warriors" hidden="false" targetId="13d1-9270-6539-08ed" type="rule"/>
-            <infoLink id="c1ff-7f6a-4dda-a429" name="Hammer of Wrath (X)" hidden="false" targetId="aec0-c3aa-1e4e-1779" type="rule">
+            <infoLink name="Hammer of Wrath (X)" id="e109-ede2-f519-f47e" hidden="false" targetId="aec0-c3aa-1e4e-1779" type="rule">
               <modifiers>
-                <modifier type="set" field="name" value="Hammer of Wrath (1) [(2) if Infernal Tempest Dominion]"/>
+                <modifier type="set" value="Hammer of Wrath (1)" field="name"/>
+                <modifier type="set" value="true" field="hidden">
+                  <conditions>
+                    <condition type="instanceOf" value="0" field="selections" scope="89f7-b7a1-aab2-e47a" childId="6508-4f6a-0dc1-8f56" shared="true" includeChildSelections="true"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+            </infoLink>
+            <infoLink name="Hammer of Wrath (X)" id="dec4-3894-b516-b609" hidden="false" targetId="aec0-c3aa-1e4e-1779" type="rule">
+              <modifiers>
+                <modifier type="set" value="true" field="hidden">
+                  <conditions>
+                    <condition type="notInstanceOf" value="0" field="selections" scope="89f7-b7a1-aab2-e47a" childId="6508-4f6a-0dc1-8f56" shared="true" includeChildSelections="true"/>
+                  </conditions>
+                </modifier>
+                <modifier type="set" value="Hammer of Wrath (2)" field="name"/>
               </modifiers>
             </infoLink>
           </infoLinks>
@@ -372,9 +387,9 @@ The End and the Death – When fighting in a Challenge, successful Invulnerable 
           <profiles>
             <profile id="64ac-3e3a-7b9a-f6e6" name="Bound Daemon Regent" publicationId="cb13-da24-e6da-75b3" page="17" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName="Unit">
               <modifiers>
-                <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Heavy)">
+                <modifier type="append" value="(Heavy)" field="ddd7-6f5c-a939-b69e">
                   <conditions>
-                    <condition field="selections" scope="ancestor" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9231-183c-b97b-63f9" type="instanceOf"/>
+                    <condition type="instanceOf" value="1" field="selections" scope="89f7-b7a1-aab2-e47a" childId="8cf6-d802-d054-6a86" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
                   </conditions>
                 </modifier>
               </modifiers>
@@ -406,9 +421,24 @@ The End and the Death – When fighting in a Challenge, successful Invulnerable 
               </modifiers>
             </infoLink>
             <infoLink id="bfa4-05a9-a6cd-02a4" name="Traitor" hidden="false" targetId="eff2-8b0e-21da-2f0d" type="rule"/>
-            <infoLink id="653b-ac44-d5ab-ee1c" name="Hammer of Wrath (X)" hidden="false" targetId="aec0-c3aa-1e4e-1779" type="rule">
+            <infoLink name="Hammer of Wrath (X)" id="8054-b5ed-1933-f818" hidden="false" targetId="aec0-c3aa-1e4e-1779" type="rule">
               <modifiers>
-                <modifier type="set" field="name" value="Hammer of Wrath (1) [(2) if Infernal Tempest Dominion]"/>
+                <modifier type="set" value="Hammer of Wrath (1)" field="name"/>
+                <modifier type="set" value="true" field="hidden">
+                  <conditions>
+                    <condition type="instanceOf" value="0" field="selections" scope="89f7-b7a1-aab2-e47a" childId="6508-4f6a-0dc1-8f56" shared="true" includeChildSelections="true"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+            </infoLink>
+            <infoLink name="Hammer of Wrath (X)" id="e937-da2a-d3b2-5b6c" hidden="false" targetId="aec0-c3aa-1e4e-1779" type="rule">
+              <modifiers>
+                <modifier type="set" value="true" field="hidden">
+                  <conditions>
+                    <condition type="notInstanceOf" value="0" field="selections" scope="89f7-b7a1-aab2-e47a" childId="6508-4f6a-0dc1-8f56" shared="true" includeChildSelections="true"/>
+                  </conditions>
+                </modifier>
+                <modifier type="set" value="Hammer of Wrath (2)" field="name"/>
               </modifiers>
             </infoLink>
           </infoLinks>
@@ -450,12 +480,55 @@ The End and the Death – When fighting in a Challenge, successful Invulnerable 
           </costs>
         </selectionEntry>
       </selectionEntries>
-      <entryLinks>
-        <entryLink id="a412-00f9-330a-a548" name="The Ætheric Dominion (Unit)" hidden="false" collective="false" import="true" targetId="caad-e621-38e5-cb5f" type="selectionEntryGroup"/>
-      </entryLinks>
       <costs>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="130"/>
       </costs>
+      <modifierGroups>
+        <modifierGroup type="and">
+          <modifiers>
+            <modifier type="add" value="c42-1919-c37e-51f0" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="ca6c-e8cf-7bc1-eaa0" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="9556-82c1-c70a-126e" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="8ed0-3582-f536-c48e" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="f074-f60a-9aa6-c52a" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="3d70-1d54-a791-ac60" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="6508-4f6a-0dc1-8f56" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="e4fb-66cd-e07d-609b" shared="true" includeChildSelections="true" includeChildForces="false"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="bcf6-8350-9099-1e91" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="9508-8124-d34a-500a" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="8cf6-d802-d054-6a86" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="b7db-bf16-47c5-dc05" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="a1d4-4662-c944-19cc" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="1214-3abe-c6d1-2038" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="2774-1a32-f196-be76" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="945c-b969-75eb-19d9" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </modifierGroup>
+      </modifierGroups>
     </selectionEntry>
     <selectionEntry id="aa91-7f0d-cade-cbc5" name="Bound Ka’bandha" publicationId="cb13-da24-e6da-75b3" page="19" hidden="false" collective="false" import="true" type="unit">
       <constraints>
@@ -629,7 +702,7 @@ During a Reaction made in any Phase, a player may not choose to activate a model
       <modifiers>
         <modifier type="add" field="category" value="9231-183c-b97b-63f9">
           <conditions>
-            <condition field="selections" scope="519f-866e-e6fe-20e0" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b7db-bf16-47c5-dc05" type="equalTo"/>
+            <condition field="selections" scope="ancestor" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8cf6-d802-d054-6a86" type="instanceOf"/>
           </conditions>
         </modifier>
       </modifiers>
@@ -648,7 +721,7 @@ During a Reaction made in any Phase, a player may not choose to activate a model
               <modifiers>
                 <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Heavy)">
                   <conditions>
-                    <condition field="selections" scope="ancestor" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9231-183c-b97b-63f9" type="instanceOf"/>
+                    <condition field="selections" scope="519f-866e-e6fe-20e0" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8cf6-d802-d054-6a86" type="instanceOf"/>
                   </conditions>
                 </modifier>
               </modifiers>
@@ -679,17 +752,27 @@ During a Reaction made in any Phase, a player may not choose to activate a model
                 <modifier type="set" field="name" value="Bulky (3)"/>
               </modifiers>
             </infoLink>
-            <infoLink id="2b07-17d2-c7c7-997e" name="Hammer of Wrath (X)" hidden="false" targetId="aec0-c3aa-1e4e-1779" type="rule">
+            <infoLink id="9806-b0f1-d650-c1d5" name="Traitor" hidden="false" targetId="eff2-8b0e-21da-2f0d" type="rule"/>
+            <infoLink name="Hammer of Wrath (X)" id="bc78-5f8a-e461-eca2" hidden="false" targetId="aec0-c3aa-1e4e-1779" type="rule">
               <modifiers>
-                <modifier type="set" field="name" value="Hammer of Wrath (1) [(2) if Infernal Tempest Dominion]"/>
-                <modifier type="set" field="hidden" value="true">
+                <modifier type="set" value="Hammer of Wrath (1)" field="name"/>
+                <modifier type="set" value="true" field="hidden">
                   <conditions>
-                    <condition field="selections" scope="519f-866e-e6fe-20e0" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e4fb-66cd-e07d-609b" type="equalTo"/>
+                    <condition type="instanceOf" value="0" field="selections" scope="ancestor" childId="6508-4f6a-0dc1-8f56" shared="true" includeChildSelections="true"/>
                   </conditions>
                 </modifier>
               </modifiers>
             </infoLink>
-            <infoLink id="9806-b0f1-d650-c1d5" name="Traitor" hidden="false" targetId="eff2-8b0e-21da-2f0d" type="rule"/>
+            <infoLink name="Hammer of Wrath (X)" id="8689-a8d7-fed4-0db4" hidden="false" targetId="aec0-c3aa-1e4e-1779" type="rule">
+              <modifiers>
+                <modifier type="set" value="true" field="hidden">
+                  <conditions>
+                    <condition type="notInstanceOf" value="0" field="selections" scope="ancestor" childId="6508-4f6a-0dc1-8f56" shared="true" includeChildSelections="true"/>
+                  </conditions>
+                </modifier>
+                <modifier type="set" value="Hammer of Wrath (2)" field="name"/>
+              </modifiers>
+            </infoLink>
           </infoLinks>
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="40"/>
@@ -701,14 +784,64 @@ During a Reaction made in any Phase, a player may not choose to activate a model
           <entryLinks>
             <entryLink import="true" name="Brute Armaments" hidden="false" id="b90f-25c1-086a-893e" type="selectionEntry" targetId="663d-649f-e56a-8095"/>
           </entryLinks>
+          <modifiers>
+            <modifier type="add" value="9231-183c-b97b-63f9" field="category">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="8cf6-d802-d054-6a86" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
+              </conditions>
+            </modifier>
+          </modifiers>
         </selectionEntry>
       </selectionEntries>
-      <entryLinks>
-        <entryLink id="7ee4-d117-f5ee-fec6" name="The Ætheric Dominion (Unit)" hidden="false" collective="false" import="true" targetId="caad-e621-38e5-cb5f" type="selectionEntryGroup"/>
-      </entryLinks>
       <costs>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15"/>
       </costs>
+      <modifierGroups>
+        <modifierGroup type="and">
+          <modifiers>
+            <modifier type="add" value="c42-1919-c37e-51f0" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="ca6c-e8cf-7bc1-eaa0" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="9556-82c1-c70a-126e" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="8ed0-3582-f536-c48e" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="f074-f60a-9aa6-c52a" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="3d70-1d54-a791-ac60" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="6508-4f6a-0dc1-8f56" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="e4fb-66cd-e07d-609b" shared="true" includeChildSelections="true" includeChildForces="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="bcf6-8350-9099-1e91" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="9508-8124-d34a-500a" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="8cf6-d802-d054-6a86" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="b7db-bf16-47c5-dc05" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="a1d4-4662-c944-19cc" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="1214-3abe-c6d1-2038" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="2774-1a32-f196-be76" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="945c-b969-75eb-19d9" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </modifierGroup>
+      </modifierGroups>
     </selectionEntry>
     <selectionEntry type="upgrade" import="true" name="Brute Armaments" hidden="false" id="663d-649f-e56a-8095" publicationId="cb13-da24-e6da-75b3" page="18">
       <constraints>

--- a/2022 - Daemons - Bound Daemons.cat
+++ b/2022 - Daemons - Bound Daemons.cat
@@ -314,7 +314,7 @@ The End and the Death – When fighting in a Challenge, successful Invulnerable 
               <modifiers>
                 <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Heavy)">
                   <conditions>
-                    <condition field="selections" scope="89f7-b7a1-aab2-e47a" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8cf6-d802-d054-6a86" type="instanceOf"/>
+                    <condition field="selections" scope="77cd-426a-d300-31a1" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9231-183c-b97b-63f9" type="instanceOf"/>
                   </conditions>
                 </modifier>
               </modifiers>
@@ -378,6 +378,13 @@ The End and the Death – When fighting in a Challenge, successful Invulnerable 
           <entryLinks>
             <entryLink import="true" name="Brute Armaments" hidden="false" id="ca28-a223-5bf2-7061" type="selectionEntry" targetId="663d-649f-e56a-8095"/>
           </entryLinks>
+          <modifiers>
+            <modifier type="add" value="9231-183c-b97b-63f9" field="category">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="8cf6-d802-d054-6a86" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
+              </conditions>
+            </modifier>
+          </modifiers>
         </selectionEntry>
         <selectionEntry id="6979-74bc-2519-6bba" name="Bound Daemon Regent" hidden="false" collective="false" import="true" type="model">
           <constraints>
@@ -389,7 +396,7 @@ The End and the Death – When fighting in a Challenge, successful Invulnerable 
               <modifiers>
                 <modifier type="append" value="(Heavy)" field="ddd7-6f5c-a939-b69e">
                   <conditions>
-                    <condition type="instanceOf" value="1" field="selections" scope="89f7-b7a1-aab2-e47a" childId="8cf6-d802-d054-6a86" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
+                    <condition type="instanceOf" value="1" field="selections" scope="6979-74bc-2519-6bba" childId="9231-183c-b97b-63f9" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
                   </conditions>
                 </modifier>
               </modifiers>
@@ -478,6 +485,13 @@ The End and the Death – When fighting in a Challenge, successful Invulnerable 
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
           </costs>
+          <modifiers>
+            <modifier type="add" value="9231-183c-b97b-63f9" field="category">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="8cf6-d802-d054-6a86" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
+              </conditions>
+            </modifier>
+          </modifiers>
         </selectionEntry>
       </selectionEntries>
       <costs>
@@ -700,9 +714,9 @@ During a Reaction made in any Phase, a player may not choose to activate a model
     </selectionEntry>
     <selectionEntry id="519f-866e-e6fe-20e0" name="Bound Daemon Brutes" publicationId="cb13-da24-e6da-75b3" page="18" hidden="false" collective="false" import="true" type="unit">
       <modifiers>
-        <modifier type="add" field="category" value="9231-183c-b97b-63f9">
+        <modifier type="add" value="9231-183c-b97b-63f9" field="category">
           <conditions>
-            <condition field="selections" scope="ancestor" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8cf6-d802-d054-6a86" type="instanceOf"/>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="8cf6-d802-d054-6a86" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
           </conditions>
         </modifier>
       </modifiers>
@@ -721,7 +735,7 @@ During a Reaction made in any Phase, a player may not choose to activate a model
               <modifiers>
                 <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Heavy)">
                   <conditions>
-                    <condition field="selections" scope="519f-866e-e6fe-20e0" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8cf6-d802-d054-6a86" type="instanceOf"/>
+                    <condition type="instanceOf" value="1" field="selections" scope="12a1-9b89-fe2e-29dd" childId="9231-183c-b97b-63f9" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
                   </conditions>
                 </modifier>
               </modifiers>
@@ -816,7 +830,7 @@ During a Reaction made in any Phase, a player may not choose to activate a model
             </modifier>
             <modifier type="add" value="6508-4f6a-0dc1-8f56" field="category">
               <conditions>
-                <condition type="greaterThan" value="0" field="selections" scope="force" childId="e4fb-66cd-e07d-609b" shared="true" includeChildSelections="true" includeChildForces="true"/>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="e4fb-66cd-e07d-609b" shared="true" includeChildSelections="true" includeChildForces="false"/>
               </conditions>
             </modifier>
             <modifier type="add" value="bcf6-8350-9099-1e91" field="category">

--- a/2022 - Daemons - Bound Daemons.cat
+++ b/2022 - Daemons - Bound Daemons.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="e545-295b-4cd9-f235" name="Daemons - Bound Daemons" revision="11" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="56" type="catalogue">
+<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="e545-295b-4cd9-f235" name="Daemons - Bound Daemons" revision="12" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="56" type="catalogue">
   <entryLinks>
     <entryLink id="250f-d164-bb7e-7025" name="Bound Daemon Brutes" hidden="false" collective="false" import="false" targetId="519f-866e-e6fe-20e0" type="selectionEntry">
       <modifiers>
@@ -293,9 +293,9 @@ The End and the Death – When fighting in a Challenge, successful Invulnerable 
     </selectionEntry>
     <selectionEntry id="89f7-b7a1-aab2-e47a" name="Bound Daemon Regent" publicationId="cb13-da24-e6da-75b3" page="17" hidden="false" collective="false" import="true" type="unit">
       <modifiers>
-        <modifier type="add" field="category" value="9231-183c-b97b-63f9">
+        <modifier type="add" value="9231-183c-b97b-63f9" field="category">
           <conditions>
-            <condition field="selections" scope="ancestor" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8cf6-d802-d054-6a86" type="instanceOf"/>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="8cf6-d802-d054-6a86" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
           </conditions>
         </modifier>
       </modifiers>
@@ -347,24 +347,19 @@ The End and the Death – When fighting in a Challenge, successful Invulnerable 
             </infoLink>
             <infoLink id="9366-e6e8-3161-e418" name="Traitor" hidden="false" targetId="eff2-8b0e-21da-2f0d" type="rule"/>
             <infoLink id="9c3d-13ec-4b8a-6a23" name="Chosen Warriors" hidden="false" targetId="13d1-9270-6539-08ed" type="rule"/>
-            <infoLink name="Hammer of Wrath (X)" id="e109-ede2-f519-f47e" hidden="false" targetId="aec0-c3aa-1e4e-1779" type="rule">
+            <infoLink name="Hammer of Wrath (X)" id="cf37-6a2a-59e8-a5ed" hidden="false" targetId="aec0-c3aa-1e4e-1779" type="rule">
               <modifiers>
-                <modifier type="set" value="Hammer of Wrath (1)" field="name"/>
-                <modifier type="set" value="true" field="hidden">
+                <modifier type="set" value="Hammer of Wrath (" field="name"/>
+                <modifier type="append" value="1 [IT X])" field="name">
                   <conditions>
-                    <condition type="instanceOf" value="0" field="selections" scope="89f7-b7a1-aab2-e47a" childId="6508-4f6a-0dc1-8f56" shared="true" includeChildSelections="true"/>
+                    <condition type="notInstanceOf" value="0" field="selections" scope="ancestor" childId="6508-4f6a-0dc1-8f56" shared="true" includeChildSelections="true"/>
                   </conditions>
                 </modifier>
-              </modifiers>
-            </infoLink>
-            <infoLink name="Hammer of Wrath (X)" id="dec4-3894-b516-b609" hidden="false" targetId="aec0-c3aa-1e4e-1779" type="rule">
-              <modifiers>
-                <modifier type="set" value="true" field="hidden">
+                <modifier type="append" value="2 - Deflagerate [IT ✓])" field="name">
                   <conditions>
-                    <condition type="notInstanceOf" value="0" field="selections" scope="89f7-b7a1-aab2-e47a" childId="6508-4f6a-0dc1-8f56" shared="true" includeChildSelections="true"/>
+                    <condition type="instanceOf" value="0" field="selections" scope="ancestor" childId="6508-4f6a-0dc1-8f56" shared="true" includeChildSelections="true"/>
                   </conditions>
                 </modifier>
-                <modifier type="set" value="Hammer of Wrath (2)" field="name"/>
               </modifiers>
             </infoLink>
           </infoLinks>
@@ -376,7 +371,7 @@ The End and the Death – When fighting in a Challenge, successful Invulnerable 
             <categoryLink targetId="40f3-05e8-5ddc-636a" id="7c92-d8f4-4b19-82f0" name="Bound Sub-type" primary="false"/>
           </categoryLinks>
           <entryLinks>
-            <entryLink import="true" name="Brute Armaments" hidden="false" id="ca28-a223-5bf2-7061" type="selectionEntry" targetId="663d-649f-e56a-8095"/>
+            <entryLink import="true" name="Brute Armaments" hidden="false" id="ca28-a223-5bf2-7061" type="selectionEntry" targetId="663d-649f-e56a-8095" collective="true"/>
           </entryLinks>
           <modifiers>
             <modifier type="add" value="9231-183c-b97b-63f9" field="category">
@@ -428,24 +423,19 @@ The End and the Death – When fighting in a Challenge, successful Invulnerable 
               </modifiers>
             </infoLink>
             <infoLink id="bfa4-05a9-a6cd-02a4" name="Traitor" hidden="false" targetId="eff2-8b0e-21da-2f0d" type="rule"/>
-            <infoLink name="Hammer of Wrath (X)" id="8054-b5ed-1933-f818" hidden="false" targetId="aec0-c3aa-1e4e-1779" type="rule">
+            <infoLink name="Hammer of Wrath (X)" id="9e35-b2b7-fdc4-cfce" hidden="false" targetId="aec0-c3aa-1e4e-1779" type="rule">
               <modifiers>
-                <modifier type="set" value="Hammer of Wrath (1)" field="name"/>
-                <modifier type="set" value="true" field="hidden">
+                <modifier type="set" value="Hammer of Wrath (" field="name"/>
+                <modifier type="append" value="1 [IT X])" field="name">
                   <conditions>
-                    <condition type="instanceOf" value="0" field="selections" scope="89f7-b7a1-aab2-e47a" childId="6508-4f6a-0dc1-8f56" shared="true" includeChildSelections="true"/>
+                    <condition type="notInstanceOf" value="0" field="selections" scope="ancestor" childId="6508-4f6a-0dc1-8f56" shared="true" includeChildSelections="true"/>
                   </conditions>
                 </modifier>
-              </modifiers>
-            </infoLink>
-            <infoLink name="Hammer of Wrath (X)" id="e937-da2a-d3b2-5b6c" hidden="false" targetId="aec0-c3aa-1e4e-1779" type="rule">
-              <modifiers>
-                <modifier type="set" value="true" field="hidden">
+                <modifier type="append" value="2 - Deflagerate [IT ✓])" field="name">
                   <conditions>
-                    <condition type="notInstanceOf" value="0" field="selections" scope="89f7-b7a1-aab2-e47a" childId="6508-4f6a-0dc1-8f56" shared="true" includeChildSelections="true"/>
+                    <condition type="instanceOf" value="0" field="selections" scope="ancestor" childId="6508-4f6a-0dc1-8f56" shared="true" includeChildSelections="true"/>
                   </conditions>
                 </modifier>
-                <modifier type="set" value="Hammer of Wrath (2)" field="name"/>
               </modifiers>
             </infoLink>
           </infoLinks>
@@ -767,24 +757,19 @@ During a Reaction made in any Phase, a player may not choose to activate a model
               </modifiers>
             </infoLink>
             <infoLink id="9806-b0f1-d650-c1d5" name="Traitor" hidden="false" targetId="eff2-8b0e-21da-2f0d" type="rule"/>
-            <infoLink name="Hammer of Wrath (X)" id="bc78-5f8a-e461-eca2" hidden="false" targetId="aec0-c3aa-1e4e-1779" type="rule">
+            <infoLink name="Hammer of Wrath (X)" id="a2b7-dc16-7e2b-598f" hidden="false" targetId="aec0-c3aa-1e4e-1779" type="rule">
               <modifiers>
-                <modifier type="set" value="Hammer of Wrath (1)" field="name"/>
-                <modifier type="set" value="true" field="hidden">
-                  <conditions>
-                    <condition type="instanceOf" value="0" field="selections" scope="ancestor" childId="6508-4f6a-0dc1-8f56" shared="true" includeChildSelections="true"/>
-                  </conditions>
-                </modifier>
-              </modifiers>
-            </infoLink>
-            <infoLink name="Hammer of Wrath (X)" id="8689-a8d7-fed4-0db4" hidden="false" targetId="aec0-c3aa-1e4e-1779" type="rule">
-              <modifiers>
-                <modifier type="set" value="true" field="hidden">
+                <modifier type="set" value="Hammer of Wrath (" field="name"/>
+                <modifier type="append" value="1 [IT X])" field="name">
                   <conditions>
                     <condition type="notInstanceOf" value="0" field="selections" scope="ancestor" childId="6508-4f6a-0dc1-8f56" shared="true" includeChildSelections="true"/>
                   </conditions>
                 </modifier>
-                <modifier type="set" value="Hammer of Wrath (2)" field="name"/>
+                <modifier type="append" value="2 - Deflagerate [IT ✓])" field="name">
+                  <conditions>
+                    <condition type="instanceOf" value="0" field="selections" scope="ancestor" childId="6508-4f6a-0dc1-8f56" shared="true" includeChildSelections="true"/>
+                  </conditions>
+                </modifier>
               </modifiers>
             </infoLink>
           </infoLinks>
@@ -796,7 +781,7 @@ During a Reaction made in any Phase, a player may not choose to activate a model
             <categoryLink targetId="40f3-05e8-5ddc-636a" id="776a-d8e9-4e56-8a41" name="Bound Sub-type" primary="false"/>
           </categoryLinks>
           <entryLinks>
-            <entryLink import="true" name="Brute Armaments" hidden="false" id="b90f-25c1-086a-893e" type="selectionEntry" targetId="663d-649f-e56a-8095"/>
+            <entryLink import="true" name="Brute Armaments" hidden="false" id="b90f-25c1-086a-893e" type="selectionEntry" targetId="663d-649f-e56a-8095" collective="true"/>
           </entryLinks>
           <modifiers>
             <modifier type="add" value="9231-183c-b97b-63f9" field="category">
@@ -857,7 +842,7 @@ During a Reaction made in any Phase, a player may not choose to activate a model
         </modifierGroup>
       </modifierGroups>
     </selectionEntry>
-    <selectionEntry type="upgrade" import="true" name="Brute Armaments" hidden="false" id="663d-649f-e56a-8095" publicationId="cb13-da24-e6da-75b3" page="18">
+    <selectionEntry type="upgrade" import="true" name="Brute Armaments" hidden="false" id="663d-649f-e56a-8095" publicationId="cb13-da24-e6da-75b3" page="18" collective="true">
       <constraints>
         <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="0987-0e69-34d6-dcd8" includeChildSelections="false"/>
         <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="4b0d-7e61-907c-6384" includeChildSelections="false"/>

--- a/2022 - Daemons - Daemons of the Ruinstorm.cat
+++ b/2022 - Daemons - Daemons of the Ruinstorm.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" library="false" id="ac63-5340-2e9e-1eb6" name="Daemons - Daemons of the Ruinstorm" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="77" revision="14" battleScribeVersion="2.03" type="catalogue">
+<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" library="false" id="ac63-5340-2e9e-1eb6" name="Daemons - Daemons of the Ruinstorm" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="77" revision="15" battleScribeVersion="2.03" type="catalogue">
   <entryLinks>
     <entryLink import="false" name="Daemons of the Ruinstorm" hidden="false" type="selectionEntry" id="e271-f450-1c28-5b7b" targetId="afca-3047-fb26-d097">
       <constraints>
@@ -162,7 +162,7 @@
               <modifiers>
                 <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Heavy)">
                   <conditions>
-                    <condition field="selections" scope="2f3f-adc4-b19f-a5c7" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b7db-bf16-47c5-dc05" type="atLeast"/>
+                    <condition type="instanceOf" value="1" field="selections" scope="2f3f-adc4-b19f-a5c7" childId="8cf6-d802-d054-6a86" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
                   </conditions>
                 </modifier>
               </modifiers>
@@ -179,7 +179,6 @@
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="350"/>
       </costs>
       <entryLinks>
-        <entryLink import="true" name="The Ætheric Dominion (Unit)" hidden="false" type="selectionEntryGroup" id="d12d-ef33-dfdb-2ec" targetId="caad-e621-38e5-cb5f"/>
         <entryLink import="true" name="Warlord" hidden="false" type="selectionEntry" id="c7e9-b5ee-aac-92c0" targetId="0176-56a3-d590-b103"/>
         <entryLink import="true" name="Warlord Traits (Ruinstorm Daemons)" hidden="false" type="selectionEntryGroup" id="2a1-8be4-17b-75ca" targetId="2f76-74c1-d329-d3ab"/>
       </entryLinks>
@@ -211,7 +210,7 @@
             <modifier type="set" value="Hammer of Wrath (1)" field="name"/>
             <modifier type="set" value="true" field="hidden">
               <conditions>
-                <condition type="equalTo" value="0" field="selections" scope="force" childId="e4fb-66cd-e07d-609b" shared="true" includeChildSelections="true"/>
+                <condition type="notInstanceOf" value="0" field="selections" scope="ancestor" childId="6508-4f6a-0dc1-8f56" shared="true"/>
               </conditions>
             </modifier>
           </modifiers>
@@ -285,10 +284,56 @@
       <modifiers>
         <modifier type="add" field="category" value="9231-183c-b97b-63f9">
           <conditions>
-            <condition field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b7db-bf16-47c5-dc05" type="atLeast"/>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="8cf6-d802-d054-6a86" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
           </conditions>
         </modifier>
       </modifiers>
+      <modifierGroups>
+        <modifierGroup type="and">
+          <modifiers>
+            <modifier type="add" value="c42-1919-c37e-51f0" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="ca6c-e8cf-7bc1-eaa0" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="9556-82c1-c70a-126e" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="8ed0-3582-f536-c48e" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="f074-f60a-9aa6-c52a" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="3d70-1d54-a791-ac60" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="6508-4f6a-0dc1-8f56" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="e4fb-66cd-e07d-609b" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="bcf6-8350-9099-1e91" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="9508-8124-d34a-500a" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="8cf6-d802-d054-6a86" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="b7db-bf16-47c5-dc05" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="a1d4-4662-c944-19cc" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="1214-3abe-c6d1-2038" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="2774-1a32-f196-be76" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="945c-b969-75eb-19d9" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </modifierGroup>
+      </modifierGroups>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Ruinstorm Daemon Hierarch" hidden="false" id="ae8b-ee65-95b6-a8f9" publicationId="8775-88f5-cfdd-24f6" page="7">
       <selectionEntries>
@@ -315,7 +360,7 @@
               <modifiers>
                 <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Heavy)">
                   <conditions>
-                    <condition field="selections" scope="ae8b-ee65-95b6-a8f9" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b7db-bf16-47c5-dc05" type="atLeast"/>
+                    <condition type="instanceOf" value="1" field="selections" scope="ae8b-ee65-95b6-a8f9" childId="8cf6-d802-d054-6a86" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
                   </conditions>
                 </modifier>
               </modifiers>
@@ -331,7 +376,6 @@
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="250"/>
       </costs>
       <entryLinks>
-        <entryLink import="true" name="The Ætheric Dominion (Unit)" hidden="false" type="selectionEntryGroup" id="d43f-71c8-cbf2-cff0" targetId="caad-e621-38e5-cb5f"/>
         <entryLink import="true" name="Infernal Armaments" hidden="false" type="selectionEntry" id="40ef-9284-1d09-74c0" targetId="9abc-11e8-9031-d104">
           <constraints>
             <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="de9-d9cd-9f99-404d"/>
@@ -368,7 +412,7 @@
             <modifier type="set" value="Hammer of Wrath (1)" field="name"/>
             <modifier type="set" value="true" field="hidden">
               <conditions>
-                <condition type="equalTo" value="0" field="selections" scope="force" childId="e4fb-66cd-e07d-609b" shared="true" includeChildSelections="true"/>
+                <condition type="notInstanceOf" value="0" field="selections" scope="ancestor" childId="6508-4f6a-0dc1-8f56" shared="true"/>
               </conditions>
             </modifier>
           </modifiers>
@@ -421,10 +465,56 @@
       <modifiers>
         <modifier type="add" field="category" value="9231-183c-b97b-63f9">
           <conditions>
-            <condition field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b7db-bf16-47c5-dc05" type="atLeast"/>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="8cf6-d802-d054-6a86" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
           </conditions>
         </modifier>
       </modifiers>
+      <modifierGroups>
+        <modifierGroup type="and">
+          <modifiers>
+            <modifier type="add" value="c42-1919-c37e-51f0" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="ca6c-e8cf-7bc1-eaa0" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="9556-82c1-c70a-126e" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="8ed0-3582-f536-c48e" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="f074-f60a-9aa6-c52a" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="3d70-1d54-a791-ac60" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="6508-4f6a-0dc1-8f56" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="e4fb-66cd-e07d-609b" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="bcf6-8350-9099-1e91" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="9508-8124-d34a-500a" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="8cf6-d802-d054-6a86" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="b7db-bf16-47c5-dc05" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="a1d4-4662-c944-19cc" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="1214-3abe-c6d1-2038" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="2774-1a32-f196-be76" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="945c-b969-75eb-19d9" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </modifierGroup>
+      </modifierGroups>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Ruinstorm Daemon Harbinger" hidden="false" id="5a2e-abe2-3044-3c1c" publicationId="8775-88f5-cfdd-24f6" page="8">
       <selectionEntries>
@@ -451,7 +541,7 @@
               <modifiers>
                 <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Heavy)">
                   <conditions>
-                    <condition field="selections" scope="5a2e-abe2-3044-3c1c" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b7db-bf16-47c5-dc05" type="atLeast"/>
+                    <condition type="instanceOf" value="1" field="selections" scope="5a2e-abe2-3044-3c1c" childId="8cf6-d802-d054-6a86" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
                   </conditions>
                 </modifier>
               </modifiers>
@@ -473,7 +563,7 @@
                 <modifier type="set" value="Hammer of Wrath (1)" field="name"/>
                 <modifier type="set" value="true" field="hidden">
                   <conditions>
-                    <condition type="equalTo" value="0" field="selections" scope="force" childId="e4fb-66cd-e07d-609b" shared="true" includeChildSelections="true"/>
+                    <condition type="notInstanceOf" value="0" field="selections" scope="ancestor" childId="6508-4f6a-0dc1-8f56" shared="true"/>
                   </conditions>
                 </modifier>
               </modifiers>
@@ -543,7 +633,7 @@
               <modifiers>
                 <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Heavy)">
                   <conditions>
-                    <condition field="selections" scope="5a2e-abe2-3044-3c1c" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b7db-bf16-47c5-dc05" type="atLeast"/>
+                    <condition type="instanceOf" value="1" field="selections" scope="5a2e-abe2-3044-3c1c" childId="8cf6-d802-d054-6a86" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
                   </conditions>
                 </modifier>
               </modifiers>
@@ -562,18 +652,24 @@
               </modifiers>
             </infoLink>
             <infoLink id="9e4d-875f-444c-e9ce" name="Traitor" hidden="false" targetId="eff2-8b0e-21da-2f0d" type="rule"/>
-            <infoLink id="44f3-3000-56bb-5d25" name="Hammer of Wrath (X)" hidden="false" targetId="aec0-c3aa-1e4e-1779" type="rule">
+            <infoLink name="Hammer of Wrath (X)" id="8fd5-2720-429c-209f" hidden="false" targetId="aec0-c3aa-1e4e-1779" type="rule">
               <modifiers>
-                <modifier type="set" field="name" value="Hammer of Wrath (1)">
+                <modifier type="set" value="Hammer of Wrath (1)" field="name"/>
+                <modifier type="set" value="true" field="hidden">
                   <conditions>
-                    <condition type="equalTo" value="0" field="selections" scope="force" childId="e4fb-66cd-e07d-609b" shared="true" includeChildSelections="true"/>
+                    <condition type="instanceOf" value="0" field="selections" scope="ancestor" childId="6508-4f6a-0dc1-8f56" shared="true" includeChildSelections="true"/>
                   </conditions>
                 </modifier>
-                <modifier type="set" field="name" value="Hammer of Wrath (2)">
+              </modifiers>
+            </infoLink>
+            <infoLink name="Hammer of Wrath (X)" id="1ab2-8c64-cb89-261d" hidden="false" targetId="aec0-c3aa-1e4e-1779" type="rule">
+              <modifiers>
+                <modifier type="set" value="true" field="hidden">
                   <conditions>
-                    <condition type="atLeast" value="1" field="selections" scope="force" childId="e4fb-66cd-e07d-609b" shared="true" includeChildSelections="true"/>
+                    <condition type="notInstanceOf" value="0" field="selections" scope="ancestor" childId="6508-4f6a-0dc1-8f56" shared="true" includeChildSelections="true"/>
                   </conditions>
                 </modifier>
+                <modifier type="set" value="Hammer of Wrath (2)" field="name"/>
               </modifiers>
             </infoLink>
           </infoLinks>
@@ -601,19 +697,62 @@
       <costs>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="135"/>
       </costs>
-      <entryLinks>
-        <entryLink import="true" name="The Ætheric Dominion (Unit)" hidden="false" type="selectionEntryGroup" id="5d3d-4561-ca3-1b5a" targetId="caad-e621-38e5-cb5f"/>
-      </entryLinks>
       <categoryLinks>
         <categoryLink targetId="e699-d9cd-e68e-46d9" id="e2f3-8a17-7b35-4909" primary="false" name="Daemon Unit Type"/>
       </categoryLinks>
       <modifiers>
         <modifier type="add" field="category" value="9231-183c-b97b-63f9">
           <conditions>
-            <condition field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b7db-bf16-47c5-dc05" type="atLeast"/>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="8cf6-d802-d054-6a86" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
           </conditions>
         </modifier>
       </modifiers>
+      <modifierGroups>
+        <modifierGroup type="and">
+          <modifiers>
+            <modifier type="add" value="c42-1919-c37e-51f0" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="ca6c-e8cf-7bc1-eaa0" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="9556-82c1-c70a-126e" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="8ed0-3582-f536-c48e" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="f074-f60a-9aa6-c52a" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="3d70-1d54-a791-ac60" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="6508-4f6a-0dc1-8f56" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="e4fb-66cd-e07d-609b" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="bcf6-8350-9099-1e91" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="9508-8124-d34a-500a" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="8cf6-d802-d054-6a86" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="b7db-bf16-47c5-dc05" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="a1d4-4662-c944-19cc" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="1214-3abe-c6d1-2038" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="2774-1a32-f196-be76" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="945c-b969-75eb-19d9" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </modifierGroup>
+      </modifierGroups>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Ruinstorm Daemon Brutes" hidden="false" id="2219-cb60-b52-a36c" publicationId="8775-88f5-cfdd-24f6" page="9">
       <selectionEntries>
@@ -643,7 +782,7 @@
               <modifiers>
                 <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Heavy)">
                   <conditions>
-                    <condition field="selections" scope="2219-cb60-b52-a36c" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b7db-bf16-47c5-dc05" type="atLeast"/>
+                    <condition type="instanceOf" value="1" field="selections" scope="2219-cb60-b52-a36c" childId="8cf6-d802-d054-6a86" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
                   </conditions>
                 </modifier>
               </modifiers>
@@ -657,9 +796,6 @@
       <costs>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15"/>
       </costs>
-      <entryLinks>
-        <entryLink import="true" name="The Ætheric Dominion (Unit)" hidden="false" type="selectionEntryGroup" id="b5cc-4b7f-66f9-183f" targetId="caad-e621-38e5-cb5f"/>
-      </entryLinks>
       <categoryLinks>
         <categoryLink targetId="e699-d9cd-e68e-46d9" id="eddf-34f6-417f-401a" primary="false" name="Daemon Unit Type"/>
       </categoryLinks>
@@ -675,25 +811,31 @@
             <modifier type="set" field="name" value="Æthereal Invulnerability (5+)"/>
           </modifiers>
         </infoLink>
-        <infoLink id="fd20-b609-3248-6d51" name="Hammer of Wrath (X)" hidden="false" targetId="aec0-c3aa-1e4e-1779" type="rule">
+        <infoLink name="Hammer of Wrath (X)" id="4005-fbfc-51f8-3dc4" hidden="false" targetId="aec0-c3aa-1e4e-1779" type="rule">
           <modifiers>
-            <modifier type="set" field="name" value="Hammer of Wrath (1)">
+            <modifier type="set" value="Hammer of Wrath (1)" field="name"/>
+            <modifier type="set" value="true" field="hidden">
               <conditions>
-                <condition type="equalTo" value="0" field="selections" scope="force" childId="e4fb-66cd-e07d-609b" shared="true" includeChildSelections="true"/>
+                <condition type="instanceOf" value="0" field="selections" scope="ancestor" childId="6508-4f6a-0dc1-8f56" shared="true" includeChildSelections="true"/>
               </conditions>
             </modifier>
-            <modifier type="set" field="name" value="Hammer of Wrath (2)">
+          </modifiers>
+        </infoLink>
+        <infoLink name="Hammer of Wrath (X)" id="05eb-6421-0257-5bdc" hidden="false" targetId="aec0-c3aa-1e4e-1779" type="rule">
+          <modifiers>
+            <modifier type="set" value="true" field="hidden">
               <conditions>
-                <condition type="atLeast" value="1" field="selections" scope="force" childId="e4fb-66cd-e07d-609b" shared="true" includeChildSelections="true"/>
+                <condition type="notInstanceOf" value="0" field="selections" scope="ancestor" childId="6508-4f6a-0dc1-8f56" shared="true" includeChildSelections="true"/>
               </conditions>
             </modifier>
+            <modifier type="set" value="Hammer of Wrath (2)" field="name"/>
           </modifiers>
         </infoLink>
       </infoLinks>
       <modifiers>
         <modifier type="add" field="category" value="9231-183c-b97b-63f9">
           <conditions>
-            <condition field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b7db-bf16-47c5-dc05" type="atLeast"/>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="8cf6-d802-d054-6a86" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
           </conditions>
         </modifier>
       </modifiers>
@@ -713,13 +855,58 @@
           </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
+      <modifierGroups>
+        <modifierGroup type="and">
+          <modifiers>
+            <modifier type="add" value="c42-1919-c37e-51f0" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="ca6c-e8cf-7bc1-eaa0" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="9556-82c1-c70a-126e" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="8ed0-3582-f536-c48e" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="f074-f60a-9aa6-c52a" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="3d70-1d54-a791-ac60" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="6508-4f6a-0dc1-8f56" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="e4fb-66cd-e07d-609b" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="bcf6-8350-9099-1e91" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="9508-8124-d34a-500a" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="8cf6-d802-d054-6a86" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="b7db-bf16-47c5-dc05" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="a1d4-4662-c944-19cc" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="1214-3abe-c6d1-2038" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="2774-1a32-f196-be76" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="945c-b969-75eb-19d9" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </modifierGroup>
+      </modifierGroups>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Ruinstorm Daemon Beasts" hidden="false" id="69ad-927-c71b-6b24" publicationId="8775-88f5-cfdd-24f6" page="10">
       <costs>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20"/>
       </costs>
       <entryLinks>
-        <entryLink import="true" name="The Ætheric Dominion (Unit)" hidden="false" type="selectionEntryGroup" id="db7d-815a-fd7-6518" targetId="caad-e621-38e5-cb5f"/>
         <entryLink import="true" name="Ætheric Flight" hidden="false" type="selectionEntry" id="7f27-c850-ccf-95ab" targetId="7647-8112-eaf7-fbea">
           <modifiers>
             <modifier type="increment" value="5" field="d2ee-04cb-5f8a-2642">
@@ -750,7 +937,7 @@
             <modifier type="set" value="Hammer of Wrath (1)" field="name"/>
             <modifier type="set" value="true" field="hidden">
               <conditions>
-                <condition type="equalTo" value="0" field="selections" scope="force" childId="e4fb-66cd-e07d-609b" shared="true" includeChildSelections="true"/>
+                <condition type="notInstanceOf" value="0" field="selections" scope="ancestor" childId="6508-4f6a-0dc1-8f56" shared="true"/>
               </conditions>
             </modifier>
           </modifiers>
@@ -785,7 +972,7 @@
                   <modifiers>
                     <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Heavy)">
                       <conditions>
-                        <condition field="selections" scope="69ad-927-c71b-6b24" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b7db-bf16-47c5-dc05" type="atLeast"/>
+                        <condition type="instanceOf" value="1" field="selections" scope="69ad-927-c71b-6b24" childId="8cf6-d802-d054-6a86" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
                       </conditions>
                     </modifier>
                   </modifiers>
@@ -831,7 +1018,7 @@
                   <modifiers>
                     <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Heavy)">
                       <conditions>
-                        <condition field="selections" scope="69ad-927-c71b-6b24" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b7db-bf16-47c5-dc05" type="atLeast"/>
+                        <condition type="instanceOf" value="1" field="selections" scope="69ad-927-c71b-6b24" childId="8cf6-d802-d054-6a86" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
                       </conditions>
                     </modifier>
                   </modifiers>
@@ -862,10 +1049,56 @@
       <modifiers>
         <modifier type="add" field="category" value="9231-183c-b97b-63f9">
           <conditions>
-            <condition field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b7db-bf16-47c5-dc05" type="atLeast"/>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="8cf6-d802-d054-6a86" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
           </conditions>
         </modifier>
       </modifiers>
+      <modifierGroups>
+        <modifierGroup type="and">
+          <modifiers>
+            <modifier type="add" value="c42-1919-c37e-51f0" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="ca6c-e8cf-7bc1-eaa0" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="9556-82c1-c70a-126e" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="8ed0-3582-f536-c48e" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="f074-f60a-9aa6-c52a" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="3d70-1d54-a791-ac60" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="6508-4f6a-0dc1-8f56" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="e4fb-66cd-e07d-609b" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="bcf6-8350-9099-1e91" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="9508-8124-d34a-500a" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="8cf6-d802-d054-6a86" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="b7db-bf16-47c5-dc05" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="a1d4-4662-c944-19cc" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="1214-3abe-c6d1-2038" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="2774-1a32-f196-be76" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="945c-b969-75eb-19d9" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </modifierGroup>
+      </modifierGroups>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Ruinstorm Lesser Daemons" hidden="false" id="157c-7592-a6b9-f96" publicationId="8775-88f5-cfdd-24f6" page="11">
       <selectionEntries>
@@ -895,7 +1128,7 @@
               <modifiers>
                 <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Heavy)">
                   <conditions>
-                    <condition field="selections" scope="157c-7592-a6b9-f96" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b7db-bf16-47c5-dc05" type="atLeast"/>
+                    <condition type="instanceOf" value="1" field="selections" scope="157c-7592-a6b9-f96" childId="8cf6-d802-d054-6a86" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
                   </conditions>
                 </modifier>
               </modifiers>
@@ -910,9 +1143,6 @@
       <costs>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20"/>
       </costs>
-      <entryLinks>
-        <entryLink import="true" name="The Ætheric Dominion (Unit)" hidden="false" type="selectionEntryGroup" id="984b-1653-1706-eaf" targetId="caad-e621-38e5-cb5f"/>
-      </entryLinks>
       <categoryLinks>
         <categoryLink targetId="e699-d9cd-e68e-46d9" id="83d4-7ef0-2bce-18cb" primary="false" name="Daemon Unit Type"/>
         <categoryLink targetId="6399-5c65-7833-1025" id="7bf1-d30-86a3-e2e5" primary="false" name="Line Sub-type"/>
@@ -929,7 +1159,7 @@
             <modifier type="set" value="Hammer of Wrath (1)" field="name"/>
             <modifier type="set" value="true" field="hidden">
               <conditions>
-                <condition type="equalTo" value="0" field="selections" scope="force" childId="e4fb-66cd-e07d-609b" shared="true" includeChildSelections="true"/>
+                <condition type="notInstanceOf" value="0" field="selections" scope="ancestor" childId="6508-4f6a-0dc1-8f56" shared="true"/>
               </conditions>
             </modifier>
           </modifiers>
@@ -958,10 +1188,56 @@
       <modifiers>
         <modifier type="add" field="category" value="9231-183c-b97b-63f9">
           <conditions>
-            <condition field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b7db-bf16-47c5-dc05" type="atLeast"/>
+            <condition field="selections" scope="ancestor" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8cf6-d802-d054-6a86" type="instanceOf"/>
           </conditions>
         </modifier>
       </modifiers>
+      <modifierGroups>
+        <modifierGroup type="and">
+          <modifiers>
+            <modifier type="add" value="c42-1919-c37e-51f0" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="ca6c-e8cf-7bc1-eaa0" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="9556-82c1-c70a-126e" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="8ed0-3582-f536-c48e" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="f074-f60a-9aa6-c52a" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="3d70-1d54-a791-ac60" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="6508-4f6a-0dc1-8f56" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="e4fb-66cd-e07d-609b" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="bcf6-8350-9099-1e91" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="9508-8124-d34a-500a" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="8cf6-d802-d054-6a86" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="b7db-bf16-47c5-dc05" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="a1d4-4662-c944-19cc" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="1214-3abe-c6d1-2038" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="2774-1a32-f196-be76" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="945c-b969-75eb-19d9" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </modifierGroup>
+      </modifierGroups>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Ruinstorm Daemon Swarms" hidden="false" id="bb35-e585-a226-28e" publicationId="8775-88f5-cfdd-24f6" page="12">
       <selectionEntries>
@@ -991,7 +1267,7 @@
               <modifiers>
                 <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Heavy)">
                   <conditions>
-                    <condition field="selections" scope="bb35-e585-a226-28e" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b7db-bf16-47c5-dc05" type="atLeast"/>
+                    <condition type="instanceOf" value="1" field="selections" scope="bb35-e585-a226-28e" childId="8cf6-d802-d054-6a86" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
                   </conditions>
                 </modifier>
               </modifiers>
@@ -1007,9 +1283,6 @@
       <costs>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5"/>
       </costs>
-      <entryLinks>
-        <entryLink import="true" name="The Ætheric Dominion (Unit)" hidden="false" type="selectionEntryGroup" id="8b54-9c7b-7706-f5fb" targetId="caad-e621-38e5-cb5f"/>
-      </entryLinks>
       <categoryLinks>
         <categoryLink targetId="e699-d9cd-e68e-46d9" id="7e4d-5d59-2dfb-7bc" primary="false" name="Daemon Unit Type"/>
         <categoryLink targetId="6399-5c65-7833-1025" id="3401-3a7f-8da3-70a3" primary="false" name="Line Sub-type"/>
@@ -1029,7 +1302,7 @@
             <modifier type="set" value="Hammer of Wrath (1)" field="name"/>
             <modifier type="set" value="true" field="hidden">
               <conditions>
-                <condition type="equalTo" value="0" field="selections" scope="force" childId="e4fb-66cd-e07d-609b" shared="true" includeChildSelections="true"/>
+                <condition type="notInstanceOf" value="0" field="selections" scope="ancestor" childId="6508-4f6a-0dc1-8f56" shared="true"/>
               </conditions>
             </modifier>
           </modifiers>
@@ -1038,10 +1311,56 @@
       <modifiers>
         <modifier type="add" field="category" value="9231-183c-b97b-63f9">
           <conditions>
-            <condition field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b7db-bf16-47c5-dc05" type="atLeast"/>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="8cf6-d802-d054-6a86" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
           </conditions>
         </modifier>
       </modifiers>
+      <modifierGroups>
+        <modifierGroup type="and">
+          <modifiers>
+            <modifier type="add" value="c42-1919-c37e-51f0" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="ca6c-e8cf-7bc1-eaa0" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="9556-82c1-c70a-126e" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="8ed0-3582-f536-c48e" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="f074-f60a-9aa6-c52a" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="3d70-1d54-a791-ac60" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="6508-4f6a-0dc1-8f56" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="e4fb-66cd-e07d-609b" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="bcf6-8350-9099-1e91" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="9508-8124-d34a-500a" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="8cf6-d802-d054-6a86" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="b7db-bf16-47c5-dc05" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="a1d4-4662-c944-19cc" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="1214-3abe-c6d1-2038" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="2774-1a32-f196-be76" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="945c-b969-75eb-19d9" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </modifierGroup>
+      </modifierGroups>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Ruinstorm Daemon Cavalry" hidden="false" id="b7b5-c59a-768c-276c" publicationId="8775-88f5-cfdd-24f6" page="13">
       <selectionEntries>
@@ -1071,7 +1390,7 @@
               <modifiers>
                 <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Heavy)">
                   <conditions>
-                    <condition field="selections" scope="b7b5-c59a-768c-276c" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b7db-bf16-47c5-dc05" type="atLeast"/>
+                    <condition type="instanceOf" value="1" field="selections" scope="b7b5-c59a-768c-276c" childId="8cf6-d802-d054-6a86" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
                   </conditions>
                 </modifier>
               </modifiers>
@@ -1085,9 +1404,6 @@
       <costs>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="50"/>
       </costs>
-      <entryLinks>
-        <entryLink import="true" name="The Ætheric Dominion (Unit)" hidden="false" type="selectionEntryGroup" id="9090-c089-e5b6-db5" targetId="caad-e621-38e5-cb5f"/>
-      </entryLinks>
       <categoryLinks>
         <categoryLink targetId="e699-d9cd-e68e-46d9" id="9407-be20-96bd-e31" primary="false" name="Daemon Unit Type"/>
       </categoryLinks>
@@ -1123,7 +1439,7 @@
             <modifier type="set" value="Hammer of Wrath (1)" field="name"/>
             <modifier type="set" value="true" field="hidden">
               <conditions>
-                <condition type="equalTo" value="0" field="selections" scope="force" childId="e4fb-66cd-e07d-609b" shared="true" includeChildSelections="true"/>
+                <condition type="notInstanceOf" value="0" field="selections" scope="ancestor" childId="6508-4f6a-0dc1-8f56" shared="true"/>
               </conditions>
             </modifier>
           </modifiers>
@@ -1132,10 +1448,56 @@
       <modifiers>
         <modifier type="add" field="category" value="9231-183c-b97b-63f9">
           <conditions>
-            <condition field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b7db-bf16-47c5-dc05" type="atLeast"/>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="8cf6-d802-d054-6a86" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
           </conditions>
         </modifier>
       </modifiers>
+      <modifierGroups>
+        <modifierGroup type="and">
+          <modifiers>
+            <modifier type="add" value="c42-1919-c37e-51f0" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="ca6c-e8cf-7bc1-eaa0" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="9556-82c1-c70a-126e" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="8ed0-3582-f536-c48e" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="f074-f60a-9aa6-c52a" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="3d70-1d54-a791-ac60" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="6508-4f6a-0dc1-8f56" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="e4fb-66cd-e07d-609b" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="bcf6-8350-9099-1e91" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="9508-8124-d34a-500a" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="8cf6-d802-d054-6a86" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="b7db-bf16-47c5-dc05" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="a1d4-4662-c944-19cc" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="1214-3abe-c6d1-2038" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="2774-1a32-f196-be76" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="945c-b969-75eb-19d9" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </modifierGroup>
+      </modifierGroups>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Ruinstorm Daemon Harriers" hidden="false" id="14c1-3063-c9b4-d99b" publicationId="8775-88f5-cfdd-24f6" page="14">
       <selectionEntries>
@@ -1162,7 +1524,7 @@
               <modifiers>
                 <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Heavy)">
                   <conditions>
-                    <condition field="selections" scope="14c1-3063-c9b4-d99b" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b7db-bf16-47c5-dc05" type="atLeast"/>
+                    <condition type="instanceOf" value="1" field="selections" scope="14c1-3063-c9b4-d99b" childId="8cf6-d802-d054-6a86" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
                   </conditions>
                 </modifier>
               </modifiers>
@@ -1177,7 +1539,6 @@
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="150"/>
       </costs>
       <entryLinks>
-        <entryLink import="true" name="The Ætheric Dominion (Unit)" hidden="false" type="selectionEntryGroup" id="8599-7755-d965-7c69" targetId="caad-e621-38e5-cb5f"/>
         <entryLink import="true" name="Immaterial Wings" hidden="false" type="selectionEntry" id="941f-9942-11d8-2dcd" targetId="fd64-626a-d3d4-9b8e">
           <constraints>
             <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="a848-40a2-d07f-da6a"/>
@@ -1199,7 +1560,7 @@
             <modifier type="set" value="Hammer of Wrath (1)" field="name"/>
             <modifier type="set" value="true" field="hidden">
               <conditions>
-                <condition type="equalTo" value="0" field="selections" scope="force" childId="e4fb-66cd-e07d-609b" shared="true" includeChildSelections="true"/>
+                <condition type="notInstanceOf" value="0" field="selections" scope="ancestor" childId="6508-4f6a-0dc1-8f56" shared="true"/>
               </conditions>
             </modifier>
           </modifiers>
@@ -1228,10 +1589,56 @@
       <modifiers>
         <modifier type="add" field="category" value="9231-183c-b97b-63f9">
           <conditions>
-            <condition field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b7db-bf16-47c5-dc05" type="atLeast"/>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="8cf6-d802-d054-6a86" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
           </conditions>
         </modifier>
       </modifiers>
+      <modifierGroups>
+        <modifierGroup type="and">
+          <modifiers>
+            <modifier type="add" value="c42-1919-c37e-51f0" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="ca6c-e8cf-7bc1-eaa0" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="9556-82c1-c70a-126e" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="8ed0-3582-f536-c48e" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="f074-f60a-9aa6-c52a" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="3d70-1d54-a791-ac60" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="6508-4f6a-0dc1-8f56" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="e4fb-66cd-e07d-609b" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="bcf6-8350-9099-1e91" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="9508-8124-d34a-500a" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="8cf6-d802-d054-6a86" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="b7db-bf16-47c5-dc05" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="a1d4-4662-c944-19cc" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="1214-3abe-c6d1-2038" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="2774-1a32-f196-be76" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="945c-b969-75eb-19d9" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </modifierGroup>
+      </modifierGroups>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Greater Ruinstorm Daemon Beast" hidden="false" id="41a0-6caa-af06-3684" publicationId="8775-88f5-cfdd-24f6" page="15">
       <selectionEntries>
@@ -1261,7 +1668,7 @@
               <modifiers>
                 <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Heavy)">
                   <conditions>
-                    <condition field="selections" scope="41a0-6caa-af06-3684" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b7db-bf16-47c5-dc05" type="atLeast"/>
+                    <condition type="instanceOf" value="1" field="selections" scope="41a0-6caa-af06-3684" childId="8cf6-d802-d054-6a86" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
                   </conditions>
                 </modifier>
               </modifiers>
@@ -1277,7 +1684,6 @@
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25"/>
       </costs>
       <entryLinks>
-        <entryLink import="true" name="The Ætheric Dominion (Unit)" hidden="false" type="selectionEntryGroup" id="f88e-efeb-fa59-6265" targetId="caad-e621-38e5-cb5f"/>
         <entryLink import="true" name="Infernal Armaments" hidden="false" type="selectionEntry" id="35a5-f23c-e05c-e958" targetId="9abc-11e8-9031-d104">
           <constraints>
             <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="9219-1720-fe80-925b"/>
@@ -1295,29 +1701,81 @@
             <modifier type="set" field="name" value="Æthereal Invulnerability (5+)"/>
           </modifiers>
         </infoLink>
-        <infoLink id="fcac-c911-350e-eac7" name="Hammer of Wrath (X)" hidden="false" targetId="aec0-c3aa-1e4e-1779" type="rule">
+        <infoLink id="3fca-6f8-15aa-91c0" name="Traitor" hidden="false" targetId="eff2-8b0e-21da-2f0d" type="rule"/>
+        <infoLink name="Hammer of Wrath (X)" id="675e-0a1f-0703-ddf9" hidden="false" targetId="aec0-c3aa-1e4e-1779" type="rule">
           <modifiers>
-            <modifier type="set" field="name" value="Hammer of Wrath (3)">
+            <modifier type="set" value="Hammer of Wrath (3)" field="name"/>
+            <modifier type="set" value="true" field="hidden">
               <conditions>
-                <condition type="equalTo" value="0" field="selections" scope="parent" childId="e4fb-66cd-e07d-609b" shared="true"/>
-              </conditions>
-            </modifier>
-            <modifier type="set" field="name" value="Hammer of Wrath (3+1)">
-              <conditions>
-                <condition type="atLeast" value="1" field="selections" scope="parent" childId="e4fb-66cd-e07d-609b" shared="true"/>
+                <condition type="instanceOf" value="0" field="selections" scope="ancestor" childId="6508-4f6a-0dc1-8f56" shared="true" includeChildSelections="true"/>
               </conditions>
             </modifier>
           </modifiers>
         </infoLink>
-        <infoLink id="3fca-6f8-15aa-91c0" name="Traitor" hidden="false" targetId="eff2-8b0e-21da-2f0d" type="rule"/>
+        <infoLink name="Hammer of Wrath (X)" id="07d5-ba21-25a0-addd" hidden="false" targetId="aec0-c3aa-1e4e-1779" type="rule">
+          <modifiers>
+            <modifier type="set" value="true" field="hidden">
+              <conditions>
+                <condition type="notInstanceOf" value="0" field="selections" scope="ancestor" childId="6508-4f6a-0dc1-8f56" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="set" value="Hammer of Wrath (3+1)" field="name"/>
+          </modifiers>
+        </infoLink>
       </infoLinks>
       <modifiers>
         <modifier type="add" field="category" value="9231-183c-b97b-63f9">
           <conditions>
-            <condition field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b7db-bf16-47c5-dc05" type="atLeast"/>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="8cf6-d802-d054-6a86" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
           </conditions>
         </modifier>
       </modifiers>
+      <modifierGroups>
+        <modifierGroup type="and">
+          <modifiers>
+            <modifier type="add" value="c42-1919-c37e-51f0" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="ca6c-e8cf-7bc1-eaa0" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="9556-82c1-c70a-126e" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="8ed0-3582-f536-c48e" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="f074-f60a-9aa6-c52a" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="3d70-1d54-a791-ac60" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="6508-4f6a-0dc1-8f56" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="e4fb-66cd-e07d-609b" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="bcf6-8350-9099-1e91" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="9508-8124-d34a-500a" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="8cf6-d802-d054-6a86" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="b7db-bf16-47c5-dc05" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="a1d4-4662-c944-19cc" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="1214-3abe-c6d1-2038" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="2774-1a32-f196-be76" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="945c-b969-75eb-19d9" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </modifierGroup>
+      </modifierGroups>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Ruinstorm Daemon Behemoth" hidden="false" id="240a-1822-9e4f-3080" publicationId="8775-88f5-cfdd-24f6" page="16">
       <selectionEntries>
@@ -1340,7 +1798,7 @@
               <modifiers>
                 <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Heavy)">
                   <conditions>
-                    <condition field="selections" scope="240a-1822-9e4f-3080" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b7db-bf16-47c5-dc05" type="atLeast"/>
+                    <condition type="instanceOf" value="1" field="selections" scope="240a-1822-9e4f-3080" childId="8cf6-d802-d054-6a86" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
                   </conditions>
                 </modifier>
               </modifiers>
@@ -1411,9 +1869,6 @@
           </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
-      <entryLinks>
-        <entryLink import="true" name="The Ætheric Dominion (Unit)" hidden="false" type="selectionEntryGroup" id="dc61-4e39-99b9-8398" targetId="caad-e621-38e5-cb5f"/>
-      </entryLinks>
       <infoLinks>
         <infoLink id="c667-25ba-81a5-446d" name="Æthereal Invulnerability (X)" hidden="false" targetId="e05e-ed23-64fb-a535" type="rule">
           <modifiers>
@@ -1421,16 +1876,6 @@
           </modifiers>
         </infoLink>
         <infoLink name="Empyrean Avatar" hidden="false" type="rule" id="c1d7-f721-2ad5-2e98" targetId="c694-20c8-455-baca"/>
-        <infoLink id="9937-1e8e-33f9-57f5" name="Hammer of Wrath (X)" hidden="false" targetId="aec0-c3aa-1e4e-1779" type="rule">
-          <modifiers>
-            <modifier type="set" field="name" value="Hammer of Wrath (3)"/>
-            <modifier type="set" value="true" field="hidden">
-              <conditions>
-                <condition type="atLeast" value="1" field="selections" scope="force" childId="e4fb-66cd-e07d-609b" shared="true" includeChildSelections="true"/>
-              </conditions>
-            </modifier>
-          </modifiers>
-        </infoLink>
         <infoLink id="f8a7-a4c6-2d04-cf4e" name="It Will Not Die (X)" hidden="false" targetId="2784-d0be-a4e2-890f" type="rule">
           <modifiers>
             <modifier type="set" value="It Will Not Die (5+)" field="name"/>
@@ -1442,24 +1887,80 @@
             <modifier type="set" value="Bulky (7)" field="name"/>
           </modifiers>
         </infoLink>
-        <infoLink name="Hammer of Wrath (X)" hidden="false" type="rule" id="6724-11c8-843c-fc0b" targetId="aec0-c3aa-1e4e-1779">
+        <infoLink name="Hammer of Wrath (X)" id="d834-1b25-d4f0-d8e5" hidden="false" targetId="aec0-c3aa-1e4e-1779" type="rule">
           <modifiers>
-            <modifier type="set" value="Hammer of Wrath (4)" field="name"/>
+            <modifier type="set" value="Hammer of Wrath (3)" field="name"/>
             <modifier type="set" value="true" field="hidden">
               <conditions>
-                <condition type="equalTo" value="0" field="selections" scope="force" childId="e4fb-66cd-e07d-609b" shared="true" includeChildSelections="true"/>
+                <condition type="instanceOf" value="0" field="selections" scope="ancestor" childId="6508-4f6a-0dc1-8f56" shared="true" includeChildSelections="true"/>
               </conditions>
             </modifier>
+          </modifiers>
+        </infoLink>
+        <infoLink name="Hammer of Wrath (X)" id="8c15-0fa5-5cca-ea1a" hidden="false" targetId="aec0-c3aa-1e4e-1779" type="rule">
+          <modifiers>
+            <modifier type="set" value="true" field="hidden">
+              <conditions>
+                <condition type="notInstanceOf" value="0" field="selections" scope="ancestor" childId="6508-4f6a-0dc1-8f56" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="set" value="Hammer of Wrath (3+1)" field="name"/>
           </modifiers>
         </infoLink>
       </infoLinks>
       <modifiers>
         <modifier type="add" field="category" value="9231-183c-b97b-63f9">
           <conditions>
-            <condition field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b7db-bf16-47c5-dc05" type="atLeast"/>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="8cf6-d802-d054-6a86" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
           </conditions>
         </modifier>
       </modifiers>
+      <modifierGroups>
+        <modifierGroup type="and">
+          <modifiers>
+            <modifier type="add" value="c42-1919-c37e-51f0" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="ca6c-e8cf-7bc1-eaa0" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="9556-82c1-c70a-126e" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="8ed0-3582-f536-c48e" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="f074-f60a-9aa6-c52a" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="3d70-1d54-a791-ac60" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="6508-4f6a-0dc1-8f56" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="e4fb-66cd-e07d-609b" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="bcf6-8350-9099-1e91" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="9508-8124-d34a-500a" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="8cf6-d802-d054-6a86" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="b7db-bf16-47c5-dc05" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="a1d4-4662-c944-19cc" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="1214-3abe-c6d1-2038" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="2774-1a32-f196-be76" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="945c-b969-75eb-19d9" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </modifierGroup>
+      </modifierGroups>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Ruinstorm Arch-Daemon" hidden="false" id="1fbb-b82e-ae1e-5a12" publicationId="8775-88f5-cfdd-24f6" page="17">
       <selectionEntries>
@@ -1482,7 +1983,7 @@
               <modifiers>
                 <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Heavy)">
                   <conditions>
-                    <condition field="selections" scope="1fbb-b82e-ae1e-5a12" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b7db-bf16-47c5-dc05" type="atLeast"/>
+                    <condition type="instanceOf" value="1" field="selections" scope="1fbb-b82e-ae1e-5a12" childId="8cf6-d802-d054-6a86" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
                   </conditions>
                 </modifier>
               </modifiers>
@@ -1519,18 +2020,24 @@
           </modifiers>
         </infoLink>
         <infoLink id="20df-2bd-59c2-ae77" name="Traitor" hidden="false" targetId="eff2-8b0e-21da-2f0d" type="rule"/>
-        <infoLink id="97ec-1603-fd56-24b1" name="Hammer of Wrath (X)" hidden="false" targetId="aec0-c3aa-1e4e-1779" type="rule">
+        <infoLink name="Hammer of Wrath (X)" id="49f2-61f9-7a5d-df07" hidden="false" targetId="aec0-c3aa-1e4e-1779" type="rule">
           <modifiers>
-            <modifier type="set" field="name" value="Hammer of Wrath (D3)">
+            <modifier type="set" value="Hammer of Wrath (3)" field="name"/>
+            <modifier type="set" value="true" field="hidden">
               <conditions>
-                <condition type="equalTo" value="0" field="selections" scope="force" childId="e4fb-66cd-e07d-609b" shared="true" includeChildSelections="true"/>
+                <condition type="instanceOf" value="0" field="selections" scope="ancestor" childId="6508-4f6a-0dc1-8f56" shared="true" includeChildSelections="true"/>
               </conditions>
             </modifier>
-            <modifier type="set" field="name" value="Hammer of Wrath (D3+1)">
+          </modifiers>
+        </infoLink>
+        <infoLink name="Hammer of Wrath (X)" id="40c0-d4fd-30a8-87ea" hidden="false" targetId="aec0-c3aa-1e4e-1779" type="rule">
+          <modifiers>
+            <modifier type="set" value="true" field="hidden">
               <conditions>
-                <condition type="atLeast" value="1" field="selections" scope="force" childId="e4fb-66cd-e07d-609b" shared="true" includeChildSelections="true"/>
+                <condition type="notInstanceOf" value="0" field="selections" scope="ancestor" childId="6508-4f6a-0dc1-8f56" shared="true" includeChildSelections="true"/>
               </conditions>
             </modifier>
+            <modifier type="set" value="Hammer of Wrath (3+1)" field="name"/>
           </modifiers>
         </infoLink>
       </infoLinks>
@@ -1541,7 +2048,6 @@
             <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="53f8-20f7-4962-f7c5"/>
           </constraints>
         </entryLink>
-        <entryLink import="true" name="The Ætheric Dominion (Unit)" hidden="false" type="selectionEntryGroup" id="8100-95ec-9194-4e21" targetId="caad-e621-38e5-cb5f"/>
       </entryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup name="Ruinstorm Arch-Daemon may take up to three of the following options" hidden="false" id="a55f-e665-3b09-a2a6">
@@ -1594,10 +2100,56 @@
       <modifiers>
         <modifier type="add" field="category" value="9231-183c-b97b-63f9">
           <conditions>
-            <condition field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b7db-bf16-47c5-dc05" type="atLeast"/>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="8cf6-d802-d054-6a86" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
           </conditions>
         </modifier>
       </modifiers>
+      <modifierGroups>
+        <modifierGroup type="and">
+          <modifiers>
+            <modifier type="add" value="c42-1919-c37e-51f0" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="ca6c-e8cf-7bc1-eaa0" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="9556-82c1-c70a-126e" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="8ed0-3582-f536-c48e" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="f074-f60a-9aa6-c52a" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="3d70-1d54-a791-ac60" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="6508-4f6a-0dc1-8f56" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="e4fb-66cd-e07d-609b" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="bcf6-8350-9099-1e91" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="9508-8124-d34a-500a" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="8cf6-d802-d054-6a86" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="b7db-bf16-47c5-dc05" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="a1d4-4662-c944-19cc" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="1214-3abe-c6d1-2038" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="2774-1a32-f196-be76" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="945c-b969-75eb-19d9" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </modifierGroup>
+      </modifierGroups>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Ka’bandha Unbound" hidden="false" id="baa5-baed-1a62-c820" publicationId="8775-88f5-cfdd-24f6" page="18">
       <selectionEntries>

--- a/2022 - Daemons - Daemons of the Ruinstorm.cat
+++ b/2022 - Daemons - Daemons of the Ruinstorm.cat
@@ -214,12 +214,68 @@
         </infoLink>
         <infoLink name="Hammer of Wrath (X)" hidden="false" type="rule" id="41e0-d71f-ba88-64a6" targetId="aec0-c3aa-1e4e-1779">
           <modifiers>
-            <modifier type="set" value="Hammer of Wrath (1)" field="name"/>
             <modifier type="set" value="true" field="hidden">
+              <conditionGroups>
+                <conditionGroup type="and">
+                  <conditions>
+                    <condition type="notInstanceOf" value="0" field="selections" scope="ancestor" childId="6508-4f6a-0dc1-8f56" shared="true"/>
+                    <condition type="equalTo" value="0" field="selections" scope="2f3f-adc4-b19f-a5c7" childId="fd64-626a-d3d4-9b8e" shared="true" includeChildSelections="true"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+            <modifier type="set" value="Hammer of Wrath (" field="name"/>
+            <modifier type="append" value="1" field="name">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditionGroups>
+                    <conditionGroup type="and">
+                      <conditions>
+                        <condition type="notInstanceOf" value="0" field="selections" scope="ancestor" childId="6508-4f6a-0dc1-8f56" shared="true" includeChildSelections="true"/>
+                        <condition type="equalTo" value="1" field="selections" scope="2f3f-adc4-b19f-a5c7" childId="fd64-626a-d3d4-9b8e" shared="true" includeChildSelections="true"/>
+                      </conditions>
+                    </conditionGroup>
+                    <conditionGroup type="and">
+                      <conditions>
+                        <condition type="instanceOf" value="0" field="selections" scope="ancestor" childId="6508-4f6a-0dc1-8f56" shared="true" includeChildSelections="true"/>
+                        <condition type="equalTo" value="0" field="selections" scope="2f3f-adc4-b19f-a5c7" childId="fd64-626a-d3d4-9b8e" shared="true" includeChildSelections="true"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+            <modifier type="append" value="2" field="name">
+              <conditionGroups>
+                <conditionGroup type="and">
+                  <conditions>
+                    <condition type="instanceOf" value="0" field="selections" scope="ancestor" childId="6508-4f6a-0dc1-8f56" shared="true" includeChildSelections="true"/>
+                    <condition type="equalTo" value="1" field="selections" scope="2f3f-adc4-b19f-a5c7" childId="fd64-626a-d3d4-9b8e" shared="true" includeChildSelections="true"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+            <modifier type="append" value=" - Deflagerate [IT ✓]" field="name" join="">
               <conditions>
-                <condition type="notInstanceOf" value="0" field="selections" scope="ancestor" childId="6508-4f6a-0dc1-8f56" shared="true"/>
+                <condition type="instanceOf" value="0" field="selections" scope="ancestor" childId="6508-4f6a-0dc1-8f56" shared="true" includeChildSelections="true"/>
               </conditions>
             </modifier>
+            <modifier type="append" value="[IW ✓]" field="name">
+              <conditions>
+                <condition type="equalTo" value="1" field="selections" scope="2f3f-adc4-b19f-a5c7" childId="fd64-626a-d3d4-9b8e" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="append" value="[IT X]" field="name" join="">
+              <conditions>
+                <condition type="notInstanceOf" value="0" field="selections" scope="ancestor" childId="6508-4f6a-0dc1-8f56" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="append" value="[IW X]" field="name">
+              <conditions>
+                <condition type="equalTo" value="0" field="selections" scope="2f3f-adc4-b19f-a5c7" childId="fd64-626a-d3d4-9b8e" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="append" value=")" field="name"/>
           </modifiers>
         </infoLink>
       </infoLinks>
@@ -423,12 +479,68 @@
         </infoLink>
         <infoLink name="Hammer of Wrath (X)" hidden="false" type="rule" id="9b4c-d419-6ff1-68b1" targetId="aec0-c3aa-1e4e-1779">
           <modifiers>
-            <modifier type="set" value="Hammer of Wrath (1)" field="name"/>
             <modifier type="set" value="true" field="hidden">
+              <conditionGroups>
+                <conditionGroup type="and">
+                  <conditions>
+                    <condition type="notInstanceOf" value="0" field="selections" scope="ancestor" childId="6508-4f6a-0dc1-8f56" shared="true"/>
+                    <condition type="equalTo" value="0" field="selections" scope="ae8b-ee65-95b6-a8f9" childId="fd64-626a-d3d4-9b8e" shared="true" includeChildSelections="true"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+            <modifier type="set" value="Hammer of Wrath (" field="name"/>
+            <modifier type="append" value="1" field="name">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditionGroups>
+                    <conditionGroup type="and">
+                      <conditions>
+                        <condition type="notInstanceOf" value="0" field="selections" scope="ancestor" childId="6508-4f6a-0dc1-8f56" shared="true" includeChildSelections="true"/>
+                        <condition type="equalTo" value="1" field="selections" scope="ae8b-ee65-95b6-a8f9" childId="fd64-626a-d3d4-9b8e" shared="true" includeChildSelections="true"/>
+                      </conditions>
+                    </conditionGroup>
+                    <conditionGroup type="and">
+                      <conditions>
+                        <condition type="instanceOf" value="0" field="selections" scope="ancestor" childId="6508-4f6a-0dc1-8f56" shared="true" includeChildSelections="true"/>
+                        <condition type="equalTo" value="0" field="selections" scope="ae8b-ee65-95b6-a8f9" childId="fd64-626a-d3d4-9b8e" shared="true" includeChildSelections="true"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+            <modifier type="append" value="2" field="name">
+              <conditionGroups>
+                <conditionGroup type="and">
+                  <conditions>
+                    <condition type="instanceOf" value="0" field="selections" scope="ancestor" childId="6508-4f6a-0dc1-8f56" shared="true" includeChildSelections="true"/>
+                    <condition type="equalTo" value="1" field="selections" scope="ae8b-ee65-95b6-a8f9" childId="fd64-626a-d3d4-9b8e" shared="true" includeChildSelections="true"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+            <modifier type="append" value=" - Deflagerate [IT ✓]" field="name" join="">
               <conditions>
-                <condition type="notInstanceOf" value="0" field="selections" scope="ancestor" childId="6508-4f6a-0dc1-8f56" shared="true"/>
+                <condition type="instanceOf" value="0" field="selections" scope="ancestor" childId="6508-4f6a-0dc1-8f56" shared="true" includeChildSelections="true"/>
               </conditions>
             </modifier>
+            <modifier type="append" value="[IW ✓]" field="name">
+              <conditions>
+                <condition type="equalTo" value="1" field="selections" scope="ae8b-ee65-95b6-a8f9" childId="fd64-626a-d3d4-9b8e" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="append" value="[IT X]" field="name" join="">
+              <conditions>
+                <condition type="notInstanceOf" value="0" field="selections" scope="ancestor" childId="6508-4f6a-0dc1-8f56" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="append" value="[IW X]" field="name">
+              <conditions>
+                <condition type="equalTo" value="0" field="selections" scope="ae8b-ee65-95b6-a8f9" childId="fd64-626a-d3d4-9b8e" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="append" value=")" field="name"/>
           </modifiers>
         </infoLink>
       </infoLinks>
@@ -555,7 +667,7 @@
               <modifiers>
                 <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Heavy)">
                   <conditions>
-                    <condition type="instanceOf" value="1" field="selections" scope="5a2e-abe2-3044-3c1c" childId="9231-183c-b97b-63f9" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
+                    <condition type="instanceOf" value="1" field="selections" scope="45fa-e6f-ff0-9c02" childId="9231-183c-b97b-63f9" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
                   </conditions>
                 </modifier>
               </modifiers>
@@ -574,7 +686,7 @@
             <infoLink id="ae51-3edb-f81-998e" name="Traitor" hidden="false" targetId="eff2-8b0e-21da-2f0d" type="rule"/>
             <infoLink name="Hammer of Wrath (X)" hidden="false" type="rule" id="663e-f215-a5a3-5da9" targetId="aec0-c3aa-1e4e-1779">
               <modifiers>
-                <modifier type="set" value="Hammer of Wrath (1)" field="name"/>
+                <modifier type="set" value="Hammer of Wrath (1 - Deflagerate [IT ✓])" field="name"/>
                 <modifier type="set" value="true" field="hidden">
                   <conditions>
                     <condition type="notInstanceOf" value="0" field="selections" scope="ancestor" childId="6508-4f6a-0dc1-8f56" shared="true"/>
@@ -675,22 +787,17 @@
             <infoLink id="9e4d-875f-444c-e9ce" name="Traitor" hidden="false" targetId="eff2-8b0e-21da-2f0d" type="rule"/>
             <infoLink name="Hammer of Wrath (X)" id="8fd5-2720-429c-209f" hidden="false" targetId="aec0-c3aa-1e4e-1779" type="rule">
               <modifiers>
-                <modifier type="set" value="Hammer of Wrath (1)" field="name"/>
-                <modifier type="set" value="true" field="hidden">
-                  <conditions>
-                    <condition type="instanceOf" value="0" field="selections" scope="ancestor" childId="6508-4f6a-0dc1-8f56" shared="true" includeChildSelections="true"/>
-                  </conditions>
-                </modifier>
-              </modifiers>
-            </infoLink>
-            <infoLink name="Hammer of Wrath (X)" id="1ab2-8c64-cb89-261d" hidden="false" targetId="aec0-c3aa-1e4e-1779" type="rule">
-              <modifiers>
-                <modifier type="set" value="true" field="hidden">
+                <modifier type="set" value="Hammer of Wrath (" field="name"/>
+                <modifier type="append" value="1 [IT X])" field="name">
                   <conditions>
                     <condition type="notInstanceOf" value="0" field="selections" scope="ancestor" childId="6508-4f6a-0dc1-8f56" shared="true" includeChildSelections="true"/>
                   </conditions>
                 </modifier>
-                <modifier type="set" value="Hammer of Wrath (2)" field="name"/>
+                <modifier type="append" value="2 - Deflagerate [IT ✓])" field="name">
+                  <conditions>
+                    <condition type="instanceOf" value="0" field="selections" scope="ancestor" childId="6508-4f6a-0dc1-8f56" shared="true" includeChildSelections="true"/>
+                  </conditions>
+                </modifier>
               </modifiers>
             </infoLink>
           </infoLinks>
@@ -829,22 +936,17 @@
           <infoLinks>
             <infoLink name="Hammer of Wrath (X)" id="3747-569d-88cb-2a66" hidden="false" targetId="aec0-c3aa-1e4e-1779" type="rule">
               <modifiers>
-                <modifier type="set" value="Hammer of Wrath (1)" field="name"/>
-                <modifier type="set" value="true" field="hidden">
-                  <conditions>
-                    <condition type="instanceOf" value="0" field="selections" scope="ancestor" childId="6508-4f6a-0dc1-8f56" shared="true" includeChildSelections="true"/>
-                  </conditions>
-                </modifier>
-              </modifiers>
-            </infoLink>
-            <infoLink name="Hammer of Wrath (X)" id="581e-cf77-39e0-5e02" hidden="false" targetId="aec0-c3aa-1e4e-1779" type="rule">
-              <modifiers>
-                <modifier type="set" value="true" field="hidden">
+                <modifier type="set" value="Hammer of Wrath (" field="name"/>
+                <modifier type="append" value="1 [IT X])" field="name">
                   <conditions>
                     <condition type="notInstanceOf" value="0" field="selections" scope="ancestor" childId="6508-4f6a-0dc1-8f56" shared="true" includeChildSelections="true"/>
                   </conditions>
                 </modifier>
-                <modifier type="set" value="Hammer of Wrath (2)" field="name"/>
+                <modifier type="append" value="2 - Deflagerate [IT ✓])" field="name">
+                  <conditions>
+                    <condition type="instanceOf" value="0" field="selections" scope="ancestor" childId="6508-4f6a-0dc1-8f56" shared="true" includeChildSelections="true"/>
+                  </conditions>
+                </modifier>
               </modifiers>
             </infoLink>
           </infoLinks>
@@ -969,16 +1071,6 @@
           </modifiers>
         </infoLink>
         <infoLink id="62c4-c339-363b-79a8" name="Traitor" hidden="false" targetId="eff2-8b0e-21da-2f0d" type="rule"/>
-        <infoLink name="Hammer of Wrath (X)" hidden="false" type="rule" id="71ec-9e8f-4c64-8e9d" targetId="aec0-c3aa-1e4e-1779">
-          <modifiers>
-            <modifier type="set" value="Hammer of Wrath (1)" field="name"/>
-            <modifier type="set" value="true" field="hidden">
-              <conditions>
-                <condition type="notInstanceOf" value="0" field="selections" scope="ancestor" childId="6508-4f6a-0dc1-8f56" shared="true"/>
-              </conditions>
-            </modifier>
-          </modifiers>
-        </infoLink>
       </infoLinks>
       <selectionEntryGroups>
         <selectionEntryGroup name="Daemon Beasts" hidden="false" id="8d09-1913-b79f-5c35" defaultSelectionEntryId="e8d9-781b-531d-9386">
@@ -1034,6 +1126,18 @@
               <categoryLinks>
                 <categoryLink targetId="e699-d9cd-e68e-46d9" id="bf28-d2d0-4185-9f31" name="Daemon Unit Type" primary="false"/>
               </categoryLinks>
+              <infoLinks>
+                <infoLink name="Hammer of Wrath (X)" id="b498-6483-26a7-008a" hidden="false" type="rule" targetId="aec0-c3aa-1e4e-1779">
+                  <modifiers>
+                    <modifier type="set" value="true" field="hidden">
+                      <conditions>
+                        <condition type="notInstanceOf" value="0" field="selections" scope="ancestor" childId="6508-4f6a-0dc1-8f56" shared="true" includeChildSelections="true"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="set" value="Hammer of Wrath (1 - Deflagerate [IT ✓])" field="name"/>
+                  </modifiers>
+                </infoLink>
+              </infoLinks>
             </selectionEntry>
             <selectionEntry type="model" import="true" name="Daemon Beast w/ Immaterial Flame" hidden="false" id="5828-5d74-9c9b-edc5" publicationId="8775-88f5-cfdd-24f6" page="10">
               <costs>
@@ -1087,24 +1191,24 @@
                   </conditions>
                 </modifier>
               </modifiers>
+              <infoLinks>
+                <infoLink name="Hammer of Wrath (X)" id="30fc-3179-c876-41e4" hidden="false" type="rule" targetId="aec0-c3aa-1e4e-1779">
+                  <modifiers>
+                    <modifier type="set" value="true" field="hidden">
+                      <conditions>
+                        <condition type="notInstanceOf" value="0" field="selections" scope="ancestor" childId="6508-4f6a-0dc1-8f56" shared="true" includeChildSelections="true"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="set" value="Hammer of Wrath (1 - Deflagerate [IT ✓])" field="name"/>
+                  </modifiers>
+                </infoLink>
+              </infoLinks>
             </selectionEntry>
           </selectionEntries>
           <constraints>
             <constraint type="min" value="3" field="selections" scope="parent" shared="true" id="c742-33ce-5486-cd41"/>
             <constraint type="max" value="9" field="selections" scope="parent" shared="true" id="f09-f2e2-9697-c2e"/>
           </constraints>
-          <infoLinks>
-            <infoLink name="Hammer of Wrath (X)" id="4bf3-8cfb-dae9-400c" hidden="false" targetId="aec0-c3aa-1e4e-1779" type="rule">
-              <modifiers>
-                <modifier type="set" value="Hammer of Wrath (1)" field="name"/>
-                <modifier type="set" value="true" field="hidden">
-                  <conditions>
-                    <condition type="notInstanceOf" value="0" field="selections" scope="ancestor" childId="6508-4f6a-0dc1-8f56" shared="true" includeChildSelections="true"/>
-                  </conditions>
-                </modifier>
-              </modifiers>
-            </infoLink>
-          </infoLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <modifiers>
@@ -1202,7 +1306,7 @@
           <infoLinks>
             <infoLink name="Hammer of Wrath (X)" id="f9e5-eb89-d5b3-e7f9" hidden="false" targetId="aec0-c3aa-1e4e-1779" type="rule">
               <modifiers>
-                <modifier type="set" value="Hammer of Wrath (1)" field="name"/>
+                <modifier type="set" value="Hammer of Wrath (1 - Deflagerate [IT ✓])" field="name"/>
                 <modifier type="set" value="true" field="hidden">
                   <conditions>
                     <condition type="notInstanceOf" value="1" field="selections" scope="ancestor" childId="6508-4f6a-0dc1-8f56" shared="true" includeChildSelections="true"/>
@@ -1358,7 +1462,7 @@
           <infoLinks>
             <infoLink name="Hammer of Wrath (X)" id="ae97-f4e1-3942-7ee0" hidden="false" targetId="aec0-c3aa-1e4e-1779" type="rule">
               <modifiers>
-                <modifier type="set" value="Hammer of Wrath (1)" field="name"/>
+                <modifier type="set" value="Hammer of Wrath (1 - Deflagerate [IT ✓])" field="name"/>
                 <modifier type="set" value="true" field="hidden">
                   <conditions>
                     <condition type="notInstanceOf" value="0" field="selections" scope="ancestor" childId="6508-4f6a-0dc1-8f56" shared="true" includeChildSelections="true"/>
@@ -1522,7 +1626,7 @@
         <infoLink id="1105-9717-b770-9f35" name="Traitor" hidden="false" targetId="eff2-8b0e-21da-2f0d" type="rule"/>
         <infoLink name="Hammer of Wrath (X)" hidden="false" type="rule" id="f808-d189-7f7d-f216" targetId="aec0-c3aa-1e4e-1779">
           <modifiers>
-            <modifier type="set" value="Hammer of Wrath (1)" field="name"/>
+            <modifier type="set" value="Hammer of Wrath (1 - Deflagerate [IT ✓])" field="name"/>
             <modifier type="set" value="true" field="hidden">
               <conditions>
                 <condition type="notInstanceOf" value="0" field="selections" scope="ancestor" childId="6508-4f6a-0dc1-8f56" shared="true"/>
@@ -1650,10 +1754,15 @@
         <infoLink id="c02d-11c2-315c-259f" name="Traitor" hidden="false" targetId="eff2-8b0e-21da-2f0d" type="rule"/>
         <infoLink name="Hammer of Wrath (X)" hidden="false" type="rule" id="25cc-41da-4e8-d8b8" targetId="aec0-c3aa-1e4e-1779">
           <modifiers>
-            <modifier type="set" value="Hammer of Wrath (1+1)" field="name"/>
-            <modifier type="set" value="true" field="hidden">
+            <modifier type="set" value="Hammer of Wrath (" field="name"/>
+            <modifier type="append" value="1 [IW ✓] [IT X])" field="name">
               <conditions>
-                <condition type="notInstanceOf" value="0" field="selections" scope="ancestor" childId="6508-4f6a-0dc1-8f56" shared="true"/>
+                <condition type="notInstanceOf" value="0" field="selections" scope="ancestor" childId="6508-4f6a-0dc1-8f56" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="append" value="2 [IW ✓] [IT ✓])" field="name">
+              <conditions>
+                <condition type="instanceOf" value="0" field="selections" scope="ancestor" childId="6508-4f6a-0dc1-8f56" shared="true" includeChildSelections="true"/>
               </conditions>
             </modifier>
           </modifiers>
@@ -1804,22 +1913,17 @@
         <infoLink id="3fca-6f8-15aa-91c0" name="Traitor" hidden="false" targetId="eff2-8b0e-21da-2f0d" type="rule"/>
         <infoLink name="Hammer of Wrath (X)" id="675e-0a1f-0703-ddf9" hidden="false" targetId="aec0-c3aa-1e4e-1779" type="rule">
           <modifiers>
-            <modifier type="set" value="Hammer of Wrath (3)" field="name"/>
-            <modifier type="set" value="true" field="hidden">
-              <conditions>
-                <condition type="instanceOf" value="0" field="selections" scope="ancestor" childId="6508-4f6a-0dc1-8f56" shared="true" includeChildSelections="true"/>
-              </conditions>
-            </modifier>
-          </modifiers>
-        </infoLink>
-        <infoLink name="Hammer of Wrath (X)" id="07d5-ba21-25a0-addd" hidden="false" targetId="aec0-c3aa-1e4e-1779" type="rule">
-          <modifiers>
-            <modifier type="set" value="true" field="hidden">
+            <modifier type="set" value="Hammer of Wrath (" field="name"/>
+            <modifier type="append" value="3 [IT X])" field="name">
               <conditions>
                 <condition type="notInstanceOf" value="0" field="selections" scope="ancestor" childId="6508-4f6a-0dc1-8f56" shared="true" includeChildSelections="true"/>
               </conditions>
             </modifier>
-            <modifier type="set" value="Hammer of Wrath (3+1)" field="name"/>
+            <modifier type="append" value="4 - Deflagerate [IT ✓])" field="name">
+              <conditions>
+                <condition type="instanceOf" value="0" field="selections" scope="ancestor" childId="6508-4f6a-0dc1-8f56" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
           </modifiers>
         </infoLink>
       </infoLinks>
@@ -1996,22 +2100,68 @@
         </infoLink>
         <infoLink name="Hammer of Wrath (X)" id="d834-1b25-d4f0-d8e5" hidden="false" targetId="aec0-c3aa-1e4e-1779" type="rule">
           <modifiers>
-            <modifier type="set" value="Hammer of Wrath (3)" field="name"/>
-            <modifier type="set" value="true" field="hidden">
+            <modifier type="set" value="Hammer of Wrath (" field="name"/>
+            <modifier type="append" value="3" field="name">
+              <conditionGroups>
+                <conditionGroup type="and">
+                  <conditions>
+                    <condition type="notInstanceOf" value="0" field="selections" scope="ancestor" childId="6508-4f6a-0dc1-8f56" shared="true" includeChildSelections="true"/>
+                    <condition type="equalTo" value="0" field="selections" scope="240a-1822-9e4f-3080" childId="fd64-626a-d3d4-9b8e" shared="true" includeChildSelections="true"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+            <modifier type="append" value="4" field="name">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditionGroups>
+                    <conditionGroup type="and">
+                      <conditions>
+                        <condition type="instanceOf" value="0" field="selections" scope="ancestor" childId="6508-4f6a-0dc1-8f56" shared="true" includeChildSelections="true"/>
+                        <condition type="equalTo" value="0" field="selections" scope="240a-1822-9e4f-3080" childId="fd64-626a-d3d4-9b8e" shared="true" includeChildSelections="true"/>
+                      </conditions>
+                    </conditionGroup>
+                    <conditionGroup type="and">
+                      <conditions>
+                        <condition type="notInstanceOf" value="0" field="selections" scope="ancestor" childId="6508-4f6a-0dc1-8f56" shared="true" includeChildSelections="true"/>
+                        <condition type="equalTo" value="1" field="selections" scope="240a-1822-9e4f-3080" childId="fd64-626a-d3d4-9b8e" shared="true" includeChildSelections="true"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+            <modifier type="append" value="5" field="name">
+              <conditionGroups>
+                <conditionGroup type="and">
+                  <conditions>
+                    <condition type="instanceOf" value="0" field="selections" scope="ancestor" childId="6508-4f6a-0dc1-8f56" shared="true" includeChildSelections="true"/>
+                    <condition type="equalTo" value="1" field="selections" scope="240a-1822-9e4f-3080" childId="fd64-626a-d3d4-9b8e" shared="true" includeChildSelections="true"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+            <modifier type="append" value=" - Deflagerate [IT ✓]" field="name" join="">
               <conditions>
                 <condition type="instanceOf" value="0" field="selections" scope="ancestor" childId="6508-4f6a-0dc1-8f56" shared="true" includeChildSelections="true"/>
               </conditions>
             </modifier>
-          </modifiers>
-        </infoLink>
-        <infoLink name="Hammer of Wrath (X)" id="8c15-0fa5-5cca-ea1a" hidden="false" targetId="aec0-c3aa-1e4e-1779" type="rule">
-          <modifiers>
-            <modifier type="set" value="true" field="hidden">
+            <modifier type="append" value="[IW ✓]" field="name">
+              <conditions>
+                <condition type="equalTo" value="1" field="selections" scope="240a-1822-9e4f-3080" childId="fd64-626a-d3d4-9b8e" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="append" value="[IT X]" field="name" join="">
               <conditions>
                 <condition type="notInstanceOf" value="0" field="selections" scope="ancestor" childId="6508-4f6a-0dc1-8f56" shared="true" includeChildSelections="true"/>
               </conditions>
             </modifier>
-            <modifier type="set" value="Hammer of Wrath (3+1)" field="name"/>
+            <modifier type="append" value="[IW X]" field="name">
+              <conditions>
+                <condition type="equalTo" value="0" field="selections" scope="240a-1822-9e4f-3080" childId="fd64-626a-d3d4-9b8e" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="append" value=")" field="name"/>
           </modifiers>
         </infoLink>
       </infoLinks>
@@ -2136,22 +2286,68 @@
         <infoLink id="20df-2bd-59c2-ae77" name="Traitor" hidden="false" targetId="eff2-8b0e-21da-2f0d" type="rule"/>
         <infoLink name="Hammer of Wrath (X)" id="49f2-61f9-7a5d-df07" hidden="false" targetId="aec0-c3aa-1e4e-1779" type="rule">
           <modifiers>
-            <modifier type="set" value="Hammer of Wrath (3)" field="name"/>
-            <modifier type="set" value="true" field="hidden">
+            <modifier type="set" value="Hammer of Wrath (" field="name"/>
+            <modifier type="append" value="3" field="name">
+              <conditionGroups>
+                <conditionGroup type="and">
+                  <conditions>
+                    <condition type="notInstanceOf" value="0" field="selections" scope="ancestor" childId="6508-4f6a-0dc1-8f56" shared="true" includeChildSelections="true"/>
+                    <condition type="equalTo" value="0" field="selections" scope="1fbb-b82e-ae1e-5a12" childId="fd64-626a-d3d4-9b8e" shared="true" includeChildSelections="true"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+            <modifier type="append" value="4" field="name">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditionGroups>
+                    <conditionGroup type="and">
+                      <conditions>
+                        <condition type="notInstanceOf" value="0" field="selections" scope="ancestor" childId="6508-4f6a-0dc1-8f56" shared="true" includeChildSelections="true"/>
+                        <condition type="equalTo" value="1" field="selections" scope="1fbb-b82e-ae1e-5a12" childId="fd64-626a-d3d4-9b8e" shared="true" includeChildSelections="true"/>
+                      </conditions>
+                    </conditionGroup>
+                    <conditionGroup type="and">
+                      <conditions>
+                        <condition type="instanceOf" value="0" field="selections" scope="ancestor" childId="6508-4f6a-0dc1-8f56" shared="true" includeChildSelections="true"/>
+                        <condition type="equalTo" value="0" field="selections" scope="1fbb-b82e-ae1e-5a12" childId="fd64-626a-d3d4-9b8e" shared="true" includeChildSelections="true"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+            <modifier type="append" value="5" field="name">
+              <conditionGroups>
+                <conditionGroup type="and">
+                  <conditions>
+                    <condition type="instanceOf" value="0" field="selections" scope="ancestor" childId="6508-4f6a-0dc1-8f56" shared="true" includeChildSelections="true"/>
+                    <condition type="equalTo" value="1" field="selections" scope="1fbb-b82e-ae1e-5a12" childId="fd64-626a-d3d4-9b8e" shared="true" includeChildSelections="true"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+            <modifier type="append" value=" - Deflagerate [IT ✓]" field="name" join="">
               <conditions>
                 <condition type="instanceOf" value="0" field="selections" scope="ancestor" childId="6508-4f6a-0dc1-8f56" shared="true" includeChildSelections="true"/>
               </conditions>
             </modifier>
-          </modifiers>
-        </infoLink>
-        <infoLink name="Hammer of Wrath (X)" id="40c0-d4fd-30a8-87ea" hidden="false" targetId="aec0-c3aa-1e4e-1779" type="rule">
-          <modifiers>
-            <modifier type="set" value="true" field="hidden">
+            <modifier type="append" value="[IW ✓]" field="name">
+              <conditions>
+                <condition type="equalTo" value="1" field="selections" scope="1fbb-b82e-ae1e-5a12" childId="fd64-626a-d3d4-9b8e" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="append" value="[IT X]" field="name" join="">
               <conditions>
                 <condition type="notInstanceOf" value="0" field="selections" scope="ancestor" childId="6508-4f6a-0dc1-8f56" shared="true" includeChildSelections="true"/>
               </conditions>
             </modifier>
-            <modifier type="set" value="Hammer of Wrath (3+1)" field="name"/>
+            <modifier type="append" value="[IW X]" field="name">
+              <conditions>
+                <condition type="equalTo" value="0" field="selections" scope="1fbb-b82e-ae1e-5a12" childId="fd64-626a-d3d4-9b8e" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="append" value=")" field="name"/>
           </modifiers>
         </infoLink>
       </infoLinks>
@@ -2162,6 +2358,7 @@
             <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="53f8-20f7-4962-f7c5"/>
           </constraints>
         </entryLink>
+        <entryLink import="true" name="The Ætheric Dominion (X)" hidden="false" id="716c-4b06-e82d-5dc7" type="selectionEntryGroup" targetId="002f-0e40-9d49-2a22"/>
       </entryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup name="Ruinstorm Arch-Daemon may take up to three of the following options" hidden="false" id="a55f-e665-3b09-a2a6">
@@ -2859,11 +3056,7 @@ During a Reaction made in any Phase, a player may not choose to activate a model
             <modifier type="set" value="Bulky (2 or +1 if higher)" field="name"/>
           </modifiers>
         </infoLink>
-        <infoLink name="Hammer of Wrath (X)" id="8f8e-f995-49a3-a352" hidden="false" type="rule" targetId="aec0-c3aa-1e4e-1779">
-          <modifiers>
-            <modifier type="set" value="Hammer of Wrath (1 or +1 if higher)" field="name"/>
-          </modifiers>
-        </infoLink>
+        <infoLink name="Hammer of Wrath (X)" id="8f8e-f995-49a3-a352" hidden="false" type="rule" targetId="aec0-c3aa-1e4e-1779"/>
       </infoLinks>
     </selectionEntry>
     <selectionEntry type="upgrade" import="true" name="Miasma of Rage" hidden="false" id="ce6-3fae-8519-e10d">

--- a/2022 - Daemons - Daemons of the Ruinstorm.cat
+++ b/2022 - Daemons - Daemons of the Ruinstorm.cat
@@ -162,7 +162,7 @@
               <modifiers>
                 <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Heavy)">
                   <conditions>
-                    <condition type="instanceOf" value="1" field="selections" scope="2f3f-adc4-b19f-a5c7" childId="8cf6-d802-d054-6a86" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
+                    <condition type="instanceOf" value="1" field="selections" scope="2f3f-adc4-b19f-a5c7" childId="9231-183c-b97b-63f9" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
                   </conditions>
                 </modifier>
               </modifiers>
@@ -173,6 +173,13 @@
             <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="f366-260f-4815-b01d" name="Character" primary="false"/>
             <categoryLink targetId="7d95-f9d1-440a-67bd" id="4729-9aff-48a8-b0ff" name="Monstrous Sub-type" primary="false"/>
           </categoryLinks>
+          <modifiers>
+            <modifier type="add" value="9231-183c-b97b-63f9" field="category">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="3964-e438-272c-42cc" childId="9231-183c-b97b-63f9" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
+              </conditions>
+            </modifier>
+          </modifiers>
         </selectionEntry>
       </selectionEntries>
       <costs>
@@ -360,7 +367,7 @@
               <modifiers>
                 <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Heavy)">
                   <conditions>
-                    <condition type="instanceOf" value="1" field="selections" scope="ae8b-ee65-95b6-a8f9" childId="8cf6-d802-d054-6a86" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
+                    <condition type="instanceOf" value="1" field="selections" scope="ae8b-ee65-95b6-a8f9" childId="9231-183c-b97b-63f9" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
                   </conditions>
                 </modifier>
               </modifiers>
@@ -370,6 +377,13 @@
             <categoryLink targetId="e699-d9cd-e68e-46d9" id="df2c-3c89-475f-a078" name="Daemon Unit Type" primary="false"/>
             <categoryLink targetId="f75a-d5c1-59ba-5c5a" id="f12d-a1e4-4ba4-aee2" name="Character" primary="false"/>
           </categoryLinks>
+          <modifiers>
+            <modifier type="add" value="9231-183c-b97b-63f9" field="category">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="bba5-7153-f7d2-facf" childId="9231-183c-b97b-63f9" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
+              </conditions>
+            </modifier>
+          </modifiers>
         </selectionEntry>
       </selectionEntries>
       <costs>
@@ -541,7 +555,7 @@
               <modifiers>
                 <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Heavy)">
                   <conditions>
-                    <condition type="instanceOf" value="1" field="selections" scope="5a2e-abe2-3044-3c1c" childId="8cf6-d802-d054-6a86" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
+                    <condition type="instanceOf" value="1" field="selections" scope="5a2e-abe2-3044-3c1c" childId="9231-183c-b97b-63f9" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
                   </conditions>
                 </modifier>
               </modifiers>
@@ -607,6 +621,13 @@
             <entryLink import="true" name="Warlord" hidden="false" type="selectionEntry" id="4c82-36a0-e269-75c9" targetId="0176-56a3-d590-b103"/>
             <entryLink import="true" name="Warlord Traits (Ruinstorm Daemons)" hidden="false" type="selectionEntryGroup" id="9cfe-8d86-748f-2bf1" targetId="2f76-74c1-d329-d3ab"/>
           </entryLinks>
+          <modifiers>
+            <modifier type="add" value="9231-183c-b97b-63f9" field="category">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="45fa-e6f-ff0-9c02" childId="9231-183c-b97b-63f9" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
+              </conditions>
+            </modifier>
+          </modifiers>
         </selectionEntry>
         <selectionEntry type="model" import="true" name="Daemon Attendant" hidden="false" id="ddd6-2d23-531f-12b7" publicationId="8775-88f5-cfdd-24f6" page="8">
           <costs>
@@ -633,7 +654,7 @@
               <modifiers>
                 <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Heavy)">
                   <conditions>
-                    <condition type="instanceOf" value="1" field="selections" scope="5a2e-abe2-3044-3c1c" childId="8cf6-d802-d054-6a86" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
+                    <condition type="instanceOf" value="1" field="selections" scope="ddd6-2d23-531f-12b7" childId="9231-183c-b97b-63f9" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
                   </conditions>
                 </modifier>
               </modifiers>
@@ -692,6 +713,13 @@
           <categoryLinks>
             <categoryLink targetId="e699-d9cd-e68e-46d9" id="c1f3-ac66-41ed-8304" name="Daemon Unit Type" primary="false"/>
           </categoryLinks>
+          <modifiers>
+            <modifier type="add" value="9231-183c-b97b-63f9" field="category">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="ddd6-2d23-531f-12b7" childId="9231-183c-b97b-63f9" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
+              </conditions>
+            </modifier>
+          </modifiers>
         </selectionEntry>
       </selectionEntries>
       <costs>
@@ -782,7 +810,7 @@
               <modifiers>
                 <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Heavy)">
                   <conditions>
-                    <condition type="instanceOf" value="1" field="selections" scope="2219-cb60-b52-a36c" childId="8cf6-d802-d054-6a86" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
+                    <condition type="instanceOf" value="1" field="selections" scope="e3e-4f46-2300-a35" childId="9231-183c-b97b-63f9" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
                   </conditions>
                 </modifier>
               </modifiers>
@@ -791,6 +819,35 @@
           <categoryLinks>
             <categoryLink targetId="e699-d9cd-e68e-46d9" id="4b32-5023-4ef3-bad3" name="Daemon Unit Type" primary="false"/>
           </categoryLinks>
+          <modifiers>
+            <modifier type="add" value="9231-183c-b97b-63f9" field="category">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="9231-183c-b97b-63f9" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <infoLinks>
+            <infoLink name="Hammer of Wrath (X)" id="3747-569d-88cb-2a66" hidden="false" targetId="aec0-c3aa-1e4e-1779" type="rule">
+              <modifiers>
+                <modifier type="set" value="Hammer of Wrath (1)" field="name"/>
+                <modifier type="set" value="true" field="hidden">
+                  <conditions>
+                    <condition type="instanceOf" value="0" field="selections" scope="ancestor" childId="6508-4f6a-0dc1-8f56" shared="true" includeChildSelections="true"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+            </infoLink>
+            <infoLink name="Hammer of Wrath (X)" id="581e-cf77-39e0-5e02" hidden="false" targetId="aec0-c3aa-1e4e-1779" type="rule">
+              <modifiers>
+                <modifier type="set" value="true" field="hidden">
+                  <conditions>
+                    <condition type="notInstanceOf" value="0" field="selections" scope="ancestor" childId="6508-4f6a-0dc1-8f56" shared="true" includeChildSelections="true"/>
+                  </conditions>
+                </modifier>
+                <modifier type="set" value="Hammer of Wrath (2)" field="name"/>
+              </modifiers>
+            </infoLink>
+          </infoLinks>
         </selectionEntry>
       </selectionEntries>
       <costs>
@@ -809,26 +866,6 @@
         <infoLink id="eaa7-e67f-765d-8210" name="Æthereal Invulnerability (X)" hidden="false" targetId="e05e-ed23-64fb-a535" type="rule">
           <modifiers>
             <modifier type="set" field="name" value="Æthereal Invulnerability (5+)"/>
-          </modifiers>
-        </infoLink>
-        <infoLink name="Hammer of Wrath (X)" id="4005-fbfc-51f8-3dc4" hidden="false" targetId="aec0-c3aa-1e4e-1779" type="rule">
-          <modifiers>
-            <modifier type="set" value="Hammer of Wrath (1)" field="name"/>
-            <modifier type="set" value="true" field="hidden">
-              <conditions>
-                <condition type="instanceOf" value="0" field="selections" scope="ancestor" childId="6508-4f6a-0dc1-8f56" shared="true" includeChildSelections="true"/>
-              </conditions>
-            </modifier>
-          </modifiers>
-        </infoLink>
-        <infoLink name="Hammer of Wrath (X)" id="05eb-6421-0257-5bdc" hidden="false" targetId="aec0-c3aa-1e4e-1779" type="rule">
-          <modifiers>
-            <modifier type="set" value="true" field="hidden">
-              <conditions>
-                <condition type="notInstanceOf" value="0" field="selections" scope="ancestor" childId="6508-4f6a-0dc1-8f56" shared="true" includeChildSelections="true"/>
-              </conditions>
-            </modifier>
-            <modifier type="set" value="Hammer of Wrath (2)" field="name"/>
           </modifiers>
         </infoLink>
       </infoLinks>
@@ -972,7 +1009,7 @@
                   <modifiers>
                     <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Heavy)">
                       <conditions>
-                        <condition type="instanceOf" value="1" field="selections" scope="69ad-927-c71b-6b24" childId="8cf6-d802-d054-6a86" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
+                        <condition type="instanceOf" value="1" field="selections" scope="e8d9-781b-531d-9386" childId="9231-183c-b97b-63f9" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
                       </conditions>
                     </modifier>
                   </modifiers>
@@ -988,6 +1025,11 @@
               </entryLinks>
               <modifiers>
                 <modifier type="decrement" value="3" field="e343-4e07-35a4-9ab"/>
+                <modifier type="add" value="9231-183c-b97b-63f9" field="category">
+                  <conditions>
+                    <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="9231-183c-b97b-63f9" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
+                  </conditions>
+                </modifier>
               </modifiers>
               <categoryLinks>
                 <categoryLink targetId="e699-d9cd-e68e-46d9" id="bf28-d2d0-4185-9f31" name="Daemon Unit Type" primary="false"/>
@@ -1018,7 +1060,7 @@
                   <modifiers>
                     <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Heavy)">
                       <conditions>
-                        <condition type="instanceOf" value="1" field="selections" scope="69ad-927-c71b-6b24" childId="8cf6-d802-d054-6a86" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
+                        <condition type="instanceOf" value="1" field="selections" scope="5828-5d74-9c9b-edc5" childId="9231-183c-b97b-63f9" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
                       </conditions>
                     </modifier>
                   </modifiers>
@@ -1038,12 +1080,31 @@
               <categoryLinks>
                 <categoryLink targetId="e699-d9cd-e68e-46d9" id="9520-afe4-45b9-822d" name="Daemon Unit Type" primary="false"/>
               </categoryLinks>
+              <modifiers>
+                <modifier type="add" value="9231-183c-b97b-63f9" field="category">
+                  <conditions>
+                    <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="9231-183c-b97b-63f9" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
             </selectionEntry>
           </selectionEntries>
           <constraints>
             <constraint type="min" value="3" field="selections" scope="parent" shared="true" id="c742-33ce-5486-cd41"/>
             <constraint type="max" value="9" field="selections" scope="parent" shared="true" id="f09-f2e2-9697-c2e"/>
           </constraints>
+          <infoLinks>
+            <infoLink name="Hammer of Wrath (X)" id="4bf3-8cfb-dae9-400c" hidden="false" targetId="aec0-c3aa-1e4e-1779" type="rule">
+              <modifiers>
+                <modifier type="set" value="Hammer of Wrath (1)" field="name"/>
+                <modifier type="set" value="true" field="hidden">
+                  <conditions>
+                    <condition type="notInstanceOf" value="0" field="selections" scope="ancestor" childId="6508-4f6a-0dc1-8f56" shared="true" includeChildSelections="true"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+            </infoLink>
+          </infoLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <modifiers>
@@ -1128,7 +1189,7 @@
               <modifiers>
                 <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Heavy)">
                   <conditions>
-                    <condition type="instanceOf" value="1" field="selections" scope="157c-7592-a6b9-f96" childId="8cf6-d802-d054-6a86" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
+                    <condition type="instanceOf" value="1" field="selections" scope="5da5-c15b-dfe5-d1b5" childId="9231-183c-b97b-63f9" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
                   </conditions>
                 </modifier>
               </modifiers>
@@ -1138,6 +1199,25 @@
             <categoryLink targetId="e699-d9cd-e68e-46d9" id="90e7-f681-4b31-bad7" name="Daemon Unit Type" primary="false"/>
             <categoryLink targetId="6399-5c65-7833-1025" id="1460-27e8-499e-8488" name="Line Sub-type" primary="false"/>
           </categoryLinks>
+          <infoLinks>
+            <infoLink name="Hammer of Wrath (X)" id="f9e5-eb89-d5b3-e7f9" hidden="false" targetId="aec0-c3aa-1e4e-1779" type="rule">
+              <modifiers>
+                <modifier type="set" value="Hammer of Wrath (1)" field="name"/>
+                <modifier type="set" value="true" field="hidden">
+                  <conditions>
+                    <condition type="notInstanceOf" value="1" field="selections" scope="ancestor" childId="6508-4f6a-0dc1-8f56" shared="true" includeChildSelections="true"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+            </infoLink>
+          </infoLinks>
+          <modifiers>
+            <modifier type="add" value="9231-183c-b97b-63f9" field="category">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="5da5-c15b-dfe5-d1b5" childId="9231-183c-b97b-63f9" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
+              </conditions>
+            </modifier>
+          </modifiers>
         </selectionEntry>
       </selectionEntries>
       <costs>
@@ -1152,16 +1232,6 @@
         <infoLink id="e70-800b-7e94-4943" name="Æthereal Invulnerability (X)" hidden="false" targetId="e05e-ed23-64fb-a535" type="rule">
           <modifiers>
             <modifier type="set" field="name" value="Æthereal Invulnerability (5+)"/>
-          </modifiers>
-        </infoLink>
-        <infoLink name="Hammer of Wrath (X)" hidden="false" type="rule" id="2e40-9836-1db8-4c1" targetId="aec0-c3aa-1e4e-1779">
-          <modifiers>
-            <modifier type="set" value="Hammer of Wrath (1)" field="name"/>
-            <modifier type="set" value="true" field="hidden">
-              <conditions>
-                <condition type="notInstanceOf" value="0" field="selections" scope="ancestor" childId="6508-4f6a-0dc1-8f56" shared="true"/>
-              </conditions>
-            </modifier>
           </modifiers>
         </infoLink>
       </infoLinks>
@@ -1267,7 +1337,7 @@
               <modifiers>
                 <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Heavy)">
                   <conditions>
-                    <condition type="instanceOf" value="1" field="selections" scope="bb35-e585-a226-28e" childId="8cf6-d802-d054-6a86" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
+                    <condition type="instanceOf" value="1" field="selections" scope="cb8c-b27a-ea4e-1c91" childId="9231-183c-b97b-63f9" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
                   </conditions>
                 </modifier>
               </modifiers>
@@ -1278,6 +1348,25 @@
             <categoryLink targetId="6399-5c65-7833-1025" id="5117-229f-4e4b-9d10" name="Line Sub-type" primary="false"/>
             <categoryLink targetId="59a4-7b61-600a-c457" id="17da-3c9d-454c-8c01" name="Skirmish Sub-type" primary="false"/>
           </categoryLinks>
+          <modifiers>
+            <modifier type="add" value="9231-183c-b97b-63f9" field="category">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="cb8c-b27a-ea4e-1c91" childId="9231-183c-b97b-63f9" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <infoLinks>
+            <infoLink name="Hammer of Wrath (X)" id="ae97-f4e1-3942-7ee0" hidden="false" targetId="aec0-c3aa-1e4e-1779" type="rule">
+              <modifiers>
+                <modifier type="set" value="Hammer of Wrath (1)" field="name"/>
+                <modifier type="set" value="true" field="hidden">
+                  <conditions>
+                    <condition type="notInstanceOf" value="0" field="selections" scope="ancestor" childId="6508-4f6a-0dc1-8f56" shared="true" includeChildSelections="true"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+            </infoLink>
+          </infoLinks>
         </selectionEntry>
       </selectionEntries>
       <costs>
@@ -1297,16 +1386,6 @@
         </infoLink>
         <infoLink name="Swarm" hidden="false" type="rule" id="eea2-a8c-2c72-49ba" targetId="0bc2-fcb2-dd25-c10a"/>
         <infoLink name="Support Squad" hidden="false" type="rule" id="8282-b9ea-e72a-3905" targetId="768e-56d6-ca52-24ae"/>
-        <infoLink name="Hammer of Wrath (X)" hidden="false" type="rule" id="62be-99e4-c9c6-1c81" targetId="aec0-c3aa-1e4e-1779">
-          <modifiers>
-            <modifier type="set" value="Hammer of Wrath (1)" field="name"/>
-            <modifier type="set" value="true" field="hidden">
-              <conditions>
-                <condition type="notInstanceOf" value="0" field="selections" scope="ancestor" childId="6508-4f6a-0dc1-8f56" shared="true"/>
-              </conditions>
-            </modifier>
-          </modifiers>
-        </infoLink>
       </infoLinks>
       <modifiers>
         <modifier type="add" field="category" value="9231-183c-b97b-63f9">
@@ -1399,6 +1478,13 @@
           <categoryLinks>
             <categoryLink targetId="e699-d9cd-e68e-46d9" id="3f19-20e7-4450-badd" name="Daemon Unit Type" primary="false"/>
           </categoryLinks>
+          <modifiers>
+            <modifier type="add" value="9231-183c-b97b-63f9" field="category">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="635d-bc63-b7de-84e3" childId="9231-183c-b97b-63f9" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
+              </conditions>
+            </modifier>
+          </modifiers>
         </selectionEntry>
       </selectionEntries>
       <costs>
@@ -1524,7 +1610,7 @@
               <modifiers>
                 <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Heavy)">
                   <conditions>
-                    <condition type="instanceOf" value="1" field="selections" scope="14c1-3063-c9b4-d99b" childId="8cf6-d802-d054-6a86" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
+                    <condition type="instanceOf" value="1" field="selections" scope="14c1-3063-c9b4-d99b" childId="9231-183c-b97b-63f9" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
                   </conditions>
                 </modifier>
               </modifiers>
@@ -1533,6 +1619,13 @@
           <categoryLinks>
             <categoryLink targetId="e699-d9cd-e68e-46d9" id="192c-3067-4751-8c8a" name="Daemon Unit Type" primary="false"/>
           </categoryLinks>
+          <modifiers>
+            <modifier type="add" value="9231-183c-b97b-63f9" field="category">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="273c-d18c-4113-9be3" childId="9231-183c-b97b-63f9" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
+              </conditions>
+            </modifier>
+          </modifiers>
         </selectionEntry>
       </selectionEntries>
       <costs>
@@ -1668,7 +1761,7 @@
               <modifiers>
                 <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Heavy)">
                   <conditions>
-                    <condition type="instanceOf" value="1" field="selections" scope="41a0-6caa-af06-3684" childId="8cf6-d802-d054-6a86" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
+                    <condition type="instanceOf" value="1" field="selections" scope="4f8b-41ab-2b96-abdd" childId="9231-183c-b97b-63f9" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
                   </conditions>
                 </modifier>
               </modifiers>
@@ -1678,6 +1771,13 @@
             <categoryLink targetId="e699-d9cd-e68e-46d9" id="7ca2-ecec-440a-b9fc" name="Daemon Unit Type" primary="false"/>
             <categoryLink targetId="7d95-f9d1-440a-67bd" id="3cae-b86c-4395-a3d6" name="Monstrous Sub-type" primary="false"/>
           </categoryLinks>
+          <modifiers>
+            <modifier type="add" value="9231-183c-b97b-63f9" field="category">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="4f8b-41ab-2b96-abdd" childId="9231-183c-b97b-63f9" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
+              </conditions>
+            </modifier>
+          </modifiers>
         </selectionEntry>
       </selectionEntries>
       <costs>
@@ -1798,7 +1898,7 @@
               <modifiers>
                 <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Heavy)">
                   <conditions>
-                    <condition type="instanceOf" value="1" field="selections" scope="240a-1822-9e4f-3080" childId="8cf6-d802-d054-6a86" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
+                    <condition type="instanceOf" value="1" field="selections" scope="b128-73e-2b19-55c8" childId="9231-183c-b97b-63f9" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
                   </conditions>
                 </modifier>
               </modifiers>
@@ -1812,6 +1912,13 @@
             <categoryLink targetId="e699-d9cd-e68e-46d9" id="c715-e5b8-4d68-8e7b" name="Daemon Unit Type" primary="false"/>
             <categoryLink targetId="7d95-f9d1-440a-67bd" id="a797-6dc9-4343-a422" name="Monstrous Sub-type" primary="false"/>
           </categoryLinks>
+          <modifiers>
+            <modifier type="add" value="9231-183c-b97b-63f9" field="category">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="9231-183c-b97b-63f9" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
+              </conditions>
+            </modifier>
+          </modifiers>
         </selectionEntry>
       </selectionEntries>
       <costs>
@@ -1983,7 +2090,7 @@
               <modifiers>
                 <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Heavy)">
                   <conditions>
-                    <condition type="instanceOf" value="1" field="selections" scope="1fbb-b82e-ae1e-5a12" childId="8cf6-d802-d054-6a86" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
+                    <condition type="instanceOf" value="1" field="selections" scope="1fbb-b82e-ae1e-5a12" childId="9231-183c-b97b-63f9" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
                   </conditions>
                 </modifier>
               </modifiers>
@@ -1997,6 +2104,13 @@
             <categoryLink targetId="e699-d9cd-e68e-46d9" id="794f-5d11-4d31-8378" name="Daemon Unit Type" primary="false"/>
             <categoryLink targetId="f479-3c81-1e42-1b3a" id="390d-0f39-4a2f-8d01" name="Gargantuan Unit Sub-type" primary="false"/>
           </categoryLinks>
+          <modifiers>
+            <modifier type="add" value="9231-183c-b97b-63f9" field="category">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="9231-183c-b97b-63f9" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
+              </conditions>
+            </modifier>
+          </modifiers>
         </selectionEntry>
       </selectionEntries>
       <costs>

--- a/2022 - Daemons - Daemons of the Ruinstorm.cat
+++ b/2022 - Daemons - Daemons of the Ruinstorm.cat
@@ -255,7 +255,7 @@
                 </conditionGroup>
               </conditionGroups>
             </modifier>
-            <modifier type="append" value=" - Deflagerate [IT ✓]" field="name" join="">
+            <modifier type="append" value=" - Deflagrate [IT ✓]" field="name" join="">
               <conditions>
                 <condition type="instanceOf" value="0" field="selections" scope="ancestor" childId="6508-4f6a-0dc1-8f56" shared="true" includeChildSelections="true"/>
               </conditions>
@@ -520,7 +520,7 @@
                 </conditionGroup>
               </conditionGroups>
             </modifier>
-            <modifier type="append" value=" - Deflagerate [IT ✓]" field="name" join="">
+            <modifier type="append" value=" - Deflagrate [IT ✓]" field="name" join="">
               <conditions>
                 <condition type="instanceOf" value="0" field="selections" scope="ancestor" childId="6508-4f6a-0dc1-8f56" shared="true" includeChildSelections="true"/>
               </conditions>
@@ -686,7 +686,7 @@
             <infoLink id="ae51-3edb-f81-998e" name="Traitor" hidden="false" targetId="eff2-8b0e-21da-2f0d" type="rule"/>
             <infoLink name="Hammer of Wrath (X)" hidden="false" type="rule" id="663e-f215-a5a3-5da9" targetId="aec0-c3aa-1e4e-1779">
               <modifiers>
-                <modifier type="set" value="Hammer of Wrath (1 - Deflagerate [IT ✓])" field="name"/>
+                <modifier type="set" value="Hammer of Wrath (1 - Deflagrate [IT ✓])" field="name"/>
                 <modifier type="set" value="true" field="hidden">
                   <conditions>
                     <condition type="notInstanceOf" value="0" field="selections" scope="ancestor" childId="6508-4f6a-0dc1-8f56" shared="true"/>
@@ -793,7 +793,7 @@
                     <condition type="notInstanceOf" value="0" field="selections" scope="ancestor" childId="6508-4f6a-0dc1-8f56" shared="true" includeChildSelections="true"/>
                   </conditions>
                 </modifier>
-                <modifier type="append" value="2 - Deflagerate [IT ✓])" field="name">
+                <modifier type="append" value="2 - Deflagrate [IT ✓])" field="name">
                   <conditions>
                     <condition type="instanceOf" value="0" field="selections" scope="ancestor" childId="6508-4f6a-0dc1-8f56" shared="true" includeChildSelections="true"/>
                   </conditions>
@@ -942,7 +942,7 @@
                     <condition type="notInstanceOf" value="0" field="selections" scope="ancestor" childId="6508-4f6a-0dc1-8f56" shared="true" includeChildSelections="true"/>
                   </conditions>
                 </modifier>
-                <modifier type="append" value="2 - Deflagerate [IT ✓])" field="name">
+                <modifier type="append" value="2 - Deflagrate [IT ✓])" field="name">
                   <conditions>
                     <condition type="instanceOf" value="0" field="selections" scope="ancestor" childId="6508-4f6a-0dc1-8f56" shared="true" includeChildSelections="true"/>
                   </conditions>
@@ -1134,7 +1134,7 @@
                         <condition type="notInstanceOf" value="0" field="selections" scope="ancestor" childId="6508-4f6a-0dc1-8f56" shared="true" includeChildSelections="true"/>
                       </conditions>
                     </modifier>
-                    <modifier type="set" value="Hammer of Wrath (1 - Deflagerate [IT ✓])" field="name"/>
+                    <modifier type="set" value="Hammer of Wrath (1 - Deflagrate [IT ✓])" field="name"/>
                   </modifiers>
                 </infoLink>
               </infoLinks>
@@ -1199,7 +1199,7 @@
                         <condition type="notInstanceOf" value="0" field="selections" scope="ancestor" childId="6508-4f6a-0dc1-8f56" shared="true" includeChildSelections="true"/>
                       </conditions>
                     </modifier>
-                    <modifier type="set" value="Hammer of Wrath (1 - Deflagerate [IT ✓])" field="name"/>
+                    <modifier type="set" value="Hammer of Wrath (1 - Deflagrate [IT ✓])" field="name"/>
                   </modifiers>
                 </infoLink>
               </infoLinks>
@@ -1306,7 +1306,7 @@
           <infoLinks>
             <infoLink name="Hammer of Wrath (X)" id="f9e5-eb89-d5b3-e7f9" hidden="false" targetId="aec0-c3aa-1e4e-1779" type="rule">
               <modifiers>
-                <modifier type="set" value="Hammer of Wrath (1 - Deflagerate [IT ✓])" field="name"/>
+                <modifier type="set" value="Hammer of Wrath (1 - Deflagrate [IT ✓])" field="name"/>
                 <modifier type="set" value="true" field="hidden">
                   <conditions>
                     <condition type="notInstanceOf" value="1" field="selections" scope="ancestor" childId="6508-4f6a-0dc1-8f56" shared="true" includeChildSelections="true"/>
@@ -1462,7 +1462,7 @@
           <infoLinks>
             <infoLink name="Hammer of Wrath (X)" id="ae97-f4e1-3942-7ee0" hidden="false" targetId="aec0-c3aa-1e4e-1779" type="rule">
               <modifiers>
-                <modifier type="set" value="Hammer of Wrath (1 - Deflagerate [IT ✓])" field="name"/>
+                <modifier type="set" value="Hammer of Wrath (1 - Deflagrate [IT ✓])" field="name"/>
                 <modifier type="set" value="true" field="hidden">
                   <conditions>
                     <condition type="notInstanceOf" value="0" field="selections" scope="ancestor" childId="6508-4f6a-0dc1-8f56" shared="true" includeChildSelections="true"/>
@@ -1626,7 +1626,7 @@
         <infoLink id="1105-9717-b770-9f35" name="Traitor" hidden="false" targetId="eff2-8b0e-21da-2f0d" type="rule"/>
         <infoLink name="Hammer of Wrath (X)" hidden="false" type="rule" id="f808-d189-7f7d-f216" targetId="aec0-c3aa-1e4e-1779">
           <modifiers>
-            <modifier type="set" value="Hammer of Wrath (1 - Deflagerate [IT ✓])" field="name"/>
+            <modifier type="set" value="Hammer of Wrath (1 - Deflagrate [IT ✓])" field="name"/>
             <modifier type="set" value="true" field="hidden">
               <conditions>
                 <condition type="notInstanceOf" value="0" field="selections" scope="ancestor" childId="6508-4f6a-0dc1-8f56" shared="true"/>
@@ -1760,7 +1760,7 @@
                 <condition type="notInstanceOf" value="0" field="selections" scope="ancestor" childId="6508-4f6a-0dc1-8f56" shared="true" includeChildSelections="true"/>
               </conditions>
             </modifier>
-            <modifier type="append" value="2 [IW ✓] [IT ✓])" field="name">
+            <modifier type="append" value="2 - Deflagrate [IW ✓] [IT ✓])" field="name">
               <conditions>
                 <condition type="instanceOf" value="0" field="selections" scope="ancestor" childId="6508-4f6a-0dc1-8f56" shared="true" includeChildSelections="true"/>
               </conditions>
@@ -1919,7 +1919,7 @@
                 <condition type="notInstanceOf" value="0" field="selections" scope="ancestor" childId="6508-4f6a-0dc1-8f56" shared="true" includeChildSelections="true"/>
               </conditions>
             </modifier>
-            <modifier type="append" value="4 - Deflagerate [IT ✓])" field="name">
+            <modifier type="append" value="4 - Deflagrate [IT ✓])" field="name">
               <conditions>
                 <condition type="instanceOf" value="0" field="selections" scope="ancestor" childId="6508-4f6a-0dc1-8f56" shared="true" includeChildSelections="true"/>
               </conditions>
@@ -2141,7 +2141,7 @@
                 </conditionGroup>
               </conditionGroups>
             </modifier>
-            <modifier type="append" value=" - Deflagerate [IT ✓]" field="name" join="">
+            <modifier type="append" value=" - Deflagrate [IT ✓]" field="name" join="">
               <conditions>
                 <condition type="instanceOf" value="0" field="selections" scope="ancestor" childId="6508-4f6a-0dc1-8f56" shared="true" includeChildSelections="true"/>
               </conditions>
@@ -2327,7 +2327,7 @@
                 </conditionGroup>
               </conditionGroups>
             </modifier>
-            <modifier type="append" value=" - Deflagerate [IT ✓]" field="name" join="">
+            <modifier type="append" value=" - Deflagrate [IT ✓]" field="name" join="">
               <conditions>
                 <condition type="instanceOf" value="0" field="selections" scope="ancestor" childId="6508-4f6a-0dc1-8f56" shared="true" includeChildSelections="true"/>
               </conditions>

--- a/2022 - Daemons - Daemons of the Ruinstorm.cat
+++ b/2022 - Daemons - Daemons of the Ruinstorm.cat
@@ -1650,7 +1650,7 @@
         <infoLink id="c02d-11c2-315c-259f" name="Traitor" hidden="false" targetId="eff2-8b0e-21da-2f0d" type="rule"/>
         <infoLink name="Hammer of Wrath (X)" hidden="false" type="rule" id="25cc-41da-4e8-d8b8" targetId="aec0-c3aa-1e4e-1779">
           <modifiers>
-            <modifier type="set" value="Hammer of Wrath (1)" field="name"/>
+            <modifier type="set" value="Hammer of Wrath (1+1)" field="name"/>
             <modifier type="set" value="true" field="hidden">
               <conditions>
                 <condition type="notInstanceOf" value="0" field="selections" scope="ancestor" childId="6508-4f6a-0dc1-8f56" shared="true"/>
@@ -2853,6 +2853,18 @@ During a Reaction made in any Phase, a player may not choose to activate a model
       <constraints>
         <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="165a-67fd-7320-7538"/>
       </constraints>
+      <infoLinks>
+        <infoLink name="Bulky (X)" id="bb47-3002-5fef-4b73" hidden="false" type="rule" targetId="676c-7b75-4b6f-9405">
+          <modifiers>
+            <modifier type="set" value="Bulky (2 or +1 if higher)" field="name"/>
+          </modifiers>
+        </infoLink>
+        <infoLink name="Hammer of Wrath (X)" id="8f8e-f995-49a3-a352" hidden="false" type="rule" targetId="aec0-c3aa-1e4e-1779">
+          <modifiers>
+            <modifier type="set" value="Hammer of Wrath (1 or +1 if higher)" field="name"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
     </selectionEntry>
     <selectionEntry type="upgrade" import="true" name="Miasma of Rage" hidden="false" id="ce6-3fae-8519-e10d">
       <profiles>

--- a/2022 - Horus Heresy.gst
+++ b/2022 - Horus Heresy.gst
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<gameSystem xmlns="http://www.battlescribe.net/schema/gameSystemSchema" id="28d4-bd2e-4858-ece6" name="Horus Heresy (2022)" revision="126" battleScribeVersion="2.03" type="gameSystem">
+<gameSystem xmlns="http://www.battlescribe.net/schema/gameSystemSchema" id="28d4-bd2e-4858-ece6" name="Horus Heresy (2022)" revision="127" battleScribeVersion="2.03" type="gameSystem">
   <publications>
     <publication name="Github" hidden="false" id="e2a4-ac85-1bef-22f5" publisherUrl="https://github.com/BSData/horus-heresy" shortName="BSData/horus-heresy"/>
     <publication id="e77a-823a-da94-16b9" name="Warhammer: The Horus Heresy - Age of Darkness Rulebook" shortName="Main Rules" publicationDate="June 2022"/>
@@ -920,7 +920,7 @@ Conversely, if an Independent Character joins a unit after that unit has been th
     </categoryEntry>
     <categoryEntry id="0ea2-efb5-b7af-226e" name="Fast Sub-type" hidden="false">
       <rules>
-        <rule id="2cbf-c1a1-844a-6456" name="Fast Vehicles" hidden="false">
+        <rule id="2cbf-c1a1-844a-6456" name="Fast Vehicles" hidden="true">
           <description>When a Fast Vehicle moves, other than to pivot in place, it is always considered to have moved at Combat Speed regardless of how many inches it moves, unless it chooses to move Flat-out.
 In addition, when a Fast Vehicle moves, it may choose to move at Flat-out:</description>
         </rule>
@@ -1119,7 +1119,17 @@ In addition, when a Fast Vehicle moves, it may choose to move at Flat-out:</desc
         <constraint field="selections" scope="force" value="-1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6098-fe90-8855-def8" type="max"/>
       </constraints>
     </categoryEntry>
-    <categoryEntry id="4303-1348-cce4-9501" name="Antigrav Sub-type" hidden="false"/>
+    <categoryEntry id="4303-1348-cce4-9501" name="Antigrav Sub-type" hidden="false">
+      <rules>
+        <rule name="Antigrav Sub-type" id="d33c-5dd3-b848-885d" hidden="false">
+          <description>The following rules apply to all models with the Antigrav
+sub-type:
+• A unit that includes only models with the Antigrav sub-type may ignore the effects of any and all terrain it passes over during movement, including passing over vertical terrain and Impassable Terrain without penalty
+or restriction. However, such units may not begin or end their movement in Impassable Terrain, and if beginning or ending their movement in Dangerous Terrain must take Dangerous Terrain tests as normal.
+• Models with the Antigrav sub-type may never benefit from Cover Saves of any kind.</description>
+        </rule>
+      </rules>
+    </categoryEntry>
     <categoryEntry id="e333-681c-ddca-24f6" name="Crusade" hidden="false"/>
     <categoryEntry id="4aca-2849-7f41-0200" name="SA or IM Unit" hidden="false">
       <modifiers>

--- a/2022 - Imperialis Militia.cat
+++ b/2022 - Imperialis Militia.cat
@@ -10121,6 +10121,7 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
       </selectionEntries>
       <entryLinks>
         <entryLink id="93f1-4fba-7e2b-9f33" name="Provenance Options" hidden="false" collective="false" import="true" targetId="5fb4-282e-7957-1492" type="selectionEntryGroup"/>
+        <entryLink import="true" name="The Ætheric Dominion (X)" hidden="false" id="ad5d-1ed0-8998-fd46" type="selectionEntryGroup" targetId="002f-0e40-9d49-2a22"/>
       </entryLinks>
       <costs>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
@@ -10621,7 +10622,7 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
       <modifiers>
         <modifier type="add" field="category" value="9231-183c-b97b-63f9">
           <conditions>
-            <condition field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b7db-bf16-47c5-dc05" type="equalTo"/>
+            <condition field="selections" scope="ancestor" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b7db-bf16-47c5-dc05" type="instanceOf"/>
           </conditions>
         </modifier>
       </modifiers>
@@ -10630,7 +10631,6 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
         <categoryLink id="7a15-dc82-ffcd-db05" name="Bound Sub-type" hidden="false" targetId="40f3-05e8-5ddc-636a" primary="false"/>
       </categoryLinks>
       <entryLinks>
-        <entryLink id="c53d-e01a-7483-aa48" name="The Ætheric Dominion (Unit)" hidden="false" collective="false" import="true" targetId="caad-e621-38e5-cb5f" type="selectionEntryGroup"/>
         <entryLink id="3d84-14ff-b8ef-51b1" name="Bound Daemon Brute" hidden="false" collective="false" import="true" targetId="12a1-9b89-fe2e-29dd" type="selectionEntry"/>
       </entryLinks>
       <costs>
@@ -10655,7 +10655,6 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
             </modifier>
           </modifiers>
         </entryLink>
-        <entryLink import="true" name="The Ætheric Dominion (Unit)" hidden="false" type="selectionEntryGroup" id="850d-2b23-959e-b06d" targetId="caad-e621-38e5-cb5f"/>
       </entryLinks>
       <infoLinks>
         <infoLink name="Traitor" hidden="false" type="rule" id="fa15-d302-8a5d-cbc0" targetId="eff2-8b0e-21da-2f0d"/>
@@ -10671,9 +10670,10 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
         </infoLink>
         <infoLink id="20ad-3b87-7f90-13ae" name="Hammer of Wrath (X)" hidden="false" targetId="aec0-c3aa-1e4e-1779" type="rule">
           <modifiers>
-            <modifier type="set" field="name" value="Hammer of Wrath (1)">
+            <modifier type="set" field="name" value="Hammer of Wrath (1)"/>
+            <modifier type="set" value="true" field="hidden">
               <conditions>
-                <condition type="atLeast" value="1" field="selections" scope="parent" childId="e4fb-66cd-e07d-609b" shared="true"/>
+                <condition type="notInstanceOf" value="1" field="selections" scope="ancestor" childId="e4fb-66cd-e07d-609b" shared="true"/>
               </conditions>
             </modifier>
           </modifiers>
@@ -10682,7 +10682,7 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
       <modifiers>
         <modifier type="add" field="category" value="9231-183c-b97b-63f9">
           <conditions>
-            <condition field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b7db-bf16-47c5-dc05" type="atLeast"/>
+            <condition field="selections" scope="ancestor" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b7db-bf16-47c5-dc05" type="instanceOf"/>
           </conditions>
         </modifier>
       </modifiers>
@@ -10696,7 +10696,6 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
       </categoryLinks>
       <entryLinks>
         <entryLink import="true" name="Daemon Brute" hidden="false" type="selectionEntry" id="8838-1f4d-99ad-c5a6" targetId="e3e-4f46-2300-a35"/>
-        <entryLink import="true" name="The Ætheric Dominion (Unit)" hidden="false" type="selectionEntryGroup" id="c199-83a6-b057-7da4" targetId="caad-e621-38e5-cb5f"/>
       </entryLinks>
       <infoLinks>
         <infoLink id="ce10-5041-d503-82f7" name="Æthereal Invulnerability (X)" hidden="false" targetId="e05e-ed23-64fb-a535" type="rule">
@@ -10713,12 +10712,12 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
           <modifiers>
             <modifier type="set" field="name" value="Hammer of Wrath (1)">
               <conditions>
-                <condition type="equalTo" value="0" field="selections" scope="parent" childId="e4fb-66cd-e07d-609b" shared="true"/>
+                <condition type="notInstanceOf" value="0" field="selections" scope="ancestor" childId="e4fb-66cd-e07d-609b" shared="true"/>
               </conditions>
             </modifier>
             <modifier type="set" field="name" value="Hammer of Wrath (2)">
               <conditions>
-                <condition type="atLeast" value="1" field="selections" scope="parent" childId="e4fb-66cd-e07d-609b" shared="true"/>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e4fb-66cd-e07d-609b" shared="true"/>
               </conditions>
             </modifier>
           </modifiers>
@@ -10728,7 +10727,7 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
       <modifiers>
         <modifier type="add" field="category" value="9231-183c-b97b-63f9">
           <conditions>
-            <condition field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b7db-bf16-47c5-dc05" type="atLeast"/>
+            <condition field="selections" scope="ancestor" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b7db-bf16-47c5-dc05" type="instanceOf"/>
           </conditions>
         </modifier>
       </modifiers>
@@ -10773,12 +10772,11 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
       <modifiers>
         <modifier type="add" field="category" value="9231-183c-b97b-63f9">
           <conditions>
-            <condition field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b7db-bf16-47c5-dc05" type="atLeast"/>
+            <condition field="selections" scope="ancestor" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b7db-bf16-47c5-dc05" type="instanceOf"/>
           </conditions>
         </modifier>
       </modifiers>
       <entryLinks>
-        <entryLink import="true" name="The Ætheric Dominion (Unit)" hidden="false" type="selectionEntryGroup" id="e10c-2d2d-4422-98bf" targetId="caad-e621-38e5-cb5f"/>
         <entryLink import="true" name="Daemon Swarm" hidden="false" type="selectionEntry" id="9561-3d96-affe-6942" targetId="cb8c-b27a-ea4e-1c91"/>
       </entryLinks>
     </selectionEntry>
@@ -10790,7 +10788,6 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
         <categoryLink targetId="e699-d9cd-e68e-46d9" id="f504-44e8-e7f5-54d3" primary="false" name="Daemon Unit Type"/>
       </categoryLinks>
       <entryLinks>
-        <entryLink import="true" name="The Ætheric Dominion (Unit)" hidden="false" type="selectionEntryGroup" id="1a90-ab1a-5dff-166a" targetId="caad-e621-38e5-cb5f"/>
         <entryLink import="true" name="Lesser Daemon" hidden="false" type="selectionEntry" id="9f17-1c62-e6ab-7996" targetId="5da5-c15b-dfe5-d1b5"/>
       </entryLinks>
       <selectionEntryGroups>
@@ -10821,9 +10818,10 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
         </infoLink>
         <infoLink id="f9e5-eb89-d5b3-e7f9" name="Hammer of Wrath (X)" hidden="false" targetId="aec0-c3aa-1e4e-1779" type="rule">
           <modifiers>
-            <modifier type="set" field="name" value="Hammer of Wrath (1)">
+            <modifier type="set" field="name" value="Hammer of Wrath (1)"/>
+            <modifier type="set" value="true" field="hidden">
               <conditions>
-                <condition type="atLeast" value="1" field="selections" scope="parent" childId="e4fb-66cd-e07d-609b" shared="true"/>
+                <condition type="notInstanceOf" value="1" field="selections" scope="ancestor" childId="e4fb-66cd-e07d-609b" shared="true"/>
               </conditions>
             </modifier>
           </modifiers>

--- a/2022 - Imperialis Militia.cat
+++ b/2022 - Imperialis Militia.cat
@@ -10636,6 +10636,52 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
       <costs>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15"/>
       </costs>
+      <modifierGroups>
+        <modifierGroup type="and">
+          <modifiers>
+            <modifier type="add" value="c42-1919-c37e-51f0" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="ca6c-e8cf-7bc1-eaa0" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="9556-82c1-c70a-126e" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="8ed0-3582-f536-c48e" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="f074-f60a-9aa6-c52a" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="3d70-1d54-a791-ac60" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="6508-4f6a-0dc1-8f56" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="e4fb-66cd-e07d-609b" shared="true" includeChildSelections="true" includeChildForces="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="bcf6-8350-9099-1e91" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="9508-8124-d34a-500a" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="8cf6-d802-d054-6a86" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="b7db-bf16-47c5-dc05" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="a1d4-4662-c944-19cc" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="1214-3abe-c6d1-2038" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="2774-1a32-f196-be76" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="945c-b969-75eb-19d9" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </modifierGroup>
+      </modifierGroups>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Ruinstorm Daemon Beasts (Rogue Psyker)" hidden="false" id="d4a1-49ca-a50c-938a">
       <costs>
@@ -10673,7 +10719,7 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
             <modifier type="set" field="name" value="Hammer of Wrath (1)"/>
             <modifier type="set" value="true" field="hidden">
               <conditions>
-                <condition type="notInstanceOf" value="1" field="selections" scope="ancestor" childId="e4fb-66cd-e07d-609b" shared="true"/>
+                <condition type="notInstanceOf" value="1" field="selections" scope="bd4-3569-8ef7-b242" childId="e4fb-66cd-e07d-609b" shared="true" includeChildSelections="true"/>
               </conditions>
             </modifier>
           </modifiers>
@@ -10686,6 +10732,52 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
           </conditions>
         </modifier>
       </modifiers>
+      <modifierGroups>
+        <modifierGroup type="and">
+          <modifiers>
+            <modifier type="add" value="c42-1919-c37e-51f0" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="ca6c-e8cf-7bc1-eaa0" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="9556-82c1-c70a-126e" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="8ed0-3582-f536-c48e" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="f074-f60a-9aa6-c52a" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="3d70-1d54-a791-ac60" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="6508-4f6a-0dc1-8f56" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="e4fb-66cd-e07d-609b" shared="true" includeChildSelections="true" includeChildForces="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="bcf6-8350-9099-1e91" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="9508-8124-d34a-500a" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="8cf6-d802-d054-6a86" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="b7db-bf16-47c5-dc05" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="a1d4-4662-c944-19cc" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="1214-3abe-c6d1-2038" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="2774-1a32-f196-be76" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="945c-b969-75eb-19d9" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </modifierGroup>
+      </modifierGroups>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Ruinstorm Daemon Brutes (Rogue Psyker)" hidden="false" id="742c-94f0-7102-2b4a">
       <costs>
@@ -10706,20 +10798,6 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
         <infoLink id="806e-6d25-519f-599" name="Bulky (X)" hidden="false" targetId="676c-7b75-4b6f-9405" type="rule">
           <modifiers>
             <modifier type="set" value="Bulky (3)" field="name"/>
-          </modifiers>
-        </infoLink>
-        <infoLink id="804f-8506-4a73-bb73" name="Hammer of Wrath (X)" hidden="false" targetId="aec0-c3aa-1e4e-1779" type="rule">
-          <modifiers>
-            <modifier type="set" field="name" value="Hammer of Wrath (1)">
-              <conditions>
-                <condition type="notInstanceOf" value="0" field="selections" scope="ancestor" childId="e4fb-66cd-e07d-609b" shared="true"/>
-              </conditions>
-            </modifier>
-            <modifier type="set" field="name" value="Hammer of Wrath (2)">
-              <conditions>
-                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e4fb-66cd-e07d-609b" shared="true"/>
-              </conditions>
-            </modifier>
           </modifiers>
         </infoLink>
         <infoLink id="cb3c-85a9-7bc2-5508" name="Traitor" hidden="false" targetId="eff2-8b0e-21da-2f0d" type="rule"/>
@@ -10747,6 +10825,52 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
           </constraints>
         </selectionEntryGroup>
       </selectionEntryGroups>
+      <modifierGroups>
+        <modifierGroup type="and">
+          <modifiers>
+            <modifier type="add" value="c42-1919-c37e-51f0" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="ca6c-e8cf-7bc1-eaa0" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="9556-82c1-c70a-126e" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="8ed0-3582-f536-c48e" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="f074-f60a-9aa6-c52a" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="3d70-1d54-a791-ac60" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="6508-4f6a-0dc1-8f56" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="e4fb-66cd-e07d-609b" shared="true" includeChildSelections="true" includeChildForces="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="bcf6-8350-9099-1e91" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="9508-8124-d34a-500a" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="8cf6-d802-d054-6a86" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="b7db-bf16-47c5-dc05" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="a1d4-4662-c944-19cc" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="1214-3abe-c6d1-2038" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="2774-1a32-f196-be76" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="945c-b969-75eb-19d9" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </modifierGroup>
+      </modifierGroups>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Ruinstorm Daemon Swarms (Rogue Psyker)" hidden="false" id="35ce-dce-186d-4000">
       <costs>
@@ -10756,15 +10880,6 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
         <categoryLink targetId="e699-d9cd-e68e-46d9" id="4c49-865a-fc97-7c58" primary="false" name="Daemon Unit Type"/>
       </categoryLinks>
       <infoLinks>
-        <infoLink id="48c7-6e7a-dca2-a2b7" name="Hammer of Wrath (X)" hidden="false" targetId="aec0-c3aa-1e4e-1779" type="rule">
-          <modifiers>
-            <modifier type="set" field="name" value="Hammer of Wrath (1)">
-              <conditions>
-                <condition type="atLeast" value="1" field="selections" scope="parent" childId="e4fb-66cd-e07d-609b" shared="true"/>
-              </conditions>
-            </modifier>
-          </modifiers>
-        </infoLink>
         <infoLink name="Support Squad" hidden="false" type="rule" id="3b6e-32f8-5d2a-3c89" targetId="768e-56d6-ca52-24ae"/>
         <infoLink name="Swarm" hidden="false" type="rule" id="bb0a-6a7c-f9c-96bf" targetId="0bc2-fcb2-dd25-c10a"/>
         <infoLink id="6961-8f0c-258d-85d0" name="Traitor" hidden="false" targetId="eff2-8b0e-21da-2f0d" type="rule"/>
@@ -10779,6 +10894,52 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
       <entryLinks>
         <entryLink import="true" name="Daemon Swarm" hidden="false" type="selectionEntry" id="9561-3d96-affe-6942" targetId="cb8c-b27a-ea4e-1c91"/>
       </entryLinks>
+      <modifierGroups>
+        <modifierGroup type="and">
+          <modifiers>
+            <modifier type="add" value="c42-1919-c37e-51f0" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="ca6c-e8cf-7bc1-eaa0" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="9556-82c1-c70a-126e" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="8ed0-3582-f536-c48e" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="f074-f60a-9aa6-c52a" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="3d70-1d54-a791-ac60" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="6508-4f6a-0dc1-8f56" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="e4fb-66cd-e07d-609b" shared="true" includeChildSelections="true" includeChildForces="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="bcf6-8350-9099-1e91" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="9508-8124-d34a-500a" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="8cf6-d802-d054-6a86" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="b7db-bf16-47c5-dc05" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="a1d4-4662-c944-19cc" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="1214-3abe-c6d1-2038" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="2774-1a32-f196-be76" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="945c-b969-75eb-19d9" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </modifierGroup>
+      </modifierGroups>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Ruinstorm Lesser Daemons (Rogue Psyker)" hidden="false" id="1add-d983-171e-cd1d">
       <costs>
@@ -10816,25 +10977,61 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
             <modifier type="set" field="name" value="Æthereal Invulnerability (5+)"/>
           </modifiers>
         </infoLink>
-        <infoLink id="f9e5-eb89-d5b3-e7f9" name="Hammer of Wrath (X)" hidden="false" targetId="aec0-c3aa-1e4e-1779" type="rule">
-          <modifiers>
-            <modifier type="set" field="name" value="Hammer of Wrath (1)"/>
-            <modifier type="set" value="true" field="hidden">
-              <conditions>
-                <condition type="notInstanceOf" value="1" field="selections" scope="ancestor" childId="e4fb-66cd-e07d-609b" shared="true"/>
-              </conditions>
-            </modifier>
-          </modifiers>
-        </infoLink>
         <infoLink id="8030-7271-51-55b5" name="Traitor" hidden="false" targetId="eff2-8b0e-21da-2f0d" type="rule"/>
       </infoLinks>
       <modifiers>
         <modifier type="add" field="category" value="9231-183c-b97b-63f9">
           <conditions>
-            <condition field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b7db-bf16-47c5-dc05" type="atLeast"/>
+            <condition field="selections" scope="ancestor" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b7db-bf16-47c5-dc05" type="instanceOf"/>
           </conditions>
         </modifier>
       </modifiers>
+      <modifierGroups>
+        <modifierGroup type="and">
+          <modifiers>
+            <modifier type="add" value="c42-1919-c37e-51f0" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="ca6c-e8cf-7bc1-eaa0" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="9556-82c1-c70a-126e" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="8ed0-3582-f536-c48e" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="f074-f60a-9aa6-c52a" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="3d70-1d54-a791-ac60" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="6508-4f6a-0dc1-8f56" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="e4fb-66cd-e07d-609b" shared="true" includeChildSelections="true" includeChildForces="false"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="bcf6-8350-9099-1e91" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="9508-8124-d34a-500a" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="8cf6-d802-d054-6a86" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="b7db-bf16-47c5-dc05" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="a1d4-4662-c944-19cc" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="1214-3abe-c6d1-2038" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="2774-1a32-f196-be76" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="945c-b969-75eb-19d9" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </modifierGroup>
+      </modifierGroups>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Militia Triaros Conveyor" hidden="false" id="620a-5824-8cea-f025" publicationId="bde1-6db1-163b-3b76" page="38">
       <costs>

--- a/2022 - LA - Word Bearers.cat
+++ b/2022 - LA - Word Bearers.cat
@@ -5817,7 +5817,6 @@ Threatening Entreaties - Kor Phaeron and the unit he has joined gain the Fearles
         <categoryLink id="bda0-69f3-9a67-867f" name="Bound Sub-type" hidden="false" targetId="40f3-05e8-5ddc-636a" primary="false"/>
       </categoryLinks>
       <entryLinks>
-        <entryLink id="b66c-cc27-85cb-d896" name="The Ætheric Dominion (Unit)" hidden="false" collective="false" import="true" targetId="caad-e621-38e5-cb5f" type="selectionEntryGroup"/>
         <entryLink id="d4e0-363a-09d2-2c94" name="Bound Daemon Attendant" hidden="false" collective="false" import="true" targetId="77cd-426a-d300-31a1" type="selectionEntry"/>
         <entryLink id="9d75-6fb5-326f-f5a7" name="Bound Daemon Regent" hidden="false" collective="false" import="true" targetId="6979-74bc-2519-6bba" type="selectionEntry"/>
       </entryLinks>
@@ -5838,7 +5837,6 @@ Threatening Entreaties - Kor Phaeron and the unit he has joined gain the Fearles
         <categoryLink id="2c84-da60-2762-c184" name="Bound Sub-type" hidden="false" targetId="40f3-05e8-5ddc-636a" primary="false"/>
       </categoryLinks>
       <entryLinks>
-        <entryLink id="8719-b207-984d-582c" name="The Ætheric Dominion (Unit)" hidden="false" collective="false" import="true" targetId="caad-e621-38e5-cb5f" type="selectionEntryGroup"/>
         <entryLink id="97a2-a51e-51dd-4680" name="Bound Daemon Brute" hidden="false" collective="false" import="true" targetId="12a1-9b89-fe2e-29dd" type="selectionEntry"/>
       </entryLinks>
       <costs>
@@ -5863,7 +5861,6 @@ Threatening Entreaties - Kor Phaeron and the unit he has joined gain the Fearles
             </modifier>
           </modifiers>
         </entryLink>
-        <entryLink import="true" name="The Ætheric Dominion (Unit)" hidden="false" type="selectionEntryGroup" id="6d0c-433c-9ccc-2922" targetId="caad-e621-38e5-cb5f"/>
       </entryLinks>
       <infoLinks>
         <infoLink name="Traitor" hidden="false" type="rule" id="99b-377b-84f1-96c8" targetId="eff2-8b0e-21da-2f0d"/>
@@ -5904,7 +5901,6 @@ Threatening Entreaties - Kor Phaeron and the unit he has joined gain the Fearles
       </categoryLinks>
       <entryLinks>
         <entryLink import="true" name="Daemon Brute" hidden="false" type="selectionEntry" id="f0e3-7d1f-1f4d-ed7b" targetId="e3e-4f46-2300-a35"/>
-        <entryLink import="true" name="The Ætheric Dominion (Unit)" hidden="false" type="selectionEntryGroup" id="b6d8-cbc2-5c46-610e" targetId="caad-e621-38e5-cb5f"/>
         <entryLink import="true" name="Infernal Armaments" hidden="false" type="selectionEntry" id="9071-3e03-be60-47f1" targetId="9abc-11e8-9031-d104"/>
       </entryLinks>
       <infoLinks>
@@ -5969,7 +5965,6 @@ Threatening Entreaties - Kor Phaeron and the unit he has joined gain the Fearles
         </infoLink>
       </infoLinks>
       <entryLinks>
-        <entryLink import="true" name="The Ætheric Dominion (Unit)" hidden="false" type="selectionEntryGroup" id="9f12-2cdf-442-88cb" targetId="caad-e621-38e5-cb5f"/>
         <entryLink import="true" name="Infernal Armaments" hidden="false" type="selectionEntry" id="cc31-85a3-787b-16ff" targetId="9abc-11e8-9031-d104">
           <constraints>
             <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="71a4-ae7b-216d-b832"/>
@@ -6027,7 +6022,6 @@ Threatening Entreaties - Kor Phaeron and the unit he has joined gain the Fearles
         </infoLink>
       </infoLinks>
       <entryLinks>
-        <entryLink import="true" name="The Ætheric Dominion (Unit)" hidden="false" type="selectionEntryGroup" id="6121-d959-c07-24b9" targetId="caad-e621-38e5-cb5f"/>
         <entryLink import="true" name="Ruinstorm Behemoth" hidden="false" type="selectionEntry" id="b160-c287-b0fa-a119" targetId="b128-73e-2b19-55c8"/>
         <entryLink import="true" name="May take up to two of the following options:" hidden="false" type="selectionEntryGroup" id="a6b0-48ff-1d92-7ee2" targetId="98ce-5174-21c-546a"/>
         <entryLink import="true" name="Weapon" hidden="false" type="selectionEntryGroup" id="e164-532-b8e-4a1c" targetId="d09c-34b9-8314-e1f8"/>
@@ -6065,7 +6059,6 @@ Threatening Entreaties - Kor Phaeron and the unit he has joined gain the Fearles
         </infoLink>
       </infoLinks>
       <entryLinks>
-        <entryLink import="true" name="The Ætheric Dominion (Unit)" hidden="false" type="selectionEntryGroup" id="7e7c-82db-b036-41bc" targetId="caad-e621-38e5-cb5f"/>
         <entryLink import="true" name="Daemon Cavalry" hidden="false" type="selectionEntry" id="9c36-6a0b-a630-3abb" targetId="635d-bc63-b7de-84e3"/>
         <entryLink import="true" name="Weapons" hidden="false" type="selectionEntryGroup" id="add9-4e64-ccb6-e72f" targetId="a8a4-643c-91b2-9d35"/>
       </entryLinks>
@@ -6081,7 +6074,6 @@ Threatening Entreaties - Kor Phaeron and the unit he has joined gain the Fearles
         <infoLink id="bbf7-b35d-7a50-b5d5" name="Traitor" hidden="false" targetId="eff2-8b0e-21da-2f0d" type="rule"/>
       </infoLinks>
       <entryLinks>
-        <entryLink import="true" name="The Ætheric Dominion (Unit)" hidden="false" type="selectionEntryGroup" id="ad72-3e47-ac6b-3054" targetId="caad-e621-38e5-cb5f"/>
         <entryLink import="true" name="Harbinger" hidden="false" type="selectionEntry" id="b6c6-7d89-5cc4-e39a" targetId="45fa-e6f-ff0-9c02"/>
         <entryLink import="true" name="Daemon Attendant" hidden="false" type="selectionEntry" id="8d4e-e524-757f-7965" targetId="ddd6-2d23-531f-12b7"/>
       </entryLinks>
@@ -6130,7 +6122,6 @@ Threatening Entreaties - Kor Phaeron and the unit he has joined gain the Fearles
         </infoLink>
       </infoLinks>
       <entryLinks>
-        <entryLink import="true" name="The Ætheric Dominion (Unit)" hidden="false" type="selectionEntryGroup" id="3408-c5d2-efc9-37d7" targetId="caad-e621-38e5-cb5f"/>
         <entryLink import="true" name="Warlord Traits (Ruinstorm Daemons)" hidden="false" type="selectionEntryGroup" id="52d1-64db-ca90-8225" targetId="2f76-74c1-d329-d3ab"/>
         <entryLink import="true" name="May take up to two of the following options:" hidden="false" type="selectionEntryGroup" id="499c-b32b-f7ee-c369" targetId="ea1-884d-4e8a-4a66"/>
         <entryLink import="true" name="Warlord" hidden="false" type="selectionEntry" id="e075-f1fa-d916-b2d8" targetId="0176-56a3-d590-b103"/>
@@ -6175,7 +6166,6 @@ Threatening Entreaties - Kor Phaeron and the unit he has joined gain the Fearles
         </infoLink>
       </infoLinks>
       <entryLinks>
-        <entryLink import="true" name="The Ætheric Dominion (Unit)" hidden="false" type="selectionEntryGroup" id="adca-a6ea-b57b-2c90" targetId="caad-e621-38e5-cb5f"/>
         <entryLink import="true" name="Weapons" hidden="false" type="selectionEntryGroup" id="5392-962a-ac73-e569" targetId="38df-f8ac-dd92-a3e5"/>
         <entryLink import="true" name="Immaterial Wings" hidden="false" type="selectionEntry" id="64bc-2cf6-17a7-d75d" targetId="fd64-626a-d3d4-9b8e">
           <constraints>
@@ -6202,7 +6192,6 @@ Threatening Entreaties - Kor Phaeron and the unit he has joined gain the Fearles
         </infoLink>
       </infoLinks>
       <entryLinks>
-        <entryLink import="true" name="The Ætheric Dominion (Unit)" hidden="false" type="selectionEntryGroup" id="65c2-a37f-615d-612f" targetId="caad-e621-38e5-cb5f"/>
         <entryLink import="true" name="Lesser Daemon" hidden="false" type="selectionEntry" id="17ca-c2a2-11f3-c889" targetId="5da5-c15b-dfe5-d1b5"/>
       </entryLinks>
       <costs>
@@ -6257,7 +6246,6 @@ Threatening Entreaties - Kor Phaeron and the unit he has joined gain the Fearles
         <infoLink name="Swarm" hidden="false" type="rule" id="4c68-1d80-a45c-537" targetId="0bc2-fcb2-dd25-c10a"/>
       </infoLinks>
       <entryLinks>
-        <entryLink import="true" name="The Ætheric Dominion (Unit)" hidden="false" type="selectionEntryGroup" id="d0f5-88f9-92cf-c1f9" targetId="caad-e621-38e5-cb5f"/>
         <entryLink import="true" name="Daemon Swarm" hidden="false" type="selectionEntry" id="c1ea-e0f0-b5aa-d8bf" targetId="cb8c-b27a-ea4e-1c91"/>
       </entryLinks>
       <costs>
@@ -6299,7 +6287,6 @@ Threatening Entreaties - Kor Phaeron and the unit he has joined gain the Fearles
         </infoLink>
       </infoLinks>
       <entryLinks>
-        <entryLink import="true" name="The Ætheric Dominion (Unit)" hidden="false" type="selectionEntryGroup" id="c6b5-1772-2956-768b" targetId="caad-e621-38e5-cb5f"/>
         <entryLink import="true" name="Warlord" hidden="false" type="selectionEntry" id="bf12-48da-af80-6ddf" targetId="0176-56a3-d590-b103"/>
         <entryLink import="true" name="Warlord Traits (Ruinstorm Daemons)" hidden="false" type="selectionEntryGroup" id="ee18-fe50-7b84-2f5d" targetId="2f76-74c1-d329-d3ab"/>
         <entryLink import="true" name="May take up to three of the following options:" hidden="false" type="selectionEntryGroup" id="1a32-1a58-e759-497" targetId="e1f6-c1d2-62c2-381b"/>

--- a/2022 - LA - Word Bearers.cat
+++ b/2022 - LA - Word Bearers.cat
@@ -6125,7 +6125,7 @@ Threatening Entreaties - Kor Phaeron and the unit he has joined gain the Fearles
                 <condition type="notInstanceOf" value="0" field="selections" scope="ancestor" childId="6508-4f6a-0dc1-8f56" shared="true" includeChildSelections="true"/>
               </conditions>
             </modifier>
-            <modifier type="append" value="4 - Deflagerate [IT ✓])" field="name">
+            <modifier type="append" value="4 - Deflagrate [IT ✓])" field="name">
               <conditions>
                 <condition type="instanceOf" value="0" field="selections" scope="ancestor" childId="6508-4f6a-0dc1-8f56" shared="true" includeChildSelections="true"/>
               </conditions>
@@ -6264,7 +6264,7 @@ Threatening Entreaties - Kor Phaeron and the unit he has joined gain the Fearles
                 </conditionGroup>
               </conditionGroups>
             </modifier>
-            <modifier type="append" value=" - Deflagerate [IT ✓]" field="name" join="">
+            <modifier type="append" value=" - Deflagrate [IT ✓]" field="name" join="">
               <conditions>
                 <condition type="instanceOf" value="0" field="selections" scope="ancestor" childId="6508-4f6a-0dc1-8f56" shared="true" includeChildSelections="true"/>
               </conditions>
@@ -6363,7 +6363,7 @@ Threatening Entreaties - Kor Phaeron and the unit he has joined gain the Fearles
         </infoLink>
         <infoLink name="Hammer of Wrath (X)" id="ef1b-a68a-3967-46ca" hidden="false" type="rule" targetId="aec0-c3aa-1e4e-1779">
           <modifiers>
-            <modifier type="set" value="Hammer of Wrath (1 - Deflagerate [IT ✓])" field="name"/>
+            <modifier type="set" value="Hammer of Wrath (1 - Deflagrate [IT ✓])" field="name"/>
             <modifier type="set" value="true" field="hidden">
               <conditions>
                 <condition type="notInstanceOf" value="0" field="selections" scope="ancestor" childId="6508-4f6a-0dc1-8f56" shared="true"/>
@@ -6567,7 +6567,7 @@ Threatening Entreaties - Kor Phaeron and the unit he has joined gain the Fearles
                 </conditionGroup>
               </conditionGroups>
             </modifier>
-            <modifier type="append" value=" - Deflagerate [IT ✓]" field="name" join="">
+            <modifier type="append" value=" - Deflagrate [IT ✓]" field="name" join="">
               <conditions>
                 <condition type="instanceOf" value="0" field="selections" scope="ancestor" childId="6508-4f6a-0dc1-8f56" shared="true" includeChildSelections="true"/>
               </conditions>
@@ -6679,7 +6679,7 @@ Threatening Entreaties - Kor Phaeron and the unit he has joined gain the Fearles
                 <condition type="notInstanceOf" value="0" field="selections" scope="ancestor" childId="6508-4f6a-0dc1-8f56" shared="true" includeChildSelections="true"/>
               </conditions>
             </modifier>
-            <modifier type="append" value="2 [IW ✓] [IT ✓])" field="name">
+            <modifier type="append" value="2 - Deflagrate [IW ✓] [IT ✓])" field="name">
               <conditions>
                 <condition type="instanceOf" value="0" field="selections" scope="ancestor" childId="6508-4f6a-0dc1-8f56" shared="true" includeChildSelections="true"/>
               </conditions>
@@ -6984,7 +6984,7 @@ Threatening Entreaties - Kor Phaeron and the unit he has joined gain the Fearles
                 </conditionGroup>
               </conditionGroups>
             </modifier>
-            <modifier type="append" value=" - Deflagerate [IT ✓]" field="name" join="">
+            <modifier type="append" value=" - Deflagrate [IT ✓]" field="name" join="">
               <conditions>
                 <condition type="instanceOf" value="0" field="selections" scope="ancestor" childId="6508-4f6a-0dc1-8f56" shared="true" includeChildSelections="true"/>
               </conditions>

--- a/2022 - LA - Word Bearers.cat
+++ b/2022 - LA - Word Bearers.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="1df7-bbbc-b70e-6a3f" name="LA -  XVII: Word Bearers" revision="46" battleScribeVersion="2.03" authorName="UrsinePatriarch" authorContact="BSData Developers Discord" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="67" type="catalogue">
+<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="1df7-bbbc-b70e-6a3f" name="LA -  XVII: Word Bearers" revision="47" battleScribeVersion="2.03" authorName="UrsinePatriarch" authorContact="BSData Developers Discord" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="67" type="catalogue">
   <categoryEntries>
     <categoryEntry id="821c-0c83-5ed0-ff6b" name="Harbinger of Chaos Restriction" hidden="false">
       <modifiers>
@@ -3958,6 +3958,7 @@ In addition, once per battle, one friendly unit composed entirely of models with
                 </entryLink>
                 <entryLink id="6feb-3285-8e03-cde7" name="Devotion" hidden="false" collective="false" import="true" targetId="580d-f719-30eb-d878" type="selectionEntry"/>
                 <entryLink id="9843-329d-51b4-2149" name="Illuminarum" hidden="false" collective="false" import="true" targetId="4dd8-ebdd-1395-f138" type="selectionEntry"/>
+                <entryLink import="true" name="The Ætheric Dominion (X)" hidden="false" id="5cb9-c86f-a629-c8b3" type="selectionEntryGroup" targetId="002f-0e40-9d49-2a22"/>
               </entryLinks>
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25"/>
@@ -4798,6 +4799,7 @@ Psychic Weapon</description>
           </profiles>
         </entryLink>
         <entryLink id="ea81-799d-c4ba-16ab" name="Retinue" hidden="false" collective="false" import="true" targetId="bda8-b52d-c914-4ac2" type="selectionEntryGroup"/>
+        <entryLink import="true" name="The Ætheric Dominion (X)" hidden="false" id="73ef-df1f-2835-6f36" type="selectionEntryGroup" targetId="002f-0e40-9d49-2a22"/>
       </entryLinks>
       <costs>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="165"/>
@@ -5806,9 +5808,9 @@ Threatening Entreaties - Kor Phaeron and the unit he has joined gain the Fearles
     </selectionEntry>
     <selectionEntry id="0da5-927a-258d-8507" name="Bound Daemon Regent (Lorgar/Erebus)" publicationId="cb13-da24-e6da-75b3" page="17" hidden="false" collective="false" import="true" type="unit">
       <modifiers>
-        <modifier type="add" field="category" value="9231-183c-b97b-63f9">
+        <modifier type="add" value="9231-183c-b97b-63f9" field="category">
           <conditions>
-            <condition field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b7db-bf16-47c5-dc05" type="equalTo"/>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="8cf6-d802-d054-6a86" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
           </conditions>
         </modifier>
       </modifiers>
@@ -5823,12 +5825,58 @@ Threatening Entreaties - Kor Phaeron and the unit he has joined gain the Fearles
       <costs>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="130"/>
       </costs>
+      <modifierGroups>
+        <modifierGroup type="and">
+          <modifiers>
+            <modifier type="add" value="c42-1919-c37e-51f0" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="ca6c-e8cf-7bc1-eaa0" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="9556-82c1-c70a-126e" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="8ed0-3582-f536-c48e" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="f074-f60a-9aa6-c52a" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="3d70-1d54-a791-ac60" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="6508-4f6a-0dc1-8f56" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="e4fb-66cd-e07d-609b" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="bcf6-8350-9099-1e91" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="9508-8124-d34a-500a" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="8cf6-d802-d054-6a86" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="b7db-bf16-47c5-dc05" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="a1d4-4662-c944-19cc" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="1214-3abe-c6d1-2038" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="2774-1a32-f196-be76" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="945c-b969-75eb-19d9" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </modifierGroup>
+      </modifierGroups>
     </selectionEntry>
     <selectionEntry id="fd8b-8d8d-901a-6ee3" name="Bound Daemon Brutes (Lorgar/Erebus)" publicationId="cb13-da24-e6da-75b3" page="18" hidden="false" collective="false" import="true" type="unit">
       <modifiers>
-        <modifier type="add" field="category" value="9231-183c-b97b-63f9">
+        <modifier type="add" value="9231-183c-b97b-63f9" field="category">
           <conditions>
-            <condition field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b7db-bf16-47c5-dc05" type="equalTo"/>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="8cf6-d802-d054-6a86" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
           </conditions>
         </modifier>
       </modifiers>
@@ -5842,6 +5890,52 @@ Threatening Entreaties - Kor Phaeron and the unit he has joined gain the Fearles
       <costs>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15"/>
       </costs>
+      <modifierGroups>
+        <modifierGroup type="and">
+          <modifiers>
+            <modifier type="add" value="c42-1919-c37e-51f0" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="ca6c-e8cf-7bc1-eaa0" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="9556-82c1-c70a-126e" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="8ed0-3582-f536-c48e" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="f074-f60a-9aa6-c52a" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="3d70-1d54-a791-ac60" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="6508-4f6a-0dc1-8f56" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="e4fb-66cd-e07d-609b" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="bcf6-8350-9099-1e91" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="9508-8124-d34a-500a" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="8cf6-d802-d054-6a86" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="b7db-bf16-47c5-dc05" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="a1d4-4662-c944-19cc" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="1214-3abe-c6d1-2038" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="2774-1a32-f196-be76" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="945c-b969-75eb-19d9" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </modifierGroup>
+      </modifierGroups>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Ruinstorm Daemon Beasts (Lorgar/Erebus)" hidden="false" id="cca0-3900-65ca-bd5d">
       <costs>
@@ -5874,23 +5968,60 @@ Threatening Entreaties - Kor Phaeron and the unit he has joined gain the Fearles
             <modifier type="set" value="Bulky (3)" field="name"/>
           </modifiers>
         </infoLink>
-        <infoLink id="62dc-152c-b4f-6f9f" name="Hammer of Wrath (X)" hidden="false" targetId="aec0-c3aa-1e4e-1779" type="rule">
-          <modifiers>
-            <modifier type="set" field="name" value="Hammer of Wrath (1)">
-              <conditions>
-                <condition type="atLeast" value="1" field="selections" scope="parent" childId="e4fb-66cd-e07d-609b" shared="true"/>
-              </conditions>
-            </modifier>
-          </modifiers>
-        </infoLink>
       </infoLinks>
       <modifiers>
-        <modifier type="add" field="category" value="9231-183c-b97b-63f9">
+        <modifier type="add" value="9231-183c-b97b-63f9" field="category">
           <conditions>
-            <condition field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b7db-bf16-47c5-dc05" type="atLeast"/>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="8cf6-d802-d054-6a86" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
           </conditions>
         </modifier>
       </modifiers>
+      <modifierGroups>
+        <modifierGroup type="and">
+          <modifiers>
+            <modifier type="add" value="c42-1919-c37e-51f0" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="ca6c-e8cf-7bc1-eaa0" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="9556-82c1-c70a-126e" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="8ed0-3582-f536-c48e" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="f074-f60a-9aa6-c52a" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="3d70-1d54-a791-ac60" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="6508-4f6a-0dc1-8f56" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="e4fb-66cd-e07d-609b" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="bcf6-8350-9099-1e91" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="9508-8124-d34a-500a" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="8cf6-d802-d054-6a86" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="b7db-bf16-47c5-dc05" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="a1d4-4662-c944-19cc" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="1214-3abe-c6d1-2038" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="2774-1a32-f196-be76" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="945c-b969-75eb-19d9" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </modifierGroup>
+      </modifierGroups>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Ruinstorm Daemon Brutes (Lorgar/Erebus)" hidden="false" id="c640-5d22-9d97-4959">
       <costs>
@@ -5901,7 +6032,12 @@ Threatening Entreaties - Kor Phaeron and the unit he has joined gain the Fearles
       </categoryLinks>
       <entryLinks>
         <entryLink import="true" name="Daemon Brute" hidden="false" type="selectionEntry" id="f0e3-7d1f-1f4d-ed7b" targetId="e3e-4f46-2300-a35"/>
-        <entryLink import="true" name="Infernal Armaments" hidden="false" type="selectionEntry" id="9071-3e03-be60-47f1" targetId="9abc-11e8-9031-d104"/>
+        <entryLink import="true" name="Infernal Armaments" hidden="false" type="selectionEntry" id="9071-3e03-be60-47f1" targetId="9abc-11e8-9031-d104">
+          <constraints>
+            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="5843-c53c-52fe-693f"/>
+            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="c370-f491-ade0-d30d"/>
+          </constraints>
+        </entryLink>
       </entryLinks>
       <infoLinks>
         <infoLink id="99d9-64d3-87a3-df20" name="Æthereal Invulnerability (X)" hidden="false" targetId="e05e-ed23-64fb-a535" type="rule">
@@ -5914,29 +6050,61 @@ Threatening Entreaties - Kor Phaeron and the unit he has joined gain the Fearles
             <modifier type="set" value="Bulky (3)" field="name"/>
           </modifiers>
         </infoLink>
-        <infoLink id="b344-3aa5-a992-625c" name="Hammer of Wrath (X)" hidden="false" targetId="aec0-c3aa-1e4e-1779" type="rule">
-          <modifiers>
-            <modifier type="set" field="name" value="Hammer of Wrath (1)">
-              <conditions>
-                <condition type="equalTo" value="0" field="selections" scope="parent" childId="e4fb-66cd-e07d-609b" shared="true"/>
-              </conditions>
-            </modifier>
-            <modifier type="set" field="name" value="Hammer of Wrath (2)">
-              <conditions>
-                <condition type="atLeast" value="1" field="selections" scope="parent" childId="e4fb-66cd-e07d-609b" shared="true"/>
-              </conditions>
-            </modifier>
-          </modifiers>
-        </infoLink>
         <infoLink id="4c67-dfc4-85f1-c053" name="Traitor" hidden="false" targetId="eff2-8b0e-21da-2f0d" type="rule"/>
       </infoLinks>
       <modifiers>
-        <modifier type="add" field="category" value="9231-183c-b97b-63f9">
+        <modifier type="add" value="9231-183c-b97b-63f9" field="category">
           <conditions>
-            <condition field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b7db-bf16-47c5-dc05" type="atLeast"/>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="8cf6-d802-d054-6a86" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
           </conditions>
         </modifier>
       </modifiers>
+      <modifierGroups>
+        <modifierGroup type="and">
+          <modifiers>
+            <modifier type="add" value="c42-1919-c37e-51f0" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="ca6c-e8cf-7bc1-eaa0" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="9556-82c1-c70a-126e" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="8ed0-3582-f536-c48e" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="f074-f60a-9aa6-c52a" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="3d70-1d54-a791-ac60" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="6508-4f6a-0dc1-8f56" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="e4fb-66cd-e07d-609b" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="bcf6-8350-9099-1e91" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="9508-8124-d34a-500a" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="8cf6-d802-d054-6a86" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="b7db-bf16-47c5-dc05" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="a1d4-4662-c944-19cc" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="1214-3abe-c6d1-2038" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="2774-1a32-f196-be76" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="945c-b969-75eb-19d9" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </modifierGroup>
+      </modifierGroups>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Greater Ruinstorm Daemon Beast (Lorgar)" hidden="false" id="59d-9e40-117a-7a34">
       <categoryLinks>
@@ -5944,23 +6112,24 @@ Threatening Entreaties - Kor Phaeron and the unit he has joined gain the Fearles
       </categoryLinks>
       <infoLinks>
         <infoLink id="2b72-655d-a776-8d5" name="Traitor" hidden="false" targetId="eff2-8b0e-21da-2f0d" type="rule"/>
-        <infoLink id="abfe-21b8-5125-8e33" name="Hammer of Wrath (X)" hidden="false" targetId="aec0-c3aa-1e4e-1779" type="rule">
-          <modifiers>
-            <modifier type="set" field="name" value="Hammer of Wrath (3)">
-              <conditions>
-                <condition type="equalTo" value="0" field="selections" scope="parent" childId="e4fb-66cd-e07d-609b" shared="true"/>
-              </conditions>
-            </modifier>
-            <modifier type="set" field="name" value="Hammer of Wrath (3+1)">
-              <conditions>
-                <condition type="atLeast" value="1" field="selections" scope="parent" childId="e4fb-66cd-e07d-609b" shared="true"/>
-              </conditions>
-            </modifier>
-          </modifiers>
-        </infoLink>
         <infoLink id="11f-8c8-ecbc-1c38" name="Æthereal Invulnerability (X)" hidden="false" targetId="e05e-ed23-64fb-a535" type="rule">
           <modifiers>
             <modifier type="set" field="name" value="Æthereal Invulnerability (5+)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink name="Hammer of Wrath (X)" id="0b9d-67ab-0809-da53" hidden="false" targetId="aec0-c3aa-1e4e-1779" type="rule">
+          <modifiers>
+            <modifier type="set" value="Hammer of Wrath (" field="name"/>
+            <modifier type="append" value="3 [IT X])" field="name">
+              <conditions>
+                <condition type="notInstanceOf" value="0" field="selections" scope="ancestor" childId="6508-4f6a-0dc1-8f56" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="append" value="4 - Deflagerate [IT ✓])" field="name">
+              <conditions>
+                <condition type="instanceOf" value="0" field="selections" scope="ancestor" childId="6508-4f6a-0dc1-8f56" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
           </modifiers>
         </infoLink>
       </infoLinks>
@@ -5977,12 +6146,58 @@ Threatening Entreaties - Kor Phaeron and the unit he has joined gain the Fearles
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25"/>
       </costs>
       <modifiers>
-        <modifier type="add" field="category" value="9231-183c-b97b-63f9">
+        <modifier type="add" value="9231-183c-b97b-63f9" field="category">
           <conditions>
-            <condition field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b7db-bf16-47c5-dc05" type="atLeast"/>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="8cf6-d802-d054-6a86" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
           </conditions>
         </modifier>
       </modifiers>
+      <modifierGroups>
+        <modifierGroup type="and">
+          <modifiers>
+            <modifier type="add" value="c42-1919-c37e-51f0" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="ca6c-e8cf-7bc1-eaa0" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="9556-82c1-c70a-126e" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="8ed0-3582-f536-c48e" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="f074-f60a-9aa6-c52a" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="3d70-1d54-a791-ac60" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="6508-4f6a-0dc1-8f56" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="e4fb-66cd-e07d-609b" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="bcf6-8350-9099-1e91" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="9508-8124-d34a-500a" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="8cf6-d802-d054-6a86" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="b7db-bf16-47c5-dc05" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="a1d4-4662-c944-19cc" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="1214-3abe-c6d1-2038" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="2774-1a32-f196-be76" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="945c-b969-75eb-19d9" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </modifierGroup>
+      </modifierGroups>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Ruinstorm Daemon Behemoth (Lorgar)" hidden="false" id="6344-7863-4f0b-deaa">
       <categoryLinks>
@@ -5996,20 +6211,6 @@ Threatening Entreaties - Kor Phaeron and the unit he has joined gain the Fearles
           </modifiers>
         </infoLink>
         <infoLink name="Empyrean Avatar" hidden="false" type="rule" id="4ded-82cc-a717-8fd0" targetId="c694-20c8-455-baca"/>
-        <infoLink id="da81-e148-36a0-be2d" name="Hammer of Wrath (X)" hidden="false" targetId="aec0-c3aa-1e4e-1779" type="rule">
-          <modifiers>
-            <modifier type="set" field="name" value="Hammer of Wrath (3)">
-              <conditions>
-                <condition type="equalTo" value="0" field="selections" scope="parent" childId="e4fb-66cd-e07d-609b" shared="true"/>
-              </conditions>
-            </modifier>
-            <modifier type="set" field="name" value="Hammer of Wrath (3+1)">
-              <conditions>
-                <condition type="atLeast" value="1" field="selections" scope="parent" childId="e4fb-66cd-e07d-609b" shared="true"/>
-              </conditions>
-            </modifier>
-          </modifiers>
-        </infoLink>
         <infoLink id="2cb8-9990-51b9-15c0" name="Bulky (X)" hidden="false" targetId="676c-7b75-4b6f-9405" type="rule">
           <modifiers>
             <modifier type="set" value="Bulky (7)" field="name"/>
@@ -6018,6 +6219,72 @@ Threatening Entreaties - Kor Phaeron and the unit he has joined gain the Fearles
         <infoLink id="1a74-eb0f-313f-3c91" name="Æthereal Invulnerability (X)" hidden="false" targetId="e05e-ed23-64fb-a535" type="rule">
           <modifiers>
             <modifier type="set" field="name" value="Æthereal Invulnerability (4+)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink name="Hammer of Wrath (X)" id="a583-6931-ca6b-760b" hidden="false" targetId="aec0-c3aa-1e4e-1779" type="rule">
+          <modifiers>
+            <modifier type="set" value="Hammer of Wrath (" field="name"/>
+            <modifier type="append" value="3" field="name">
+              <conditionGroups>
+                <conditionGroup type="and">
+                  <conditions>
+                    <condition type="notInstanceOf" value="0" field="selections" scope="ancestor" childId="6508-4f6a-0dc1-8f56" shared="true" includeChildSelections="true"/>
+                    <condition type="equalTo" value="0" field="selections" scope="6344-7863-4f0b-deaa" childId="fd64-626a-d3d4-9b8e" shared="true" includeChildSelections="true"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+            <modifier type="append" value="4" field="name">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditionGroups>
+                    <conditionGroup type="and">
+                      <conditions>
+                        <condition type="instanceOf" value="0" field="selections" scope="ancestor" childId="6508-4f6a-0dc1-8f56" shared="true" includeChildSelections="true"/>
+                        <condition type="equalTo" value="0" field="selections" scope="6344-7863-4f0b-deaa" childId="fd64-626a-d3d4-9b8e" shared="true" includeChildSelections="true"/>
+                      </conditions>
+                    </conditionGroup>
+                    <conditionGroup type="and">
+                      <conditions>
+                        <condition type="notInstanceOf" value="0" field="selections" scope="ancestor" childId="6508-4f6a-0dc1-8f56" shared="true" includeChildSelections="true"/>
+                        <condition type="equalTo" value="1" field="selections" scope="6344-7863-4f0b-deaa" childId="fd64-626a-d3d4-9b8e" shared="true" includeChildSelections="true"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+            <modifier type="append" value="5" field="name">
+              <conditionGroups>
+                <conditionGroup type="and">
+                  <conditions>
+                    <condition type="instanceOf" value="0" field="selections" scope="ancestor" childId="6508-4f6a-0dc1-8f56" shared="true" includeChildSelections="true"/>
+                    <condition type="equalTo" value="1" field="selections" scope="6344-7863-4f0b-deaa" childId="fd64-626a-d3d4-9b8e" shared="true" includeChildSelections="true"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+            <modifier type="append" value=" - Deflagerate [IT ✓]" field="name" join="">
+              <conditions>
+                <condition type="instanceOf" value="0" field="selections" scope="ancestor" childId="6508-4f6a-0dc1-8f56" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="append" value="[IW ✓]" field="name">
+              <conditions>
+                <condition type="equalTo" value="1" field="selections" scope="6344-7863-4f0b-deaa" childId="fd64-626a-d3d4-9b8e" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="append" value="[IT X]" field="name" join="">
+              <conditions>
+                <condition type="notInstanceOf" value="0" field="selections" scope="ancestor" childId="6508-4f6a-0dc1-8f56" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="append" value="[IW X]" field="name">
+              <conditions>
+                <condition type="equalTo" value="0" field="selections" scope="6344-7863-4f0b-deaa" childId="fd64-626a-d3d4-9b8e" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="append" value=")" field="name"/>
           </modifiers>
         </infoLink>
       </infoLinks>
@@ -6030,12 +6297,58 @@ Threatening Entreaties - Kor Phaeron and the unit he has joined gain the Fearles
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="350"/>
       </costs>
       <modifiers>
-        <modifier type="add" field="category" value="9231-183c-b97b-63f9">
+        <modifier type="add" value="9231-183c-b97b-63f9" field="category">
           <conditions>
-            <condition field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b7db-bf16-47c5-dc05" type="atLeast"/>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="8cf6-d802-d054-6a86" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
           </conditions>
         </modifier>
       </modifiers>
+      <modifierGroups>
+        <modifierGroup type="and">
+          <modifiers>
+            <modifier type="add" value="c42-1919-c37e-51f0" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="ca6c-e8cf-7bc1-eaa0" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="9556-82c1-c70a-126e" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="8ed0-3582-f536-c48e" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="f074-f60a-9aa6-c52a" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="3d70-1d54-a791-ac60" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="6508-4f6a-0dc1-8f56" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="e4fb-66cd-e07d-609b" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="bcf6-8350-9099-1e91" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="9508-8124-d34a-500a" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="8cf6-d802-d054-6a86" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="b7db-bf16-47c5-dc05" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="a1d4-4662-c944-19cc" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="1214-3abe-c6d1-2038" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="2774-1a32-f196-be76" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="945c-b969-75eb-19d9" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </modifierGroup>
+      </modifierGroups>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Ruinstorm Daemon Cavalry (Lorgar)" hidden="false" id="f2d-471c-3b99-1752">
       <categoryLinks>
@@ -6043,18 +6356,19 @@ Threatening Entreaties - Kor Phaeron and the unit he has joined gain the Fearles
       </categoryLinks>
       <infoLinks>
         <infoLink id="ebc7-6015-e730-7897" name="Traitor" hidden="false" targetId="eff2-8b0e-21da-2f0d" type="rule"/>
-        <infoLink id="4353-5a1f-63ab-ac62" name="Hammer of Wrath (X)" hidden="false" targetId="aec0-c3aa-1e4e-1779" type="rule">
-          <modifiers>
-            <modifier type="set" field="name" value="Hammer of Wrath (1)">
-              <conditions>
-                <condition type="atLeast" value="1" field="selections" scope="parent" childId="e4fb-66cd-e07d-609b" shared="true"/>
-              </conditions>
-            </modifier>
-          </modifiers>
-        </infoLink>
         <infoLink id="e3c2-599f-4bce-7045" name="Æthereal Invulnerability (X)" hidden="false" targetId="e05e-ed23-64fb-a535" type="rule">
           <modifiers>
             <modifier type="set" field="name" value="Æthereal Invulnerability (5+)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink name="Hammer of Wrath (X)" id="ef1b-a68a-3967-46ca" hidden="false" type="rule" targetId="aec0-c3aa-1e4e-1779">
+          <modifiers>
+            <modifier type="set" value="Hammer of Wrath (1 - Deflagerate [IT ✓])" field="name"/>
+            <modifier type="set" value="true" field="hidden">
+              <conditions>
+                <condition type="notInstanceOf" value="0" field="selections" scope="ancestor" childId="6508-4f6a-0dc1-8f56" shared="true"/>
+              </conditions>
+            </modifier>
           </modifiers>
         </infoLink>
       </infoLinks>
@@ -6065,6 +6379,59 @@ Threatening Entreaties - Kor Phaeron and the unit he has joined gain the Fearles
       <costs>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="50"/>
       </costs>
+      <modifiers>
+        <modifier type="add" value="9231-183c-b97b-63f9" field="category">
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="8cf6-d802-d054-6a86" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <modifierGroups>
+        <modifierGroup type="and">
+          <modifiers>
+            <modifier type="add" value="c42-1919-c37e-51f0" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="ca6c-e8cf-7bc1-eaa0" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="9556-82c1-c70a-126e" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="8ed0-3582-f536-c48e" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="f074-f60a-9aa6-c52a" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="3d70-1d54-a791-ac60" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="6508-4f6a-0dc1-8f56" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="e4fb-66cd-e07d-609b" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="bcf6-8350-9099-1e91" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="9508-8124-d34a-500a" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="8cf6-d802-d054-6a86" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="b7db-bf16-47c5-dc05" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="a1d4-4662-c944-19cc" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="1214-3abe-c6d1-2038" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="2774-1a32-f196-be76" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="945c-b969-75eb-19d9" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </modifierGroup>
+      </modifierGroups>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Ruinstorm Daemon Harbinger (Lorgar/Erebus)" hidden="false" id="8599-a03d-8af7-4ba1">
       <categoryLinks>
@@ -6081,12 +6448,58 @@ Threatening Entreaties - Kor Phaeron and the unit he has joined gain the Fearles
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="135"/>
       </costs>
       <modifiers>
-        <modifier type="add" field="category" value="9231-183c-b97b-63f9">
+        <modifier type="add" value="9231-183c-b97b-63f9" field="category">
           <conditions>
-            <condition field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b7db-bf16-47c5-dc05" type="atLeast"/>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="8cf6-d802-d054-6a86" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
           </conditions>
         </modifier>
       </modifiers>
+      <modifierGroups>
+        <modifierGroup type="and">
+          <modifiers>
+            <modifier type="add" value="c42-1919-c37e-51f0" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="ca6c-e8cf-7bc1-eaa0" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="9556-82c1-c70a-126e" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="8ed0-3582-f536-c48e" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="f074-f60a-9aa6-c52a" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="3d70-1d54-a791-ac60" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="6508-4f6a-0dc1-8f56" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="e4fb-66cd-e07d-609b" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="bcf6-8350-9099-1e91" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="9508-8124-d34a-500a" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="8cf6-d802-d054-6a86" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="b7db-bf16-47c5-dc05" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="a1d4-4662-c944-19cc" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="1214-3abe-c6d1-2038" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="2774-1a32-f196-be76" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="945c-b969-75eb-19d9" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </modifierGroup>
+      </modifierGroups>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Ruinstorm Daemon Hierarch (Lorgar/Erebus)" hidden="false" id="e9d5-f180-aedf-521b">
       <categoryLinks>
@@ -6100,15 +6513,6 @@ Threatening Entreaties - Kor Phaeron and the unit he has joined gain the Fearles
             <modifier type="set" value="It Will Not Die (6+)" field="name"/>
           </modifiers>
         </infoLink>
-        <infoLink id="3380-e19b-6292-405f" name="Hammer of Wrath (X)" hidden="false" targetId="aec0-c3aa-1e4e-1779" type="rule">
-          <modifiers>
-            <modifier type="set" field="name" value="Hammer of Wrath (1)">
-              <conditions>
-                <condition type="atLeast" value="1" field="selections" scope="e9d5-f180-aedf-521b" childId="e4fb-66cd-e07d-609b" shared="true"/>
-              </conditions>
-            </modifier>
-          </modifiers>
-        </infoLink>
         <infoLink name="Empyrean Avatar" hidden="false" type="rule" id="afb0-e428-5906-3599" targetId="c694-20c8-455-baca"/>
         <infoLink id="6184-1b08-73ad-d737" name="Bulky (X)" hidden="false" targetId="676c-7b75-4b6f-9405" type="rule">
           <modifiers>
@@ -6118,6 +6522,72 @@ Threatening Entreaties - Kor Phaeron and the unit he has joined gain the Fearles
         <infoLink id="1df8-b42f-967c-7b70" name="Æthereal Invulnerability (X)" hidden="false" targetId="e05e-ed23-64fb-a535" type="rule">
           <modifiers>
             <modifier type="set" field="name" value="Æthereal Invulnerability (4+)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink name="Hammer of Wrath (X)" id="2d30-2695-f364-0691" hidden="false" type="rule" targetId="aec0-c3aa-1e4e-1779">
+          <modifiers>
+            <modifier type="set" value="true" field="hidden">
+              <conditionGroups>
+                <conditionGroup type="and">
+                  <conditions>
+                    <condition type="notInstanceOf" value="0" field="selections" scope="ancestor" childId="6508-4f6a-0dc1-8f56" shared="true"/>
+                    <condition type="equalTo" value="0" field="selections" scope="e9d5-f180-aedf-521b" childId="fd64-626a-d3d4-9b8e" shared="true" includeChildSelections="true"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+            <modifier type="set" value="Hammer of Wrath (" field="name"/>
+            <modifier type="append" value="1" field="name">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditionGroups>
+                    <conditionGroup type="and">
+                      <conditions>
+                        <condition type="notInstanceOf" value="0" field="selections" scope="ancestor" childId="6508-4f6a-0dc1-8f56" shared="true" includeChildSelections="true"/>
+                        <condition type="equalTo" value="1" field="selections" scope="e9d5-f180-aedf-521b" childId="fd64-626a-d3d4-9b8e" shared="true" includeChildSelections="true"/>
+                      </conditions>
+                    </conditionGroup>
+                    <conditionGroup type="and">
+                      <conditions>
+                        <condition type="instanceOf" value="0" field="selections" scope="ancestor" childId="6508-4f6a-0dc1-8f56" shared="true" includeChildSelections="true"/>
+                        <condition type="equalTo" value="0" field="selections" scope="e9d5-f180-aedf-521b" childId="fd64-626a-d3d4-9b8e" shared="true" includeChildSelections="true"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+            <modifier type="append" value="2" field="name">
+              <conditionGroups>
+                <conditionGroup type="and">
+                  <conditions>
+                    <condition type="instanceOf" value="0" field="selections" scope="ancestor" childId="6508-4f6a-0dc1-8f56" shared="true" includeChildSelections="true"/>
+                    <condition type="equalTo" value="1" field="selections" scope="e9d5-f180-aedf-521b" childId="fd64-626a-d3d4-9b8e" shared="true" includeChildSelections="true"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+            <modifier type="append" value=" - Deflagerate [IT ✓]" field="name" join="">
+              <conditions>
+                <condition type="instanceOf" value="0" field="selections" scope="ancestor" childId="6508-4f6a-0dc1-8f56" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="append" value="[IW ✓]" field="name">
+              <conditions>
+                <condition type="equalTo" value="1" field="selections" scope="e9d5-f180-aedf-521b" childId="fd64-626a-d3d4-9b8e" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="append" value="[IT X]" field="name" join="">
+              <conditions>
+                <condition type="notInstanceOf" value="0" field="selections" scope="ancestor" childId="6508-4f6a-0dc1-8f56" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="append" value="[IW X]" field="name">
+              <conditions>
+                <condition type="equalTo" value="0" field="selections" scope="e9d5-f180-aedf-521b" childId="fd64-626a-d3d4-9b8e" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="append" value=")" field="name"/>
           </modifiers>
         </infoLink>
       </infoLinks>
@@ -6134,15 +6604,61 @@ Threatening Entreaties - Kor Phaeron and the unit he has joined gain the Fearles
         <entryLink import="true" name="Hierarch" hidden="false" type="selectionEntry" id="2e71-3697-c5bd-80d8" targetId="bba5-7153-f7d2-facf"/>
       </entryLinks>
       <modifiers>
-        <modifier type="add" field="category" value="9231-183c-b97b-63f9">
+        <modifier type="add" value="9231-183c-b97b-63f9" field="category">
           <conditions>
-            <condition field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b7db-bf16-47c5-dc05" type="atLeast"/>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="8cf6-d802-d054-6a86" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
           </conditions>
         </modifier>
       </modifiers>
       <costs>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="250"/>
       </costs>
+      <modifierGroups>
+        <modifierGroup type="and">
+          <modifiers>
+            <modifier type="add" value="c42-1919-c37e-51f0" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="ca6c-e8cf-7bc1-eaa0" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="9556-82c1-c70a-126e" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="8ed0-3582-f536-c48e" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="f074-f60a-9aa6-c52a" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="3d70-1d54-a791-ac60" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="6508-4f6a-0dc1-8f56" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="e4fb-66cd-e07d-609b" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="bcf6-8350-9099-1e91" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="9508-8124-d34a-500a" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="8cf6-d802-d054-6a86" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="b7db-bf16-47c5-dc05" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="a1d4-4662-c944-19cc" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="1214-3abe-c6d1-2038" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="2774-1a32-f196-be76" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="945c-b969-75eb-19d9" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </modifierGroup>
+      </modifierGroups>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Ruinstorm Daemon Harriers (Lorgar)" hidden="false" id="8c8f-683c-4690-4c3c">
       <categoryLinks>
@@ -6150,18 +6666,24 @@ Threatening Entreaties - Kor Phaeron and the unit he has joined gain the Fearles
       </categoryLinks>
       <infoLinks>
         <infoLink id="a5e9-89f4-2704-53fe" name="Traitor" hidden="false" targetId="eff2-8b0e-21da-2f0d" type="rule"/>
-        <infoLink id="efbc-29d2-c618-5612" name="Hammer of Wrath (X)" hidden="false" targetId="aec0-c3aa-1e4e-1779" type="rule">
-          <modifiers>
-            <modifier type="set" field="name" value="Hammer of Wrath (1)">
-              <conditions>
-                <condition type="atLeast" value="1" field="selections" scope="parent" childId="e4fb-66cd-e07d-609b" shared="true"/>
-              </conditions>
-            </modifier>
-          </modifiers>
-        </infoLink>
         <infoLink id="b042-313c-338c-37d" name="Æthereal Invulnerability (X)" hidden="false" targetId="e05e-ed23-64fb-a535" type="rule">
           <modifiers>
             <modifier type="set" field="name" value="Æthereal Invulnerability (5+)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink name="Hammer of Wrath (X)" id="27d3-9751-444b-c2f0" hidden="false" type="rule" targetId="aec0-c3aa-1e4e-1779">
+          <modifiers>
+            <modifier type="set" value="Hammer of Wrath (" field="name"/>
+            <modifier type="append" value="1 [IW ✓] [IT X])" field="name">
+              <conditions>
+                <condition type="notInstanceOf" value="0" field="selections" scope="ancestor" childId="6508-4f6a-0dc1-8f56" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="append" value="2 [IW ✓] [IT ✓])" field="name">
+              <conditions>
+                <condition type="instanceOf" value="0" field="selections" scope="ancestor" childId="6508-4f6a-0dc1-8f56" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
           </modifiers>
         </infoLink>
       </infoLinks>
@@ -6177,6 +6699,59 @@ Threatening Entreaties - Kor Phaeron and the unit he has joined gain the Fearles
       <costs>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="150"/>
       </costs>
+      <modifiers>
+        <modifier type="add" value="9231-183c-b97b-63f9" field="category">
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="8cf6-d802-d054-6a86" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <modifierGroups>
+        <modifierGroup type="and">
+          <modifiers>
+            <modifier type="add" value="c42-1919-c37e-51f0" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="ca6c-e8cf-7bc1-eaa0" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="9556-82c1-c70a-126e" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="8ed0-3582-f536-c48e" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="f074-f60a-9aa6-c52a" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="3d70-1d54-a791-ac60" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="6508-4f6a-0dc1-8f56" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="e4fb-66cd-e07d-609b" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="bcf6-8350-9099-1e91" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="9508-8124-d34a-500a" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="8cf6-d802-d054-6a86" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="b7db-bf16-47c5-dc05" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="a1d4-4662-c944-19cc" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="1214-3abe-c6d1-2038" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="2774-1a32-f196-be76" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="945c-b969-75eb-19d9" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </modifierGroup>
+      </modifierGroups>
     </selectionEntry>
     <selectionEntry type="unit" import="false" name="Ruinstorm Lesser Daemons (Lorgar)" hidden="false" id="1aef-763e-42a7-b78f">
       <categoryLinks>
@@ -6218,12 +6793,58 @@ Threatening Entreaties - Kor Phaeron and the unit he has joined gain the Fearles
         </selectionEntryGroup>
       </selectionEntryGroups>
       <modifiers>
-        <modifier type="add" field="category" value="9231-183c-b97b-63f9">
+        <modifier type="add" value="9231-183c-b97b-63f9" field="category">
           <conditions>
-            <condition field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b7db-bf16-47c5-dc05" type="atLeast"/>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="8cf6-d802-d054-6a86" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
           </conditions>
         </modifier>
       </modifiers>
+      <modifierGroups>
+        <modifierGroup type="and">
+          <modifiers>
+            <modifier type="add" value="c42-1919-c37e-51f0" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="ca6c-e8cf-7bc1-eaa0" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="9556-82c1-c70a-126e" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="8ed0-3582-f536-c48e" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="f074-f60a-9aa6-c52a" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="3d70-1d54-a791-ac60" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="6508-4f6a-0dc1-8f56" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="e4fb-66cd-e07d-609b" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="bcf6-8350-9099-1e91" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="9508-8124-d34a-500a" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="8cf6-d802-d054-6a86" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="b7db-bf16-47c5-dc05" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="a1d4-4662-c944-19cc" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="1214-3abe-c6d1-2038" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="2774-1a32-f196-be76" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="945c-b969-75eb-19d9" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </modifierGroup>
+      </modifierGroups>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Ruinstorm Daemon Swarms (Lorgar)" hidden="false" id="646-b4d8-aea6-60a0">
       <categoryLinks>
@@ -6233,15 +6854,6 @@ Threatening Entreaties - Kor Phaeron and the unit he has joined gain the Fearles
       </categoryLinks>
       <infoLinks>
         <infoLink id="8f7c-636-d15e-b4ef" name="Traitor" hidden="false" targetId="eff2-8b0e-21da-2f0d" type="rule"/>
-        <infoLink id="66cd-6f27-7166-639f" name="Hammer of Wrath (X)" hidden="false" targetId="aec0-c3aa-1e4e-1779" type="rule">
-          <modifiers>
-            <modifier type="set" field="name" value="Hammer of Wrath (1)">
-              <conditions>
-                <condition type="atLeast" value="1" field="selections" scope="parent" childId="e4fb-66cd-e07d-609b" shared="true"/>
-              </conditions>
-            </modifier>
-          </modifiers>
-        </infoLink>
         <infoLink name="Support Squad" hidden="false" type="rule" id="3717-b4c2-903d-7c9c" targetId="768e-56d6-ca52-24ae"/>
         <infoLink name="Swarm" hidden="false" type="rule" id="4c68-1d80-a45c-537" targetId="0bc2-fcb2-dd25-c10a"/>
       </infoLinks>
@@ -6251,6 +6863,59 @@ Threatening Entreaties - Kor Phaeron and the unit he has joined gain the Fearles
       <costs>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15"/>
       </costs>
+      <modifiers>
+        <modifier type="add" value="9231-183c-b97b-63f9" field="category">
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="8cf6-d802-d054-6a86" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <modifierGroups>
+        <modifierGroup type="and">
+          <modifiers>
+            <modifier type="add" value="c42-1919-c37e-51f0" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="ca6c-e8cf-7bc1-eaa0" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="9556-82c1-c70a-126e" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="8ed0-3582-f536-c48e" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="f074-f60a-9aa6-c52a" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="3d70-1d54-a791-ac60" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="6508-4f6a-0dc1-8f56" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="e4fb-66cd-e07d-609b" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="bcf6-8350-9099-1e91" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="9508-8124-d34a-500a" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="8cf6-d802-d054-6a86" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="b7db-bf16-47c5-dc05" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="a1d4-4662-c944-19cc" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="1214-3abe-c6d1-2038" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="2774-1a32-f196-be76" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="945c-b969-75eb-19d9" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </modifierGroup>
+      </modifierGroups>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Ruinstorm Daemon Sovereign (Lorgar/Erebus)" hidden="false" id="e0f2-1da3-accb-7ac2">
       <categoryLinks>
@@ -6265,15 +6930,6 @@ Threatening Entreaties - Kor Phaeron and the unit he has joined gain the Fearles
             <modifier type="set" value="It Will Not Die (5+)" field="name"/>
           </modifiers>
         </infoLink>
-        <infoLink id="da14-3e86-ff62-45d2" name="Hammer of Wrath (X)" hidden="false" targetId="aec0-c3aa-1e4e-1779" type="rule">
-          <modifiers>
-            <modifier type="set" field="name" value="Hammer of Wrath (1)">
-              <conditions>
-                <condition type="atLeast" value="1" field="selections" scope="e0f2-1da3-accb-7ac2" childId="e4fb-66cd-e07d-609b" shared="true"/>
-              </conditions>
-            </modifier>
-          </modifiers>
-        </infoLink>
         <infoLink name="Empyrean Avatar" hidden="false" type="rule" id="5b88-7169-d4a5-1152" targetId="c694-20c8-455-baca"/>
         <infoLink id="bc82-8ba6-e7df-849f" name="Bulky (X)" hidden="false" targetId="676c-7b75-4b6f-9405" type="rule">
           <modifiers>
@@ -6283,6 +6939,72 @@ Threatening Entreaties - Kor Phaeron and the unit he has joined gain the Fearles
         <infoLink id="eee0-71f0-bf95-d90" name="Æthereal Invulnerability (X)" hidden="false" targetId="e05e-ed23-64fb-a535" type="rule">
           <modifiers>
             <modifier type="set" field="name" value="Æthereal Invulnerability (4+)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink name="Hammer of Wrath (X)" id="61a3-11ef-7c96-d2dc" hidden="false" type="rule" targetId="aec0-c3aa-1e4e-1779">
+          <modifiers>
+            <modifier type="set" value="true" field="hidden">
+              <conditionGroups>
+                <conditionGroup type="and">
+                  <conditions>
+                    <condition type="notInstanceOf" value="0" field="selections" scope="ancestor" childId="6508-4f6a-0dc1-8f56" shared="true"/>
+                    <condition type="equalTo" value="0" field="selections" scope="e0f2-1da3-accb-7ac2" childId="fd64-626a-d3d4-9b8e" shared="true" includeChildSelections="true"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+            <modifier type="set" value="Hammer of Wrath (" field="name"/>
+            <modifier type="append" value="1" field="name">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditionGroups>
+                    <conditionGroup type="and">
+                      <conditions>
+                        <condition type="notInstanceOf" value="0" field="selections" scope="ancestor" childId="6508-4f6a-0dc1-8f56" shared="true" includeChildSelections="true"/>
+                        <condition type="equalTo" value="1" field="selections" scope="e0f2-1da3-accb-7ac2" childId="fd64-626a-d3d4-9b8e" shared="true" includeChildSelections="true"/>
+                      </conditions>
+                    </conditionGroup>
+                    <conditionGroup type="and">
+                      <conditions>
+                        <condition type="instanceOf" value="0" field="selections" scope="ancestor" childId="6508-4f6a-0dc1-8f56" shared="true" includeChildSelections="true"/>
+                        <condition type="equalTo" value="0" field="selections" scope="e0f2-1da3-accb-7ac2" childId="fd64-626a-d3d4-9b8e" shared="true" includeChildSelections="true"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+            <modifier type="append" value="2" field="name">
+              <conditionGroups>
+                <conditionGroup type="and">
+                  <conditions>
+                    <condition type="instanceOf" value="0" field="selections" scope="ancestor" childId="6508-4f6a-0dc1-8f56" shared="true" includeChildSelections="true"/>
+                    <condition type="equalTo" value="1" field="selections" scope="e0f2-1da3-accb-7ac2" childId="fd64-626a-d3d4-9b8e" shared="true" includeChildSelections="true"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+            <modifier type="append" value=" - Deflagerate [IT ✓]" field="name" join="">
+              <conditions>
+                <condition type="instanceOf" value="0" field="selections" scope="ancestor" childId="6508-4f6a-0dc1-8f56" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="append" value="[IW ✓]" field="name">
+              <conditions>
+                <condition type="equalTo" value="1" field="selections" scope="e0f2-1da3-accb-7ac2" childId="fd64-626a-d3d4-9b8e" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="append" value="[IT X]" field="name" join="">
+              <conditions>
+                <condition type="notInstanceOf" value="0" field="selections" scope="ancestor" childId="6508-4f6a-0dc1-8f56" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="append" value="[IW X]" field="name">
+              <conditions>
+                <condition type="equalTo" value="0" field="selections" scope="e0f2-1da3-accb-7ac2" childId="fd64-626a-d3d4-9b8e" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="append" value=")" field="name"/>
           </modifiers>
         </infoLink>
       </infoLinks>
@@ -6296,6 +7018,59 @@ Threatening Entreaties - Kor Phaeron and the unit he has joined gain the Fearles
       <costs>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="350"/>
       </costs>
+      <modifiers>
+        <modifier type="add" value="9231-183c-b97b-63f9" field="category">
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="8cf6-d802-d054-6a86" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <modifierGroups>
+        <modifierGroup type="and">
+          <modifiers>
+            <modifier type="add" value="c42-1919-c37e-51f0" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="ca6c-e8cf-7bc1-eaa0" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="9556-82c1-c70a-126e" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="8ed0-3582-f536-c48e" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="f074-f60a-9aa6-c52a" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="3d70-1d54-a791-ac60" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="6508-4f6a-0dc1-8f56" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="e4fb-66cd-e07d-609b" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="bcf6-8350-9099-1e91" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="9508-8124-d34a-500a" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="8cf6-d802-d054-6a86" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="b7db-bf16-47c5-dc05" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="a1d4-4662-c944-19cc" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="1214-3abe-c6d1-2038" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" value="2774-1a32-f196-be76" field="category">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="force" childId="945c-b969-75eb-19d9" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </modifierGroup>
+      </modifierGroups>
     </selectionEntry>
   </sharedSelectionEntries>
   <sharedSelectionEntryGroups>

--- a/2022 - Mech Library.cat
+++ b/2022 - Mech Library.cat
@@ -7594,7 +7594,6 @@ A unit composed entirely of models with Utan jump boosters may not Run. During R
       <categoryLinks>
         <categoryLink targetId="a443-dbf4-cb6c-4da1" id="af0-7a45-f939-713b" primary="false" name="Corrupted Engine Sub-type"/>
         <categoryLink targetId="4280-4963-02b5-e31d" id="7fdd-1633-d072-3977" primary="false" name="Dreadnought Unit Type"/>
-        <categoryLink targetId="f074-f60a-9aa6-c52a" id="1f3b-bc68-b474-2154" primary="false" name="Heedless Slaughter"/>
       </categoryLinks>
       <costs>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
@@ -7772,7 +7771,6 @@ A unit composed entirely of models with Utan jump boosters may not Run. During R
         <categoryLink targetId="a443-dbf4-cb6c-4da1" id="9ff1-2e56-f502-d653" primary="false" name="Corrupted Engine Sub-type"/>
         <categoryLink targetId="4280-4963-02b5-e31d" id="527f-7bcf-e17a-4a0b" primary="false" name="Dreadnought Unit Type"/>
         <categoryLink targetId="9231-183c-b97b-63f9" id="4b4c-beca-7b8e-2a07" primary="false" name="Heavy Sub-type"/>
-        <categoryLink targetId="bcf6-8350-9099-1e91" id="558f-4a2c-c0c3-df0" primary="false" name="Malevolent Artifice"/>
       </categoryLinks>
       <costs>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="265"/>

--- a/Daemon Library.cat
+++ b/Daemon Library.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" library="true" id="31bf-eb23-33a-3d65" name="Daemon Library" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="77" revision="6" battleScribeVersion="2.03" type="catalogue" authorName="a">
+<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" library="true" id="31bf-eb23-33a-3d65" name="Daemon Library" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="77" revision="7" battleScribeVersion="2.03" type="catalogue" authorName="a">
   <sharedSelectionEntryGroups>
     <selectionEntryGroup id="002f-0e40-9d49-2a22" name="The Ætheric Dominion (X)" hidden="false" collective="false" import="true">
       <constraints>
@@ -31,11 +31,6 @@ A unit which includes models with this special rule without a specific Ætheric 
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
           </costs>
           <modifiers>
-            <modifier type="set" value="1" field="5b94-5ed5-4856-5d3d">
-              <conditions>
-                <condition type="atLeast" value="1" field="selections" scope="force" childId="ca6c-e8cf-7bc1-eaa0" shared="true" includeChildSelections="true"/>
-              </conditions>
-            </modifier>
             <modifier type="set" value="0" field="1b96-95de-21aa-94f4">
               <conditionGroups>
                 <conditionGroup type="or">
@@ -71,11 +66,6 @@ Additionally, a unit entirely composed of models with this special rule adds +1 
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
           </costs>
           <modifiers>
-            <modifier type="set" value="1" field="5d04-bd7d-dced-173a">
-              <conditions>
-                <condition type="atLeast" value="1" field="selections" scope="force" childId="3d70-1d54-a791-ac60" shared="true" includeChildSelections="true"/>
-              </conditions>
-            </modifier>
             <modifier type="set" value="0" field="15a6-3993-5dd2-b14">
               <conditionGroups>
                 <conditionGroup type="or">
@@ -141,11 +131,6 @@ D3 - Result
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
           </costs>
           <modifiers>
-            <modifier type="set" value="1" field="a479-4aa6-f789-880a">
-              <conditions>
-                <condition type="atLeast" value="1" field="selections" scope="force" childId="8ed0-3582-f536-c48e" shared="true" includeChildSelections="true"/>
-              </conditions>
-            </modifier>
             <modifier type="set" value="0" field="3b89-dc3-165b-e9ce">
               <conditionGroups>
                 <conditionGroup type="or">
@@ -162,6 +147,9 @@ D3 - Result
               </conditionGroups>
             </modifier>
           </modifiers>
+          <categoryLinks>
+            <categoryLink targetId="9556-82c1-c70a-126e" id="d912-34cf-3f4a-8e22" primary="false" name="Formless Distortion"/>
+          </categoryLinks>
         </selectionEntry>
         <selectionEntry id="b7db-bf16-47c5-dc05" name="Putrid Corruption" publicationId="8775-88f5-cfdd-24f6" page="3" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
@@ -177,11 +165,6 @@ D3 - Result
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
           </costs>
           <modifiers>
-            <modifier type="set" value="1" field="16d2-6ab1-cba5-8828">
-              <conditions>
-                <condition type="atLeast" value="1" field="selections" scope="force" childId="b7db-bf16-47c5-dc05" shared="true" includeChildSelections="true"/>
-              </conditions>
-            </modifier>
             <modifier type="set" value="0" field="df60-2ef1-7656-9bd4">
               <conditionGroups>
                 <conditionGroup type="or">
@@ -216,12 +199,7 @@ D3 - Result
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
           </costs>
           <modifiers>
-            <modifier type="set" value="1" field="5850-fc1b-fba6-42b0">
-              <conditions>
-                <condition type="atLeast" value="1" field="selections" scope="force" childId="945c-b969-75eb-19d9" shared="true" includeChildSelections="true"/>
-              </conditions>
-            </modifier>
-            <modifier type="set" value="0" field="5850-fc1b-fba6-42b0">
+            <modifier type="set" value="0" field="2c74-20f9-5431-4525">
               <conditionGroups>
                 <conditionGroup type="or">
                   <conditions>
@@ -237,6 +215,9 @@ D3 - Result
               </conditionGroups>
             </modifier>
           </modifiers>
+          <categoryLinks>
+            <categoryLink targetId="2774-1a32-f196-be76" id="64c3-8913-231f-55af" primary="false" name="Ravenous Dissolution"/>
+          </categoryLinks>
         </selectionEntry>
         <selectionEntry id="1214-3abe-c6d1-2038" name="Rapturous Sensation" publicationId="8775-88f5-cfdd-24f6" page="3" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
@@ -254,12 +235,7 @@ Additionally, units entirely composed of models with this special rule must re-r
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
           </costs>
           <modifiers>
-            <modifier type="set" value="1" field="630c-571e-f8f5-9419">
-              <conditions>
-                <condition type="atLeast" value="1" field="selections" scope="force" childId="1214-3abe-c6d1-2038" shared="true" includeChildSelections="true"/>
-              </conditions>
-            </modifier>
-            <modifier type="set" value="0" field="630c-571e-f8f5-9419">
+            <modifier type="set" value="0" field="9f74-713f-9742-119e">
               <conditionGroups>
                 <conditionGroup type="or">
                   <conditions>
@@ -275,6 +251,9 @@ Additionally, units entirely composed of models with this special rule must re-r
               </conditionGroups>
             </modifier>
           </modifiers>
+          <categoryLinks>
+            <categoryLink targetId="a1d4-4662-c944-19cc" id="d1d3-9004-1185-6ece" primary="false" name="Rapturous Sensation"/>
+          </categoryLinks>
         </selectionEntry>
         <selectionEntry id="9508-8124-d34a-500a" name="Malevolent Artifice" publicationId="8775-88f5-cfdd-24f6" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
@@ -290,11 +269,6 @@ Additionally, units entirely composed of models with this special rule must re-r
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
           </costs>
           <modifiers>
-            <modifier type="set" value="1" field="813c-889b-e59a-8005">
-              <conditions>
-                <condition type="atLeast" value="1" field="selections" scope="force" childId="9508-8124-d34a-500a" shared="true" includeChildSelections="true"/>
-              </conditions>
-            </modifier>
             <modifier type="set" value="0" field="cc04-6295-5d05-77ec">
               <conditionGroups>
                 <conditionGroup type="or">
@@ -363,11 +337,6 @@ Additionally, models with this special rule gain a Shooting Attack with the foll
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
           </costs>
           <modifiers>
-            <modifier type="set" value="1" field="6add-ddd3-87db-6d42">
-              <conditions>
-                <condition type="atLeast" value="1" field="selections" scope="force" childId="e4fb-66cd-e07d-609b" shared="true" includeChildSelections="true"/>
-              </conditions>
-            </modifier>
             <modifier type="set" value="0" field="56cb-9c09-b338-b107">
               <conditionGroups>
                 <conditionGroup type="or">
@@ -384,173 +353,9 @@ Additionally, models with this special rule gain a Shooting Attack with the foll
               </conditionGroups>
             </modifier>
           </modifiers>
-        </selectionEntry>
-      </selectionEntries>
-    </selectionEntryGroup>
-    <selectionEntryGroup name="The Ætheric Dominion (Unit)" hidden="false" id="caad-e621-38e5-cb5f" defaultSelectionEntryId="6f0a-b22e-3349-6465">
-      <entryLinks>
-        <entryLink import="true" name="Encroaching Ruin" hidden="false" type="selectionEntry" id="eed1-ba72-c275-c739" targetId="ca6c-e8cf-7bc1-eaa0">
-          <modifiers>
-            <modifier type="set" value="true" field="hidden">
-              <conditionGroups>
-                <conditionGroup type="or">
-                  <conditions>
-                    <condition type="atLeast" value="1" field="selections" scope="force" childId="8ed0-3582-f536-c48e" shared="true" includeChildSelections="true"/>
-                    <condition type="atLeast" value="1" field="selections" scope="force" childId="3d70-1d54-a791-ac60" shared="true" includeChildSelections="true"/>
-                    <condition type="atLeast" value="1" field="selections" scope="force" childId="e4fb-66cd-e07d-609b" shared="true" includeChildSelections="true"/>
-                    <condition type="atLeast" value="1" field="selections" scope="force" childId="9508-8124-d34a-500a" shared="true" includeChildSelections="true"/>
-                    <condition type="atLeast" value="1" field="selections" scope="force" childId="b7db-bf16-47c5-dc05" shared="true" includeChildSelections="true"/>
-                    <condition type="atLeast" value="1" field="selections" scope="force" childId="1214-3abe-c6d1-2038" shared="true" includeChildSelections="true"/>
-                    <condition type="atLeast" value="1" field="selections" scope="force" childId="945c-b969-75eb-19d9" shared="true" includeChildSelections="true"/>
-                  </conditions>
-                </conditionGroup>
-              </conditionGroups>
-            </modifier>
-          </modifiers>
-        </entryLink>
-        <entryLink import="true" name="Formless Distortion" hidden="false" type="selectionEntry" id="dff0-de72-145c-88fc" targetId="8ed0-3582-f536-c48e">
-          <modifiers>
-            <modifier type="set" value="true" field="hidden">
-              <conditionGroups>
-                <conditionGroup type="or">
-                  <conditions>
-                    <condition type="atLeast" value="1" field="selections" scope="force" childId="ca6c-e8cf-7bc1-eaa0" shared="true" includeChildSelections="true"/>
-                    <condition type="atLeast" value="1" field="selections" scope="force" childId="3d70-1d54-a791-ac60" shared="true" includeChildSelections="true"/>
-                    <condition type="atLeast" value="1" field="selections" scope="force" childId="e4fb-66cd-e07d-609b" shared="true" includeChildSelections="true"/>
-                    <condition type="atLeast" value="1" field="selections" scope="force" childId="9508-8124-d34a-500a" shared="true" includeChildSelections="true"/>
-                    <condition type="atLeast" value="1" field="selections" scope="force" childId="b7db-bf16-47c5-dc05" shared="true" includeChildSelections="true"/>
-                    <condition type="atLeast" value="1" field="selections" scope="force" childId="1214-3abe-c6d1-2038" shared="true" includeChildSelections="true"/>
-                    <condition type="atLeast" value="1" field="selections" scope="force" childId="945c-b969-75eb-19d9" shared="true" includeChildSelections="true"/>
-                  </conditions>
-                </conditionGroup>
-              </conditionGroups>
-            </modifier>
-          </modifiers>
-        </entryLink>
-        <entryLink import="true" name="Heedless Slaughter" hidden="false" type="selectionEntry" id="ea56-db41-6ce5-ca26" targetId="3d70-1d54-a791-ac60">
-          <modifiers>
-            <modifier type="set" value="true" field="hidden">
-              <conditionGroups>
-                <conditionGroup type="or">
-                  <conditions>
-                    <condition type="atLeast" value="1" field="selections" scope="force" childId="ca6c-e8cf-7bc1-eaa0" shared="true" includeChildSelections="true"/>
-                    <condition type="atLeast" value="1" field="selections" scope="force" childId="8ed0-3582-f536-c48e" shared="true" includeChildSelections="true"/>
-                    <condition type="atLeast" value="1" field="selections" scope="force" childId="e4fb-66cd-e07d-609b" shared="true" includeChildSelections="true"/>
-                    <condition type="atLeast" value="1" field="selections" scope="force" childId="9508-8124-d34a-500a" shared="true" includeChildSelections="true"/>
-                    <condition type="atLeast" value="1" field="selections" scope="force" childId="b7db-bf16-47c5-dc05" shared="true" includeChildSelections="true"/>
-                    <condition type="atLeast" value="1" field="selections" scope="force" childId="1214-3abe-c6d1-2038" shared="true" includeChildSelections="true"/>
-                    <condition type="atLeast" value="1" field="selections" scope="force" childId="945c-b969-75eb-19d9" shared="true" includeChildSelections="true"/>
-                  </conditions>
-                </conditionGroup>
-              </conditionGroups>
-            </modifier>
-          </modifiers>
-        </entryLink>
-        <entryLink import="true" name="Infernal Tempest" hidden="false" type="selectionEntry" id="cf55-b3e-407c-753" targetId="e4fb-66cd-e07d-609b">
-          <modifiers>
-            <modifier type="set" value="true" field="hidden">
-              <conditionGroups>
-                <conditionGroup type="or">
-                  <conditions>
-                    <condition type="atLeast" value="1" field="selections" scope="force" childId="ca6c-e8cf-7bc1-eaa0" shared="true" includeChildSelections="true"/>
-                    <condition type="atLeast" value="1" field="selections" scope="force" childId="8ed0-3582-f536-c48e" shared="true" includeChildSelections="true"/>
-                    <condition type="atLeast" value="1" field="selections" scope="force" childId="3d70-1d54-a791-ac60" shared="true" includeChildSelections="true"/>
-                    <condition type="atLeast" value="1" field="selections" scope="force" childId="9508-8124-d34a-500a" shared="true" includeChildSelections="true"/>
-                    <condition type="atLeast" value="1" field="selections" scope="force" childId="b7db-bf16-47c5-dc05" shared="true" includeChildSelections="true"/>
-                    <condition type="atLeast" value="1" field="selections" scope="force" childId="1214-3abe-c6d1-2038" shared="true" includeChildSelections="true"/>
-                    <condition type="atLeast" value="1" field="selections" scope="force" childId="945c-b969-75eb-19d9" shared="true" includeChildSelections="true"/>
-                  </conditions>
-                </conditionGroup>
-              </conditionGroups>
-            </modifier>
-          </modifiers>
-        </entryLink>
-        <entryLink import="true" name="Putrid Corruption" hidden="false" type="selectionEntry" id="8f6-6f06-6105-ed3e" targetId="b7db-bf16-47c5-dc05">
-          <modifiers>
-            <modifier type="set" value="true" field="hidden">
-              <conditionGroups>
-                <conditionGroup type="or">
-                  <conditions>
-                    <condition type="atLeast" value="1" field="selections" scope="force" childId="ca6c-e8cf-7bc1-eaa0" shared="true" includeChildSelections="true"/>
-                    <condition type="atLeast" value="1" field="selections" scope="force" childId="8ed0-3582-f536-c48e" shared="true" includeChildSelections="true"/>
-                    <condition type="atLeast" value="1" field="selections" scope="force" childId="3d70-1d54-a791-ac60" shared="true" includeChildSelections="true"/>
-                    <condition type="atLeast" value="1" field="selections" scope="force" childId="e4fb-66cd-e07d-609b" shared="true" includeChildSelections="true"/>
-                    <condition type="atLeast" value="1" field="selections" scope="force" childId="9508-8124-d34a-500a" shared="true" includeChildSelections="true"/>
-                    <condition type="atLeast" value="1" field="selections" scope="force" childId="1214-3abe-c6d1-2038" shared="true" includeChildSelections="true"/>
-                    <condition type="atLeast" value="1" field="selections" scope="force" childId="945c-b969-75eb-19d9" shared="true" includeChildSelections="true"/>
-                  </conditions>
-                </conditionGroup>
-              </conditionGroups>
-            </modifier>
-          </modifiers>
-        </entryLink>
-        <entryLink import="true" name="Malevolent Artifice" hidden="false" type="selectionEntry" id="eaa5-a01e-d6ee-244f" targetId="9508-8124-d34a-500a">
-          <modifiers>
-            <modifier type="set" value="true" field="hidden">
-              <conditionGroups>
-                <conditionGroup type="or">
-                  <conditions>
-                    <condition type="atLeast" value="1" field="selections" scope="force" childId="ca6c-e8cf-7bc1-eaa0" shared="true" includeChildSelections="true"/>
-                    <condition type="atLeast" value="1" field="selections" scope="force" childId="8ed0-3582-f536-c48e" shared="true" includeChildSelections="true"/>
-                    <condition type="atLeast" value="1" field="selections" scope="force" childId="3d70-1d54-a791-ac60" shared="true" includeChildSelections="true"/>
-                    <condition type="atLeast" value="1" field="selections" scope="force" childId="e4fb-66cd-e07d-609b" shared="true" includeChildSelections="true"/>
-                    <condition type="atLeast" value="1" field="selections" scope="force" childId="b7db-bf16-47c5-dc05" shared="true" includeChildSelections="true"/>
-                    <condition type="atLeast" value="1" field="selections" scope="force" childId="1214-3abe-c6d1-2038" shared="true" includeChildSelections="true"/>
-                    <condition type="atLeast" value="1" field="selections" scope="force" childId="945c-b969-75eb-19d9" shared="true" includeChildSelections="true"/>
-                  </conditions>
-                </conditionGroup>
-              </conditionGroups>
-            </modifier>
-          </modifiers>
-        </entryLink>
-        <entryLink import="true" name="Rapturous Sensation" hidden="false" type="selectionEntry" id="8186-6ff8-79d-83cc" targetId="1214-3abe-c6d1-2038">
-          <modifiers>
-            <modifier type="set" value="true" field="hidden">
-              <conditionGroups>
-                <conditionGroup type="or">
-                  <conditions>
-                    <condition type="atLeast" value="1" field="selections" scope="force" childId="ca6c-e8cf-7bc1-eaa0" shared="true" includeChildSelections="true"/>
-                    <condition type="atLeast" value="1" field="selections" scope="force" childId="8ed0-3582-f536-c48e" shared="true" includeChildSelections="true"/>
-                    <condition type="atLeast" value="1" field="selections" scope="force" childId="3d70-1d54-a791-ac60" shared="true" includeChildSelections="true"/>
-                    <condition type="atLeast" value="1" field="selections" scope="force" childId="e4fb-66cd-e07d-609b" shared="true" includeChildSelections="true"/>
-                    <condition type="atLeast" value="1" field="selections" scope="force" childId="9508-8124-d34a-500a" shared="true" includeChildSelections="true"/>
-                    <condition type="atLeast" value="1" field="selections" scope="force" childId="b7db-bf16-47c5-dc05" shared="true" includeChildSelections="true"/>
-                    <condition type="atLeast" value="1" field="selections" scope="force" childId="945c-b969-75eb-19d9" shared="true" includeChildSelections="true"/>
-                  </conditions>
-                </conditionGroup>
-              </conditionGroups>
-            </modifier>
-          </modifiers>
-        </entryLink>
-        <entryLink import="true" name="Ravenous Dissolution" hidden="false" type="selectionEntry" id="ef2c-d069-8347-93b2" targetId="945c-b969-75eb-19d9">
-          <modifiers>
-            <modifier type="set" value="true" field="hidden">
-              <conditionGroups>
-                <conditionGroup type="or">
-                  <conditions>
-                    <condition type="atLeast" value="1" field="selections" scope="force" childId="ca6c-e8cf-7bc1-eaa0" shared="true" includeChildSelections="true"/>
-                    <condition type="atLeast" value="1" field="selections" scope="force" childId="8ed0-3582-f536-c48e" shared="true" includeChildSelections="true"/>
-                    <condition type="atLeast" value="1" field="selections" scope="force" childId="3d70-1d54-a791-ac60" shared="true" includeChildSelections="true"/>
-                    <condition type="atLeast" value="1" field="selections" scope="force" childId="e4fb-66cd-e07d-609b" shared="true" includeChildSelections="true"/>
-                    <condition type="atLeast" value="1" field="selections" scope="force" childId="9508-8124-d34a-500a" shared="true" includeChildSelections="true"/>
-                    <condition type="atLeast" value="1" field="selections" scope="force" childId="b7db-bf16-47c5-dc05" shared="true" includeChildSelections="true"/>
-                    <condition type="atLeast" value="1" field="selections" scope="force" childId="1214-3abe-c6d1-2038" shared="true" includeChildSelections="true"/>
-                  </conditions>
-                </conditionGroup>
-              </conditionGroups>
-            </modifier>
-          </modifiers>
-        </entryLink>
-      </entryLinks>
-      <constraints>
-        <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="425d-1914-f9a4-b2e1"/>
-        <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="56c-50b1-e156-305"/>
-      </constraints>
-      <selectionEntries>
-        <selectionEntry type="upgrade" import="true" name="None (Use this to switch between if you change your Whole Army Dominion)" hidden="false" id="6f0a-b22e-3349-6465">
-          <constraints>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="d5bc-6a4b-8099-c40b"/>
-          </constraints>
+          <categoryLinks>
+            <categoryLink targetId="6508-4f6a-0dc1-8f56" id="f640-7c10-df4e-07fa" primary="false" name="Infernal Tempest"/>
+          </categoryLinks>
         </selectionEntry>
       </selectionEntries>
     </selectionEntryGroup>
@@ -570,9 +375,6 @@ Additionally, a unit entirely composed of models with this special rule adds +1 
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
           </costs>
-          <categoryLinks>
-            <categoryLink name="Heedless Slaughter" hidden="false" id="21ca-02c5-a88e-dac4" targetId="f074-f60a-9aa6-c52a" primary="false"/>
-          </categoryLinks>
           <infoLinks>
             <infoLink name="The Ætheric Dominion (X) Corrupted Engines" id="ab0c-5041-ddcd-416d" hidden="false" type="rule" targetId="58e5-d2ef-f25e-496d"/>
           </infoLinks>
@@ -590,9 +392,6 @@ Additionally, a unit entirely composed of models with this special rule adds +1 
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
           </costs>
-          <categoryLinks>
-            <categoryLink name="Malevolent Artifice" hidden="false" id="185b-d332-87a8-4c8f" targetId="bcf6-8350-9099-1e91" primary="false"/>
-          </categoryLinks>
           <infoLinks>
             <infoLink name="The Ætheric Dominion (X) Corrupted Engines" id="0ee3-37a7-f623-07c7" hidden="false" type="rule" targetId="58e5-d2ef-f25e-496d"/>
           </infoLinks>
@@ -605,6 +404,10 @@ Additionally, a unit entirely composed of models with this special rule adds +1 
     <categoryEntry name="Heedless Slaughter" hidden="false" id="f074-f60a-9aa6-c52a"/>
     <categoryEntry name="Malevolent Artifice" hidden="false" id="bcf6-8350-9099-1e91"/>
     <categoryEntry name="Putrid Corruption" hidden="false" id="8cf6-d802-d054-6a86"/>
+    <categoryEntry name="Formless Distortion" id="9556-82c1-c70a-126e" hidden="false"/>
+    <categoryEntry name="Infernal Tempest" id="6508-4f6a-0dc1-8f56" hidden="false"/>
+    <categoryEntry name="Rapturous Sensation" id="a1d4-4662-c944-19cc" hidden="false"/>
+    <categoryEntry name="Ravenous Dissolution" id="2774-1a32-f196-be76" hidden="false"/>
   </categoryEntries>
   <sharedRules>
     <rule id="e05e-ed23-64fb-a535" name="Æthereal Invulnerability (X)" publicationId="cb13-da24-e6da-75b3" page="Various" hidden="false">

--- a/Daemon Library.cat
+++ b/Daemon Library.cat
@@ -158,7 +158,10 @@ D3 - Result
           </constraints>
           <rules>
             <rule id="94eb-7da4-953-529f" name="Putrid Corruption" publicationId="8775-88f5-cfdd-24f6" page="3" hidden="false">
-              <description>Models with this special rule gain the Heavy Unit Sub-type and may make a special Corrupted Resilience roll to avoid being Wounded (this is a Damage Mitigation roll which is made after unsaved Wounds are suffered). Corrupted Resilience rolls may not be taken against unsaved Wounds that have the Instant Death, Psychic Focus or Force special rule. To make a  Corrupted Resilience roll, roll a D6 each time an unsaved Wound is suffered. On a result of 5+, the unsaved Wound is discounted – treat it as having been saved. On any other result the Wound is taken as normal.</description>
+              <description>Models with this special rule gain the Heavy Unit Sub-type and may make a special Corrupted Resilience roll to avoid being Wounded (this is a Damage Mitigation roll which is made after unsaved Wounds are suffered). Corrupted Resilience rolls may not be taken against unsaved Wounds that have the Instant Death, Psychic Focus or Force special rule. To make a Corrupted Resilience roll, roll a D6 each time an unsaved Wound is suffered. On a result of 5+, the unsaved Wound is discounted – treat it as having been saved. On any other result the Wound is taken as normal.
+
+
+BS NOTE: This does not always seem to apply the unit type to all units. Unsure how to resolve.</description>
             </rule>
           </rules>
           <costs>
@@ -297,7 +300,10 @@ Additionally, units entirely composed of models with this special rule must re-r
           <rules>
             <rule id="457b-86dd-cedd-ce60" name="Infernal Tempest" publicationId="8775-88f5-cfdd-24f6" page="4" hidden="false">
               <description>Models with this special rule gain the Hammer of Wrath (1) special rule or, if they already have a version of the Hammer of Wrath (X) special rule, they increase the value in brackets by +1. All wounds inflicted by any variant of the Hammer of Wrath (X) special rule possessed by a unit with this special rule also gain the Deflagrate special rule.
-Additionally, models with this special rule gain a Shooting Attack with the following profile: (Elemental Eruption)</description>
+Additionally, models with this special rule gain a Shooting Attack with the following profile: (Elemental Eruption)
+
+
+BS NOTE: This does not always seem to apply. If you add/remove a model in the army it seems to work most of the time.</description>
             </rule>
           </rules>
           <infoLinks>


### PR DESCRIPTION
From @Mayegelt:
Put a branch up. Though its only kind of working. Might work better in NR than in BS due to how it functions.
https://github.com/BSData/horus-heresy/tree/Daemons

As such its slightly proof of concept, but needs some work.

Basically removed the "Units" version of the dominions. Added a "Add category" to all the units to add if that dominion is chosen. then also added a category for each, rather than before we just had 2.
This will add the "Heavy" or "Hammer of Wraths" as appropriate. An alternative is just link to a "If X is selected in force then" thing. Though i think that is part of the prob we have ATM.



### Related Issues
I assume:
* closes #3590
* closes #3575
* closes #3581

## Not done yet

To Do:
1) Need to get the HoW and Heavy to consistanty add in Militia & SM forces (not sure why its not working. Might be a bug in BS for Militia). I think its working now. But prob needs a look at.

2) Need to add the dominions to Esoteris, Lorgar, Ebebus. But not worth doing someone can't get the one for Rogue Psyker in Militia to work. So might need a different work around. If it does work its just copy and paste the group selection entry link.

3) Strange bug (again might be BS) that the last unit added doesn't get the HoW or Heavy they should get if dominion is picked. Seems that you have to update the unit (add a model or option) for it to apply to the last unit. Or just delete the last unit created.

## Test Case

Please upload a roster do demonstrate your changes. 
